### PR TITLE
Added API docs generation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,36 @@ foundryup
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 ```
 
+### Generate API Docs from Proto Files
+1. Install the `protoc-gen-doc` plugin for `protoc`.
+   Install via Go:
+   ```
+   go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@latest
+   ```  
+   Ensure the plugin is in your PATH:
+   ```
+   export PATH="$PATH:$(go env GOPATH)/bin"
+   ```
+   Verify the plugin is installed:
+   ```
+   which protoc-gen-doc
+   ```
+2. Generate API references in HTML format
+    ```
+    protoc --doc_out=./docs --doc_opt=html,docs.html ./protobuf/avs.proto
+    ```
+
+3. Alternatively, generate API references in Markdown format
+    ```
+    protoc --doc_out=./docs --doc_opt=markdown,docs.md ./protobuf/avs.proto
+    ```
+    This command will generate a markdown version of the gRPC API documentation. To enhance the clarity of the generated documentation, the following improvements should be made to the .proto file:
+    - **Group Definitions by Command**: Organize the API methods and their descriptions by command categories to make it easier for users to find relevant information.
+    - **Elaborate on Input Fields**: Provide detailed descriptions for each input field, including data types, expected values, and any constraints or special considerations.
+    - **Add Examples**: Include usage examples for each API method to demonstrate how to construct requests and interpret responses.
+    - **Link to Related Resources**: Where applicable, link to additional resources or documentation that provide further context or implementation details.
+
+
 ## Getting started
 
 Coming soon


### PR DESCRIPTION
I fixed a few things for our website docs today, and tried to update the API Reference.

I tried a few options to generate API references directly from .proto file, and this default method works the most smooth, so I’m adding it here. **The generated HTML version looks nice**, and markdown is okay.

My goal is to find an automatic way to update docs from the .proto file so we can rapidly update the API reference on our website /docs.

Although the documentation can now be generated, I haven’t added it to the website yet. This is because many input fields still require detailed explanations, and we need to organize the definitions by command groups to create a more user-friendly structure. I believe updating the .proto file and leveraging the protoc-gen-doc plugin can help achieve this, but I suggest we focus on testing the APIs in the Studio first before finalizing the structure.

Generated HTML screenshot
![CleanShot 2024-11-21 at 23 33 46@2x](https://github.com/user-attachments/assets/728816e9-fe81-40a5-a6b1-728bc118ee2a)
