### PR TITLE
prevent modify original storage by clone the node

### DIFF
--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -215,6 +215,12 @@ func NewVMWithData(task *model.Task, triggerMetadata *avsproto.TriggerMetadata, 
 			}
 		}
 
+		if triggerMetadata.BlockNumber > 0 {
+			v.vars[triggerVarName] = map[string]any{
+				"block_number": triggerMetadata.BlockNumber,
+			}
+		}
+
 		if triggerMetadata.Epoch > 0 {
 			v.vars[triggerVarName] = map[string]any{
 				"epoch": triggerMetadata.Epoch,

--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -49,16 +49,29 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 		StartAt:    t0,
 	}
 
-	// TODO: for global secret, we NEED to limit apikey to only send to a certain authorized endpoint for a certain secret to avoid leakage
-	if strings.Contains(node.Url, "{{") {
-		node.Url = r.vm.preprocessText(node.Url)
+	// Clone the restapi node to 
+	processedNode := &avsproto.RestAPINode{
+		Url:     node.Url,
+		Method:  node.Method,
+		Body:    node.Body,
+		Headers: make(map[string]string),
 	}
-	if strings.Contains(node.Body, "{{") {
-		node.Body = r.vm.preprocessText(node.Body)
+
+	// Copy headers
+	for k, v := range node.Headers {
+		processedNode.Headers[k] = v
 	}
-	for headerName, headerValue := range node.Headers {
+
+	// Preprocess URL, body, and headers without modifying original node
+	if strings.Contains(processedNode.Url, "{{") {
+		processedNode.Url = r.vm.preprocessText(processedNode.Url)
+	}
+	if strings.Contains(processedNode.Body, "{{") {
+		processedNode.Body = r.vm.preprocessText(processedNode.Body)
+	}
+	for headerName, headerValue := range processedNode.Headers {
 		if strings.Contains(headerValue, "{{") {
-			node.Headers[headerName] = r.vm.preprocessText(headerValue)
+			processedNode.Headers[headerName] = r.vm.preprocessText(headerValue)
 		}
 	}
 
@@ -74,30 +87,32 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 	var log strings.Builder
 
 	request := r.client.R().
-		SetBody([]byte(node.Body))
+		SetBody([]byte(processedNode.Body))
 
-	for k, v := range node.Headers {
+	for k, v := range processedNode.Headers {
 		request = request.SetHeader(k, v)
 	}
 
 	var resp *resty.Response
-	if strings.EqualFold(node.Method, "post") {
-		resp, err = request.Post(node.Url)
-	} else if strings.EqualFold(node.Method, "get") {
-		resp, err = request.Get(node.Url)
-	} else if strings.EqualFold(node.Method, "delete") {
-		resp, err = request.Delete(node.Url)
+	if strings.EqualFold(processedNode.Method, "post") {
+		resp, err = request.Post(processedNode.Url)
+	} else if strings.EqualFold(processedNode.Method, "get") {
+		resp, err = request.Get(processedNode.Url)
+	} else if strings.EqualFold(processedNode.Method, "delete") {
+		resp, err = request.Delete(processedNode.Url)
 	} else {
-		resp, err = request.Get(node.Url)
+		resp, err = request.Get(processedNode.Url)
 	}
 
-	u, err := url.Parse(node.Url)
+	fmt.Println("post to url", processedNode.Url, "with body", processedNode.Body)
+
+	u, err := url.Parse(processedNode.Url)
 	if err != nil {
-		s.Error = fmt.Sprintf("cannot parse url: %s", node.Url)
+		s.Error = fmt.Sprintf("cannot parse url: %s", processedNode.Url)
 		return nil, err
 	}
 
-	log.WriteString(fmt.Sprintf("Execute %s %s at %s", node.Method, u.Hostname(), time.Now()))
+	log.WriteString(fmt.Sprintf("Execute %s %s at %s", processedNode.Method, u.Hostname(), time.Now()))
 	s.Log = log.String()
 
 	s.OutputData = string(resp.Body())


### PR DESCRIPTION
when pre-processing data, we assigned data to the node. but we pass a pointer so the original storage is changed. we need to clone memory instead.