### PR TITLE
add dev release tag to build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,7 +63,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            RELEASE_TAG=${{ inputs.tag || github.ref_name }}
+            RELEASE_TAG=${{ inputs.tag || github.sha ||  github.head_ref || github.ref_name }}
           platforms: linux/amd64,linux/arm64
           context: .
           file: dockerfiles/operator.Dockerfile


### PR DESCRIPTION
inject the sha into release tag for dev build so we can see the commit on telemetry instead of branch name