### PR TITLE
fix: add input variables support for workflow definitions

### DIFF
--- a/core/taskengine/input_variables_test.go
+++ b/core/taskengine/input_variables_test.go
@@ -1,0 +1,588 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestInputVariables_SimulateTask tests input variables functionality in SimulateTask
+func TestInputVariables_SimulateTask(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+	user := testutil.TestUser1()
+
+	// Create input variables
+	inputVariables := map[string]interface{}{
+		"userToken": "0x1234567890abcdef",
+		"amount":    1000000,
+		"recipient": "0xabcdef1234567890",
+		"isEnabled": true,
+		"config": map[string]interface{}{
+			"slippage": 0.5,
+			"gasLimit": 200000,
+		},
+		"tokenList": []interface{}{"USDC", "USDT", "DAI"},
+	}
+
+	// Create nodes that reference input variables
+	nodes := []*avsproto.TaskNode{
+		{
+			Id:   "customcode1",
+			Name: "testInputVariables",
+			Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{
+						// JavaScript code that uses input variables
+						Source: `
+							// Test basic variable access
+							const token = userToken;
+							const amt = amount;
+							const recip = recipient;
+							const enabled = isEnabled;
+							
+							// Test object access
+							const slippage = config.slippage;
+							const gas = config.gasLimit;
+							
+							// Test array access
+							const firstToken = tokenList[0];
+							const tokenCount = tokenList.length;
+							
+							return {
+								token: token,
+								amount: amt,
+								recipient: recip,
+								enabled: enabled,
+								slippage: slippage,
+								gasLimit: gas,
+								firstToken: firstToken,
+								tokenCount: tokenCount,
+								message: "Input variables work!"
+							};
+						`,
+					},
+				},
+			},
+		},
+	}
+
+	trigger := &avsproto.TaskTrigger{
+		Id:   "trigger1",
+		Name: "manualTrigger",
+		Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+		TriggerType: &avsproto.TaskTrigger_Manual{
+			Manual: &avsproto.ManualTrigger{
+				Config: &avsproto.ManualTrigger_Config{
+					Data: func() *structpb.Value {
+						data, _ := structpb.NewValue(map[string]interface{}{
+							"test": "data",
+						})
+						return data
+					}(),
+				},
+			},
+		},
+	}
+
+	edges := []*avsproto.TaskEdge{
+		{
+			Id:     "edge1",
+			Source: "trigger1",
+			Target: "customcode1",
+		},
+	}
+
+	// Execute SimulateTask with input variables
+	execution, err := engine.SimulateTask(user, trigger, nodes, edges, inputVariables)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	// Verify execution was successful
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS, execution.Status)
+	assert.Empty(t, execution.Error)
+	assert.Len(t, execution.Steps, 2) // trigger + custom code node
+
+	// Find the custom code step
+	var customCodeStep *avsproto.Execution_Step
+	for _, step := range execution.Steps {
+		if step.Name == "testInputVariables" {
+			customCodeStep = step
+			break
+		}
+	}
+	require.NotNil(t, customCodeStep, "Custom code step not found")
+
+	// Verify the step was successful
+	assert.True(t, customCodeStep.Success)
+	assert.Empty(t, customCodeStep.Error)
+
+	// Verify the output contains expected values from input variables
+	require.NotNil(t, customCodeStep.GetCustomCode())
+	require.NotNil(t, customCodeStep.GetCustomCode().Data)
+
+	// Convert output to map for easier verification
+	outputInterface := customCodeStep.GetCustomCode().Data.AsInterface()
+	outputMap, ok := outputInterface.(map[string]interface{})
+	require.True(t, ok, "Expected output to be a map")
+	require.NotNil(t, outputMap)
+
+	// Verify all input variables were accessible
+	assert.Equal(t, "0x1234567890abcdef", outputMap["token"])
+	assert.Equal(t, float64(1000000), outputMap["amount"]) // JSON numbers are float64
+	assert.Equal(t, "0xabcdef1234567890", outputMap["recipient"])
+	assert.Equal(t, true, outputMap["enabled"])
+	assert.Equal(t, 0.5, outputMap["slippage"])
+	assert.Equal(t, float64(200000), outputMap["gasLimit"])
+	assert.Equal(t, "USDC", outputMap["firstToken"])
+	assert.Equal(t, float64(3), outputMap["tokenCount"])
+	assert.Equal(t, "Input variables work!", outputMap["message"])
+
+	t.Logf("✅ SimulateTask with input variables completed successfully")
+}
+
+// TestInputVariables_DeployedTask tests input variables functionality in deployed task execution
+func TestInputVariables_DeployedTask(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	executor := NewExecutor(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
+
+	// Create input variables using protobuf Values (as they would be stored)
+	inputVarsProto := make(map[string]*structpb.Value)
+
+	// Basic types
+	userTokenValue, _ := structpb.NewValue("0x1234567890abcdef")
+	inputVarsProto["userToken"] = userTokenValue
+
+	amountValue, _ := structpb.NewValue(1000000)
+	inputVarsProto["amount"] = amountValue
+
+	recipientValue, _ := structpb.NewValue("0xabcdef1234567890")
+	inputVarsProto["recipient"] = recipientValue
+
+	isEnabledValue, _ := structpb.NewValue(true)
+	inputVarsProto["isEnabled"] = isEnabledValue
+
+	// Complex object
+	configObj := map[string]interface{}{
+		"slippage": 0.5,
+		"gasLimit": 200000,
+	}
+	configValue, _ := structpb.NewValue(configObj)
+	inputVarsProto["config"] = configValue
+
+	// Array
+	tokenList := []interface{}{"USDC", "USDT", "DAI"}
+	tokenListValue, _ := structpb.NewValue(tokenList)
+	inputVarsProto["tokenList"] = tokenListValue
+
+	// Create a task with input variables
+	task := &model.Task{
+		Task: &avsproto.Task{
+			Id:             "test-task-input-vars",
+			Owner:          "", // Empty owner to skip wallet validation
+			Status:         avsproto.TaskStatus_Active,
+			Name:           "Test Input Variables",
+			ExecutionCount: 0,
+			InputVariables: inputVarsProto, // Store input variables with the task
+			Trigger: &avsproto.TaskTrigger{
+				Id:   "trigger1",
+				Name: "manualTrigger",
+				Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+				TriggerType: &avsproto.TaskTrigger_Manual{
+					Manual: &avsproto.ManualTrigger{
+						Config: &avsproto.ManualTrigger_Config{},
+					},
+				},
+			},
+			Nodes: []*avsproto.TaskNode{
+				{
+					Id:   "customcode1",
+					Name: "testInputVariables",
+					Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+					TaskType: &avsproto.TaskNode_CustomCode{
+						CustomCode: &avsproto.CustomCodeNode{
+							Config: &avsproto.CustomCodeNode_Config{
+								// JavaScript code that uses input variables
+								Source: `
+									// Test basic variable access
+									const token = userToken;
+									const amt = amount;
+									const recip = recipient;
+									const enabled = isEnabled;
+									
+									// Test object access
+									const slippage = config.slippage;
+									const gas = config.gasLimit;
+									
+									// Test array access
+									const firstToken = tokenList[0];
+									const tokenCount = tokenList.length;
+									
+									return {
+										token: token,
+										amount: amt,
+										recipient: recip,
+										enabled: enabled,
+										slippage: slippage,
+										gasLimit: gas,
+										firstToken: firstToken,
+										tokenCount: tokenCount,
+										message: "Deployed task input variables work!",
+										executionType: "deployed"
+									};
+								`,
+							},
+						},
+					},
+				},
+			},
+			Edges: []*avsproto.TaskEdge{
+				{
+					Id:     "edge1",
+					Source: "trigger1",
+					Target: "customcode1",
+				},
+			},
+		},
+	}
+
+	// Execute the deployed task
+	executionId := ulid.Make().String()
+	queueData := &QueueExecutionData{
+		ExecutionID:   executionId,
+		TriggerType:   avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+		TriggerOutput: &avsproto.ManualTrigger_Output{},
+	}
+
+	execution, err := executor.RunTask(task, queueData)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	// Verify execution was successful
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS, execution.Status)
+	assert.Empty(t, execution.Error)
+	assert.Len(t, execution.Steps, 2) // trigger + custom code node
+
+	// Find the custom code step
+	var customCodeStep *avsproto.Execution_Step
+	for _, step := range execution.Steps {
+		if step.Name == "testInputVariables" {
+			customCodeStep = step
+			break
+		}
+	}
+	require.NotNil(t, customCodeStep, "Custom code step not found")
+
+	// Verify the step was successful
+	assert.True(t, customCodeStep.Success)
+	assert.Empty(t, customCodeStep.Error)
+
+	// Verify the output contains expected values from input variables
+	require.NotNil(t, customCodeStep.GetCustomCode())
+	require.NotNil(t, customCodeStep.GetCustomCode().Data)
+
+	// Convert output to map for easier verification
+	outputInterface := customCodeStep.GetCustomCode().Data.AsInterface()
+	outputMap, ok := outputInterface.(map[string]interface{})
+	require.True(t, ok, "Expected output to be a map")
+	require.NotNil(t, outputMap)
+
+	// Verify all input variables were accessible
+	assert.Equal(t, "0x1234567890abcdef", outputMap["token"])
+	assert.Equal(t, float64(1000000), outputMap["amount"]) // JSON numbers are float64
+	assert.Equal(t, "0xabcdef1234567890", outputMap["recipient"])
+	assert.Equal(t, true, outputMap["enabled"])
+	assert.Equal(t, 0.5, outputMap["slippage"])
+	assert.Equal(t, float64(200000), outputMap["gasLimit"])
+	assert.Equal(t, "USDC", outputMap["firstToken"])
+	assert.Equal(t, float64(3), outputMap["tokenCount"])
+	assert.Equal(t, "Deployed task input variables work!", outputMap["message"])
+	assert.Equal(t, "deployed", outputMap["executionType"])
+
+	t.Logf("✅ Deployed task with input variables completed successfully")
+}
+
+// TestInputVariables_CreateTask tests input variables in task creation
+func TestInputVariables_CreateTask(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+	user := testutil.TestUser1()
+
+	// Create input variables using protobuf Values
+	inputVarsProto := make(map[string]*structpb.Value)
+
+	userTokenValue, _ := structpb.NewValue("0x1234567890abcdef")
+	inputVarsProto["userToken"] = userTokenValue
+
+	amountValue, _ := structpb.NewValue(1000000)
+	inputVarsProto["amount"] = amountValue
+
+	// Create a CreateTaskReq with input variables
+	createReq := &avsproto.CreateTaskReq{
+		Trigger: &avsproto.TaskTrigger{
+			Id:   "trigger1",
+			Name: "manualTrigger",
+			Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+			TriggerType: &avsproto.TaskTrigger_Manual{
+				Manual: &avsproto.ManualTrigger{
+					Config: &avsproto.ManualTrigger_Config{},
+				},
+			},
+		},
+		Nodes: []*avsproto.TaskNode{
+			{
+				Id:   "customcode1",
+				Name: "testNode",
+				Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+				TaskType: &avsproto.TaskNode_CustomCode{
+					CustomCode: &avsproto.CustomCodeNode{
+						Config: &avsproto.CustomCodeNode_Config{
+							Source: "return { token: userToken, amount: amount };",
+						},
+					},
+				},
+			},
+		},
+		Edges: []*avsproto.TaskEdge{
+			{
+				Id:     "edge1",
+				Source: "trigger1",
+				Target: "customcode1",
+			},
+		},
+		Name:           "Test Task with Input Variables",
+		MaxExecution:   10,
+		InputVariables: inputVarsProto, // Include input variables in creation request
+	}
+
+	// Create the task
+	task, err := engine.CreateTask(user, createReq)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+
+	// Verify input variables were stored with the task
+	assert.NotNil(t, task.InputVariables)
+	assert.Len(t, task.InputVariables, 2)
+
+	// Verify the values were stored correctly
+	storedToken := task.InputVariables["userToken"]
+	require.NotNil(t, storedToken)
+	assert.Equal(t, "0x1234567890abcdef", storedToken.AsInterface())
+
+	storedAmount := task.InputVariables["amount"]
+	require.NotNil(t, storedAmount)
+	assert.Equal(t, float64(1000000), storedAmount.AsInterface())
+
+	t.Logf("✅ Task creation with input variables completed successfully")
+	t.Logf("Task ID: %s", task.Id)
+	t.Logf("Input variables stored: %d", len(task.InputVariables))
+}
+
+// TestInputVariables_TemplateResolution tests that input variables are properly resolved in templates
+func TestInputVariables_TemplateResolution(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+	user := testutil.TestUser1()
+
+	// Create input variables with template-style usage
+	inputVariables := map[string]interface{}{
+		"contractAddress": "0x1234567890abcdef",
+		"methodName":      "transfer",
+		"recipient":       "0xabcdef1234567890",
+		"amount":          "1000000000000000000", // 1 ETH in wei
+	}
+
+	// Create a custom code node that uses template-style variable access
+	nodes := []*avsproto.TaskNode{
+		{
+			Id:   "template_test",
+			Name: "templateTest",
+			Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{
+						// Test that variables are available for template resolution
+						Source: `
+							// Variables should be directly accessible
+							if (typeof contractAddress === 'undefined') {
+								throw new Error('contractAddress not available');
+							}
+							if (typeof methodName === 'undefined') {
+								throw new Error('methodName not available');
+							}
+							if (typeof recipient === 'undefined') {
+								throw new Error('recipient not available');
+							}
+							if (typeof amount === 'undefined') {
+								throw new Error('amount not available');
+							}
+							
+							return {
+								contract: contractAddress,
+								method: methodName,
+								to: recipient,
+								value: amount,
+								templateResolution: true
+							};
+						`,
+					},
+				},
+			},
+		},
+	}
+
+	trigger := &avsproto.TaskTrigger{
+		Id:   "trigger1",
+		Name: "manualTrigger",
+		Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+		TriggerType: &avsproto.TaskTrigger_Manual{
+			Manual: &avsproto.ManualTrigger{
+				Config: &avsproto.ManualTrigger_Config{
+					Data: func() *structpb.Value {
+						data, _ := structpb.NewValue(map[string]interface{}{
+							"test": "data",
+						})
+						return data
+					}(),
+				},
+			},
+		},
+	}
+
+	edges := []*avsproto.TaskEdge{
+		{
+			Id:     "edge1",
+			Source: "trigger1",
+			Target: "template_test",
+		},
+	}
+
+	// Execute SimulateTask
+	execution, err := engine.SimulateTask(user, trigger, nodes, edges, inputVariables)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	// Verify execution was successful
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS, execution.Status)
+	assert.Empty(t, execution.Error)
+
+	// Find the template test step
+	var templateStep *avsproto.Execution_Step
+	for _, step := range execution.Steps {
+		if step.Name == "templateTest" {
+			templateStep = step
+			break
+		}
+	}
+	require.NotNil(t, templateStep, "Template test step not found")
+
+	// Verify the step was successful (no undefined variable errors)
+	assert.True(t, templateStep.Success)
+	assert.Empty(t, templateStep.Error)
+
+	// Verify the output contains resolved template values
+	require.NotNil(t, templateStep.GetCustomCode())
+	require.NotNil(t, templateStep.GetCustomCode().Data)
+	outputInterface := templateStep.GetCustomCode().Data.AsInterface()
+	outputMap, ok := outputInterface.(map[string]interface{})
+	require.True(t, ok, "Expected output to be a map")
+	require.NotNil(t, outputMap)
+
+	assert.Equal(t, "0x1234567890abcdef", outputMap["contract"])
+	assert.Equal(t, "transfer", outputMap["method"])
+	assert.Equal(t, "0xabcdef1234567890", outputMap["to"])
+	assert.Equal(t, "1000000000000000000", outputMap["value"])
+	assert.Equal(t, true, outputMap["templateResolution"])
+
+	t.Logf("✅ Template resolution with input variables completed successfully")
+}
+
+// TestInputVariables_EmptyInputVariables tests behavior when no input variables are provided
+func TestInputVariables_EmptyInputVariables(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+	user := testutil.TestUser1()
+
+	// No input variables provided
+	var inputVariables map[string]interface{}
+
+	nodes := []*avsproto.TaskNode{
+		{
+			Id:   "customcode1",
+			Name: "testEmpty",
+			Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{
+						Source: `
+							// Should work without input variables
+							return {
+								message: "No input variables needed",
+								success: true
+							};
+						`,
+					},
+				},
+			},
+		},
+	}
+
+	trigger := &avsproto.TaskTrigger{
+		Id:   "trigger1",
+		Name: "manualTrigger",
+		Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+		TriggerType: &avsproto.TaskTrigger_Manual{
+			Manual: &avsproto.ManualTrigger{
+				Config: &avsproto.ManualTrigger_Config{
+					Data: func() *structpb.Value {
+						data, _ := structpb.NewValue(map[string]interface{}{
+							"test": "data",
+						})
+						return data
+					}(),
+				},
+			},
+		},
+	}
+
+	edges := []*avsproto.TaskEdge{
+		{
+			Id:     "edge1",
+			Source: "trigger1",
+			Target: "customcode1",
+		},
+	}
+
+	// Execute SimulateTask with no input variables
+	execution, err := engine.SimulateTask(user, trigger, nodes, edges, inputVariables)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	// Verify execution was successful even without input variables
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS, execution.Status)
+	assert.Empty(t, execution.Error)
+
+	t.Logf("✅ Empty input variables test completed successfully")
+}

