### PR TITLE
hide version and metric links for old node

### DIFF
--- a/aggregator/http_server.go
+++ b/aggregator/http_server.go
@@ -37,12 +37,14 @@ func (agg *Aggregator) startHttpServer(ctx context.Context) {
 		tpl, err := template.ParseFS(res, "resources/*.gohtml")
 
 		if err != nil {
+			agg.logger.Errorf("error rendering telemetry %v", err)
 			return err
 		}
 
 		data := agg.operatorPool.GetAll()
 		var buf bytes.Buffer
 		if err := tpl.Execute(&buf, data); err != nil {
+			agg.logger.Errorf("error rendering telemetry %v", err)
 			return err
 		}
 

--- a/aggregator/resources/index.gohtml
+++ b/aggregator/resources/index.gohtml
@@ -29,13 +29,16 @@
 
         <div class="flex min-w-0 gap-x-4">
           <div class="min-w-0 flex-auto">
+            {{ if ne .Version "" }}
             <p class="text-sm font-semibold leading-6 text-white">
               v{{ .Version }}
             </p>
-            {{/* 
-            <p class="text-sm font-semibold leading-6 text-white">
+            {{ end }}
+            {{ if gt .MetricsPort 0 }}
+            <p class="text-sm leading-6 text-white">
               <a href="http://{{ .RemoteIP }}:{{ .MetricsPort }}/metrics">Metric</a>
-            </p>*}}
+            </p>
+            {{ end }}
           </div>
         </div>
 


### PR DESCRIPTION
there is old node if they haven't update yet, they won't have the data so we won't display the link or version info