### PR TITLE
Fixed runTask returns undefined for eventTrigger problem

### DIFF
--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -200,6 +200,7 @@ func New(db storage.Storage, config *config.Config, queue *apqueue.Queue, logger
 
 	// Initialize TokenEnrichmentService
 	// Always try to initialize, even without RPC, so we can serve whitelist data
+	logger.Debug("initializing TokenEnrichmentService", "has_rpc", rpcConn != nil)
 	tokenService, err := NewTokenEnrichmentService(rpcConn, logger)
 	if err != nil {
 		logger.Warn("Failed to initialize TokenEnrichmentService", "error", err)
@@ -1020,27 +1021,48 @@ func (n *Engine) AggregateChecksResultWithState(address string, payload *avsprot
 	}
 
 	// Enrich EventTrigger output if TokenEnrichmentService is available and it's a Transfer event
-	if payload.TriggerType == avsproto.TriggerType_TRIGGER_TYPE_EVENT && n.tokenEnrichmentService != nil {
-		if eventOutput := triggerData.Output.(*avsproto.EventTrigger_Output); eventOutput != nil {
-			if evmLog := eventOutput.GetEvmLog(); evmLog != nil {
-				n.logger.Debug("enriching EventTrigger output from operator",
-					"task_id", payload.TaskId,
-					"tx_hash", evmLog.TransactionHash,
-					"block_number", evmLog.BlockNumber)
+	if payload.TriggerType == avsproto.TriggerType_TRIGGER_TYPE_EVENT {
+		n.logger.Debug("processing event trigger",
+			"task_id", payload.TaskId,
+			"has_token_service", n.tokenEnrichmentService != nil)
 
-				// Fetch full event data from the blockchain using the minimal data from operator
-				if enrichedEventOutput, err := n.enrichEventTriggerFromOperatorData(evmLog); err == nil {
-					// Replace the minimal event output with the enriched one
-					triggerData.Output = enrichedEventOutput
-					n.logger.Debug("successfully enriched EventTrigger output",
+		if n.tokenEnrichmentService != nil {
+			if eventOutput := triggerData.Output.(*avsproto.EventTrigger_Output); eventOutput != nil {
+				if evmLog := eventOutput.GetEvmLog(); evmLog != nil {
+					n.logger.Debug("enriching EventTrigger output from operator",
 						"task_id", payload.TaskId,
-						"has_transfer_log", enrichedEventOutput.GetTransferLog() != nil)
+						"tx_hash", evmLog.TransactionHash,
+						"block_number", evmLog.BlockNumber,
+						"log_index", evmLog.Index,
+						"address", evmLog.Address,
+						"topics_count", len(evmLog.Topics),
+						"data_length", len(evmLog.Data))
+
+					// Fetch full event data from the blockchain using the minimal data from operator
+					if enrichedEventOutput, err := n.enrichEventTriggerFromOperatorData(evmLog); err == nil {
+						// Replace the minimal event output with the enriched one
+						triggerData.Output = enrichedEventOutput
+						n.logger.Debug("successfully enriched EventTrigger output",
+							"task_id", payload.TaskId,
+							"has_transfer_log", enrichedEventOutput.GetTransferLog() != nil,
+							"has_evm_log", enrichedEventOutput.GetEvmLog() != nil)
+					} else {
+						n.logger.Warn("failed to enrich EventTrigger output, using minimal data",
+							"task_id", payload.TaskId,
+							"error", err)
+					}
 				} else {
-					n.logger.Warn("failed to enrich EventTrigger output, using minimal data",
+					n.logger.Debug("EventTrigger output has no EvmLog data",
 						"task_id", payload.TaskId,
-						"error", err)
+						"has_transfer_log", eventOutput.GetTransferLog() != nil)
 				}
+			} else {
+				n.logger.Debug("EventTrigger output is nil",
+					"task_id", payload.TaskId)
 			}
+		} else {
+			n.logger.Debug("TokenEnrichmentService not available for event enrichment",
+				"task_id", payload.TaskId)
 		}
 	}
 
@@ -1048,6 +1070,26 @@ func (n *Engine) AggregateChecksResultWithState(address string, payload *avsprot
 		TriggerType:   triggerData.Type,
 		TriggerOutput: triggerData.Output,
 		ExecutionID:   ulid.Make().String(),
+	}
+
+	// For event triggers, if we have enriched data, convert it to a map format that survives JSON serialization
+	if triggerData.Type == avsproto.TriggerType_TRIGGER_TYPE_EVENT {
+		if eventOutput, ok := triggerData.Output.(*avsproto.EventTrigger_Output); ok {
+			// Convert the enriched protobuf data to a map that will survive JSON serialization
+			enrichedDataMap := buildTriggerDataMapFromProtobuf(triggerData.Type, eventOutput, n.logger)
+
+			// Store the enriched data as a map instead of protobuf structure
+			// This ensures the enriched data survives JSON serialization/deserialization
+			queueTaskData.TriggerOutput = map[string]interface{}{
+				"enriched_data": enrichedDataMap,
+				"trigger_type":  triggerData.Type.String(),
+			}
+
+			n.logger.Debug("stored enriched event trigger data for queue execution",
+				"task_id", payload.TaskId,
+				"has_token_symbol", enrichedDataMap["tokenSymbol"] != nil,
+				"has_value_formatted", enrichedDataMap["valueFormatted"] != nil)
+		}
 	}
 
 	data, err := json.Marshal(queueTaskData)
@@ -1543,7 +1585,7 @@ func (n *Engine) SimulateTask(user *model.User, trigger *avsproto.TaskTrigger, n
 
 	// Step 8.5: Update VM trigger variable with actual execution results
 	// This ensures subsequent nodes can access the trigger's actual output via eventTrigger.data
-	actualTriggerDataMap := buildTriggerDataMapFromProtobuf(queueData.TriggerType, triggerOutputProto)
+	actualTriggerDataMap := buildTriggerDataMapFromProtobuf(queueData.TriggerType, triggerOutputProto, n.logger)
 	vm.AddVar(sanitizeTriggerNameForJS(trigger.GetName()), map[string]any{"data": actualTriggerDataMap})
 
 	// Step 9: Run the workflow nodes
@@ -2463,20 +2505,34 @@ func getStringMapKeys(m map[string]interface{}) []string {
 // enrichEventTriggerFromOperatorData fetches full event data from blockchain and enriches it with token metadata
 func (n *Engine) enrichEventTriggerFromOperatorData(minimalEvmLog *avsproto.Evm_Log) (*avsproto.EventTrigger_Output, error) {
 	if minimalEvmLog.TransactionHash == "" {
+		n.logger.Debug("enrichment failed: transaction hash is empty")
 		return nil, fmt.Errorf("transaction hash is required for enrichment")
 	}
 
 	// Get RPC client (using the global rpcConn variable)
 	if rpcConn == nil {
+		n.logger.Debug("enrichment failed: RPC client not available")
 		return nil, fmt.Errorf("RPC client not available")
 	}
+
+	n.logger.Debug("starting event enrichment",
+		"tx_hash", minimalEvmLog.TransactionHash,
+		"log_index", minimalEvmLog.Index,
+		"block_number", minimalEvmLog.BlockNumber)
 
 	// Fetch transaction receipt to get the full event logs
 	ctx := context.Background()
 	receipt, err := rpcConn.TransactionReceipt(ctx, common.HexToHash(minimalEvmLog.TransactionHash))
 	if err != nil {
+		n.logger.Debug("enrichment failed: could not fetch transaction receipt",
+			"tx_hash", minimalEvmLog.TransactionHash,
+			"error", err)
 		return nil, fmt.Errorf("failed to fetch transaction receipt: %w", err)
 	}
+
+	n.logger.Debug("fetched transaction receipt",
+		"tx_hash", minimalEvmLog.TransactionHash,
+		"logs_count", len(receipt.Logs))
 
 	// Find the specific log that matches the operator's data
 	var targetLog *types.Log
@@ -2488,9 +2544,26 @@ func (n *Engine) enrichEventTriggerFromOperatorData(minimalEvmLog *avsproto.Evm_
 	}
 
 	if targetLog == nil {
+		n.logger.Debug("enrichment failed: log not found in transaction",
+			"tx_hash", minimalEvmLog.TransactionHash,
+			"expected_log_index", minimalEvmLog.Index,
+			"available_log_indices", func() []uint32 {
+				indices := make([]uint32, len(receipt.Logs))
+				for i, log := range receipt.Logs {
+					indices[i] = uint32(log.Index)
+				}
+				return indices
+			}())
 		return nil, fmt.Errorf("log with index %d not found in transaction %s",
 			minimalEvmLog.Index, minimalEvmLog.TransactionHash)
 	}
+
+	n.logger.Debug("found target log",
+		"tx_hash", minimalEvmLog.TransactionHash,
+		"log_index", targetLog.Index,
+		"address", targetLog.Address.Hex(),
+		"topics_count", len(targetLog.Topics),
+		"data_length", len(targetLog.Data))
 
 	// Create enriched EVM log with full data
 	enrichedEvmLog := &avsproto.Evm_Log{
@@ -2516,12 +2589,26 @@ func (n *Engine) enrichEventTriggerFromOperatorData(minimalEvmLog *avsproto.Evm_
 	isTransferEvent := len(targetLog.Topics) > 0 &&
 		targetLog.Topics[0].Hex() == "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 
+	n.logger.Debug("checking if transfer event",
+		"is_transfer", isTransferEvent,
+		"topics_count", len(targetLog.Topics),
+		"first_topic", func() string {
+			if len(targetLog.Topics) > 0 {
+				return targetLog.Topics[0].Hex()
+			}
+			return "none"
+		}())
+
 	if isTransferEvent && len(targetLog.Topics) >= 3 {
+		n.logger.Debug("processing as transfer event")
+
 		// Get block timestamp for transfer_log
 		header, err := rpcConn.HeaderByNumber(ctx, big.NewInt(int64(targetLog.BlockNumber)))
 		var blockTimestamp uint64
 		if err == nil {
 			blockTimestamp = header.Time * 1000 // Convert to milliseconds
+		} else {
+			n.logger.Debug("could not fetch block header for timestamp", "error", err)
 		}
 
 		// Extract from and to addresses from topics
@@ -2545,10 +2632,22 @@ func (n *Engine) enrichEventTriggerFromOperatorData(minimalEvmLog *avsproto.Evm_
 			LogIndex:         uint32(targetLog.Index),
 		}
 
+		n.logger.Debug("created transfer log",
+			"from", fromAddr,
+			"to", toAddr,
+			"value", value,
+			"token_address", targetLog.Address.Hex())
+
 		// Enrich with token metadata
 		if err := n.tokenEnrichmentService.EnrichTransferLog(enrichedEvmLog, transferLog); err != nil {
 			n.logger.Warn("failed to enrich transfer log with token metadata", "error", err)
 			// Continue without enrichment - partial data is better than no data
+		} else {
+			n.logger.Debug("successfully enriched transfer log",
+				"token_name", transferLog.TokenName,
+				"token_symbol", transferLog.TokenSymbol,
+				"token_decimals", transferLog.TokenDecimals,
+				"value_formatted", transferLog.ValueFormatted)
 		}
 
 		// Use the oneof TransferLog field
@@ -2556,11 +2655,16 @@ func (n *Engine) enrichEventTriggerFromOperatorData(minimalEvmLog *avsproto.Evm_
 			TransferLog: transferLog,
 		}
 	} else {
+		n.logger.Debug("processing as regular EVM log event")
 		// Regular event (not a transfer) - use the oneof EvmLog field
 		enrichedOutput.OutputType = &avsproto.EventTrigger_Output_EvmLog{
 			EvmLog: enrichedEvmLog,
 		}
 	}
+
+	n.logger.Debug("enrichment completed successfully",
+		"has_transfer_log", enrichedOutput.GetTransferLog() != nil,
+		"has_evm_log", enrichedOutput.GetEvmLog() != nil)
 
 	return enrichedOutput, nil
 }
@@ -3100,13 +3204,14 @@ func buildExecutionStepOutputData(triggerType avsproto.TriggerType, triggerOutpu
 // Parameters:
 //   - triggerType: the type of trigger being processed
 //   - triggerOutputProto: the protobuf trigger output structure (e.g., *avsproto.BlockTrigger_Output)
+//   - logger: optional logger for debugging (can be nil)
 //
 // Returns:
 //   - map[string]interface{}: JavaScript-accessible trigger data map
 //
 // This function differs from buildTriggerDataMap in that it works with structured protobuf data
 // rather than raw trigger output maps, making it suitable for VM initialization.
-func buildTriggerDataMapFromProtobuf(triggerType avsproto.TriggerType, triggerOutputProto interface{}) map[string]interface{} {
+func buildTriggerDataMapFromProtobuf(triggerType avsproto.TriggerType, triggerOutputProto interface{}, logger sdklogging.Logger) map[string]interface{} {
 	triggerDataMap := make(map[string]interface{})
 
 	if triggerOutputProto == nil {
@@ -3161,18 +3266,37 @@ func buildTriggerDataMapFromProtobuf(triggerType avsproto.TriggerType, triggerOu
 				triggerDataMap["valueFormatted"] = transferLogData.ValueFormatted
 				triggerDataMap["transactionIndex"] = transferLogData.TransactionIndex
 				triggerDataMap["logIndex"] = transferLogData.LogIndex
-			} else if evmLog := eventOutput.GetEvmLog(); evmLog != nil {
-				// Fall back to basic EVM log data matching runTrigger format
-				// Use camelCase field names for JavaScript compatibility
-				triggerDataMap["blockNumber"] = evmLog.BlockNumber
-				triggerDataMap["logIndex"] = evmLog.Index
-				triggerDataMap["transactionHash"] = evmLog.TransactionHash
-				triggerDataMap["address"] = evmLog.Address
-				triggerDataMap["topics"] = evmLog.Topics
-				triggerDataMap["data"] = evmLog.Data
-				triggerDataMap["blockHash"] = evmLog.BlockHash
-				triggerDataMap["transactionIndex"] = evmLog.TransactionIndex
-				triggerDataMap["removed"] = evmLog.Removed
+			} else if evmLogData := eventOutput.GetEvmLog(); evmLogData != nil {
+				// Use EVM log data for regular events
+				triggerDataMap["address"] = evmLogData.Address
+				triggerDataMap["topics"] = evmLogData.Topics
+				triggerDataMap["data"] = evmLogData.Data
+				triggerDataMap["blockNumber"] = evmLogData.BlockNumber
+				triggerDataMap["transactionHash"] = evmLogData.TransactionHash
+				triggerDataMap["transactionIndex"] = evmLogData.TransactionIndex
+				triggerDataMap["blockHash"] = evmLogData.BlockHash
+				triggerDataMap["logIndex"] = evmLogData.Index
+				triggerDataMap["removed"] = evmLogData.Removed
+			}
+		} else if enrichedDataMap, ok := triggerOutputProto.(map[string]interface{}); ok {
+			// Handle the new enriched data format that survives JSON serialization
+			if enrichedData, hasEnrichedData := enrichedDataMap["enriched_data"].(map[string]interface{}); hasEnrichedData {
+				// Copy all enriched data to the trigger data map
+				for k, v := range enrichedData {
+					triggerDataMap[k] = v
+				}
+				if logger != nil {
+					logger.Debug("loaded enriched event trigger data from queue",
+						"has_token_symbol", triggerDataMap["tokenSymbol"] != nil,
+						"has_value_formatted", triggerDataMap["valueFormatted"] != nil)
+				}
+			} else {
+				// Fallback: copy all data from the map
+				for k, v := range enrichedDataMap {
+					if k != "trigger_type" { // Skip metadata
+						triggerDataMap[k] = v
+					}
+				}
 			}
 		}
 	default:

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -261,7 +261,7 @@ func (n *Engine) MustStart() error {
 		}
 		err := protojson.Unmarshal(item.Value, task)
 		if err == nil {
-			n.tasks[task.Id] = task // Fixed: Use task.Id instead of string(item.Key)
+			n.tasks[task.Id] = task
 			loadedCount++
 		} else {
 			n.logger.Warn("Failed to unmarshal task during startup", "storage_key", string(item.Key), "error", err)

--- a/core/taskengine/engine_trigger_output_test.go
+++ b/core/taskengine/engine_trigger_output_test.go
@@ -239,26 +239,26 @@ func TestBuildTriggerDataMapFromProtobufEventTriggerComprehensive(t *testing.T) 
 			description: "Should map all TransferLog fields including the critical log_index field",
 			verifyFunc: func(t *testing.T, result map[string]interface{}) {
 				expected := map[string]interface{}{
-					"token_name":        "Test Token",
-					"token_symbol":      "TEST",
-					"token_decimals":    uint32(18),
-					"transaction_hash":  "0x1234567890abcdef",
-					"address":           "0xabcdef1234567890",
-					"block_number":      uint64(12345678),
-					"block_timestamp":   uint64(1672531200),
-					"from_address":      "0x1111111111111111",
-					"to_address":        "0x2222222222222222",
-					"value":             "1000000000000000000",
-					"value_formatted":   "1.0",
-					"transaction_index": uint32(5),
-					"log_index":         uint32(3),
-					"type":              "TRIGGER_TYPE_EVENT",
+					"tokenName":        "Test Token",
+					"tokenSymbol":      "TEST",
+					"tokenDecimals":    uint32(18),
+					"transactionHash":  "0x1234567890abcdef",
+					"address":          "0xabcdef1234567890",
+					"blockNumber":      uint64(12345678),
+					"blockTimestamp":   uint64(1672531200),
+					"fromAddress":      "0x1111111111111111",
+					"toAddress":        "0x2222222222222222",
+					"value":            "1000000000000000000",
+					"valueFormatted":   "1.0",
+					"transactionIndex": uint32(5),
+					"logIndex":         uint32(3),
+					"type":             "TRIGGER_TYPE_EVENT",
 				}
 
 				require.Equal(t, expected, result, "All TransferLog fields should be properly mapped")
 
-				require.Contains(t, result, "log_index", "log_index field should be present")
-				require.Equal(t, uint32(3), result["log_index"], "log_index should have correct value")
+				require.Contains(t, result, "logIndex", "logIndex field should be present")
+				require.Equal(t, uint32(3), result["logIndex"], "logIndex should have correct value")
 			},
 		},
 		{
@@ -281,29 +281,29 @@ func TestBuildTriggerDataMapFromProtobufEventTriggerComprehensive(t *testing.T) 
 			description: "Should map all EvmLog fields including log_index",
 			verifyFunc: func(t *testing.T, result map[string]interface{}) {
 				expected := map[string]interface{}{
-					"block_number":      uint64(12345678),
-					"log_index":         uint32(3),
-					"tx_hash":           "0x1234567890abcdef",
-					"address":           "0xabcdef1234567890",
-					"topics":            []string{"0xtopic1", "0xtopic2", "0xtopic3"},
-					"data":              "0xdeadbeef",
-					"block_hash":        "0xblockhash123456",
-					"transaction_index": uint32(5),
-					"removed":           false,
-					"type":              "TRIGGER_TYPE_EVENT",
+					"blockNumber":      uint64(12345678),
+					"logIndex":         uint32(3),
+					"transactionHash":  "0x1234567890abcdef",
+					"address":          "0xabcdef1234567890",
+					"topics":           []string{"0xtopic1", "0xtopic2", "0xtopic3"},
+					"data":             "0xdeadbeef",
+					"blockHash":        "0xblockhash123456",
+					"transactionIndex": uint32(5),
+					"removed":          false,
+					"type":             "TRIGGER_TYPE_EVENT",
 				}
 
 				require.Equal(t, expected, result, "All EvmLog fields should be properly mapped")
 
-				require.Contains(t, result, "log_index", "log_index field should be present")
-				require.Equal(t, uint32(3), result["log_index"], "log_index should have correct value")
+				require.Contains(t, result, "logIndex", "logIndex field should be present")
+				require.Equal(t, uint32(3), result["logIndex"], "logIndex should have correct value")
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := buildTriggerDataMapFromProtobuf(avsproto.TriggerType_TRIGGER_TYPE_EVENT, test.input)
+			result := buildTriggerDataMapFromProtobuf(avsproto.TriggerType_TRIGGER_TYPE_EVENT, test.input, nil)
 
 			require.NotNil(t, result, "buildTriggerDataMapFromProtobuf should never return nil")
 
@@ -325,7 +325,7 @@ func TestBuildTriggerDataMapFromProtobufFieldCompleteness(t *testing.T) {
 		}
 
 		for _, triggerType := range triggerTypes {
-			result := buildTriggerDataMapFromProtobuf(triggerType, nil)
+			result := buildTriggerDataMapFromProtobuf(triggerType, nil, nil)
 			require.Contains(t, result, "type", "All trigger types should include type field")
 			require.Equal(t, triggerType.String(), result["type"], "Type field should match trigger type")
 		}

--- a/core/taskengine/executor_test.go
+++ b/core/taskengine/executor_test.go
@@ -39,7 +39,7 @@ func TestExecutorRunTaskSucess(t *testing.T) {
 								Id:   "a1",
 								Type: "if",
 								// The test data is of this transaction https://sepolia.etherscan.io/tx/0x53beb2163994510e0984b436ebc828dc57e480ee671cfbe7ed52776c2a4830c8 which is 3.45 token
-								Expression: "Number(triggertest.data.value_formatted) >= 3",
+								Expression: "Number(triggertest.data.valueFormatted) >= 3",
 							},
 						},
 					},
@@ -390,7 +390,7 @@ func TestExecutorRunTaskReturnAllExecutionData(t *testing.T) {
 							{
 								Id:         "condition1",
 								Type:       "if",
-								Expression: "Number(triggertest.data.value_formatted) >= 3",
+								Expression: "Number(triggertest.data.valueFormatted) >= 3",
 							},
 						},
 					},

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -1717,12 +1717,3 @@ func isExpectedValidationError(err error) bool {
 	// If it doesn't match validation patterns, treat as system error
 	return false
 }
-
-// getMapKeys returns the keys of a map as a slice for debugging
-func getMapKeys(m map[string]interface{}) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}

--- a/core/taskengine/trigger/event.go
+++ b/core/taskengine/trigger/event.go
@@ -768,7 +768,7 @@ func (t *EventTrigger) buildFilterQueries() []QueryInfo {
 
 		for taskID, count := range taskQueryCounts {
 			if count > 1 {
-				t.logger.Warn("⚠️ Task has multiple unique queries - may receive duplicate events",
+				t.logger.Info("⚠️ Task has multiple unique queries - may receive duplicate events",
 					"task_id", taskID,
 					"unique_query_count", count,
 					"recommendation", "Consider combining queries to reduce duplicates")

--- a/core/taskengine/trigger_data_flattening_test.go
+++ b/core/taskengine/trigger_data_flattening_test.go
@@ -1,0 +1,417 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildTriggerDataMapEventTriggerFlattening tests the specific fix for flattening transfer_log data
+// This test verifies that the buildTriggerDataMap function correctly flattens nested transfer_log data
+// to the top level, which resolves the NaN and undefined values issue in simulateTask.
+func TestBuildTriggerDataMapEventTriggerFlattening(t *testing.T) {
+	// Test data with nested transfer_log structure (as it comes from runEventTriggerImmediately)
+	triggerOutput := map[string]interface{}{
+		"found":         true,
+		"queriesCount":  2,
+		"totalSearched": 5000,
+		"totalEvents":   1,
+		"transfer_log": map[string]interface{}{
+			"tokenName":        "USDC",
+			"tokenSymbol":      "USDC",
+			"tokenDecimals":    uint32(6),
+			"transactionHash":  "0x1b0b9bee55e3a824dedd1dcfaad1790e19e0a68d6717e385a960092077f8b6a1",
+			"address":          "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+			"blockNumber":      uint64(8560047),
+			"blockTimestamp":   uint64(1750061412000),
+			"fromAddress":      "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788",
+			"toAddress":        "0xfE66125343Aabda4A330DA667431eC1Acb7BbDA9",
+			"value":            "0x00000000000000000000000000000000000000000000000000000000004c4b40",
+			"valueFormatted":   "5",
+			"transactionIndex": uint32(63),
+			"logIndex":         uint32(83),
+		},
+	}
+
+	// Test buildTriggerDataMap with event trigger
+	result := buildTriggerDataMap(avsproto.TriggerType_TRIGGER_TYPE_EVENT, triggerOutput)
+
+	// Verify that transfer_log data is flattened to top level
+	assert.Equal(t, "USDC", result["tokenName"], "tokenName should be at top level")
+	assert.Equal(t, "USDC", result["tokenSymbol"], "tokenSymbol should be at top level")
+	assert.Equal(t, uint32(6), result["tokenDecimals"], "tokenDecimals should be at top level")
+	assert.Equal(t, "0x1b0b9bee55e3a824dedd1dcfaad1790e19e0a68d6717e385a960092077f8b6a1", result["transactionHash"], "transactionHash should be at top level")
+	assert.Equal(t, "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", result["address"], "address should be at top level")
+	assert.Equal(t, uint64(8560047), result["blockNumber"], "blockNumber should be at top level")
+	assert.Equal(t, uint64(1750061412000), result["blockTimestamp"], "blockTimestamp should be at top level")
+	assert.Equal(t, "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788", result["fromAddress"], "fromAddress should be at top level")
+	assert.Equal(t, "0xfE66125343Aabda4A330DA667431eC1Acb7BbDA9", result["toAddress"], "toAddress should be at top level")
+	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000004c4b40", result["value"], "value should be at top level")
+	assert.Equal(t, "5", result["valueFormatted"], "valueFormatted should be at top level")
+	assert.Equal(t, uint32(63), result["transactionIndex"], "transactionIndex should be at top level")
+	assert.Equal(t, uint32(83), result["logIndex"], "logIndex should be at top level")
+
+	// Verify that the nested transfer_log object is NOT present at top level
+	assert.NotContains(t, result, "transfer_log", "transfer_log should not be present as nested object")
+
+	// Test with non-transfer event (should copy all data as-is)
+	nonTransferOutput := map[string]interface{}{
+		"found":        true,
+		"someField":    "someValue",
+		"anotherField": 123,
+	}
+
+	nonTransferResult := buildTriggerDataMap(avsproto.TriggerType_TRIGGER_TYPE_EVENT, nonTransferOutput)
+	assert.Equal(t, true, nonTransferResult["found"])
+	assert.Equal(t, "someValue", nonTransferResult["someField"])
+	assert.Equal(t, 123, nonTransferResult["anotherField"])
+}
+
+// TestBuildTriggerDataMapFromProtobufConsistency tests that both buildTriggerDataMap and
+// buildTriggerDataMapFromProtobuf produce consistent field names for JavaScript access.
+func TestBuildTriggerDataMapFromProtobufConsistency(t *testing.T) {
+	// Create protobuf transfer log data
+	transferLogProto := &avsproto.EventTrigger_TransferLogOutput{
+		TokenName:        "USDC",
+		TokenSymbol:      "USDC",
+		TokenDecimals:    6,
+		TransactionHash:  "0x1b0b9bee55e3a824dedd1dcfaad1790e19e0a68d6717e385a960092077f8b6a1",
+		Address:          "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+		BlockNumber:      8560047,
+		BlockTimestamp:   1750061412000,
+		FromAddress:      "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788",
+		ToAddress:        "0xfE66125343Aabda4A330DA667431eC1Acb7BbDA9",
+		Value:            "0x00000000000000000000000000000000000000000000000000000000004c4b40",
+		ValueFormatted:   "5",
+		TransactionIndex: 63,
+		LogIndex:         83,
+	}
+
+	eventOutputProto := &avsproto.EventTrigger_Output{
+		OutputType: &avsproto.EventTrigger_Output_TransferLog{
+			TransferLog: transferLogProto,
+		},
+	}
+
+	// Test buildTriggerDataMapFromProtobuf
+	protobufResult := buildTriggerDataMapFromProtobuf(avsproto.TriggerType_TRIGGER_TYPE_EVENT, eventOutputProto, nil)
+
+	// Create raw trigger output data (as it would come from runEventTriggerImmediately)
+	rawTriggerOutput := map[string]interface{}{
+		"found":         true,
+		"queriesCount":  2,
+		"totalSearched": 5000,
+		"totalEvents":   1,
+		"transfer_log": map[string]interface{}{
+			"tokenName":        "USDC",
+			"tokenSymbol":      "USDC",
+			"tokenDecimals":    uint32(6),
+			"transactionHash":  "0x1b0b9bee55e3a824dedd1dcfaad1790e19e0a68d6717e385a960092077f8b6a1",
+			"address":          "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+			"blockNumber":      uint64(8560047),
+			"blockTimestamp":   uint64(1750061412000),
+			"fromAddress":      "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788",
+			"toAddress":        "0xfE66125343Aabda4A330DA667431eC1Acb7BbDA9",
+			"value":            "0x00000000000000000000000000000000000000000000000000000000004c4b40",
+			"valueFormatted":   "5",
+			"transactionIndex": uint32(63),
+			"logIndex":         uint32(83),
+		},
+	}
+
+	// Test buildTriggerDataMap
+	rawResult := buildTriggerDataMap(avsproto.TriggerType_TRIGGER_TYPE_EVENT, rawTriggerOutput)
+
+	// Verify that both functions produce the same field names for JavaScript access
+	expectedFields := []string{
+		"tokenName", "tokenSymbol", "tokenDecimals", "transactionHash",
+		"address", "blockNumber", "blockTimestamp", "fromAddress",
+		"toAddress", "value", "valueFormatted", "transactionIndex", "logIndex",
+	}
+
+	for _, field := range expectedFields {
+		// Both results should have the same field names
+		assert.Contains(t, protobufResult, field, "buildTriggerDataMapFromProtobuf should have field: %s", field)
+		assert.Contains(t, rawResult, field, "buildTriggerDataMap should have field: %s", field)
+
+		// Both results should have the same values for these fields
+		assert.Equal(t, protobufResult[field], rawResult[field], "Field %s should have same value in both results", field)
+	}
+
+	// Verify that neither result has the nested transfer_log structure
+	assert.NotContains(t, protobufResult, "transfer_log", "buildTriggerDataMapFromProtobuf should not have nested transfer_log")
+	assert.NotContains(t, rawResult, "transfer_log", "buildTriggerDataMap should not have nested transfer_log")
+}
+
+// TestJavaScriptFieldAccessPattern tests that the field names work correctly for JavaScript destructuring
+func TestJavaScriptFieldAccessPattern(t *testing.T) {
+	// This test simulates the JavaScript destructuring pattern used in the client code:
+	// const { tokenSymbol, valueFormatted, fromAddress, toAddress, blockTimestamp } = eventTrigger.data;
+
+	triggerOutput := map[string]interface{}{
+		"found": true,
+		"transfer_log": map[string]interface{}{
+			"tokenSymbol":    "USDC",
+			"valueFormatted": "5",
+			"fromAddress":    "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788",
+			"toAddress":      "0xfE66125343Aabda4A330DA667431eC1Acb7BbDA9",
+			"blockTimestamp": uint64(1750061412000),
+		},
+	}
+
+	result := buildTriggerDataMap(avsproto.TriggerType_TRIGGER_TYPE_EVENT, triggerOutput)
+
+	// Simulate JavaScript destructuring - these fields should all be available at top level
+	tokenSymbol, hasTokenSymbol := result["tokenSymbol"]
+	valueFormatted, hasValueFormatted := result["valueFormatted"]
+	fromAddress, hasFromAddress := result["fromAddress"]
+	toAddress, hasToAddress := result["toAddress"]
+	blockTimestamp, hasBlockTimestamp := result["blockTimestamp"]
+
+	// All fields should be present
+	assert.True(t, hasTokenSymbol, "tokenSymbol should be available for JavaScript destructuring")
+	assert.True(t, hasValueFormatted, "valueFormatted should be available for JavaScript destructuring")
+	assert.True(t, hasFromAddress, "fromAddress should be available for JavaScript destructuring")
+	assert.True(t, hasToAddress, "toAddress should be available for JavaScript destructuring")
+	assert.True(t, hasBlockTimestamp, "blockTimestamp should be available for JavaScript destructuring")
+
+	// All fields should have the correct values (not NaN or undefined)
+	assert.Equal(t, "USDC", tokenSymbol, "tokenSymbol should not be undefined")
+	assert.Equal(t, "5", valueFormatted, "valueFormatted should not be undefined")
+	assert.Equal(t, "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788", fromAddress, "fromAddress should not be undefined")
+	assert.Equal(t, "0xfE66125343Aabda4A330DA667431eC1Acb7BbDA9", toAddress, "toAddress should not be undefined")
+	assert.Equal(t, uint64(1750061412000), blockTimestamp, "blockTimestamp should not be NaN")
+
+	t.Logf("✅ All JavaScript destructuring fields are available:")
+	t.Logf("  tokenSymbol: %v", tokenSymbol)
+	t.Logf("  valueFormatted: %v", valueFormatted)
+	t.Logf("  fromAddress: %v", fromAddress)
+	t.Logf("  toAddress: %v", toAddress)
+	t.Logf("  blockTimestamp: %v", blockTimestamp)
+}
+
+// TestFallbackVariableResolutionConsistency tests that the fallback variable resolution
+// (where subsequent nodes can use tokenName to match token_name from previous nodes)
+// works consistently across all three execution paths:
+// 1. run_node_immediately (RunNodeImmediatelyRPC)
+// 2. simulateTask (SimulateTask)
+// 3. runTask (actual task execution)
+func TestFallbackVariableResolutionConsistency(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+
+	// Test data with snake_case field names (as would come from protobuf/gRPC)
+	testData := map[string]interface{}{
+		"token_name":     "USDC",
+		"token_symbol":   "USDC",
+		"token_decimals": 6,
+		"block_number":   12345,
+		"tx_hash":        "0x123abc",
+	}
+
+	// Create input variables that include a node with snake_case data
+	inputVariables := map[string]interface{}{
+		"eventTrigger": map[string]interface{}{
+			"data": testData,
+		},
+	}
+
+	// Test custom code that tries to access both camelCase and snake_case versions
+	customCodeConfig := map[string]interface{}{
+		"source": `
+			// Test accessing snake_case (original)
+			const tokenNameSnake = eventTrigger.data.token_name;
+			const tokenSymbolSnake = eventTrigger.data.token_symbol;
+			const tokenDecimalsSnake = eventTrigger.data.token_decimals;
+			
+			// Test accessing camelCase (fallback)
+			const tokenNameCamel = eventTrigger.data.tokenName;
+			const tokenSymbolCamel = eventTrigger.data.tokenSymbol;
+			const tokenDecimalsCamel = eventTrigger.data.tokenDecimals;
+			
+			return {
+				snake_case_access: {
+					token_name: tokenNameSnake,
+					token_symbol: tokenSymbolSnake,
+					token_decimals: tokenDecimalsSnake
+				},
+				camel_case_access: {
+					tokenName: tokenNameCamel,
+					tokenSymbol: tokenSymbolCamel,
+					tokenDecimals: tokenDecimalsCamel
+				},
+				both_should_work: tokenNameSnake === tokenNameCamel && tokenSymbolSnake === tokenSymbolCamel
+			};
+		`,
+	}
+
+	t.Run("RunNodeImmediately", func(t *testing.T) {
+		result, err := engine.RunNodeImmediately("customCode", customCodeConfig, inputVariables)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+
+		// Verify both access patterns work
+		assert.Equal(t, "USDC", result["snake_case_access"].(map[string]interface{})["token_name"])
+		assert.Equal(t, "USDC", result["camel_case_access"].(map[string]interface{})["tokenName"])
+		assert.True(t, result["both_should_work"].(bool), "Both snake_case and camelCase access should return the same values")
+	})
+
+	t.Run("SimulateTask", func(t *testing.T) {
+		// Create a simple task with manual trigger and custom code node
+		trigger := &avsproto.TaskTrigger{
+			Id:          "trigger1",
+			Name:        "manualTrigger",
+			Type:        avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+			TriggerType: &avsproto.TaskTrigger_Manual{Manual: true},
+		}
+
+		nodes := []*avsproto.TaskNode{
+			{
+				Id:   "node1",
+				Name: "testCustomCode",
+				TaskType: &avsproto.TaskNode_CustomCode{
+					CustomCode: &avsproto.CustomCodeNode{
+						Config: &avsproto.CustomCodeNode_Config{
+							Source: customCodeConfig["source"].(string),
+						},
+					},
+				},
+			},
+		}
+
+		edges := []*avsproto.TaskEdge{
+			{
+				Id:     "edge1",
+				Source: "trigger1",
+				Target: "node1",
+			},
+		}
+
+		user := testutil.TestUser1()
+		execution, err := engine.SimulateTask(user, trigger, nodes, edges, inputVariables)
+		assert.NoError(t, err)
+		assert.NotNil(t, execution)
+		assert.True(t, execution.Success, "Simulation should succeed")
+
+		// Find the custom code step
+		var customCodeStep *avsproto.Execution_Step
+		for _, step := range execution.Steps {
+			if step.Type == avsproto.NodeType_NODE_TYPE_CUSTOM_CODE.String() {
+				customCodeStep = step
+				break
+			}
+		}
+		assert.NotNil(t, customCodeStep, "Should find custom code execution step")
+		assert.True(t, customCodeStep.Success, "Custom code step should succeed")
+
+		// Extract the result from the custom code output
+		customCodeOutput := customCodeStep.GetCustomCode()
+		assert.NotNil(t, customCodeOutput)
+		result := customCodeOutput.Data.AsInterface().(map[string]interface{})
+
+		// Verify both access patterns work
+		assert.Equal(t, "USDC", result["snake_case_access"].(map[string]interface{})["token_name"])
+		assert.Equal(t, "USDC", result["camel_case_access"].(map[string]interface{})["tokenName"])
+		assert.True(t, result["both_should_work"].(bool), "Both snake_case and camelCase access should return the same values")
+	})
+
+	// Note: Testing actual runTask would require setting up a full task in storage and queue system,
+	// which is more complex. The key insight is that runTask uses the same VM and preprocessing
+	// infrastructure as SimulateTask, so if SimulateTask works, runTask should work too.
+	// The main difference was in the branch node preprocessing, which we've now fixed.
+}
+
+// TestBranchNodeFallbackResolution specifically tests that branch nodes can use
+// the fallback variable resolution in their condition expressions
+func TestBranchNodeFallbackResolution(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+
+	// Test data with snake_case field names
+	testData := map[string]interface{}{
+		"token_name":   "USDC",
+		"token_amount": 1000,
+	}
+
+	inputVariables := map[string]interface{}{
+		"eventTrigger": map[string]interface{}{
+			"data": testData,
+		},
+	}
+
+	// Test branch node that uses camelCase in condition (should fallback to snake_case)
+	branchConfig := map[string]interface{}{
+		"conditions": []map[string]interface{}{
+			{
+				"id":         "condition1",
+				"type":       "if",
+				"expression": "eventTrigger.data.tokenName === 'USDC' && eventTrigger.data.tokenAmount > 500",
+			},
+		},
+	}
+
+	t.Run("BranchNodeFallbackResolution", func(t *testing.T) {
+		result, err := engine.RunNodeImmediately("branch", branchConfig, inputVariables)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		if result != nil && result["success"] != nil {
+			assert.True(t, result["success"].(bool), "Branch condition should evaluate to true using fallback resolution")
+		}
+	})
+}
+
+// TestContractReadFallbackResolution tests that contract read nodes can use
+// fallback variable resolution in their configuration
+func TestContractReadFallbackResolution(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+
+	// Test data with snake_case field names
+	testData := map[string]interface{}{
+		"contract_address": "0x1234567890123456789012345678901234567890",
+	}
+
+	inputVariables := map[string]interface{}{
+		"eventTrigger": map[string]interface{}{
+			"data": testData,
+		},
+	}
+
+	// Test contract read that uses camelCase template (should fallback to snake_case)
+	contractReadConfig := map[string]interface{}{
+		"contractAddress": "{{eventTrigger.data.contractAddress}}", // camelCase template
+		"contractAbi":     `[{"inputs":[],"name":"decimals","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"}]`,
+		"methodCalls": []map[string]interface{}{
+			{
+				"methodName": "decimals",
+				"callData":   "0x313ce567",
+			},
+		},
+	}
+
+	t.Run("ContractReadFallbackResolution", func(t *testing.T) {
+		// This test will fail with RPC connection error, but we can check that the preprocessing worked
+		// by examining the error message - it should contain the resolved address, not the template
+		result, err := engine.RunNodeImmediately("contractRead", contractReadConfig, inputVariables)
+
+		// We expect an error due to RPC connection, but the address should be resolved
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "0x1234567890123456789012345678901234567890",
+			"Error should contain the resolved contract address, indicating template preprocessing worked")
+
+		// The result might be nil due to the RPC error, which is expected
+		_ = result
+	})
+}

--- a/core/taskengine/trigger_data_flattening_test.go
+++ b/core/taskengine/trigger_data_flattening_test.go
@@ -393,8 +393,8 @@ func TestContractReadFallbackResolution(t *testing.T) {
 	contractReadConfig := map[string]interface{}{
 		"contractAddress": "{{eventTrigger.data.contractAddress}}", // camelCase template
 		"contractAbi":     `[{"inputs":[],"name":"decimals","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"}]`,
-		"methodCalls": []map[string]interface{}{
-			{
+		"methodCalls": []interface{}{
+			map[string]interface{}{
 				"methodName": "decimals",
 				"callData":   "0x313ce567",
 			},

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -321,10 +321,10 @@ func NewVMWithDataAndTransferLog(task *model.Task, triggerData *TriggerData, sma
 				}
 
 				// Use shared function to build trigger data map from the TransferLog protobuf
-				triggerDataMap = buildTriggerDataMapFromProtobuf(avsproto.TriggerType_TRIGGER_TYPE_EVENT, v.parsedTriggerData.Event)
+				triggerDataMap = buildTriggerDataMapFromProtobuf(avsproto.TriggerType_TRIGGER_TYPE_EVENT, v.parsedTriggerData.Event, v.logger)
 			} else {
 				// Use shared function to build trigger data map from protobuf trigger outputs
-				triggerDataMap = buildTriggerDataMapFromProtobuf(triggerData.Type, triggerData.Output)
+				triggerDataMap = buildTriggerDataMapFromProtobuf(triggerData.Type, triggerData.Output, v.logger)
 			}
 
 			// Create dual-access map to support both camelCase and snake_case field access

--- a/core/taskengine/vm_runner_branch.go
+++ b/core/taskengine/vm_runner_branch.go
@@ -181,7 +181,7 @@ func (r *BranchProcessor) Execute(stepID string, node *avsproto.BranchNode) (*av
 		// Preprocess the expression using the VM's current variable context
 		processedExpression := condition.Expression
 		if strings.Contains(processedExpression, "{{") {
-			processedExpression = r.vm.preprocessText(processedExpression)
+			processedExpression = r.vm.preprocessTextWithVariableMapping(condition.Expression)
 		} else {
 			processedExpression = r.vm.preprocessTextWithVariableMapping(condition.Expression)
 		}

--- a/core/taskengine/vm_runner_branch.go
+++ b/core/taskengine/vm_runner_branch.go
@@ -179,12 +179,7 @@ func (r *BranchProcessor) Execute(stepID string, node *avsproto.BranchNode) (*av
 		}
 
 		// Preprocess the expression using the VM's current variable context
-		processedExpression := condition.Expression
-		if strings.Contains(processedExpression, "{{") {
-			processedExpression = r.vm.preprocessTextWithVariableMapping(condition.Expression)
-		} else {
-			processedExpression = r.vm.preprocessTextWithVariableMapping(condition.Expression)
-		}
+		processedExpression := r.vm.preprocessTextWithVariableMapping(condition.Expression)
 		log.WriteString("Processed expression for '" + condition.Id + "': " + processedExpression + "\n")
 
 		// Check if expression became empty after preprocessing (indicates variable resolution failure)

--- a/core/taskengine/vm_runner_contract_read.go
+++ b/core/taskengine/vm_runner_contract_read.go
@@ -91,10 +91,10 @@ func (r *ContractReadProcessor) buildStructuredData(method *abi.Method, result [
 // executeMethodCall executes a single method call and returns the result
 func (r *ContractReadProcessor) executeMethodCall(ctx context.Context, contractAbi *abi.ABI, contractAddress common.Address, methodCall *avsproto.ContractReadNode_MethodCall) *avsproto.ContractReadNode_MethodResult {
 	// Preprocess template variables in method call data
-	callData := r.vm.preprocessTextWithVariableMapping(methodCall.CallData)
+	preprocessedCallData := r.vm.preprocessTextWithVariableMapping(methodCall.CallData)
 	methodName := r.vm.preprocessTextWithVariableMapping(methodCall.MethodName)
 
-	calldata := common.FromHex(callData)
+	calldata := common.FromHex(preprocessedCallData)
 	msg := ethereum.CallMsg{
 		To:   &contractAddress,
 		Data: calldata,

--- a/core/taskengine/vm_runner_eth_transfer.go
+++ b/core/taskengine/vm_runner_eth_transfer.go
@@ -56,8 +56,9 @@ func (p *ETHTransferProcessor) Execute(stepID string, node *avsproto.ETHTransfer
 		return executionLog, err
 	}
 
-	destination := config.GetDestination()
-	amountStr := config.GetAmount()
+	// Preprocess template variables in configuration
+	destination := p.vm.preprocessTextWithVariableMapping(config.GetDestination())
+	amountStr := p.vm.preprocessTextWithVariableMapping(config.GetAmount())
 
 	if destination == "" {
 		err := fmt.Errorf("destination address is required for ETH transfer")

--- a/core/taskengine/vm_secrets_test.go
+++ b/core/taskengine/vm_secrets_test.go
@@ -54,7 +54,11 @@ func TestSecretAccessPath(t *testing.T) {
 	// Test 3: Verify configVars exists in apContext
 	configVars, exists := apContextMap[ConfigVarsPath]
 	if !exists {
-		t.Errorf("configVars not found in apContext, available keys: %v", getMapKeys(apContextMap))
+		var keys []string
+		for k := range apContextMap {
+			keys = append(keys, k)
+		}
+		t.Errorf("configVars not found in apContext, available keys: %v", keys)
 		return
 	}
 
@@ -62,7 +66,11 @@ func TestSecretAccessPath(t *testing.T) {
 	for key, expectedValue := range testSecrets {
 		actualValue, exists := configVars[key]
 		if !exists {
-			t.Errorf("Secret key '%s' not found in configVars, available keys: %v", key, getMapKeys(configVars))
+			var keys []string
+			for k := range configVars {
+				keys = append(keys, k)
+			}
+			t.Errorf("Secret key '%s' not found in configVars, available keys: %v", key, keys)
 			continue
 		}
 		if actualValue != expectedValue {
@@ -225,20 +233,19 @@ func TestCollectInputsIncludesSecrets(t *testing.T) {
 
 	// Verify that apContext.configVars is included
 	if _, exists := inputs[APContextConfigVarsPath]; !exists {
-		t.Errorf("apContext.configVars not found in CollectInputs output, available keys: %v", getMapKeys(inputs))
+		var keys []string
+		for k := range inputs {
+			keys = append(keys, k)
+		}
+		t.Errorf("apContext.configVars not found in CollectInputs output, available keys: %v", keys)
 	}
 
 	// Verify that test_var.data is included
 	if _, exists := inputs["test_var.data"]; !exists {
-		t.Errorf("test_var.data not found in CollectInputs output, available keys: %v", getMapKeys(inputs))
+		var keys []string
+		for k := range inputs {
+			keys = append(keys, k)
+		}
+		t.Errorf("test_var.data not found in CollectInputs output, available keys: %v", keys)
 	}
-}
-
-// Helper function to get map keys for debugging
-func getMapKeys[K comparable, V any](m map[K]V) []K {
-	keys := make([]K, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }


### PR DESCRIPTION
- **Fixed operator eventTrigger not capturing all ERC20 transfer problem (#329)**
- **Fix operator failed to notify aggregator on task trigger problem - Fixed critical bug in MustStart() where tasks were loaded using storage key instead of task ID, added database fallback, enhanced variable resolution with dual-access mapping, improved preprocessing in node runners, added comprehensive logging**
- **Fix unnecessary stack trace in event trigger query optimization warning - Changed Warn to Info level since this is informational, not an error requiring debugging**
- **Fixed runTask returns undefined for eventTrigger problem**