--- a/core/taskengine/input_variables_usage_examples_test.go
+++ b/core/taskengine/input_variables_usage_examples_test.go
@@ -1,0 +1,233 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestInputVariables_UsageExamples demonstrates exactly how to reference input variables in nodes
+func TestInputVariables_UsageExamples(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+	user := testutil.TestUser1()
+
+	// Define input variables that will be used in nodes
+	inputVariables := map[string]interface{}{
+		// Simple variables
+		"tokenContract": "0xA0b86a33E6441e4EF45bAcfCaAd5C7f899342E38",
+		"recipient":     "0x742d35Cc6634C0532925a3b8D2C0e3e0C8C8E1c7",
+		"amount":        "1000000", // 1 USDC (6 decimals)
+		"gasLimit":      200000,
+
+		// Complex object
+		"swapConfig": map[string]interface{}{
+			"routerAddress": "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
+			"amountIn":      "1000000000000000000", // 1 ETH
+			"amountOutMin":  "0",
+			"path":          []interface{}{"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "0xA0b86a33E6441e4EF45bAcfCaAd5C7f899342E38"},
+		},
+
+		// User configuration
+		"userConfig": map[string]interface{}{
+			"slippage": 0.5,
+			"deadline": 1703123400,
+		},
+	}
+
+	// Create nodes that demonstrate how to reference input variables
+	nodes := []*avsproto.TaskNode{
+		{
+			Id:   "example_node",
+			Name: "inputVariableExamples",
+			Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{
+						Source: `
+							// ==========================================
+							// HOW TO REFERENCE INPUT VARIABLES IN NODES
+							// ==========================================
+							
+							// 1. Simple variable access
+							// Input: "tokenContract": "0xA0b86a33E6441e4EF45bAcfCaAd5C7f899342E38"
+							// Usage: tokenContract
+							const contract = tokenContract;
+							
+							// 2. Simple variable access (other types)
+							// Input: "amount": "1000000"
+							// Usage: amount
+							const transferAmount = amount;
+							
+							// Input: "gasLimit": 200000
+							// Usage: gasLimit  
+							const gas = gasLimit;
+							
+							// 3. Object property access
+							// Input: "swapConfig": { "routerAddress": "0x...", "amountIn": "1000..." }
+							// Usage: swapConfig.routerAddress, swapConfig.amountIn
+							const router = swapConfig.routerAddress;
+							const amountIn = swapConfig.amountIn;
+							const amountOut = swapConfig.amountOutMin;
+							
+							// 4. Array access
+							// Input: "swapConfig": { "path": ["0x...", "0x..."] }
+							// Usage: swapConfig.path[0], swapConfig.path[1]
+							const tokenA = swapConfig.path[0];
+							const tokenB = swapConfig.path[1];
+							const pathLength = swapConfig.path.length;
+							
+							// 5. Nested object access
+							// Input: "userConfig": { "slippage": 0.5, "deadline": 1703123400 }
+							// Usage: userConfig.slippage, userConfig.deadline
+							const slippageTolerance = userConfig.slippage;
+							const transactionDeadline = userConfig.deadline;
+							
+							// Return all accessed variables for verification
+							return {
+								// Simple variables
+								contract: contract,
+								recipient: recipient,
+								amount: transferAmount,
+								gasLimit: gas,
+								
+								// Object properties
+								routerAddress: router,
+								amountIn: amountIn,
+								amountOutMin: amountOut,
+								
+								// Array elements
+								firstToken: tokenA,
+								secondToken: tokenB,
+								pathLength: pathLength,
+								
+								// Nested object properties
+								slippage: slippageTolerance,
+								deadline: transactionDeadline,
+								
+								// Verification message
+								message: "All input variables accessed successfully!"
+							};
+						`,
+					},
+				},
+			},
+		},
+	}
+
+	trigger := &avsproto.TaskTrigger{
+		Id:   "trigger1",
+		Name: "manualTrigger",
+		Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+		TriggerType: &avsproto.TaskTrigger_Manual{
+			Manual: &avsproto.ManualTrigger{
+				Config: &avsproto.ManualTrigger_Config{
+					Data: func() *structpb.Value {
+						data, _ := structpb.NewValue(map[string]interface{}{
+							"test": "data",
+						})
+						return data
+					}(),
+				},
+			},
+		},
+	}
+
+	edges := []*avsproto.TaskEdge{
+		{
+			Id:     "edge1",
+			Source: "trigger1",
+			Target: "example_node",
+		},
+	}
+
+	// Execute SimulateTask with input variables
+	execution, err := engine.SimulateTask(user, trigger, nodes, edges, inputVariables)
+	require.NoError(t, err)
+	require.NotNil(t, execution)
+
+	// Verify execution was successful
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS, execution.Status)
+	assert.Empty(t, execution.Error)
+
+	// Find the example step
+	var exampleStep *avsproto.Execution_Step
+	for _, step := range execution.Steps {
+		if step.Name == "inputVariableExamples" {
+			exampleStep = step
+			break
+		}
+	}
+	require.NotNil(t, exampleStep, "Example step not found")
+
+	// Verify the step was successful
+	assert.True(t, exampleStep.Success)
+	assert.Empty(t, exampleStep.Error)
+
+	// Verify the output contains all expected values
+	require.NotNil(t, exampleStep.GetCustomCode())
+	require.NotNil(t, exampleStep.GetCustomCode().Data)
+
+	outputInterface := exampleStep.GetCustomCode().Data.AsInterface()
+	outputMap, ok := outputInterface.(map[string]interface{})
+	require.True(t, ok, "Expected output to be a map")
+	require.NotNil(t, outputMap)
+
+	// Verify simple variables
+	assert.Equal(t, "0xA0b86a33E6441e4EF45bAcfCaAd5C7f899342E38", outputMap["contract"])
+	assert.Equal(t, "0x742d35Cc6634C0532925a3b8D2C0e3e0C8C8E1c7", outputMap["recipient"])
+	assert.Equal(t, "1000000", outputMap["amount"])
+	assert.Equal(t, float64(200000), outputMap["gasLimit"])
+
+	// Verify object properties
+	assert.Equal(t, "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D", outputMap["routerAddress"])
+	assert.Equal(t, "1000000000000000000", outputMap["amountIn"])
+	assert.Equal(t, "0", outputMap["amountOutMin"])
+
+	// Verify array elements
+	assert.Equal(t, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", outputMap["firstToken"])
+	assert.Equal(t, "0xA0b86a33E6441e4EF45bAcfCaAd5C7f899342E38", outputMap["secondToken"])
+	assert.Equal(t, float64(2), outputMap["pathLength"])
+
+	// Verify nested object properties
+	assert.Equal(t, 0.5, outputMap["slippage"])
+	assert.Equal(t, float64(1703123400), outputMap["deadline"])
+
+	// Verify success message
+	assert.Equal(t, "All input variables accessed successfully!", outputMap["message"])
+
+	t.Logf("✅ Input variable usage examples test completed successfully")
+
+	// Print examples for documentation
+	t.Logf("\n"+
+		"=== INPUT VARIABLES USAGE EXAMPLES ===\n"+
+		"Input Variables Defined:\n"+
+		"  tokenContract: %v\n"+
+		"  recipient: %v\n"+
+		"  amount: %v\n"+
+		"  gasLimit: %v\n"+
+		"  swapConfig.routerAddress: %v\n"+
+		"  swapConfig.path[0]: %v\n"+
+		"  userConfig.slippage: %v\n"+
+		"\n"+
+		"How to Reference in Nodes:\n"+
+		"  Simple: tokenContract, recipient, amount, gasLimit\n"+
+		"  Object properties: swapConfig.routerAddress, swapConfig.amountIn\n"+
+		"  Array elements: swapConfig.path[0], swapConfig.path[1]\n"+
+		"  Nested properties: userConfig.slippage, userConfig.deadline\n",
+		inputVariables["tokenContract"],
+		inputVariables["recipient"],
+		inputVariables["amount"],
+		inputVariables["gasLimit"],
+		inputVariables["swapConfig"].(map[string]interface{})["routerAddress"],
+		inputVariables["swapConfig"].(map[string]interface{})["path"].([]interface{})[0],
+		inputVariables["userConfig"].(map[string]interface{})["slippage"])
+}

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -471,6 +471,16 @@ func NewVMWithDataAndTransferLog(task *model.Task, triggerData *TriggerData, sma
 			"chain":              "Unknown", // Default value, will be updated if chainId is available
 		}
 		v.AddVar(WorkflowContextVarName, workflowContext)
