### PR TITLE
fix: enable real transactions for loop node contract writes in deployed workflow

### DIFF
--- a/core/taskengine/blockchain_constants.go
+++ b/core/taskengine/blockchain_constants.go
@@ -9,6 +9,10 @@ const (
 	// StandardGasCostHex is the hexadecimal representation of StandardGasCost
 	// Used in transaction receipts and other hex-encoded contexts
 	StandardGasCostHex = "0x5208"
+
+	// DefaultGasLimit represents the default gas limit used for UserOp construction before bundler estimation
+	// This is a placeholder value that gets replaced by actual gas estimation from the bundler
+	DefaultGasLimit = 10000000
 )
 
 // Contract method constants

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -3763,11 +3763,27 @@ func (n *Engine) evaluateConditionsAgainstEventData(eventData map[string]interfa
 		fieldType, _ := conditionMap["fieldType"].(string)
 
 		// Get the actual field value from event data
-		actualValue, exists := eventData[fieldName]
+		// Handle eventName.fieldName format by extracting just the field name
+		actualFieldName := fieldName
+		if strings.Contains(fieldName, ".") {
+			parts := strings.Split(fieldName, ".")
+			if len(parts) == 2 {
+				actualFieldName = parts[1] // Use just the field name part
+				if n.logger != nil {
+					n.logger.Debug("Parsed eventName.fieldName format",
+						"original", fieldName,
+						"eventName", parts[0],
+						"fieldName", actualFieldName)
+				}
+			}
+		}
+
+		actualValue, exists := eventData[actualFieldName]
 		if !exists {
 			if n.logger != nil {
 				n.logger.Debug("Condition field not found in event data",
-					"fieldName", fieldName,
+					"originalFieldName", fieldName,
+					"actualFieldName", actualFieldName,
 					"availableFields", GetMapKeys(eventData))
 			}
 			return false

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -3782,6 +3782,12 @@ func (n *Engine) evaluateConditionsAgainstEventData(eventData map[string]interfa
 
 		actualValue, exists := eventData[actualFieldName]
 		if !exists {
+			if n.logger != nil {
+				n.logger.Debug("Condition field not found in event data",
+					"originalFieldName", fieldName,
+					"actualFieldName", actualFieldName,
+					"availableFields", GetMapKeys(eventData))
+			}
 			return false
 		}
 

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -2178,16 +2178,24 @@ func (v *VM) RunNodeWithInputs(node *avsproto.TaskNode, inputVariables map[strin
 	tempVM.secrets = v.secrets // Inherit secrets
 	tempVM.TaskID = v.TaskID   // Inherit original TaskID for logging context
 	// Propagate simulation mode and task owner for correct execution behavior
-	// FORCE simulation for RunNodeWithInputs - it should NEVER execute real transactions
-	tempVM.IsSimulation = true // Force simulation for RunNodeWithInputs
+	// For RunNodeWithInputs calls from deployed workflows (like loop nodes), inherit the parent VM's simulation mode
+	// Only force simulation for direct SDK calls to runNodeImmediately
+	if v.isDirectSDKCall() {
+		tempVM.IsSimulation = true // Force simulation for direct SDK calls
+	} else {
+		tempVM.IsSimulation = v.IsSimulation // Inherit parent VM's simulation mode for deployed workflows
+	}
 	tempVM.TaskOwner = v.TaskOwner
 	// Propagate shared clients (e.g., Tenderly)
 	tempVM.tenderlyClient = v.tenderlyClient
 
 	// Log simulation mode for debugging
 	if v.logger != nil {
-		v.logger.Debug("RunNodeWithInputs using simulation mode",
-			"node_type", node.Type.String())
+		v.logger.Debug("RunNodeWithInputs simulation mode decision",
+			"node_type", node.Type.String(),
+			"parent_is_simulation", v.IsSimulation,
+			"is_direct_sdk_call", v.isDirectSDKCall(),
+			"temp_vm_is_simulation", tempVM.IsSimulation)
 	}
 
 	tempVM.mu.Lock()
@@ -4452,4 +4460,19 @@ func getStatusText(statusCode int) string {
 			return "Unknown"
 		}
 	}
+}
+
+// isDirectSDKCall determines if RunNodeWithInputs is being called directly from SDK (should simulate)
+// vs being called from deployed workflow execution like loop nodes (should inherit simulation mode)
+func (v *VM) isDirectSDKCall() bool {
+	// Check if this is a direct SDK call by looking for the task_type variable
+	// Direct SDK calls set task_type to "run_node_with_inputs"
+	if taskTypeVar, ok := v.vars["task_type"]; ok {
+		if taskTypeStr, ok := taskTypeVar.(string); ok {
+			return taskTypeStr == "run_node_with_inputs"
+		}
+	}
+
+	// If no task_type variable, this is likely a deployed workflow call (like from loop nodes)
+	return false
 }

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -708,7 +708,8 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 			if userOp != nil {
 				executionLogBuilder.WriteString("Gas Requirements (if estimated):\n")
 				// Only show gas limits if they were actually estimated (not default values)
-				defaultGasLimit := big.NewInt(10000000)
+				// Import the constant from preset package to avoid magic numbers
+				defaultGasLimit := big.NewInt(10000000) // TODO: Import preset.DEFAULT_GAS_LIMIT when available
 				if userOp.CallGasLimit != nil && userOp.CallGasLimit.Cmp(defaultGasLimit) != 0 {
 					executionLogBuilder.WriteString(fmt.Sprintf("  CallGasLimit: %s\n", userOp.CallGasLimit.String()))
 				}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -708,8 +708,8 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 			if userOp != nil {
 				executionLogBuilder.WriteString("Gas Requirements (if estimated):\n")
 				// Only show gas limits if they were actually estimated (not default values)
-				const DEFAULT_GAS_LIMIT_VALUE = 10000000 // Default gas limit for UserOp construction
-				defaultGasLimit := big.NewInt(DEFAULT_GAS_LIMIT_VALUE)
+				// Use the shared constant from preset package to avoid duplication
+				defaultGasLimit := preset.DEFAULT_GAS_LIMIT
 				if userOp.CallGasLimit != nil && userOp.CallGasLimit.Cmp(defaultGasLimit) != 0 {
 					executionLogBuilder.WriteString(fmt.Sprintf("  CallGasLimit: %s\n", userOp.CallGasLimit.String()))
 				}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -708,8 +708,8 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 			if userOp != nil {
 				executionLogBuilder.WriteString("Gas Requirements (if estimated):\n")
 				// Only show gas limits if they were actually estimated (not default values)
-				// Import the constant from preset package to avoid magic numbers
-				defaultGasLimit := big.NewInt(10000000) // TODO: Import preset.DEFAULT_GAS_LIMIT when available
+				const DEFAULT_GAS_LIMIT_VALUE = 10000000 // Default gas limit for UserOp construction
+				defaultGasLimit := big.NewInt(DEFAULT_GAS_LIMIT_VALUE)
 				if userOp.CallGasLimit != nil && userOp.CallGasLimit.Cmp(defaultGasLimit) != 0 {
 					executionLogBuilder.WriteString(fmt.Sprintf("  CallGasLimit: %s\n", userOp.CallGasLimit.String()))
 				}


### PR DESCRIPTION
This pull request improves how the task engine handles field name resolution and simulation mode inheritance, and makes minor code quality improvements. The main changes focus on ensuring that field names in the format `eventName.fieldName` are correctly resolved, simulation mode is properly inherited in the VM, and some redundant code is cleaned up.

**Field name resolution improvements:**

* Updated `getNestedFieldValue` and condition evaluation logic to handle field names in the format `eventName.fieldName` by falling back to just the field name if present, improving compatibility with different event data structures. [[1]](diffhunk://#diff-a765be0f1060a9bf4cdb6450dc595f9c8abb2027e73cf745f58c55732a2ffa7bR732-R739) [[2]](diffhunk://#diff-a765be0f1060a9bf4cdb6450dc595f9c8abb2027e73cf745f58c55732a2ffa7bL3766-R3784)

**Simulation mode handling:**

* Changed `RunNodeWithInputs` in `vm.go` to inherit simulation mode from the parent VM instead of always forcing simulation, ensuring correct execution behavior depending on context. Also improved logging to show the inherited simulation mode.

**Code quality and robustness:**

* Improved `evaluateInt256Condition` to explicitly check for `nil` values and to use a consistent pattern for returning comparison results, increasing robustness and clarity.
* Removed redundant debug logging when a condition is not met, reducing log noise.
* Added a comment in `executeRealUserOpTransaction` to clarify the use of a default gas limit constant and to note a future improvement to import this from a presets package.