### PR TITLE
Fix Key Not Found issue in aync execution trigger logic

### DIFF
--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -177,7 +177,7 @@ func (r *RpcServer) ListExecutions(ctx context.Context, payload *avsproto.ListEx
 	)
 	listExecResp, err := r.engine.ListExecutions(user, payload)
 	if err != nil {
-		r.config.Logger.Error("error listing executions from engine", "error", err.Error())
+		r.config.Logger.Error("error listing executions from engine", "error", err)
 		return nil, err
 	}
 

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -175,7 +175,13 @@ func (r *RpcServer) ListExecutions(ctx context.Context, payload *avsproto.ListEx
 		"task_id", payload.TaskIds,
 		"cursor", payload.Cursor,
 	)
-	return r.engine.ListExecutions(user, payload)
+	listExecResp, err := r.engine.ListExecutions(user, payload)
+	if err != nil {
+		r.config.Logger.Error("error listing executions from engine", "error", err.Error())
+		return nil, err
+	}
+
+	return listExecResp, nil
 }
 
 func (r *RpcServer) GetExecution(ctx context.Context, payload *avsproto.ExecutionReq) (*avsproto.Execution, error) {

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -72,7 +72,7 @@ func (x *TaskExecutor) Perform(job *apqueue.Job) error {
 
 	if runErr == nil {
 		// Task logic executed successfully. Clean up the TaskTriggerKey for this async execution.
-		if queueData != nil && queueData.ExecutionID != "" { // Should always be true here for a queued job
+		if queueData != nil && queueData.ExecutionID != "" { // Assumes `ExecutionID` is always set for queued jobs. Verify this assumption if the logic changes.
 			triggerKeyToClean := TaskTriggerKey(task, queueData.ExecutionID)
 			if delErr := x.db.Delete(triggerKeyToClean); delErr != nil {
 				x.logger.Error("Perform: Failed to delete TaskTriggerKey after successful async execution",

--- a/core/taskengine/executor_nil_reason_test.go
+++ b/core/taskengine/executor_nil_reason_test.go
@@ -49,7 +49,7 @@ func TestExecutorRunTaskWithNilReason(t *testing.T) {
 	}
 
 	task := &model.Task{
-		&avsproto.Task{
+		Task: &avsproto.Task{
 			Id:      "ManualTaskID",
 			Nodes:   nodes,
 			Edges:   edges,

--- a/core/taskengine/trigger/block.go
+++ b/core/taskengine/trigger/block.go
@@ -76,8 +76,6 @@ func (b *BlockTrigger) AddCheck(check *avsproto.SyncMessagesResp_TaskMetadata) e
 	return nil
 }
 
-//
-//
 func (b *BlockTrigger) RemoveCheck(taskID string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/core/taskengine/trigger/time.go
+++ b/core/taskengine/trigger/time.go
@@ -127,14 +127,12 @@ func (t *TimeTrigger) AddCheck(check *avsproto.SyncMessagesResp_TaskMetadata) er
 // It locks the mutex to ensure thread-safe access to the jobs map, checks if
 // a job exists for the provided taskID, and removes it from the scheduler and
 // the jobs map. If the job does not exist, the method does nothing.
-// 
+//
 // Parameters:
 // - taskID: The unique identifier of the task whose associated job should be removed.
 //
 // Returns:
 // - An error if the job removal from the scheduler fails. The error is logged but not returned.
-// 
-//
 func (t *TimeTrigger) RemoveCheck(taskID string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/metrics/wrapper.go
+++ b/metrics/wrapper.go
@@ -71,18 +71,18 @@ func (c *EconomicMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *EconomicMetricsCollector) Collect(ch chan<- prometheus.Metric) {
-	
+
 	for quorumNum, quorumName := range c.quorumNames {
-		
-		c.logger.Error("Failed to get operator stake", 
+
+		c.logger.Error("Failed to get operator stake",
 			"err", "Failed to get operator stake: 500 Internal Server Error: {\"id\":143,\"jsonrpc\":\"2.0\",\"error\":{\"message\":\"Unknown block\",\"code\":26}}",
 			"quorum", quorumName,
 			"quorumNum", quorumNum,
 			"operatorAddr", c.operatorAddr.Hex(),
 		)
-		
+
 		c.operatorStake.WithLabelValues(quorumName).Set(0)
 	}
-	
+
 	c.operatorStake.Collect(ch)
 }

--- a/model/task.go
+++ b/model/task.go
@@ -147,7 +147,7 @@ func (t *Task) IsRunable() bool {
 	reachedMaxRun := t.Task.MaxExecution > 0 && t.Task.ExecutionCount >= t.Task.MaxExecution
 
 	reachedExpiredTime := t.Task.ExpiredAt > 0 && time.Unix(t.Task.ExpiredAt/1000, 0).Before(time.Now())
-	
+
 	beforeStartTime := t.Task.StartAt > 0 && time.Now().UnixMilli() < t.Task.StartAt
 
 	return !reachedMaxRun && !reachedExpiredTime && !beforeStartTime

--- a/operator/worker_loop.go
+++ b/operator/worker_loop.go
@@ -37,7 +37,7 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize scheduler: %w", schedulerErr)
 	}
 	o.scheduler.Start()
-	
+
 	_, err := o.scheduler.NewJob(
 		gocron.DurationJob(time.Minute*10),
 		gocron.NewTask(func() {
@@ -63,7 +63,7 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 	if err != nil {
 		o.logger.Error("Failed to create cleanup job for block tasks map", "error", err)
 	}
-	
+
 	o.scheduler.NewJob(gocron.DurationJob(time.Second*5), gocron.NewTask(o.PingServer))
 
 	macros.SetRpc(o.config.TargetChain.EthWsUrl)


### PR DESCRIPTION
The `Failed to get task trigger key` error happens at the async code path of exeuction trigger logic, due to get triggerKey after its removal from the queue. This PR re-organize that part of the code logic.

```
2025-05-13T21:56:58.834-0700	INFO	aggregator/rpc_server.go:268	process trigger task	{"user": "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788", "task_id": "01JV6JEB6FG13Z36YBBHZJMQWB"}
2025-05-13T21:56:58.834-0700	INFO	taskengine/engine.go:593	processed manually trigger	{"user": "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788", "task_id": "01JV6JEB6FG13Z36YBBHZJMQWB"}
2025-05-13T21:56:58.834-0700	INFO	taskengine/engine.go:618	engine.TriggerTask: Synchronous execution path (IsBlocking=true). TaskTriggerKey will not be set by setExecutionStatusQueue.	{"task_id": "01JV6JEB6FG13Z36YBBHZJMQWB", "execution_id": "01JV6JEB6JRQ3ATFKNK4S1G2PT"}
2025-05-13T21:56:58.838-0700	INFO	taskengine/executor.go:178	successfully executing task	{"task_id": "01JV6JEB6FG13Z36YBBHZJMQWB", "triggermark": "block_number:8322847  type:Block"}
2025-05-13T21:56:58.838-0700	INFO	taskengine/executor.go:79	Attempting to get task trigger key	{"key": "trigger:01JV6JEB6FG13Z36YBBHZJMQWB:01JV6JEB6JRQ3ATFKNK4S1G2PT", "task_id": "01JV6JEB6FG13Z36YBBHZJMQWB", "execution_id": "01JV6JEB6JRQ3ATFKNK4S1G2PT"}
2025-05-13T21:56:58.839-0700	DEBUG	taskengine/executor.go:81	Failed to get task trigger key	{"error": "Key not found", "errorVerbose": "Key not found\ngithub.com/dgraph-io/badger/v4.init\n\t<autogenerated>:1\nruntime.doInit1\n\t/opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/proc.go:7350\nruntime.doInit\n\t/opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/proc.go:7317\nruntime.main\n\t/opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/proc.go:254\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/asm_arm64.s:1223", "task_id": "01JV6JEB6FG13Z36YBBHZJMQWB", "execution_id": "01JV6JEB6JRQ3ATFKNK4S1G2PT"}
2025-05-13T21:56:58.852-0700	INFO	aggregator/rpc_server.go:174	process list execution	{"user": "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788", "task_id": ["01JV6JEB6FG13Z36YBBHZJMQWB"], "cursor": ""}

```