+
+		// Add input variables from task definition to VM
+		// These variables were defined during workflow creation and are now available globally
+		if task.InputVariables != nil {
+			for key, protoValue := range task.InputVariables {
+				// Convert protobuf Value to Go native type
+				nativeValue := protoValue.AsInterface()
+				v.AddVar(key, nativeValue)
+			}
+		}
 	}
 
 	// Parse trigger-specific data based on the flattened structure

--- a/model/task.go
+++ b/model/task.go
@@ -129,13 +129,14 @@ func NewTaskFromProtobuf(user *User, body *avsproto.CreateTaskReq) (*Task, error
 			Owner:              owner.Hex(),
 			SmartWalletAddress: aaAddress.Hex(),
 
-			Trigger:      body.Trigger,
-			Nodes:        body.Nodes,
-			Edges:        body.Edges,
-			Name:         body.Name,
-			ExpiredAt:    body.ExpiredAt,
-			StartAt:      body.StartAt,
-			MaxExecution: body.MaxExecution,
+			Trigger:        body.Trigger,
+			Nodes:          body.Nodes,
+			Edges:          body.Edges,
+			Name:           body.Name,
+			ExpiredAt:      body.ExpiredAt,
+			StartAt:        body.StartAt,
+			MaxExecution:   body.MaxExecution,
+			InputVariables: body.InputVariables, // Store input variables with the task
 
 			// initial state for task
 			Status: avsproto.TaskStatus_Active,

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -2060,13 +2060,17 @@ type Task struct {
 	// return how many time this task has run
 	ExecutionCount int64 `protobuf:"varint,9,opt,name=execution_count,json=executionCount,proto3" json:"execution_count,omitempty"`
 	// timestamp when task was last executed (in milliseconds)
-	LastRanAt     int64        `protobuf:"varint,10,opt,name=last_ran_at,json=lastRanAt,proto3" json:"last_ran_at,omitempty"`
-	Status        TaskStatus   `protobuf:"varint,11,opt,name=status,proto3,enum=aggregator.TaskStatus" json:"status,omitempty"`
-	Trigger       *TaskTrigger `protobuf:"bytes,12,opt,name=trigger,proto3" json:"trigger,omitempty"`
-	Nodes         []*TaskNode  `protobuf:"bytes,13,rep,name=nodes,proto3" json:"nodes,omitempty"`
-	Edges         []*TaskEdge  `protobuf:"bytes,14,rep,name=edges,proto3" json:"edges,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	LastRanAt int64        `protobuf:"varint,10,opt,name=last_ran_at,json=lastRanAt,proto3" json:"last_ran_at,omitempty"`
+	Status    TaskStatus   `protobuf:"varint,11,opt,name=status,proto3,enum=aggregator.TaskStatus" json:"status,omitempty"`
+	Trigger   *TaskTrigger `protobuf:"bytes,12,opt,name=trigger,proto3" json:"trigger,omitempty"`
+	Nodes     []*TaskNode  `protobuf:"bytes,13,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	Edges     []*TaskEdge  `protobuf:"bytes,14,rep,name=edges,proto3" json:"edges,omitempty"`
+	// Input variables defined at workflow creation time
+	// These variables are available globally to all nodes during execution
+	// and can be referenced using JavaScript template syntax like ${variableName}
+	InputVariables map[string]*structpb.Value `protobuf:"bytes,15,rep,name=input_variables,json=inputVariables,proto3" json:"input_variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Task) Reset() {
@@ -2197,6 +2201,13 @@ func (x *Task) GetEdges() []*TaskEdge {
 	return nil
 }
 
+func (x *Task) GetInputVariables() map[string]*structpb.Value {
+	if x != nil {
+		return x.InputVariables
+	}
+	return nil
+}
+
 type CreateTaskReq struct {
 	state        protoimpl.MessageState `protogen:"open.v1"`
 	Trigger      *TaskTrigger           `protobuf:"bytes,1,opt,name=trigger,proto3" json:"trigger,omitempty"`
@@ -2209,8 +2220,12 @@ type CreateTaskReq struct {
 	Name               string      `protobuf:"bytes,6,opt,name=name,proto3" json:"name,omitempty"`
 	Nodes              []*TaskNode `protobuf:"bytes,7,rep,name=nodes,proto3" json:"nodes,omitempty"`
 	Edges              []*TaskEdge `protobuf:"bytes,8,rep,name=edges,proto3" json:"edges,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Input variables to be stored with the workflow definition
+	// These variables will be available globally to all nodes during execution
+	// and can be referenced using JavaScript template syntax like ${variableName}
+	InputVariables map[string]*structpb.Value `protobuf:"bytes,9,rep,name=input_variables,json=inputVariables,proto3" json:"input_variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CreateTaskReq) Reset() {
@@ -2295,6 +2310,13 @@ func (x *CreateTaskReq) GetNodes() []*TaskNode {
 func (x *CreateTaskReq) GetEdges() []*TaskEdge {
 	if x != nil {
 		return x.Edges
+	}
+	return nil
+}
+
+func (x *CreateTaskReq) GetInputVariables() map[string]*structpb.Value {
+	if x != nil {
+		return x.InputVariables
 	}
 	return nil
 }
@@ -8409,7 +8431,7 @@ const file_avs_proto_rawDesc = "" +
 	"\x04loop\x18\v \x01(\v2\x1b.aggregator.LoopNode.OutputH\x00R\x04loop\x12\x19\n" +
 	"\bstart_at\x18\x0e \x01(\x03R\astartAt\x12\x15\n" +
 	"\x06end_at\x18\x0f \x01(\x03R\x05endAtB\r\n" +
-	"\voutput_data\"\xf8\x03\n" +
+	"\voutput_data\"\xa2\x05\n" +
 	"\x04Task\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05owner\x18\x02 \x01(\tR\x05owner\x120\n" +
@@ -8426,7 +8448,11 @@ const file_avs_proto_rawDesc = "" +
 	"\x06status\x18\v \x01(\x0e2\x16.aggregator.TaskStatusR\x06status\x121\n" +
 	"\atrigger\x18\f \x01(\v2\x17.aggregator.TaskTriggerR\atrigger\x12*\n" +
 	"\x05nodes\x18\r \x03(\v2\x14.aggregator.TaskNodeR\x05nodes\x12*\n" +
-	"\x05edges\x18\x0e \x03(\v2\x14.aggregator.TaskEdgeR\x05edges\"\xbf\x02\n" +
+	"\x05edges\x18\x0e \x03(\v2\x14.aggregator.TaskEdgeR\x05edges\x12M\n" +
+	"\x0finput_variables\x18\x0f \x03(\v2$.aggregator.Task.InputVariablesEntryR\x0einputVariables\x1aY\n" +
+	"\x13InputVariablesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"\xf2\x03\n" +
 	"\rCreateTaskReq\x121\n" +
 	"\atrigger\x18\x01 \x01(\v2\x17.aggregator.TaskTriggerR\atrigger\x12\x19\n" +
 	"\bstart_at\x18\x02 \x01(\x03R\astartAt\x12\x1d\n" +
@@ -8436,7 +8462,11 @@ const file_avs_proto_rawDesc = "" +
 	"\x14smart_wallet_address\x18\x05 \x01(\tR\x12smartWalletAddress\x12\x12\n" +
 	"\x04name\x18\x06 \x01(\tR\x04name\x12*\n" +
 	"\x05nodes\x18\a \x03(\v2\x14.aggregator.TaskNodeR\x05nodes\x12*\n" +
-	"\x05edges\x18\b \x03(\v2\x14.aggregator.TaskEdgeR\x05edges\" \n" +
+	"\x05edges\x18\b \x03(\v2\x14.aggregator.TaskEdgeR\x05edges\x12V\n" +
+	"\x0finput_variables\x18\t \x03(\v2-.aggregator.CreateTaskReq.InputVariablesEntryR\x0einputVariables\x1aY\n" +
+	"\x13InputVariablesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\" \n" +
 	"\x0eCreateTaskResp\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"$\n" +
 	"\fNonceRequest\x12\x14\n" +
@@ -8842,7 +8872,7 @@ func file_avs_proto_rawDescGZIP() []byte {
 }
 
 var file_avs_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 117)
+var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 119)
 var file_avs_proto_goTypes = []any{
 	(TriggerType)(0),                                      // 0: aggregator.TriggerType
 	(NodeType)(0),                                         // 1: aggregator.NodeType
@@ -8963,12 +8993,14 @@ var file_avs_proto_goTypes = []any{
 	(*LoopNode_Config)(nil),                               // 116: aggregator.LoopNode.Config
 	(*LoopNode_Output)(nil),                               // 117: aggregator.LoopNode.Output
 	(*Execution_Step)(nil),                                // 118: aggregator.Execution.Step
-	nil,                                                   // 119: aggregator.RunNodeWithInputsReq.NodeConfigEntry
-	nil,                                                   // 120: aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	nil,                                                   // 121: aggregator.RunTriggerReq.TriggerConfigEntry
-	nil,                                                   // 122: aggregator.RunTriggerReq.TriggerInputEntry
-	nil,                                                   // 123: aggregator.SimulateTaskReq.InputVariablesEntry
-	(*structpb.Value)(nil),                                // 124: google.protobuf.Value
+	nil,                                                   // 119: aggregator.Task.InputVariablesEntry
+	nil,                                                   // 120: aggregator.CreateTaskReq.InputVariablesEntry
+	nil,                                                   // 121: aggregator.RunNodeWithInputsReq.NodeConfigEntry
+	nil,                                                   // 122: aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	nil,                                                   // 123: aggregator.RunTriggerReq.TriggerConfigEntry
+	nil,                                                   // 124: aggregator.RunTriggerReq.TriggerInputEntry
+	nil,                                                   // 125: aggregator.SimulateTaskReq.InputVariablesEntry
+	(*structpb.Value)(nil),                                // 126: google.protobuf.Value
 }
 var file_avs_proto_depIdxs = []int32{
 	7,   // 0: aggregator.GetTokenMetadataResp.token:type_name -> aggregator.TokenMetadata
@@ -9014,171 +9046,175 @@ var file_avs_proto_depIdxs = []int32{
 	16,  // 40: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
 	27,  // 41: aggregator.Task.nodes:type_name -> aggregator.TaskNode
 	26,  // 42: aggregator.Task.edges:type_name -> aggregator.TaskEdge
-	16,  // 43: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	27,  // 44: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
-	26,  // 45: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
-	35,  // 46: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
-	29,  // 47: aggregator.ListTasksResp.items:type_name -> aggregator.Task
-	54,  // 48: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
-	28,  // 49: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
-	54,  // 50: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
-	6,   // 51: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
-	0,   // 52: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
-	82,  // 53: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	78,  // 54: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	80,  // 55: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	87,  // 56: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
-	89,  // 57: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	6,   // 58: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
-	118, // 59: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
-	55,  // 60: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
-	54,  // 61: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
-	1,   // 62: aggregator.RunNodeWithInputsReq.node_type:type_name -> aggregator.NodeType
-	119, // 63: aggregator.RunNodeWithInputsReq.node_config:type_name -> aggregator.RunNodeWithInputsReq.NodeConfigEntry
-	120, // 64: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	124, // 65: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
-	124, // 66: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
-	4,   // 67: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
-	93,  // 68: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	104, // 69: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	101, // 70: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
-	96,  // 71: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	110, // 72: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	107, // 73: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
-	113, // 74: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
-	115, // 75: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
-	117, // 76: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
-	0,   // 77: aggregator.RunTriggerReq.trigger_type:type_name -> aggregator.TriggerType
-	121, // 78: aggregator.RunTriggerReq.trigger_config:type_name -> aggregator.RunTriggerReq.TriggerConfigEntry
-	122, // 79: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
-	124, // 80: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
-	124, // 81: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
-	4,   // 82: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
-	82,  // 83: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	78,  // 84: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	80,  // 85: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	87,  // 86: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
-	89,  // 87: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	16,  // 88: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	27,  // 89: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
-	26,  // 90: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
-	123, // 91: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
-	124, // 92: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
-	124, // 93: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
-	124, // 94: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
-	85,  // 95: aggregator.EventTrigger.Query.topics:type_name -> aggregator.EventTrigger.Topics
-	124, // 96: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
-	76,  // 97: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
-	84,  // 98: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
-	83,  // 99: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
-	124, // 100: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
-	124, // 101: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
-	90,  // 102: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
-	91,  // 103: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
-	124, // 104: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
-	124, // 105: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
-	124, // 106: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
-	95,  // 107: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
-	124, // 108: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
-	124, // 109: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
-	124, // 110: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
-	124, // 111: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
-	124, // 112: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
-	98,  // 113: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
-	102, // 114: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
-	124, // 115: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
-	105, // 116: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
-	124, // 117: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
-	108, // 118: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
-	124, // 119: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
-	3,   // 120: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
-	124, // 121: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
-	111, // 122: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	124, // 123: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	124, // 124: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	2,   // 125: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	124, // 126: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	124, // 127: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	124, // 128: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	124, // 129: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	82,  // 130: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	78,  // 131: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	80,  // 132: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	87,  // 133: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	89,  // 134: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	93,  // 135: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	104, // 136: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	101, // 137: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	96,  // 138: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	110, // 139: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	107, // 140: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	113, // 141: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	115, // 142: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	117, // 143: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	124, // 144: aggregator.RunNodeWithInputsReq.NodeConfigEntry.value:type_name -> google.protobuf.Value
-	124, // 145: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	124, // 146: aggregator.RunTriggerReq.TriggerConfigEntry.value:type_name -> google.protobuf.Value
-	124, // 147: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	124, // 148: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	43,  // 149: aggregator.Aggregator.GetKey:input_type -> aggregator.GetKeyReq
-	59,  // 150: aggregator.Aggregator.GetSignatureFormat:input_type -> aggregator.GetSignatureFormatReq
-	32,  // 151: aggregator.Aggregator.GetNonce:input_type -> aggregator.NonceRequest
-	45,  // 152: aggregator.Aggregator.GetWallet:input_type -> aggregator.GetWalletReq
-	47,  // 153: aggregator.Aggregator.SetWallet:input_type -> aggregator.SetWalletReq
-	34,  // 154: aggregator.Aggregator.ListWallets:input_type -> aggregator.ListWalletReq
-	48,  // 155: aggregator.Aggregator.WithdrawFunds:input_type -> aggregator.WithdrawFundsReq
-	30,  // 156: aggregator.Aggregator.CreateTask:input_type -> aggregator.CreateTaskReq
-	37,  // 157: aggregator.Aggregator.ListTasks:input_type -> aggregator.ListTasksReq
-	10,  // 158: aggregator.Aggregator.GetTask:input_type -> aggregator.IdReq
-	39,  // 159: aggregator.Aggregator.ListExecutions:input_type -> aggregator.ListExecutionsReq
-	41,  // 160: aggregator.Aggregator.GetExecution:input_type -> aggregator.ExecutionReq
-	41,  // 161: aggregator.Aggregator.GetExecutionStatus:input_type -> aggregator.ExecutionReq
-	10,  // 162: aggregator.Aggregator.CancelTask:input_type -> aggregator.IdReq
-	10,  // 163: aggregator.Aggregator.DeleteTask:input_type -> aggregator.IdReq
-	50,  // 164: aggregator.Aggregator.TriggerTask:input_type -> aggregator.TriggerTaskReq
-	52,  // 165: aggregator.Aggregator.CreateSecret:input_type -> aggregator.CreateOrUpdateSecretReq
-	57,  // 166: aggregator.Aggregator.DeleteSecret:input_type -> aggregator.DeleteSecretReq
-	53,  // 167: aggregator.Aggregator.ListSecrets:input_type -> aggregator.ListSecretsReq
-	52,  // 168: aggregator.Aggregator.UpdateSecret:input_type -> aggregator.CreateOrUpdateSecretReq
-	65,  // 169: aggregator.Aggregator.GetWorkflowCount:input_type -> aggregator.GetWorkflowCountReq
-	67,  // 170: aggregator.Aggregator.GetExecutionCount:input_type -> aggregator.GetExecutionCountReq
-	69,  // 171: aggregator.Aggregator.GetExecutionStats:input_type -> aggregator.GetExecutionStatsReq
-	71,  // 172: aggregator.Aggregator.RunNodeWithInputs:input_type -> aggregator.RunNodeWithInputsReq
-	73,  // 173: aggregator.Aggregator.RunTrigger:input_type -> aggregator.RunTriggerReq
-	75,  // 174: aggregator.Aggregator.SimulateTask:input_type -> aggregator.SimulateTaskReq
-	8,   // 175: aggregator.Aggregator.GetTokenMetadata:input_type -> aggregator.GetTokenMetadataReq
-	44,  // 176: aggregator.Aggregator.GetKey:output_type -> aggregator.KeyResp
-	60,  // 177: aggregator.Aggregator.GetSignatureFormat:output_type -> aggregator.GetSignatureFormatResp
-	33,  // 178: aggregator.Aggregator.GetNonce:output_type -> aggregator.NonceResp
-	46,  // 179: aggregator.Aggregator.GetWallet:output_type -> aggregator.GetWalletResp
-	46,  // 180: aggregator.Aggregator.SetWallet:output_type -> aggregator.GetWalletResp
-	36,  // 181: aggregator.Aggregator.ListWallets:output_type -> aggregator.ListWalletResp
-	49,  // 182: aggregator.Aggregator.WithdrawFunds:output_type -> aggregator.WithdrawFundsResp
-	31,  // 183: aggregator.Aggregator.CreateTask:output_type -> aggregator.CreateTaskResp
-	38,  // 184: aggregator.Aggregator.ListTasks:output_type -> aggregator.ListTasksResp
-	29,  // 185: aggregator.Aggregator.GetTask:output_type -> aggregator.Task
-	40,  // 186: aggregator.Aggregator.ListExecutions:output_type -> aggregator.ListExecutionsResp
-	28,  // 187: aggregator.Aggregator.GetExecution:output_type -> aggregator.Execution
-	42,  // 188: aggregator.Aggregator.GetExecutionStatus:output_type -> aggregator.ExecutionStatusResp
-	64,  // 189: aggregator.Aggregator.CancelTask:output_type -> aggregator.CancelTaskResp
-	63,  // 190: aggregator.Aggregator.DeleteTask:output_type -> aggregator.DeleteTaskResp
-	51,  // 191: aggregator.Aggregator.TriggerTask:output_type -> aggregator.TriggerTaskResp
-	61,  // 192: aggregator.Aggregator.CreateSecret:output_type -> aggregator.CreateSecretResp
-	58,  // 193: aggregator.Aggregator.DeleteSecret:output_type -> aggregator.DeleteSecretResp
-	56,  // 194: aggregator.Aggregator.ListSecrets:output_type -> aggregator.ListSecretsResp
-	62,  // 195: aggregator.Aggregator.UpdateSecret:output_type -> aggregator.UpdateSecretResp
-	66,  // 196: aggregator.Aggregator.GetWorkflowCount:output_type -> aggregator.GetWorkflowCountResp
-	68,  // 197: aggregator.Aggregator.GetExecutionCount:output_type -> aggregator.GetExecutionCountResp
-	70,  // 198: aggregator.Aggregator.GetExecutionStats:output_type -> aggregator.GetExecutionStatsResp
-	72,  // 199: aggregator.Aggregator.RunNodeWithInputs:output_type -> aggregator.RunNodeWithInputsResp
-	74,  // 200: aggregator.Aggregator.RunTrigger:output_type -> aggregator.RunTriggerResp
-	28,  // 201: aggregator.Aggregator.SimulateTask:output_type -> aggregator.Execution
-	9,   // 202: aggregator.Aggregator.GetTokenMetadata:output_type -> aggregator.GetTokenMetadataResp
-	176, // [176:203] is the sub-list for method output_type
-	149, // [149:176] is the sub-list for method input_type
-	149, // [149:149] is the sub-list for extension type_name
-	149, // [149:149] is the sub-list for extension extendee
-	0,   // [0:149] is the sub-list for field type_name
+	119, // 43: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
+	16,  // 44: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	27,  // 45: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
+	26,  // 46: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
+	120, // 47: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
+	35,  // 48: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
+	29,  // 49: aggregator.ListTasksResp.items:type_name -> aggregator.Task
+	54,  // 50: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
+	28,  // 51: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
+	54,  // 52: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
+	6,   // 53: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
+	0,   // 54: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
+	82,  // 55: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	78,  // 56: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	80,  // 57: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	87,  // 58: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
+	89,  // 59: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	6,   // 60: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
+	118, // 61: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
+	55,  // 62: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
+	54,  // 63: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
+	1,   // 64: aggregator.RunNodeWithInputsReq.node_type:type_name -> aggregator.NodeType
+	121, // 65: aggregator.RunNodeWithInputsReq.node_config:type_name -> aggregator.RunNodeWithInputsReq.NodeConfigEntry
+	122, // 66: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	126, // 67: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
+	126, // 68: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
+	4,   // 69: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
+	93,  // 70: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	104, // 71: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	101, // 72: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
+	96,  // 73: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	110, // 74: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	107, // 75: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
+	113, // 76: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
+	115, // 77: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
+	117, // 78: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
+	0,   // 79: aggregator.RunTriggerReq.trigger_type:type_name -> aggregator.TriggerType
+	123, // 80: aggregator.RunTriggerReq.trigger_config:type_name -> aggregator.RunTriggerReq.TriggerConfigEntry
+	124, // 81: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
+	126, // 82: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
+	126, // 83: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
+	4,   // 84: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
+	82,  // 85: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	78,  // 86: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	80,  // 87: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	87,  // 88: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
+	89,  // 89: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	16,  // 90: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	27,  // 91: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
+	26,  // 92: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
+	125, // 93: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
+	126, // 94: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
+	126, // 95: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
+	126, // 96: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
+	85,  // 97: aggregator.EventTrigger.Query.topics:type_name -> aggregator.EventTrigger.Topics
+	126, // 98: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
+	76,  // 99: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
+	84,  // 100: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
+	83,  // 101: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
+	126, // 102: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
+	126, // 103: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
+	90,  // 104: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
+	91,  // 105: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
+	126, // 106: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
+	126, // 107: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
+	126, // 108: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
+	95,  // 109: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
+	126, // 110: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
+	126, // 111: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
+	126, // 112: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
+	126, // 113: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
+	126, // 114: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
+	98,  // 115: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
+	102, // 116: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
+	126, // 117: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
+	105, // 118: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
+	126, // 119: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
+	108, // 120: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
+	126, // 121: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
+	3,   // 122: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
+	126, // 123: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
+	111, // 124: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	126, // 125: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	126, // 126: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	2,   // 127: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	126, // 128: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	126, // 129: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	126, // 130: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	126, // 131: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	82,  // 132: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	78,  // 133: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	80,  // 134: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	87,  // 135: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	89,  // 136: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	93,  // 137: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	104, // 138: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	101, // 139: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	96,  // 140: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	110, // 141: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	107, // 142: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	113, // 143: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	115, // 144: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	117, // 145: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	126, // 146: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	126, // 147: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	126, // 148: aggregator.RunNodeWithInputsReq.NodeConfigEntry.value:type_name -> google.protobuf.Value
+	126, // 149: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	126, // 150: aggregator.RunTriggerReq.TriggerConfigEntry.value:type_name -> google.protobuf.Value
+	126, // 151: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	126, // 152: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	43,  // 153: aggregator.Aggregator.GetKey:input_type -> aggregator.GetKeyReq
+	59,  // 154: aggregator.Aggregator.GetSignatureFormat:input_type -> aggregator.GetSignatureFormatReq
+	32,  // 155: aggregator.Aggregator.GetNonce:input_type -> aggregator.NonceRequest
+	45,  // 156: aggregator.Aggregator.GetWallet:input_type -> aggregator.GetWalletReq
+	47,  // 157: aggregator.Aggregator.SetWallet:input_type -> aggregator.SetWalletReq
+	34,  // 158: aggregator.Aggregator.ListWallets:input_type -> aggregator.ListWalletReq
+	48,  // 159: aggregator.Aggregator.WithdrawFunds:input_type -> aggregator.WithdrawFundsReq
+	30,  // 160: aggregator.Aggregator.CreateTask:input_type -> aggregator.CreateTaskReq
+	37,  // 161: aggregator.Aggregator.ListTasks:input_type -> aggregator.ListTasksReq
+	10,  // 162: aggregator.Aggregator.GetTask:input_type -> aggregator.IdReq
+	39,  // 163: aggregator.Aggregator.ListExecutions:input_type -> aggregator.ListExecutionsReq
+	41,  // 164: aggregator.Aggregator.GetExecution:input_type -> aggregator.ExecutionReq
+	41,  // 165: aggregator.Aggregator.GetExecutionStatus:input_type -> aggregator.ExecutionReq
+	10,  // 166: aggregator.Aggregator.CancelTask:input_type -> aggregator.IdReq
+	10,  // 167: aggregator.Aggregator.DeleteTask:input_type -> aggregator.IdReq
+	50,  // 168: aggregator.Aggregator.TriggerTask:input_type -> aggregator.TriggerTaskReq
+	52,  // 169: aggregator.Aggregator.CreateSecret:input_type -> aggregator.CreateOrUpdateSecretReq
+	57,  // 170: aggregator.Aggregator.DeleteSecret:input_type -> aggregator.DeleteSecretReq
+	53,  // 171: aggregator.Aggregator.ListSecrets:input_type -> aggregator.ListSecretsReq
+	52,  // 172: aggregator.Aggregator.UpdateSecret:input_type -> aggregator.CreateOrUpdateSecretReq
+	65,  // 173: aggregator.Aggregator.GetWorkflowCount:input_type -> aggregator.GetWorkflowCountReq
+	67,  // 174: aggregator.Aggregator.GetExecutionCount:input_type -> aggregator.GetExecutionCountReq
+	69,  // 175: aggregator.Aggregator.GetExecutionStats:input_type -> aggregator.GetExecutionStatsReq
+	71,  // 176: aggregator.Aggregator.RunNodeWithInputs:input_type -> aggregator.RunNodeWithInputsReq
+	73,  // 177: aggregator.Aggregator.RunTrigger:input_type -> aggregator.RunTriggerReq
+	75,  // 178: aggregator.Aggregator.SimulateTask:input_type -> aggregator.SimulateTaskReq
+	8,   // 179: aggregator.Aggregator.GetTokenMetadata:input_type -> aggregator.GetTokenMetadataReq
+	44,  // 180: aggregator.Aggregator.GetKey:output_type -> aggregator.KeyResp
+	60,  // 181: aggregator.Aggregator.GetSignatureFormat:output_type -> aggregator.GetSignatureFormatResp
+	33,  // 182: aggregator.Aggregator.GetNonce:output_type -> aggregator.NonceResp
+	46,  // 183: aggregator.Aggregator.GetWallet:output_type -> aggregator.GetWalletResp
+	46,  // 184: aggregator.Aggregator.SetWallet:output_type -> aggregator.GetWalletResp
+	36,  // 185: aggregator.Aggregator.ListWallets:output_type -> aggregator.ListWalletResp
+	49,  // 186: aggregator.Aggregator.WithdrawFunds:output_type -> aggregator.WithdrawFundsResp
+	31,  // 187: aggregator.Aggregator.CreateTask:output_type -> aggregator.CreateTaskResp
+	38,  // 188: aggregator.Aggregator.ListTasks:output_type -> aggregator.ListTasksResp
+	29,  // 189: aggregator.Aggregator.GetTask:output_type -> aggregator.Task
+	40,  // 190: aggregator.Aggregator.ListExecutions:output_type -> aggregator.ListExecutionsResp
+	28,  // 191: aggregator.Aggregator.GetExecution:output_type -> aggregator.Execution
+	42,  // 192: aggregator.Aggregator.GetExecutionStatus:output_type -> aggregator.ExecutionStatusResp
+	64,  // 193: aggregator.Aggregator.CancelTask:output_type -> aggregator.CancelTaskResp
+	63,  // 194: aggregator.Aggregator.DeleteTask:output_type -> aggregator.DeleteTaskResp
+	51,  // 195: aggregator.Aggregator.TriggerTask:output_type -> aggregator.TriggerTaskResp
+	61,  // 196: aggregator.Aggregator.CreateSecret:output_type -> aggregator.CreateSecretResp
+	58,  // 197: aggregator.Aggregator.DeleteSecret:output_type -> aggregator.DeleteSecretResp
+	56,  // 198: aggregator.Aggregator.ListSecrets:output_type -> aggregator.ListSecretsResp
+	62,  // 199: aggregator.Aggregator.UpdateSecret:output_type -> aggregator.UpdateSecretResp
+	66,  // 200: aggregator.Aggregator.GetWorkflowCount:output_type -> aggregator.GetWorkflowCountResp
+	68,  // 201: aggregator.Aggregator.GetExecutionCount:output_type -> aggregator.GetExecutionCountResp
+	70,  // 202: aggregator.Aggregator.GetExecutionStats:output_type -> aggregator.GetExecutionStatsResp
+	72,  // 203: aggregator.Aggregator.RunNodeWithInputs:output_type -> aggregator.RunNodeWithInputsResp
+	74,  // 204: aggregator.Aggregator.RunTrigger:output_type -> aggregator.RunTriggerResp
+	28,  // 205: aggregator.Aggregator.SimulateTask:output_type -> aggregator.Execution
+	9,   // 206: aggregator.Aggregator.GetTokenMetadata:output_type -> aggregator.GetTokenMetadataResp
+	180, // [180:207] is the sub-list for method output_type
+	153, // [153:180] is the sub-list for method input_type
+	153, // [153:153] is the sub-list for extension type_name
+	153, // [153:153] is the sub-list for extension extendee
+	0,   // [0:153] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }
@@ -9265,7 +9301,7 @@ func file_avs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_avs_proto_rawDesc), len(file_avs_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   117,
+			NumMessages:   119,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -679,6 +679,11 @@ message Task {
   TaskTrigger trigger = 12;
   repeated TaskNode nodes = 13;
   repeated TaskEdge edges = 14;
+  
+  // Input variables defined at workflow creation time
+  // These variables are available globally to all nodes during execution
+  // and can be referenced using JavaScript template syntax like ${variableName}
+  map<string, google.protobuf.Value> input_variables = 15;
 }
 
 
@@ -697,6 +702,11 @@ message CreateTaskReq {
   string name                  = 6;
   repeated TaskNode nodes      = 7;
   repeated TaskEdge edges      = 8;
+  
+  // Input variables to be stored with the workflow definition
+  // These variables will be available globally to all nodes during execution
+  // and can be referenced using JavaScript template syntax like ${variableName}
+  map<string, google.protobuf.Value> input_variables = 9;
 }
 
 message CreateTaskResp {


### PR DESCRIPTION
- Add input_variables field to Task and CreateTaskReq protobuf messages
- Store input variables with workflow definition during createTask
- Load input variables into VM context during workflow execution
- Input variables are available globally to all nodes using JavaScript syntax
- Supports all data types: strings, numbers, booleans, objects, arrays
- Maintains backward compatibility with existing workflows
- Add comprehensive test coverage for input variables functionality

This enables workflows to be parameterized at creation time with variables that are automatically available to all nodes during execution, improving workflow reusability and flexibility.