### PR TITLE
fix: simply triggerWorkflow for ManualTrigger

### DIFF
--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -3586,17 +3586,12 @@ func buildTriggerDataMapFromProtobuf(triggerType avsproto.TriggerType, triggerOu
 
 	switch triggerType {
 	case avsproto.TriggerType_TRIGGER_TYPE_MANUAL:
-		if manualOutput, ok := triggerOutputProto.(*avsproto.ManualTrigger_Output); ok {
-			if manualOutput.Data != nil {
-				triggerDataMap["data"] = manualOutput.Data.AsInterface()
-			} else {
-				triggerDataMap["data"] = nil
+		if manualOutput, ok := triggerOutputProto.(*avsproto.ManualTrigger_Output); ok && manualOutput.Data != nil {
+			triggerDataMap["data"] = manualOutput.Data.AsInterface()
+		} else if mapOutput, ok := triggerOutputProto.(map[string]interface{}); ok {
+			if dataField, exists := mapOutput["data"]; exists {
+				triggerDataMap["data"] = dataField
 			}
-			// Headers and PathParams are config-only fields, not included in output
-		} else {
-			// If triggerOutputProto is not the expected type (e.g., nil),
-			// set data to null to prevent template resolution issues
-			triggerDataMap["data"] = nil
 		}
 	case avsproto.TriggerType_TRIGGER_TYPE_FIXED_TIME:
 		if timeOutput, ok := triggerOutputProto.(*avsproto.FixedTimeTrigger_Output); ok {

--- a/core/taskengine/node_utils.go
+++ b/core/taskengine/node_utils.go
@@ -12,6 +12,11 @@ import (
 func buildTriggerVariableData(trigger *avsproto.TaskTrigger, triggerDataMap map[string]interface{}, triggerInputData map[string]interface{}) map[string]interface{} {
 	triggerVarData := make(map[string]interface{})
 
+	// Check if trigger is nil to avoid runtime panic
+	if trigger == nil {
+		return triggerVarData
+	}
+
 	// For manual triggers, use the actual user data from triggerInputData
 	if trigger.GetType() == avsproto.TriggerType_TRIGGER_TYPE_MANUAL {
 		if inputData, exists := triggerInputData["data"]; exists {
@@ -31,12 +36,12 @@ func buildTriggerVariableData(trigger *avsproto.TaskTrigger, triggerDataMap map[
 
 // updateTriggerVariableInVM updates the trigger variable in the VM with proper mutex handling
 // This function consolidates the common logic used in task execution and simulation
-func updateTriggerVariableInVM(vm *VM, triggerVarName string, triggerVarData map[string]any) {
+func updateTriggerVariableInVM(vm *VM, triggerVarName string, triggerVarData map[string]interface{}) {
 	vm.mu.Lock()
 	defer vm.mu.Unlock()
 
 	existingTriggerVar := vm.vars[triggerVarName]
-	if existingMap, ok := existingTriggerVar.(map[string]any); ok {
+	if existingMap, ok := existingTriggerVar.(map[string]interface{}); ok {
 		// Merge with existing trigger variable data
 		for key, value := range triggerVarData {
 			existingMap[key] = value

--- a/core/taskengine/node_utils.go
+++ b/core/taskengine/node_utils.go
@@ -9,44 +9,21 @@ import (
 
 // buildTriggerVariableData creates the proper trigger variable structure for JavaScript VM access
 // This function consolidates the common logic used in VM creation, task execution, and simulation
-func buildTriggerVariableData(trigger *avsproto.TaskTrigger, triggerDataMap map[string]interface{}, triggerInputData map[string]interface{}) map[string]any {
-	triggerVarData := map[string]any{}
+func buildTriggerVariableData(trigger *avsproto.TaskTrigger, triggerDataMap map[string]interface{}, triggerInputData map[string]interface{}) map[string]interface{} {
+	triggerVarData := make(map[string]interface{})
 
-	// For manual triggers, handle the JSON data directly
-	if trigger != nil && trigger.GetType() == avsproto.TriggerType_TRIGGER_TYPE_MANUAL {
-		// For manual triggers, preserve the proper structure with data at top level and input nested
-		// This allows templates to access ManualTrigger.data and ManualTrigger.input.headers, etc.
-
-		// Put main data at top level for direct access
-		if data, exists := triggerDataMap["data"]; exists {
-			triggerVarData["data"] = data
+	// For manual triggers, use the actual user data from triggerInputData
+	if trigger.GetType() == avsproto.TriggerType_TRIGGER_TYPE_MANUAL {
+		if inputData, exists := triggerInputData["data"]; exists {
+			triggerVarData["data"] = inputData
 		}
-
-		// Include input data structure if available
+		triggerVarData["input"] = triggerInputData
+	} else {
+		// For other trigger types, use the trigger output data
+		triggerVarData["data"] = triggerDataMap
 		if triggerInputData != nil {
 			triggerVarData["input"] = triggerInputData
-		} else {
-			// If no input data provided, create input structure from triggerDataMap
-			inputData := map[string]interface{}{}
-			for k, v := range triggerDataMap {
-				inputData[k] = v
-			}
-			triggerVarData["input"] = inputData
 		}
-	} else {
-		// For all other trigger types, put all output data under the .data field
-		// This ensures consistent access pattern: triggerName.data.field
-		if len(triggerDataMap) > 0 {
-			triggerVarData["data"] = triggerDataMap
-		} else {
-			// Handle the case where triggers have no data to prevent template resolution issues
-			triggerVarData["data"] = nil
-		}
-	}
-
-	// Add trigger input data if available
-	if triggerInputData != nil {
-		triggerVarData["input"] = triggerInputData
 	}
 
 	return triggerVarData
@@ -56,6 +33,8 @@ func buildTriggerVariableData(trigger *avsproto.TaskTrigger, triggerDataMap map[
 // This function consolidates the common logic used in task execution and simulation
 func updateTriggerVariableInVM(vm *VM, triggerVarName string, triggerVarData map[string]any) {
 	vm.mu.Lock()
+	defer vm.mu.Unlock()
+
 	existingTriggerVar := vm.vars[triggerVarName]
 	if existingMap, ok := existingTriggerVar.(map[string]any); ok {
 		// Merge with existing trigger variable data
@@ -67,7 +46,6 @@ func updateTriggerVariableInVM(vm *VM, triggerVarName string, triggerVarData map
 		// Create new trigger variable
 		vm.vars[triggerVarName] = triggerVarData
 	}
-	vm.mu.Unlock()
 }
 
 // createNodeExecutionStep creates a standardized execution step for node execution


### PR DESCRIPTION
This pull request introduces several updates to improve the handling of trigger data, task execution, and concurrency in the task engine. The key changes include refining the logic for building trigger data maps, improving task secret loading, and ensuring thread safety in virtual machine (VM) operations.

### Improvements to trigger data handling:
* [`core/taskengine/engine.go`](diffhunk://#diff-77494b7116e328f80878e42128327bd124ab4ef1d7394c1d51109a5a5e93c4bcL3589-L3599): Updated the `buildTriggerDataMapFromProtobuf` function to handle additional cases for manual trigger outputs, including support for `map[string]interface{}` and ensuring proper data extraction.
* [`core/taskengine/node_utils.go`](diffhunk://#diff-9a7d8b07a7943a783d0fe333b62211f69c896571e01d8f9fb6e78154ca3ab9f6L12-R27): Simplified the `buildTriggerVariableData` function to better handle manual and other trigger types by directly using `triggerInputData` for manual triggers and streamlining the data structure creation.

### Enhancements to task execution:
* [`core/taskengine/executor.go`](diffhunk://#diff-4b8efce1f8432755ee174fa18c454f2ee713f11d0fba1e5662ebc1058903cef0R124-R131): Added logic to load secrets for tasks in the `RunTask` function, with error handling to ensure tasks proceed with empty secrets if loading fails. Removed redundant secret-loading code. [[1]](diffhunk://#diff-4b8efce1f8432755ee174fa18c454f2ee713f11d0fba1e5662ebc1058903cef0R124-R131) [[2]](diffhunk://#diff-4b8efce1f8432755ee174fa18c454f2ee713f11d0fba1e5662ebc1058903cef0L136-L137)

### Concurrency improvements:
* [`core/taskengine/node_utils.go`](diffhunk://#diff-9a7d8b07a7943a783d0fe333b62211f69c896571e01d8f9fb6e78154ca3ab9f6R36-R37): Added a `defer` statement in `updateTriggerVariableInVM` to ensure the VM's mutex is unlocked properly, improving thread safety during variable updates. [[1]](diffhunk://#diff-9a7d8b07a7943a783d0fe333b62211f69c896571e01d8f9fb6e78154ca3ab9f6R36-R37) [[2]](diffhunk://#diff-9a7d8b07a7943a783d0fe333b62211f69c896571e01d8f9fb6e78154ca3ab9f6L70)