### PR TITLE
fix wrong conversion of strategy address

### DIFF
--- a/contracts/script/DeployServiceManager.s.sol
+++ b/contracts/script/DeployServiceManager.s.sol
@@ -88,20 +88,15 @@ contract DeployServiceManager is Script {
         {
             // need manually step in
             // beaconETH
-            deployedStrategyArray[0].token =
-                address(bytes20(bytes("0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0")));
+            deployedStrategyArray[0].token = 0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0;
             //stETH
-            deployedStrategyArray[1].token =
-                address(bytes20(bytes("0x93c4b944D05dfe6df7645A86cd2206016c51564D")));
+            deployedStrategyArray[1].token = 0x93c4b944D05dfe6df7645A86cd2206016c51564D;
             //cbETH
-            deployedStrategyArray[2].token =
-                address(bytes20(bytes("0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc")));
+            deployedStrategyArray[2].token = 0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc;
             //swETH
-            deployedStrategyArray[3].token =
-                address(bytes20(bytes("0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6")));
+            deployedStrategyArray[3].token = 0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6;
             //osETH
-            deployedStrategyArray[4].token =
-                address(bytes20(bytes("0x57ba429517c3473B6d34CA9aCd56c0e735b94c02")));
+            deployedStrategyArray[4].token = 0x57ba429517c3473B6d34CA9aCd56c0e735b94c02 ;
         }
 
         {


### PR DESCRIPTION
Fix incorrect strategies address on our service manager.

Before:
![CleanShot 2024-08-20 at 01 21 56@2x](https://github.com/user-attachments/assets/901ec8fc-bf68-439d-995f-30c867fa7102)

After:

![CleanShot 2024-08-20 at 01 22 16@2x](https://github.com/user-attachments/assets/742b1672-77d2-4d09-9e35-47a61a066c7f)



## Root cause

On mainnet, because I purposely hardcode the strategy address into here but use wrong conversion and it get the address of the variable in the vm memory, not the actually address of the token. I probably was doing some conversion before and eventually made this mistake.

Note, the issue doesn't happen testnet. On testnet, the deployment script take the value from env var https://github.com/AvaProtocol/EigenLayer-AVS/blob/main/contracts/script/DeployServiceManagerHolesky.s.sol#L89-L91 and it convert the hex string to right address.

## Fix

I corrected here in the code for the record but I had executed on-chain tx to update it here: 

Add the good one
https://etherscan.io/tx/0x8eb9cd567394d67f386de9163e5af07d9ba546d95bcc0b6c13b94f09a4884aad

Remove the bad one
https://etherscan.io/tx/0x2e83995e704278fd598aefa71e8ef4246e783113748a896f141dbb8a90b6b508
https://etherscan.io/tx/0x25fbf8ad80035938a0c8c40e3b1c8de88e23a06f8f156baf21daa31e4f86b1a5
https://etherscan.io/tx/0x11e622f42fde0d890aa2cea697451b5e2fbe73a3ba34fc2b396b583ab4299194
https://etherscan.io/tx/0x5443f32529d0678f23ce0fb1ad57a530fab82bd7d63b33a9d981eb2e1024f41b
https://etherscan.io/tx/0x0f728f9322e0a04ac9fe57ba11764d84acb2daf55563a4e8fdcb910620b6c920

## Why we didn't notice

This can be used when we calculate staking percentage to weight the staking % of operator. We didn't get to that part yet.
This doesn't affect user deposit or restaking.
