### PR TITLE
add test to ensure multiple pre-processor render won't change node data

### DIFF
--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -49,7 +49,7 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 		StartAt:    t0,
 	}
 
-	// Clone the restapi node to 
+	// Clone the restapi node to avoid modifying the pointer memory
 	processedNode := &avsproto.RestAPINode{
 		Url:     node.Url,
 		Method:  node.Method,


### PR DESCRIPTION
This PR add a test to make sure when pre-process render string with `{{ }}` block, we wont' change the original node data.