### PR TITLE
fix: add manual block trigger implementation with immediate execution

### DIFF
--- a/.github/scripts/promote-and-publish.sh
+++ b/.github/scripts/promote-and-publish.sh
@@ -69,7 +69,9 @@ for release in "${PRERELEASE_ARRAY[@]}"; do
 done
 
 # Get the latest (highest version) pre-release for Docker latest tags
-LATEST_PRERELEASE="${PRERELEASE_ARRAY[-1]}"
+# Use bash 3.2 compatible array indexing instead of negative indexing
+LAST_INDEX=$((${#PRERELEASE_ARRAY[@]} - 1))
+LATEST_PRERELEASE="${PRERELEASE_ARRAY[$LAST_INDEX]}"
 
 # Confirm promotion
 echo -e "${YELLOW}📋 About to promote ${PRERELEASE_COUNT} pre-release(s) to full release(s):${NC}"

--- a/MANUAL_BLOCK_TRIGGER_IMPLEMENTATION.md
+++ b/MANUAL_BLOCK_TRIGGER_IMPLEMENTATION.md
@@ -1,0 +1,78 @@
+# Manual Block Trigger Immediate Execution Implementation
+
+## Overview
+
+This implementation enables manual block triggers to provide real blockchain data by instructing the operator to execute triggers immediately with current block information, rather than using minimal placeholder data.
+
+## Architecture
+
+### Aggregator Side (`core/taskengine/engine.go`)
+
+1. **TriggerTask Method Enhancement**: When a manual block trigger is requested, instead of using the original simulation logic, the aggregator now:
+   - Detects block trigger type in the request
+   - Calls `instructOperatorImmediateTrigger()` to send an instruction to connected operators
+   - Returns success response indicating trigger initiation
+
+2. **instructOperatorImmediateTrigger Function**: 
+   - Gets current block number from RPC connection
+   - Creates `ImmediateTrigger` notification for all connected operators
+   - Adds notification to pending notification queue for operators
+
+### Protobuf Changes (`protobuf/node.proto`)
+
+- Added `ImmediateTrigger = 5` to the `MessageOp` enum
+- Regenerated protobuf bindings to include the new operation type
+
+### Operator Side (`operator/process_message.go`)
+
+1. **Message Processing Enhancement**: Added handling for `MessageOp_ImmediateTrigger` operations:
+   - Extracts task ID from message metadata
+   - Determines trigger type (block vs. time/cron) from task metadata
+   - Calls appropriate immediate execution function
+
+2. **Immediate Execution Functions**:
+   - `executeImmediateBlockTrigger()`: Fetches current block data from RPC and sends trigger notification
+   - `executeImmediateTimeTrigger()`: Creates current timestamp data and sends trigger notification
+
+## Data Flow
+
+1. **User Request**: Manual block trigger request sent to aggregator
+2. **Aggregator Processing**: Detects block trigger and instructs operator via `ImmediateTrigger` message
+3. **Operator Execution**: Operator receives instruction, fetches real blockchain data, and triggers workflow
+4. **Real Data Flow**: Workflow executes with actual block hash, timestamp, and other blockchain fields
+
+## Key Benefits
+
+- **Real Blockchain Data**: Manual triggers now use current block hash, timestamp, and other real blockchain fields
+- **Consistent Architecture**: Maintains separation of concerns (operator fetches data, aggregator coordinates)
+- **No Logic Duplication**: Reuses existing operator trigger mechanisms
+- **Clean Implementation**: Uses existing notification system for operator communication
+
+## Files Modified
+
+1. `protobuf/node.proto` - Added ImmediateTrigger operation
+2. `core/taskengine/engine.go` - Added immediate trigger instruction logic
+3. `operator/process_message.go` - Added immediate trigger handling and execution functions
+
+## Usage
+
+When triggering a block trigger task manually via API:
+```json
+{
+  "task_id": "task_id_here",
+  "trigger_type": "TRIGGER_TYPE_BLOCK"
+}
+```
+
+The system now:
+1. Instructs the operator to trigger immediately
+2. Operator fetches current block data (blockHash, timestamp, etc.)
+3. Workflow executes with real blockchain data instead of placeholder values
+
+## Testing
+
+The implementation has been tested to ensure:
+- Build succeeds without compilation errors
+- Protobuf bindings generate correctly
+- Quick test suite passes (with existing test issues unrelated to this change)
+- New message handling works correctly

--- a/core/taskengine/executor_trigger_output_test.go
+++ b/core/taskengine/executor_trigger_output_test.go
@@ -1,0 +1,425 @@
+package taskengine
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestTriggerOutputDataSerializationFix verifies that all trigger types properly handle
+// both protobuf objects and JSON-serialized maps in execution step output data.
+// This test addresses the issue where trigger output data was empty in execution steps
+// when tasks went through the queue system (JSON serialization/deserialization).
+func TestTriggerOutputDataSerializationFix(t *testing.T) {
+	SetRpc(testutil.GetTestRPCURL())
+	SetCache(testutil.GetDefaultCache())
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	tests := []struct {
+		name        string
+		triggerType avsproto.TriggerType
+		// Direct protobuf output (as used in TriggerTask RPC)
+		directOutput interface{}
+		// JSON-serialized output (as stored in queue after serialization/deserialization)
+		mapOutput map[string]interface{}
+	}{
+		{
+			name:        "ManualTrigger",
+			triggerType: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+			directOutput: &avsproto.ManualTrigger_Output{
+				Data: createTestStructValue(map[string]interface{}{
+					"userInput": "test-value",
+					"timestamp": time.Now().Unix(),
+				}),
+			},
+			mapOutput: map[string]interface{}{
+				"data": map[string]interface{}{
+					"userInput": "test-value",
+					"timestamp": time.Now().Unix(),
+				},
+			},
+		},
+		{
+			name:        "FixedTimeTrigger",
+			triggerType: avsproto.TriggerType_TRIGGER_TYPE_FIXED_TIME,
+			directOutput: &avsproto.FixedTimeTrigger_Output{
+				Data: createTestStructValue(map[string]interface{}{
+					"scheduledTime": time.Now().Unix(),
+					"epochIndex":    int64(5),
+				}),
+			},
+			mapOutput: map[string]interface{}{
+				"data": map[string]interface{}{
+					"scheduledTime": time.Now().Unix(),
+					"epochIndex":    int64(5),
+				},
+			},
+		},
+		{
+			name:        "CronTrigger",
+			triggerType: avsproto.TriggerType_TRIGGER_TYPE_CRON,
+			directOutput: &avsproto.CronTrigger_Output{
+				Data: createTestStructValue(map[string]interface{}{
+					"cronExpression": "0 */5 * * * *",
+					"nextRun":        time.Now().Add(5 * time.Minute).Unix(),
+				}),
+			},
+			mapOutput: map[string]interface{}{
+				"data": map[string]interface{}{
+					"cronExpression": "0 */5 * * * *",
+					"nextRun":        time.Now().Add(5 * time.Minute).Unix(),
+				},
+			},
+		},
+		{
+			name:        "BlockTrigger",
+			triggerType: avsproto.TriggerType_TRIGGER_TYPE_BLOCK,
+			directOutput: &avsproto.BlockTrigger_Output{
+				Data: createTestStructValue(map[string]interface{}{
+					"blockNumber":   int64(18500000),
+					"blockHash":     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+					"timestamp":     time.Now().Unix(),
+					"gasLimit":      int64(30000000),
+					"gasUsed":       int64(25000000),
+					"baseFeePerGas": int64(20000000000),
+				}),
+			},
+			mapOutput: map[string]interface{}{
+				"data": map[string]interface{}{
+					"blockNumber":   int64(18500000),
+					"blockHash":     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+					"timestamp":     time.Now().Unix(),
+					"gasLimit":      int64(30000000),
+					"gasUsed":       int64(25000000),
+					"baseFeePerGas": int64(20000000000),
+				},
+			},
+		},
+		{
+			name:        "EventTrigger",
+			triggerType: avsproto.TriggerType_TRIGGER_TYPE_EVENT,
+			directOutput: &avsproto.EventTrigger_Output{
+				Data: createTestStructValue(map[string]interface{}{
+					"tokenName":      "USDC",
+					"tokenSymbol":    "USDC",
+					"tokenDecimals":  6,
+					"from":           "0x2A6CEbeDF9e737A9C6188c62A68655919c7314DB",
+					"to":             "0xC114FB059434563DC65AC8D57e7976e3eaC534F4",
+					"value":          "3453120",
+					"valueFormatted": "3.45312",
+					"blockNumber":    int64(7212417),
+				}),
+			},
+			mapOutput: map[string]interface{}{
+				"data": map[string]interface{}{
+					"tokenName":      "USDC",
+					"tokenSymbol":    "USDC",
+					"tokenDecimals":  6,
+					"from":           "0x2A6CEbeDF9e737A9C6188c62A68655919c7314DB",
+					"to":             "0xC114FB059434563DC65AC8D57e7976e3eaC534F4",
+					"value":          "3453120",
+					"valueFormatted": "3.45312",
+					"blockNumber":    int64(7212417),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test both direct protobuf and JSON-serialized map cases
+			testCases := []struct {
+				name          string
+				triggerOutput interface{}
+			}{
+				{"Direct Protobuf", tt.directOutput},
+				{"JSON Serialized Map", tt.mapOutput},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					// Create a simple task with a custom code node that logs the trigger data
+					nodes := []*avsproto.TaskNode{
+						{
+							Id:   "testNode",
+							Name: "testNode",
+							TaskType: &avsproto.TaskNode_CustomCode{
+								CustomCode: &avsproto.CustomCodeNode{
+									Config: &avsproto.CustomCodeNode_Config{
+										Lang:   avsproto.Lang_JavaScript,
+										Source: "({ message: 'trigger data test' })",
+									},
+								},
+							},
+						},
+					}
+
+					trigger := &avsproto.TaskTrigger{
+						Id:   "testTrigger",
+						Name: "testTrigger",
+						Type: tt.triggerType,
+					}
+
+					edges := []*avsproto.TaskEdge{
+						{
+							Id:     "e1",
+							Source: trigger.Id,
+							Target: "testNode",
+						},
+					}
+
+					task := &model.Task{
+						Task: &avsproto.Task{
+							Id:      "test-task-" + tt.name + "-" + tc.name,
+							Nodes:   nodes,
+							Edges:   edges,
+							Trigger: trigger,
+						},
+					}
+
+					// Create executor
+					executor := NewExecutor(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
+
+					// Create queue execution data with the test trigger output
+					queueData := &QueueExecutionData{
+						TriggerType:   tt.triggerType,
+						TriggerOutput: tc.triggerOutput,
+						ExecutionID:   "test-exec-" + tt.name + "-" + tc.name,
+					}
+
+					// Run the task
+					execution, err := executor.RunTask(task, queueData)
+					if err != nil {
+						t.Fatalf("RunTask failed: %v", err)
+					}
+
+					if execution == nil {
+						t.Fatal("Execution is nil")
+					}
+
+					if len(execution.Steps) == 0 {
+						t.Fatal("No execution steps found")
+					}
+
+					// Find the trigger step (should be the first step)
+					var triggerStep *avsproto.Execution_Step
+					for _, step := range execution.Steps {
+						if step.Id == trigger.Id {
+							triggerStep = step
+							break
+						}
+					}
+
+					if triggerStep == nil {
+						t.Fatalf("Trigger step not found. Available steps: %v", getStepIds(execution.Steps))
+					}
+
+					// Verify that the trigger step has output data
+					if triggerStep.OutputData == nil {
+						t.Fatal("Trigger step OutputData is nil - the fix is not working")
+					}
+
+					// Verify the output data matches the trigger type and contains data
+					switch tt.triggerType {
+					case avsproto.TriggerType_TRIGGER_TYPE_MANUAL:
+						manualOutput := triggerStep.GetManualTrigger()
+						if manualOutput == nil {
+							t.Fatal("ManualTrigger output is nil")
+						}
+						if manualOutput.Data == nil {
+							t.Fatal("ManualTrigger data is nil")
+						}
+						verifyTriggerData(t, manualOutput.Data, "ManualTrigger")
+
+					case avsproto.TriggerType_TRIGGER_TYPE_FIXED_TIME:
+						fixedTimeOutput := triggerStep.GetFixedTimeTrigger()
+						if fixedTimeOutput == nil {
+							t.Fatal("FixedTimeTrigger output is nil")
+						}
+						if fixedTimeOutput.Data == nil {
+							t.Fatal("FixedTimeTrigger data is nil")
+						}
+						verifyTriggerData(t, fixedTimeOutput.Data, "FixedTimeTrigger")
+
+					case avsproto.TriggerType_TRIGGER_TYPE_CRON:
+						cronOutput := triggerStep.GetCronTrigger()
+						if cronOutput == nil {
+							t.Fatal("CronTrigger output is nil")
+						}
+						if cronOutput.Data == nil {
+							t.Fatal("CronTrigger data is nil")
+						}
+						verifyTriggerData(t, cronOutput.Data, "CronTrigger")
+
+					case avsproto.TriggerType_TRIGGER_TYPE_BLOCK:
+						blockOutput := triggerStep.GetBlockTrigger()
+						if blockOutput == nil {
+							t.Fatal("BlockTrigger output is nil")
+						}
+						if blockOutput.Data == nil {
+							t.Fatal("BlockTrigger data is nil")
+						}
+						verifyTriggerData(t, blockOutput.Data, "BlockTrigger")
+
+						// Special verification for BlockTrigger - check for block-specific fields
+						dataMap := convertStructValueToMap(blockOutput.Data)
+						if dataMap["blockNumber"] == nil {
+							t.Error("BlockTrigger data missing blockNumber field")
+						}
+						if dataMap["blockHash"] == nil {
+							t.Error("BlockTrigger data missing blockHash field")
+						}
+
+					case avsproto.TriggerType_TRIGGER_TYPE_EVENT:
+						eventOutput := triggerStep.GetEventTrigger()
+						if eventOutput == nil {
+							t.Fatal("EventTrigger output is nil")
+						}
+						if eventOutput.Data == nil {
+							t.Fatal("EventTrigger data is nil")
+						}
+						verifyTriggerData(t, eventOutput.Data, "EventTrigger")
+
+						// Special verification for EventTrigger - check for event-specific fields
+						dataMap := convertStructValueToMap(eventOutput.Data)
+						if dataMap["tokenSymbol"] == nil {
+							t.Error("EventTrigger data missing tokenSymbol field")
+						}
+						if dataMap["valueFormatted"] == nil {
+							t.Error("EventTrigger data missing valueFormatted field")
+						}
+
+					default:
+						t.Fatalf("Unknown trigger type: %v", tt.triggerType)
+					}
+
+					t.Logf("✅ %s %s: Trigger output data properly preserved", tt.name, tc.name)
+				})
+			}
+		})
+	}
+}
+
+// TestTriggerOutputDataJSONSerialization tests that trigger outputs survive JSON serialization
+// This simulates what happens when tasks go through the queue system
+func TestTriggerOutputDataJSONSerialization(t *testing.T) {
+	// Create sample BlockTrigger output
+	originalOutput := &avsproto.BlockTrigger_Output{
+		Data: createTestStructValue(map[string]interface{}{
+			"blockNumber": int64(18500000),
+			"timestamp":   time.Now().Unix(),
+		}),
+	}
+
+	queueData := &QueueExecutionData{
+		TriggerType:   avsproto.TriggerType_TRIGGER_TYPE_BLOCK,
+		TriggerOutput: originalOutput,
+		ExecutionID:   "test-serialization",
+	}
+
+	// Serialize to JSON (simulates queue storage)
+	jsonData, err := json.Marshal(queueData)
+	if err != nil {
+		t.Fatalf("JSON marshaling failed: %v", err)
+	}
+
+	// Deserialize from JSON (simulates queue retrieval)
+	var deserializedData QueueExecutionData
+	err = json.Unmarshal(jsonData, &deserializedData)
+	if err != nil {
+		t.Fatalf("JSON unmarshaling failed: %v", err)
+	}
+
+	// Verify that the deserialized output is now a map[string]interface{}
+	if mapOutput, ok := deserializedData.TriggerOutput.(map[string]interface{}); ok {
+		if mapOutput["data"] == nil {
+			t.Error("Deserialized trigger output missing data field")
+		}
+		t.Log("✅ JSON serialization converts protobuf to map as expected")
+	} else {
+		t.Errorf("Expected deserialized trigger output to be map[string]interface{}, got %T", deserializedData.TriggerOutput)
+	}
+}
+
+// Helper functions
+
+func createTestStructValue(data map[string]interface{}) *structpb.Value {
+	value, err := structpb.NewValue(data)
+	if err != nil {
+		panic(err)
+	}
+	return value
+}
+
+func verifyTriggerData(t *testing.T, data *structpb.Value, triggerType string) {
+	if data == nil {
+		t.Fatalf("%s data is nil", triggerType)
+	}
+
+	// Convert to map for easy verification
+	dataMap := convertStructValueToMap(data)
+	if len(dataMap) == 0 {
+		t.Errorf("%s data map is empty", triggerType)
+	}
+}
+
+func convertStructValueToMap(value *structpb.Value) map[string]interface{} {
+	if value == nil {
+		return nil
+	}
+
+	switch v := value.Kind.(type) {
+	case *structpb.Value_StructValue:
+		result := make(map[string]interface{})
+		for k, val := range v.StructValue.Fields {
+			result[k] = convertStructValueToInterface(val)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func convertStructValueToInterface(value *structpb.Value) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	switch v := value.Kind.(type) {
+	case *structpb.Value_StringValue:
+		return v.StringValue
+	case *structpb.Value_NumberValue:
+		return v.NumberValue
+	case *structpb.Value_BoolValue:
+		return v.BoolValue
+	case *structpb.Value_StructValue:
+		result := make(map[string]interface{})
+		for k, val := range v.StructValue.Fields {
+			result[k] = convertStructValueToInterface(val)
+		}
+		return result
+	case *structpb.Value_ListValue:
+		result := make([]interface{}, len(v.ListValue.Values))
+		for i, val := range v.ListValue.Values {
+			result[i] = convertStructValueToInterface(val)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func getStepIds(steps []*avsproto.Execution_Step) []string {
+	var ids []string
+	for _, step := range steps {
+		ids = append(ids, step.Id)
+	}
+	return ids
+}

--- a/operator/process_message.go
+++ b/operator/process_message.go
@@ -1,8 +1,47 @@
 package operator
 
 import (
+	"context"
+	"regexp"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
 	avspb "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
+
+// isValidTaskIDFormat validates that a string looks like a valid task ID
+// Task IDs are typically ULIDs or UUIDs with specific format constraints
+func isValidTaskIDFormat(id string) bool {
+	if id == "" {
+		return false
+	}
+
+	// Check for common task ID patterns:
+	// 1. ULID format (26 characters, base32)
+	// 2. UUID format (36 characters with hyphens)
+	// 3. Simple alphanumeric format (at least 8 characters)
+
+	// ULID pattern: 26 characters, base32 encoded
+	ulidPattern := regexp.MustCompile(`^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$`)
+	if ulidPattern.MatchString(id) {
+		return true
+	}
+
+	// UUID pattern: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+	uuidPattern := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	if uuidPattern.MatchString(id) {
+		return true
+	}
+
+	// Alphanumeric pattern: at least 8 characters, alphanumeric with optional hyphens/underscores
+	alphanumericPattern := regexp.MustCompile(`^[a-zA-Z0-9_-]{8,}$`)
+	if alphanumericPattern.MatchString(id) {
+		return true
+	}
+
+	return false
+}
 
 func (o *Operator) processMessage(resp *avspb.SyncMessagesResp) {
 	switch resp.Op {
@@ -13,6 +52,17 @@ func (o *Operator) processMessage(resp *avspb.SyncMessagesResp) {
 			taskID = resp.TaskMetadata.TaskId
 		} else {
 			// Fallback to using the message ID as task ID
+			o.logger.Warn("TaskMetadata missing, falling back to message ID as task ID",
+				"message_id", resp.Id,
+				"operation", resp.Op)
+
+			// Validate that the message ID looks like a valid task ID
+			if !isValidTaskIDFormat(resp.Id) {
+				o.logger.Error("Message ID does not appear to be a valid task ID format",
+					"message_id", resp.Id,
+					"operation", resp.Op)
+				return
+			}
 			taskID = resp.Id
 		}
 
@@ -20,5 +70,188 @@ func (o *Operator) processMessage(resp *avspb.SyncMessagesResp) {
 		o.eventTrigger.RemoveCheck(taskID)
 		o.blockTrigger.RemoveCheck(taskID)
 		o.timeTrigger.RemoveCheck(taskID)
+	case avspb.MessageOp_ImmediateTrigger:
+		// Get task ID from either TaskMetadata or message ID
+		var taskID string
+		if resp.TaskMetadata != nil {
+			taskID = resp.TaskMetadata.TaskId
+		} else {
+			// Fallback to using the message ID as task ID
+			o.logger.Warn("TaskMetadata missing, falling back to message ID as task ID",
+				"message_id", resp.Id,
+				"operation", resp.Op)
+
+			// Validate that the message ID looks like a valid task ID
+			if !isValidTaskIDFormat(resp.Id) {
+				o.logger.Error("Message ID does not appear to be a valid task ID format",
+					"message_id", resp.Id,
+					"operation", resp.Op)
+				return
+			}
+			taskID = resp.Id
+		}
+
+		o.logger.Info("processing immediate trigger request", "task_id", taskID)
+
+		// For immediate trigger, we need to know which trigger type to execute
+		// Check the task metadata to determine trigger type
+		if resp.TaskMetadata != nil && resp.TaskMetadata.Trigger != nil {
+			o.logger.Info("executing immediate trigger", "task_id", taskID)
+
+			// Execute the appropriate trigger type immediately
+			// Check the trigger type from the task metadata using the oneof field
+			if resp.TaskMetadata.Trigger.GetBlock() != nil {
+				o.executeImmediateBlockTrigger(taskID)
+			} else if resp.TaskMetadata.Trigger.GetCron() != nil {
+				o.executeImmediateTimeTrigger(taskID, avspb.TriggerType_TRIGGER_TYPE_CRON)
+			} else if resp.TaskMetadata.Trigger.GetFixedTime() != nil {
+				o.executeImmediateTimeTrigger(taskID, avspb.TriggerType_TRIGGER_TYPE_FIXED_TIME)
+			} else {
+				o.logger.Warn("unsupported immediate trigger type for task", "task_id", taskID)
+			}
+		} else {
+			o.logger.Warn("immediate trigger request missing metadata", "task_id", taskID)
+		}
+	}
+}
+
+// executeImmediateBlockTrigger executes a block trigger immediately with current block data
+func (o *Operator) executeImmediateBlockTrigger(taskID string) {
+	// Create context with timeout to avoid hanging on slow RPC endpoints
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Use shared targetEthClient instead of creating new connection
+	if o.targetEthClient == nil {
+		o.logger.Error("Target RPC client not available for immediate block trigger",
+			"task_id", taskID)
+		return
+	}
+
+	// Get current block header with timeout context
+	header, err := o.targetEthClient.HeaderByNumber(ctx, nil) // nil means latest block
+	if err != nil {
+		o.logger.Error("Failed to get current block header for immediate trigger",
+			"task_id", taskID,
+			"error", err)
+		return
+	}
+
+	blockNumber := header.Number.Uint64()
+
+	// Create block data similar to normal block trigger processing
+	blockData := map[string]interface{}{
+		"blockNumber": blockNumber,
+		"blockHash":   header.Hash().Hex(),
+		"timestamp":   header.Time,
+		"parentHash":  header.ParentHash.Hex(),
+		"difficulty":  header.Difficulty.String(),
+		"gasLimit":    header.GasLimit,
+		"gasUsed":     header.GasUsed,
+	}
+
+	o.logger.Info("🚀 Executing immediate block trigger",
+		"task_id", taskID,
+		"block_number", blockNumber,
+		"block_hash", header.Hash().Hex(),
+		"timestamp", header.Time)
+
+	// Send trigger notification to aggregator
+	if resp, err := o.nodeRpcClient.NotifyTriggers(ctx, &avspb.NotifyTriggersReq{
+		Address:     o.config.OperatorAddress,
+		Signature:   "pending",
+		TaskId:      taskID,
+		TriggerType: avspb.TriggerType_TRIGGER_TYPE_BLOCK,
+		TriggerOutput: &avspb.NotifyTriggersReq_BlockTrigger{
+			BlockTrigger: &avspb.BlockTrigger_Output{
+				Data: func() *structpb.Value {
+					dataValue, _ := structpb.NewValue(blockData)
+					return dataValue
+				}(),
+			},
+		},
+	}); err == nil {
+		o.logger.Info("✅ Successfully executed immediate block trigger",
+			"task_id", taskID,
+			"block_number", blockNumber,
+			"remaining_executions", resp.RemainingExecutions,
+			"task_still_active", resp.TaskStillActive,
+			"status", resp.Status)
+	} else {
+		o.logger.Error("❌ Failed to execute immediate block trigger",
+			"task_id", taskID,
+			"block_number", blockNumber,
+			"error", err)
+	}
+}
+
+// executeImmediateTimeTrigger executes a time/cron trigger immediately
+func (o *Operator) executeImmediateTimeTrigger(taskID string, triggerType avspb.TriggerType) {
+	// Create context with timeout to avoid hanging on slow aggregator endpoints
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Get current timestamp in nanoseconds
+	currentTime := time.Now()
+	timestampNanos := uint64(currentTime.UnixNano())
+
+	timeData := map[string]interface{}{
+		"timestamp":    timestampNanos,
+		"timestampIso": currentTime.UTC().Format("2006-01-02T15:04:05.000Z"),
+	}
+
+	o.logger.Info("🚀 Executing immediate time trigger",
+		"task_id", taskID,
+		"trigger_type", triggerType.String(),
+		"timestamp", timestampNanos,
+		"timestamp_iso", currentTime.UTC().Format("2006-01-02T15:04:05.000Z"))
+
+	// Create the NotifyTriggersReq with appropriate trigger output based on the trigger type
+	var notifyReq *avspb.NotifyTriggersReq
+	if triggerType == avspb.TriggerType_TRIGGER_TYPE_CRON {
+		notifyReq = &avspb.NotifyTriggersReq{
+			Address:     o.config.OperatorAddress,
+			Signature:   "pending",
+			TaskId:      taskID,
+			TriggerType: triggerType,
+			TriggerOutput: &avspb.NotifyTriggersReq_CronTrigger{
+				CronTrigger: &avspb.CronTrigger_Output{
+					Data: func() *structpb.Value {
+						dataValue, _ := structpb.NewValue(timeData)
+						return dataValue
+					}(),
+				},
+			},
+		}
+	} else {
+		notifyReq = &avspb.NotifyTriggersReq{
+			Address:     o.config.OperatorAddress,
+			Signature:   "pending",
+			TaskId:      taskID,
+			TriggerType: triggerType,
+			TriggerOutput: &avspb.NotifyTriggersReq_FixedTimeTrigger{
+				FixedTimeTrigger: &avspb.FixedTimeTrigger_Output{
+					Data: func() *structpb.Value {
+						dataValue, _ := structpb.NewValue(timeData)
+						return dataValue
+					}(),
+				},
+			},
+		}
+	}
+
+	// Send trigger notification to aggregator
+	if resp, err := o.nodeRpcClient.NotifyTriggers(ctx, notifyReq); err == nil {
+		o.logger.Info("✅ Successfully executed immediate time trigger",
+			"task_id", taskID,
+			"timestamp", timestampNanos,
+			"remaining_executions", resp.RemainingExecutions,
+			"task_still_active", resp.TaskStillActive,
+			"status", resp.Status)
+	} else {
+		o.logger.Error("❌ Failed to execute immediate time trigger",
+			"task_id", taskID,
+			"timestamp", timestampNanos,
+			"error", err)
 	}
 }

--- a/operator/worker_loop.go
+++ b/operator/worker_loop.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"runtime/debug"
 	"sort"
@@ -278,6 +279,45 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 			}
 			blockTasksMutex.Unlock()
 
+			// Fetch real block data from RPC to match runBlockTriggerImmediately behavior
+			blockData := map[string]interface{}{
+				"blockNumber": uint64(triggerItem.Marker),
+				"blockHash":   "",
+				"timestamp":   uint64(0),
+				"parentHash":  "",
+				"difficulty":  "",
+				"gasLimit":    uint64(0),
+				"gasUsed":     uint64(0),
+			}
+
+			// Try to fetch full block data from RPC using shared targetEthClient
+			if o.targetEthClient != nil {
+				if header, err := o.targetEthClient.HeaderByNumber(ctx, big.NewInt(triggerItem.Marker)); err == nil {
+					// Populate with real blockchain data
+					blockData["blockHash"] = header.Hash().Hex()
+					blockData["timestamp"] = header.Time
+					blockData["parentHash"] = header.ParentHash.Hex()
+					blockData["difficulty"] = header.Difficulty.String()
+					blockData["gasLimit"] = header.GasLimit
+					blockData["gasUsed"] = header.GasUsed
+
+					o.logger.Debug("✅ Fetched real block data for trigger",
+						"task_id", triggerItem.TaskID,
+						"block_number", triggerItem.Marker,
+						"block_hash", header.Hash().Hex(),
+						"timestamp", header.Time)
+				} else {
+					o.logger.Warn("⚠️ Failed to fetch block header, using minimal block data",
+						"task_id", triggerItem.TaskID,
+						"block_number", triggerItem.Marker,
+						"error", err)
+				}
+			} else {
+				o.logger.Warn("⚠️ Target RPC client not available, using minimal block data",
+					"task_id", triggerItem.TaskID,
+					"block_number", triggerItem.Marker)
+			}
+
 			if resp, err := o.nodeRpcClient.NotifyTriggers(ctx, &avspb.NotifyTriggersReq{
 				Address:     o.config.OperatorAddress,
 				Signature:   "pending",
@@ -286,15 +326,6 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 				TriggerOutput: &avspb.NotifyTriggersReq_BlockTrigger{
 					BlockTrigger: &avspb.BlockTrigger_Output{
 						Data: func() *structpb.Value {
-							blockData := map[string]interface{}{
-								"blockNumber": uint64(triggerItem.Marker),
-								"blockHash":   "",
-								"timestamp":   0,
-								"parentHash":  "",
-								"difficulty":  "",
-								"gasLimit":    0,
-								"gasUsed":     0,
-							}
 							dataValue, _ := structpb.NewValue(blockData)
 							return dataValue
 						}(),

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -419,7 +419,7 @@ type TaskStatus int32
 
 const (
 	TaskStatus_Active TaskStatus = 0
-	// Task is completed when it reaches its max_execution or its expiration time
+	// Task is completed when it reaches its max_execution count or its expiration time
 	TaskStatus_Completed TaskStatus = 1
 	TaskStatus_Failed    TaskStatus = 2
 	TaskStatus_Canceled  TaskStatus = 3

--- a/protobuf/node.pb.go
+++ b/protobuf/node.pb.go
@@ -31,6 +31,7 @@ const (
 	MessageOp_CancelTask         MessageOp = 2
 	MessageOp_DeleteTask         MessageOp = 3
 	MessageOp_CompletedTask      MessageOp = 4
+	MessageOp_ImmediateTrigger   MessageOp = 5
 )
 
 // Enum value maps for MessageOp.
@@ -41,6 +42,7 @@ var (
 		2: "CancelTask",
 		3: "DeleteTask",
 		4: "CompletedTask",
+		5: "ImmediateTrigger",
 	}
 	MessageOp_value = map[string]int32{
 		"Unset":              0,
@@ -48,6 +50,7 @@ var (
 		"CancelTask":         2,
 		"DeleteTask":         3,
 		"CompletedTask":      4,
+		"ImmediateTrigger":   5,
 	}
 )
 
@@ -1207,7 +1210,7 @@ const file_node_proto_rawDesc = "" +
 	"\x13HealthCheckResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1c\n" +
-	"\ttimestamp\x18\x03 \x01(\x04R\ttimestamp*a\n" +
+	"\ttimestamp\x18\x03 \x01(\x04R\ttimestamp*w\n" +
 	"\tMessageOp\x12\t\n" +
 	"\x05Unset\x10\x00\x12\x16\n" +
 	"\x12MonitorTaskTrigger\x10\x01\x12\x0e\n" +
@@ -1215,7 +1218,8 @@ const file_node_proto_rawDesc = "" +
 	"CancelTask\x10\x02\x12\x0e\n" +
 	"\n" +
 	"DeleteTask\x10\x03\x12\x11\n" +
-	"\rCompletedTask\x10\x042\xcc\x03\n" +
+	"\rCompletedTask\x10\x04\x12\x14\n" +
+	"\x10ImmediateTrigger\x10\x052\xcc\x03\n" +
 	"\x04Node\x12P\n" +
 	"\vHealthCheck\x12\x1e.aggregator.HealthCheckRequest\x1a\x1f.aggregator.HealthCheckResponse\"\x00\x126\n" +
 	"\x04Ping\x12\x13.aggregator.Checkin\x1a\x17.aggregator.CheckinResp\"\x00\x12M\n" +

--- a/protobuf/node.proto
+++ b/protobuf/node.proto
@@ -53,6 +53,7 @@ enum MessageOp {
   CancelTask         = 2;
   DeleteTask         = 3;
   CompletedTask      = 4;
+  ImmediateTrigger   = 5;
 }
 
 message SyncMessagesResp {


### PR DESCRIPTION
This pull request implements immediate execution for manual block triggers, ensuring that manual trigger requests use real blockchain data instead of placeholder values. It introduces a new message type for operator communication, updates both aggregator and operator logic to support this workflow, and refactors trigger output handling for better code reuse and reliability.

**Manual Block Trigger Immediate Execution**

- Added a new `ImmediateTrigger` message operation in the protobuf definitions to support instructing operators to execute triggers immediately with current block or time data.
- Enhanced the aggregator (`core/taskengine/engine.go`) to detect manual block trigger requests and send immediate trigger instructions to all connected operators, including fetching the current block number from the RPC connection. [[1]](diffhunk://#diff-77494b7116e328f80878e42128327bd124ab4ef1d7394c1d51109a5a5e93c4bcR1822-R1866) [[2]](diffhunk://#diff-77494b7116e328f80878e42128327bd124ab4ef1d7394c1d51109a5a5e93c4bcL1843-R1917)

**Operator-Side Trigger Handling**

- Updated the operator (`operator/process_message.go`) to handle the new `ImmediateTrigger` operation, determine the correct trigger type, and immediately fetch and send real blockchain or time data back to the aggregator. [[1]](diffhunk://#diff-fff66407854db28a9c82c7c764152c0d336b787830bbb1cc6253d0a1802054e2R4-R45) [[2]](diffhunk://#diff-fff66407854db28a9c82c7c764152c0d336b787830bbb1cc6253d0a1802054e2R55-R255)
- Added a dedicated target chain RPC client in the operator for trigger operations, ensuring that immediate triggers use the correct blockchain endpoint. [[1]](diffhunk://#diff-d21e1c7806e4af8743415c580c1e500c84c857641ea3b577dd8af7922a8b94d6R129-R130) [[2]](diffhunk://#diff-d21e1c7806e4af8743415c580c1e500c84c857641ea3b577dd8af7922a8b94d6R335-R348) [[3]](diffhunk://#diff-d21e1c7806e4af8743415c580c1e500c84c857641ea3b577dd8af7922a8b94d6R484)

**Refactoring and Reliability Improvements**

- Introduced a helper function in `core/taskengine/executor.go` to reconstruct trigger output data from JSON-decoded maps, reducing code duplication and improving reliability across all trigger types. [[1]](diffhunk://#diff-4b8efce1f8432755ee174fa18c454f2ee713f11d0fba1e5662ebc1058903cef0R26-R60) [[2]](diffhunk://#diff-4b8efce1f8432755ee174fa18c454f2ee713f11d0fba1e5662ebc1058903cef0L351-R420)

**Other**

- Minor script update for Bash 3.2 compatibility in `.github/scripts/promote-and-publish.sh`.

These changes collectively ensure that manual triggers are now executed with real, current blockchain data, improving the accuracy and reliability of workflows that depend on manual intervention.