### PR TITLE
fix: make event trigger responses consistent across all execution modes

### DIFF
--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -781,7 +781,7 @@ func (n *Engine) evaluateCondition(actualValue interface{}, operator, expectedVa
 // evaluateLessThan evaluates less than comparison
 func (n *Engine) evaluateLessThan(actualValue interface{}, expectedValue, fieldType string) bool {
 	switch fieldType {
-	case "decimal", "uint256", "uint128", "uint64", "uint32", "uint16", "uint8":
+	case "decimal", "int256", "uint256", "uint128", "uint64", "uint32", "uint16", "uint8", "int128", "int64", "int32", "int16", "int8":
 		actualFloat, err1 := n.convertToFloat(actualValue)
 		expectedFloat, err2 := n.convertToFloat(expectedValue)
 		if err1 != nil || err2 != nil {
@@ -796,7 +796,7 @@ func (n *Engine) evaluateLessThan(actualValue interface{}, expectedValue, fieldT
 // evaluateGreaterThan evaluates greater than comparison
 func (n *Engine) evaluateGreaterThan(actualValue interface{}, expectedValue, fieldType string) bool {
 	switch fieldType {
-	case "decimal", "uint256", "uint128", "uint64", "uint32", "uint16", "uint8":
+	case "decimal", "int256", "uint256", "uint128", "uint64", "uint32", "uint16", "uint8", "int128", "int64", "int32", "int16", "int8":
 		actualFloat, err1 := n.convertToFloat(actualValue)
 		expectedFloat, err2 := n.convertToFloat(expectedValue)
 		if err1 != nil || err2 != nil {
@@ -811,7 +811,7 @@ func (n *Engine) evaluateGreaterThan(actualValue interface{}, expectedValue, fie
 // evaluateEquals evaluates equality comparison
 func (n *Engine) evaluateEquals(actualValue interface{}, expectedValue, fieldType string) bool {
 	switch fieldType {
-	case "decimal", "uint256", "uint128", "uint64", "uint32", "uint16", "uint8":
+	case "decimal", "int256", "uint256", "uint128", "uint64", "uint32", "uint16", "uint8", "int128", "int64", "int32", "int16", "int8":
 		actualFloat, err1 := n.convertToFloat(actualValue)
 		expectedFloat, err2 := n.convertToFloat(expectedValue)
 		if err1 != nil || err2 != nil {
@@ -1328,12 +1328,20 @@ func (n *Engine) runEventTriggerWithTenderlySimulation(ctx context.Context, quer
 	// Add the parsed ABI fields as flattened data
 	response["data"] = parsedData
 
-	// Add raw event log fields as metadata (no execution context in metadata)
-	response["metadata"] = enrichmentResult.RawEventData
+	// Add raw event log fields as metadata in the expected array format
+	response["metadata"] = []interface{}{
+		map[string]interface{}{
+			"eventLog": enrichmentResult.RawEventData,
+		},
+	}
 
-	// Always successful for simulated events
-	response["success"] = true
-	response["error"] = ""
+	// Set success based on condition evaluation
+	response["success"] = allConditionsMet
+	if !allConditionsMet {
+		response["error"] = "Conditions not met for simulated event"
+	} else {
+		response["error"] = ""
+	}
 
 	// Add execution context (chainId, isSimulated, provider)
 	response["executionContext"] = GetExecutionContext(chainID, true) // true = isSimulation

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -1328,12 +1328,8 @@ func (n *Engine) runEventTriggerWithTenderlySimulation(ctx context.Context, quer
 	// Add the parsed ABI fields as flattened data
 	response["data"] = parsedData
 
-	// Add raw event log fields as metadata in the expected array format
-	response["metadata"] = []interface{}{
-		map[string]interface{}{
-			"eventLog": enrichmentResult.RawEventData,
-		},
-	}
+	// Add raw event log fields as metadata (direct format for backward compatibility)
+	response["metadata"] = enrichmentResult.RawEventData
 
 	// Set success based on condition evaluation
 	response["success"] = allConditionsMet

--- a/core/taskengine/shared_event_enrichment.go
+++ b/core/taskengine/shared_event_enrichment.go
@@ -180,12 +180,9 @@ func parseEventWithABIShared(eventLog *types.Log, contractABI *abi.ABI, query *a
 				switch input.Type.T {
 				case abi.UintTy, abi.IntTy:
 					// Convert numeric types to proper types
-					if bigInt := new(big.Int).SetBytes(topicValue.Bytes()); bigInt != nil {
-						convertedValue := converter.ConvertABIValueToInterface(bigInt, input.Type, input.Name)
-						parsedData[input.Name] = convertedValue
-					} else {
-						parsedData[input.Name] = topicValue.Hex()
-					}
+					bigInt := new(big.Int).SetBytes(topicValue.Bytes())
+					convertedValue := converter.ConvertABIValueToInterface(bigInt, input.Type, input.Name)
+					parsedData[input.Name] = convertedValue
 				case abi.BoolTy:
 					// Convert boolean from topic
 					boolVal := new(big.Int).SetBytes(topicValue.Bytes()).Cmp(big.NewInt(0)) != 0

--- a/core/taskengine/tenderly_client_test.go
+++ b/core/taskengine/tenderly_client_test.go
@@ -1410,12 +1410,12 @@ func TestEventTriggerImmediately_TenderlySimulation_Unit(t *testing.T) {
 		require.True(t, ok, "data should be a map[string]interface{}")
 		require.NotNil(t, eventData, "Should have event data")
 
-		// Verify expected fields in the raw blockchain log data
-		assert.NotNil(t, eventData["tokenContract"], "Should have contract address")
-		assert.NotNil(t, eventData["blockNumber"], "Should have block number")
-		assert.NotNil(t, eventData["transactionHash"], "Should have transaction hash")
-		assert.NotNil(t, eventData["topics"], "Should have topics")
-		assert.NotNil(t, eventData["data"], "Should have raw data")
+		// Verify expected fields in the parsed AnswerUpdated event data
+		assert.NotNil(t, eventData["current"], "Should have current price")
+		assert.NotNil(t, eventData["roundId"], "Should have round ID")
+		assert.NotNil(t, eventData["updatedAt"], "Should have updated timestamp")
+		assert.NotNil(t, eventData["eventName"], "Should have event name")
+		assert.Equal(t, "AnswerUpdated", eventData["eventName"], "Event name should be AnswerUpdated")
 
 		// Get the metadata array (new format)
 		metadata, ok := result["metadata"].([]interface{})
@@ -1489,15 +1489,17 @@ func TestEventTriggerImmediately_TenderlySimulation_Unit(t *testing.T) {
 		require.True(t, ok, "data should be a map[string]interface{}")
 		require.NotNil(t, eventData, "Should have event data")
 
-		// Verify we have raw blockchain log data (the condition logic is tested elsewhere)
-		assert.NotNil(t, eventData["tokenContract"], "Should have contract address")
-		assert.NotNil(t, eventData["blockNumber"], "Should have block number")
-		assert.NotNil(t, eventData["topics"], "Should have topics")
+		// Verify we have parsed AnswerUpdated event data (the condition logic is tested elsewhere)
+		assert.NotNil(t, eventData["current"], "Should have current price")
+		assert.NotNil(t, eventData["roundId"], "Should have round ID")
+		assert.NotNil(t, eventData["updatedAt"], "Should have updated timestamp")
+		assert.NotNil(t, eventData["eventName"], "Should have event name")
 
 		t.Logf("Condition evaluation successful.")
-		t.Logf("   Contract Address: %v", eventData["tokenContract"])
-		t.Logf("   Block Number: %v", eventData["blockNumber"])
-		t.Logf("   Topics: %v", eventData["topics"])
+		t.Logf("   Current Price: %v", eventData["current"])
+		t.Logf("   Round ID: %v", eventData["roundId"])
+		t.Logf("   Updated At: %v", eventData["updatedAt"])
+		t.Logf("   Event Name: %v", eventData["eventName"])
 		t.Logf("   Condition: simulation mode provides sample data ✅")
 	})
 
@@ -1672,18 +1674,13 @@ func TestTransferEventSampleData_ForUserDocumentation(t *testing.T) {
 		assert.NotEmpty(t, result["data"], "Should have Transfer event data")
 		assert.NotEmpty(t, result["metadata"], "Should have metadata")
 
-		// Get the metadata array (new format)
-		metadata, ok := result["metadata"].([]interface{})
-		require.True(t, ok, "metadata should be a []interface{}")
+		// Get the metadata object (new format - raw event log structure)
+		metadata, ok := result["metadata"].(map[string]interface{})
+		require.True(t, ok, "metadata should be a map[string]interface{}")
 		require.NotNil(t, metadata, "Should have metadata")
-		require.NotEmpty(t, metadata, "Should have metadata entries")
 
-		// Check the first metadata entry (simulation event log)
-		firstEntry, ok := metadata[0].(map[string]interface{})
-		require.True(t, ok, "First metadata entry should be a map")
-
-		transferData, ok := firstEntry["eventLog"].(map[string]interface{})
-		require.True(t, ok, "Should have eventLog in metadata")
+		// The metadata IS the raw event log data (no nested eventLog)
+		transferData := metadata
 
 		t.Logf("\n🎉 === SAMPLE TRANSFER EVENT DATA STRUCTURE ===")
 		t.Logf("✅ Success! Here's the raw blockchain log data structure users can reference:")
@@ -1705,7 +1702,7 @@ func TestTransferEventSampleData_ForUserDocumentation(t *testing.T) {
 		t.Logf("%s", string(prettyJSON))
 
 		t.Logf("\n🔍 Metadata Structure:")
-		metadataJSON, _ := json.MarshalIndent(metadata, "", "  ")
+		metadataJSON, _ := json.MarshalIndent(transferData, "", "  ")
 		t.Logf("%s", string(metadataJSON))
 
 		t.Logf("\n💡 === HOW TO USE THIS DATA ===")

--- a/core/taskengine/tenderly_client_test.go
+++ b/core/taskengine/tenderly_client_test.go
@@ -1387,6 +1387,18 @@ func TestEventTriggerImmediately_TenderlySimulation_Unit(t *testing.T) {
 							"values": []interface{}{ANSWER_UPDATED_SIG},
 						},
 					},
+					"contractAbi": []interface{}{
+						map[string]interface{}{
+							"anonymous": false,
+							"inputs": []interface{}{
+								map[string]interface{}{"indexed": true, "internalType": "int256", "name": "current", "type": "int256"},
+								map[string]interface{}{"indexed": true, "internalType": "uint256", "name": "roundId", "type": "uint256"},
+								map[string]interface{}{"indexed": false, "internalType": "uint256", "name": "updatedAt", "type": "uint256"},
+							},
+							"name": "AnswerUpdated",
+							"type": "event",
+						},
+					},
 				},
 			},
 		}
@@ -1460,6 +1472,18 @@ func TestEventTriggerImmediately_TenderlySimulation_Unit(t *testing.T) {
 					"topics": []interface{}{
 						map[string]interface{}{
 							"values": []interface{}{ANSWER_UPDATED_SIG},
+						},
+					},
+					"contractAbi": []interface{}{
+						map[string]interface{}{
+							"anonymous": false,
+							"inputs": []interface{}{
+								map[string]interface{}{"indexed": true, "internalType": "int256", "name": "current", "type": "int256"},
+								map[string]interface{}{"indexed": true, "internalType": "uint256", "name": "roundId", "type": "uint256"},
+								map[string]interface{}{"indexed": false, "internalType": "uint256", "name": "updatedAt", "type": "uint256"},
+							},
+							"name": "AnswerUpdated",
+							"type": "event",
 						},
 					},
 					"conditions": []interface{}{

--- a/scripts/gh_job_logs.sh
+++ b/scripts/gh_job_logs.sh
@@ -94,8 +94,15 @@ if gh run view --log --job="$JOB_ID" --repo "$REPO" > "$OUTFILE"; then
   echo "✅ Logs saved to: $OUTFILE"
   echo "📊 Log file size: $(wc -l < "$OUTFILE") lines"
   
-  # Show quick summary of failures if any
-  if grep -q "FAIL\|ERROR\|error:" "$OUTFILE" 2>/dev/null; then
+  # Show quick summary of test failures if any
+  if grep -q "--- FAIL:" "$OUTFILE" 2>/dev/null; then
+    echo ""
+    echo "🚨 Test Failures Found:"
+    grep -n "--- FAIL:" "$OUTFILE" | head -10
+    if [[ $(grep -c "--- FAIL:" "$OUTFILE") -gt 10 ]]; then
+      echo "... and $(( $(grep -c "--- FAIL:" "$OUTFILE") - 10 )) more test failures"
+    fi
+  elif grep -q "FAIL\|ERROR\|error:" "$OUTFILE" 2>/dev/null; then
     echo ""
     echo "🚨 Found failures/errors in logs:"
     grep -n "FAIL\|ERROR\|error:" "$OUTFILE" | head -5

--- a/scripts/gh_job_logs.sh
+++ b/scripts/gh_job_logs.sh
@@ -95,12 +95,12 @@ if gh run view --log --job="$JOB_ID" --repo "$REPO" > "$OUTFILE"; then
   echo "📊 Log file size: $(wc -l < "$OUTFILE") lines"
   
   # Show quick summary of test failures if any
-  if grep -q "--- FAIL:" "$OUTFILE" 2>/dev/null; then
+  if grep -q -- "--- FAIL:" "$OUTFILE" 2>/dev/null; then
     echo ""
     echo "🚨 Test Failures Found:"
-    grep -n "--- FAIL:" "$OUTFILE" | head -10
-    if [[ $(grep -c "--- FAIL:" "$OUTFILE") -gt 10 ]]; then
-      echo "... and $(( $(grep -c "--- FAIL:" "$OUTFILE") - 10 )) more test failures"
+    grep -n -- "--- FAIL:" "$OUTFILE" | head -20
+    if [[ $(grep -c -- "--- FAIL:" "$OUTFILE") -gt 20 ]]; then
+      echo "... and $(( $(grep -c -- "--- FAIL:" "$OUTFILE") - 20 )) more test failures"
     fi
   elif grep -q "FAIL\|ERROR\|error:" "$OUTFILE" 2>/dev/null; then
     echo ""


### PR DESCRIPTION
- Fix runEventTriggerWithDirectCalls to return simulated AnswerUpdated events instead of method call results
- Add proper ABI parsing for indexed parameters in event enrichment
- Ensure consistent response structure across run node immediately, simulate task, and deployed task:
  * data: parsed ABI fields (properly decoded values)
  * metadata: raw event log structure (address, topics, data, blockNumber, etc.)
  * executionContext: { chainId, isSimulated, provider }
- Remove isSimulation flag from metadata, keep it only in executionContext
- Add RawEventData field to SharedEventEnrichmentResult for proper metadata structure

This ensures oracle price events and other event triggers return consistent formats regardless of execution mode (deployed/simulate/run-immediately).