### PR TITLE
fix double nested var mapping

### DIFF
--- a/core/taskengine/vm_runner_customcode.go
+++ b/core/taskengine/vm_runner_customcode.go
@@ -31,9 +31,7 @@ func NewJSProcessor(vm *VM) *JSProcessor {
 	}
 	/// Binding the data from previous step into jsvm
 	for key, value := range vm.vars {
-		r.jsvm.Set(key, map[string]any{
-			"data": value,
-		})
+		r.jsvm.Set(key, value)
 	}
 
 	return &r

--- a/core/taskengine/vm_runner_filter.go
+++ b/core/taskengine/vm_runner_filter.go
@@ -30,9 +30,7 @@ func NewFilterProcessor(vm *VM) *FilterProcessor {
 	}
 	// Binding the data from previous step into jsvm
 	for key, value := range vm.vars {
-		r.jsvm.Set(key, map[string]any{
-			"data": value,
-		})
+		r.jsvm.Set(key, value)
 	}
 
 	return &r

--- a/core/taskengine/vm_runner_filter_test.go
+++ b/core/taskengine/vm_runner_filter_test.go
@@ -67,7 +67,8 @@ func TestFilter(t *testing.T) {
 	n := NewFilterProcessor(vm)
 	step, err := n.Execute("abc123", node)
 	varname := vm.GetNodeNameAsVar("abc123")
-	data := vm.vars[varname].([]interface{})
+	data := vm.vars[varname].(map[string]any)["data"].([]any)
+
 	if len(data) != 1 {
 		t.Errorf("expect return only one element with cost > 5 but got 0")
 	}
@@ -148,7 +149,7 @@ func TestFilterComplexLogic(t *testing.T) {
 	step, err := n.Execute("abc123", node)
 
 	varname := vm.GetNodeNameAsVar("abc123")
-	data := vm.vars[varname].([]interface{})
+	data := vm.vars[varname].(map[string]any)["data"].([]any)
 	if len(data) != 3 {
 		t.Errorf("expect return only 3 element but got %v", len(data))
 	}

--- a/core/taskengine/vm_runner_rest_test.go
+++ b/core/taskengine/vm_runner_rest_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -141,5 +142,80 @@ func TestRestRequestHandleEmptyResponse(t *testing.T) {
 
 	if step.OutputData != "" {
 		t.Errorf("expected an empty response, got: %s", step.OutputData)
+	}
+}
+
+func TestRestRequestRenderVars(t *testing.T) {
+	// Create test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := io.ReadAll(r.Body)
+		w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	node := &avsproto.RestAPINode{
+		Url: ts.URL,
+		Headers: map[string]string{
+			"Content-type": "application/x-www-form-urlencoded",
+		},
+		Body:   "my name is ${{myNode.name}}",
+		Method: "POST",
+	}
+
+	nodes := []*avsproto.TaskNode{
+		&avsproto.TaskNode{
+			Id:   "123abc",
+			Name: "restApi",
+			TaskType: &avsproto.TaskNode_RestApi{
+				RestApi: node,
+			},
+		},
+	}
+
+	trigger := &avsproto.TaskTrigger{
+		Id:   "triggertest",
+		Name: "triggertest",
+	}
+	edges := []*avsproto.TaskEdge{
+		&avsproto.TaskEdge{
+			Id:     "e1",
+			Source: trigger.Id,
+			Target: "123abc",
+		},
+	}
+
+	vm, err := NewVMWithData(&model.Task{
+		&avsproto.Task{
+			Id:      "123abc",
+			Nodes:   nodes,
+			Edges:   edges,
+			Trigger: trigger,
+		},
+	}, nil, testutil.GetTestSmartWalletConfig(), nil)
+
+	vm.AddVar("myNode", map[string]map[string]string{
+		"data": map[string]string{
+			"name": "unitest",
+		},
+	})
+
+	n := NewRestProrcessor(vm)
+
+	step, err := n.Execute("123abc", node)
+
+	if err != nil {
+		t.Errorf("expected rest node run succesfull but got error: %v", err)
+	}
+
+	if !step.Success {
+		t.Errorf("expected rest node run succesfully but failed")
+	}
+
+	if step.OutputData != "my name is unitest" {
+		t.Errorf("expected response is `my name is unitest`,  got: %s", step.OutputData)
 	}
 }


### PR DESCRIPTION
When passing data around we follow retool which use `nodeName.data` but we're accidently wrapping data twice. 