### PR TITLE
fix: modernize contractWrite processing and remove workflowContext backward compatibility

### DIFF
--- a/core/taskengine/event_trigger_test.go
+++ b/core/taskengine/event_trigger_test.go
@@ -41,7 +41,7 @@ func TestEventTriggerEndToEndRPC(t *testing.T) {
 			"matcherList": []interface{}{},
 		}
 
-		result, err := engine.RunNodeImmediately("eventTrigger", configMap, map[string]interface{}{})
+		result, err := engine.RunNodeImmediately("eventTrigger", configMap, map[string]interface{}{}, nil)
 		if err != nil {
 			t.Logf("Execution failed (this might be expected if no events exist): %v", err)
 			// Don't fail the test if RPC is unavailable or no events found

--- a/core/taskengine/run_node_error_codes_test.go
+++ b/core/taskengine/run_node_error_codes_test.go
@@ -81,7 +81,7 @@ func TestRunNodeImmediatelyErrorCodes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Execute the node
-			result, err := engine.RunNodeImmediately(tc.nodeType, tc.nodeConfig, tc.inputVariables)
+			result, err := engine.RunNodeImmediately(tc.nodeType, tc.nodeConfig, tc.inputVariables, nil)
 
 			// Verify that an error occurred
 			require.Error(t, err, "Expected error for %s", tc.name)
@@ -122,7 +122,7 @@ func TestNonStructuredErrorsReturnUnspecified(t *testing.T) {
 	}
 
 	// Execute the node
-	result, err := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables)
+	result, err := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables, nil)
 
 	// Verify that an error occurred
 	require.Error(t, err, "Expected error for non-existent node type")

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -3033,6 +3033,12 @@ func (n *Engine) extractExecutionResult(executionStep *avsproto.Execution_Step) 
 			}
 		}
 
+		// Set success flag based on execution step status
+		result["success"] = executionStep.Success
+		if !executionStep.Success {
+			result["error"] = executionStep.Error
+		}
+
 		return result, nil
 	} else if loop := executionStep.GetLoop(); loop != nil {
 		// Loop output contains the array of iteration results

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -4004,6 +4004,7 @@ func isExpectedValidationError(err error) bool {
 		"invalid addresses format",                          // EventTrigger addresses format validation
 		"invalid contractAbi format",                        // EventTrigger ABI format validation
 		"settings is required for contractWrite",            // ContractWrite settings validation
+		"settings.chain_id is required for contractWrite",   // ContractWrite chain_id validation
 	}
 
 	for _, pattern := range validationErrorPatterns {

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2757,7 +2757,7 @@ func (n *Engine) runProcessingNodeWithInputs(user *model.User, nodeType string, 
 		if settingsIface, ok := inputVariables["settings"]; ok {
 			if settings, ok := settingsIface.(map[string]interface{}); ok {
 				if n.logger != nil {
-					n.logger.Info("RunNodeImmediately: Found settings for contractWrite validation", "keys", getMapKeys(settings))
+					n.logger.Info("RunNodeImmediately: Found settings for contractWrite validation", "keys", GetMapKeys(settings))
 				}
 
 				// Require runner
@@ -2898,15 +2898,6 @@ func (n *Engine) LoadSecretsForImmediateExecution(inputVariables map[string]inte
 	}
 
 	return secrets, nil
-}
-
-// Helper function to get keys from a map
-func getMapKeys(m map[string]interface{}) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }
 
 func (n *Engine) parseUint64(value interface{}) (uint64, error) {

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -3997,6 +3997,7 @@ func isExpectedValidationError(err error) bool {
 		"invalid query format",                              // EventTrigger query format validation
 		"invalid addresses format",                          // EventTrigger addresses format validation
 		"invalid contractAbi format",                        // EventTrigger ABI format validation
+		"settings is required for contractWrite",            // ContractWrite settings validation
 	}
 
 	for _, pattern := range validationErrorPatterns {

--- a/core/taskengine/run_node_immediately_settings_test.go
+++ b/core/taskengine/run_node_immediately_settings_test.go
@@ -1,0 +1,264 @@
+package taskengine
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
+	t.Run("ContractWrite_USDC_Approve_WithSettingsFormat", func(t *testing.T) {
+		// Setup test environment
+		db := testutil.TestMustDB()
+		defer storage.Destroy(db.(*storage.BadgerStorage))
+
+		config := testutil.GetAggregatorConfig()
+		engine := New(db, config, nil, testutil.GetLogger())
+
+		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
+		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+
+		// Create test user (simulating authenticated user from JWT)
+		ownerEOA := common.HexToAddress("0xD7050816337a3f8f690F8083B5Ff8019D50c0E50")
+		runnerAddr := common.HexToAddress("0x5Df343de7d99fd64b2479189692C1dAb8f46184a")
+		factory := testutil.GetAggregatorConfig().SmartWallet.FactoryAddress
+
+		// Create authenticated user model
+		user := &model.User{
+			Address: ownerEOA,
+		}
+
+		// Seed wallet in DB for validation
+		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+			Owner:   &ownerEOA,
+			Address: &runnerAddr,
+			Factory: &factory,
+			Salt:    big.NewInt(0),
+		})
+
+		// Contract configuration for USDC approve
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b", // USDC Sepolia
+			"contractAbi": []interface{}{
+				map[string]interface{}{
+					"inputs": []interface{}{
+						map[string]interface{}{"internalType": "address", "name": "spender", "type": "address"},
+						map[string]interface{}{"internalType": "uint256", "name": "amount", "type": "uint256"},
+					},
+					"name":            "approve",
+					"outputs":         []interface{}{map[string]interface{}{"internalType": "bool", "name": "", "type": "bool"}},
+					"stateMutability": "nonpayable",
+					"type":            "function",
+				},
+			},
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName":   "approve",
+					"methodParams": []interface{}{"0x1234567890123456789012345678901234567890", "1000000"},
+				},
+			},
+			"value":    "0",
+			"gasLimit": "210000",
+		}
+
+		// Input variables using NEW settings format (not workflowContext)
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"runner":  runnerAddr.Hex(),
+				"chainId": 11155111, // Sepolia testnet
+			},
+		}
+
+		t.Logf("🧪 Testing contractWrite with new settings format:")
+		t.Logf("   User (from JWT): %s", user.Address.Hex())
+		t.Logf("   Runner (from settings): %s", runnerAddr.Hex())
+		t.Logf("   Chain ID (from settings): %d", 11155111)
+		t.Logf("   Method: approve")
+
+		// Execute with authenticated user
+		result, err := engine.RunNodeImmediately("contractWrite", nodeConfig, inputVariables, user)
+
+		// Assertions
+		require.NoError(t, err, "RunNodeImmediately should succeed with settings format")
+		require.NotNil(t, result, "Should get simulation result")
+
+		// Verify success field
+		if success, ok := result["success"].(bool); ok {
+			assert.True(t, success, "Contract write should succeed in simulation")
+		}
+
+		// Verify results structure
+		if results, ok := result["results"].([]interface{}); ok && len(results) > 0 {
+			t.Logf("✅ Got %d method results", len(results))
+
+			// Check first result
+			firstResult := results[0]
+			if methodResult, ok := firstResult.(map[string]interface{}); ok {
+				assert.Equal(t, "approve", methodResult["methodName"], "Method name should be approve")
+				if success, ok := methodResult["success"].(bool); ok {
+					assert.True(t, success, "Method should succeed")
+				}
+			}
+		} else {
+			t.Logf("ℹ️ No results array found in result: %+v", result)
+		}
+
+		t.Logf("✅ Contract write with settings format completed successfully")
+	})
+
+	t.Run("ContractWrite_ErrorWhenSettingsMissing", func(t *testing.T) {
+		// Setup test environment
+		db := testutil.TestMustDB()
+		defer storage.Destroy(db.(*storage.BadgerStorage))
+
+		config := testutil.GetAggregatorConfig()
+		engine := New(db, config, nil, testutil.GetLogger())
+
+		// Create test user
+		ownerEOA := common.HexToAddress("0xD7050816337a3f8f690F8083B5Ff8019D50c0E50")
+		user := &model.User{Address: ownerEOA}
+
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b",
+			"contractAbi": []interface{}{
+				map[string]interface{}{
+					"inputs": []interface{}{
+						map[string]interface{}{"internalType": "address", "name": "spender", "type": "address"},
+						map[string]interface{}{"internalType": "uint256", "name": "amount", "type": "uint256"},
+					},
+					"name":            "approve",
+					"outputs":         []interface{}{map[string]interface{}{"internalType": "bool", "name": "", "type": "bool"}},
+					"stateMutability": "nonpayable",
+					"type":            "function",
+				},
+			},
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName":   "approve",
+					"methodParams": []interface{}{"0x1234567890123456789012345678901234567890", "1000000"},
+				},
+			},
+		}
+
+		// Input variables WITHOUT settings (should fail)
+		inputVariables := map[string]interface{}{
+			"someOtherData": "test",
+		}
+
+		// Execute - should fail
+		_, err := engine.RunNodeImmediately("contractWrite", nodeConfig, inputVariables, user)
+
+		// Should get specific error about missing settings
+		require.Error(t, err, "Should fail when settings are missing")
+		assert.Contains(t, err.Error(), "settings is required for contractWrite", "Should get specific error message")
+
+		t.Logf("✅ Correctly rejected contractWrite without settings: %v", err)
+	})
+
+	t.Run("ContractWrite_ErrorWhenRunnerMissing", func(t *testing.T) {
+		// Setup test environment
+		db := testutil.TestMustDB()
+		defer storage.Destroy(db.(*storage.BadgerStorage))
+
+		config := testutil.GetAggregatorConfig()
+		engine := New(db, config, nil, testutil.GetLogger())
+
+		// Create test user
+		ownerEOA := common.HexToAddress("0xD7050816337a3f8f690F8083B5Ff8019D50c0E50")
+		user := &model.User{Address: ownerEOA}
+
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b",
+			"contractAbi": []interface{}{
+				map[string]interface{}{
+					"inputs": []interface{}{
+						map[string]interface{}{"internalType": "address", "name": "spender", "type": "address"},
+						map[string]interface{}{"internalType": "uint256", "name": "amount", "type": "uint256"},
+					},
+					"name":            "approve",
+					"outputs":         []interface{}{map[string]interface{}{"internalType": "bool", "name": "", "type": "bool"}},
+					"stateMutability": "nonpayable",
+					"type":            "function",
+				},
+			},
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName":   "approve",
+					"methodParams": []interface{}{"0x1234567890123456789012345678901234567890", "1000000"},
+				},
+			},
+		}
+
+		// Input variables with settings but missing runner
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"chainId": 11155111,
+				// "runner" is missing
+			},
+		}
+
+		// Execute - should fail
+		_, err := engine.RunNodeImmediately("contractWrite", nodeConfig, inputVariables, user)
+
+		// Should get specific error about missing runner
+		require.Error(t, err, "Should fail when runner is missing")
+		assert.Contains(t, err.Error(), "settings.runner is required for contractWrite", "Should get specific error message")
+
+		t.Logf("✅ Correctly rejected contractWrite without runner: %v", err)
+	})
+
+	t.Run("ContractWrite_ErrorWhenUserNotAuthenticated", func(t *testing.T) {
+		// Setup test environment
+		db := testutil.TestMustDB()
+		defer storage.Destroy(db.(*storage.BadgerStorage))
+
+		config := testutil.GetAggregatorConfig()
+		engine := New(db, config, nil, testutil.GetLogger())
+
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b",
+			"contractAbi": []interface{}{
+				map[string]interface{}{
+					"inputs": []interface{}{
+						map[string]interface{}{"internalType": "address", "name": "spender", "type": "address"},
+						map[string]interface{}{"internalType": "uint256", "name": "amount", "type": "uint256"},
+					},
+					"name":            "approve",
+					"outputs":         []interface{}{map[string]interface{}{"internalType": "bool", "name": "", "type": "bool"}},
+					"stateMutability": "nonpayable",
+					"type":            "function",
+				},
+			},
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName":   "approve",
+					"methodParams": []interface{}{"0x1234567890123456789012345678901234567890", "1000000"},
+				},
+			},
+		}
+
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"runner":  "0x5Df343de7d99fd64b2479189692C1dAb8f46184a",
+				"chainId": 11155111,
+			},
+		}
+
+		// Execute with NIL user (simulates missing JWT authentication)
+		// In real usage, user comes from verifyAuth() parsing JWT token claims["sub"] -> user.Address
+		_, err := engine.RunNodeImmediately("contractWrite", nodeConfig, inputVariables, nil)
+
+		// Should get specific error about missing authentication
+		require.Error(t, err, "Should fail when user is not authenticated")
+		assert.Contains(t, err.Error(), "authentication required for contractWrite", "Should get specific error message")
+
+		t.Logf("✅ Correctly rejected contractWrite without authentication: %v", err)
+	})
+}

--- a/core/taskengine/run_node_immediately_settings_test.go
+++ b/core/taskengine/run_node_immediately_settings_test.go
@@ -71,8 +71,8 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 		// Input variables using NEW settings format (not workflowContext)
 		inputVariables := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"runner":  runnerAddr.Hex(),
-				"chainId": 11155111, // Sepolia testnet
+				"runner":   runnerAddr.Hex(),
+				"chain_id": 11155111, // Sepolia testnet
 			},
 		}
 
@@ -199,7 +199,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 		// Input variables with settings but missing runner
 		inputVariables := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"chainId": 11155111,
+				"chain_id": 11155111,
 				// "runner" is missing
 			},
 		}
@@ -246,8 +246,8 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 
 		inputVariables := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"runner":  "0x5Df343de7d99fd64b2479189692C1dAb8f46184a",
-				"chainId": 11155111,
+				"runner":   "0x5Df343de7d99fd64b2479189692C1dAb8f46184a",
+				"chain_id": 11155111,
 			},
 		}
 

--- a/core/taskengine/run_node_immediately_tuple_test.go
+++ b/core/taskengine/run_node_immediately_tuple_test.go
@@ -121,10 +121,10 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 
 		inputVariables := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"chain":   "Sepolia",
-				"amount":  "100000000000000000", // 0.1 ETH in wei
-				"runner":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
-				"chainId": 11155111,
+				"chain":    "Sepolia",
+				"amount":   "100000000000000000", // 0.1 ETH in wei
+				"runner":   "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"chain_id": 11155111,
 				"uniswapv3_pool": map[string]interface{}{
 					"id": "0xeb502c739488180b106eded9902b7465a8c12edb",
 					"token0": map[string]interface{}{
@@ -244,9 +244,9 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 
 		inputVariables := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"amount":  "100000000000000000",
-				"runner":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
-				"chainId": 11155111,
+				"amount":   "100000000000000000",
+				"runner":   "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"chain_id": 11155111,
 				"uniswapv3_pool": map[string]interface{}{
 					"token0": map[string]interface{}{
 						"id": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",

--- a/core/taskengine/run_node_immediately_tuple_test.go
+++ b/core/taskengine/run_node_immediately_tuple_test.go
@@ -1,0 +1,370 @@
+package taskengine
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunNodeImmediately_ContractWrite_TupleWithTemplates tests contract write with tuple parameters
+// that have template variable substitution - the exact scenario from the client app
+func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
+	SetRpc(testutil.GetTestRPCURL())
+	SetCache(testutil.GetDefaultCache())
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	config := testutil.GetAggregatorConfig()
+	engine := New(db, config, nil, testutil.GetLogger())
+
+	// Create test user
+	ownerEOA := common.HexToAddress("0x72D841F43241957b558097A5110A8Ed68c6fD88c")
+	runnerAddr := common.HexToAddress("0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e")
+	factory := config.SmartWallet.FactoryAddress
+	user := &model.User{
+		Address: ownerEOA,
+	}
+
+	// Uniswap V3 QuoterV2 ABI for quoteExactInputSingle
+	quoterV2ABI := `[{
+		"inputs": [{
+			"components": [
+				{"internalType": "address", "name": "tokenIn", "type": "address"},
+				{"internalType": "address", "name": "tokenOut", "type": "address"},
+				{"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+				{"internalType": "uint24", "name": "fee", "type": "uint24"},
+				{"internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160"}
+			],
+			"internalType": "struct IQuoterV2.QuoteExactInputSingleParams",
+			"name": "params",
+			"type": "tuple"
+		}],
+		"name": "quoteExactInputSingle",
+		"outputs": [
+			{"internalType": "uint256", "name": "amountOut", "type": "uint256"},
+			{"internalType": "uint160", "name": "sqrtPriceX96After", "type": "uint160"},
+			{"internalType": "uint32", "name": "initializedTicksCrossed", "type": "uint32"},
+			{"internalType": "uint256", "name": "gasEstimate", "type": "uint256"}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	}]`
+
+	// Parse ABI to convert to protobuf Values
+	parsedABI, err := abi.JSON(strings.NewReader(quoterV2ABI))
+	require.NoError(t, err, "Should parse ABI successfully")
+
+	t.Run("Tuple_Parameter_With_Template_Substitution_JSON_Array", func(t *testing.T) {
+		// This test simulates the exact scenario from the client app:
+		// - User provides settings with nested object structure
+		// - methodParams contains a JSON array with template variables
+		// - Templates reference settings.uniswapv3-pool.token0.id etc.
+
+		// Seed wallet in DB for validation
+		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+			Owner:   &ownerEOA,
+			Address: &runnerAddr,
+			Factory: &factory,
+			Salt:    big.NewInt(0),
+		})
+
+		nodeType := "contractWrite"
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3", // Sepolia QuoterV2
+			"contractAbi": []interface{}{
+				map[string]interface{}{
+					"inputs": []interface{}{
+						map[string]interface{}{
+							"components": []interface{}{
+								map[string]interface{}{"internalType": "address", "name": "tokenIn", "type": "address"},
+								map[string]interface{}{"internalType": "address", "name": "tokenOut", "type": "address"},
+								map[string]interface{}{"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+								map[string]interface{}{"internalType": "uint24", "name": "fee", "type": "uint24"},
+								map[string]interface{}{"internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160"},
+							},
+							"internalType": "struct IQuoterV2.QuoteExactInputSingleParams",
+							"name":         "params",
+							"type":         "tuple",
+						},
+					},
+					"name": "quoteExactInputSingle",
+					"outputs": []interface{}{
+						map[string]interface{}{"internalType": "uint256", "name": "amountOut", "type": "uint256"},
+						map[string]interface{}{"internalType": "uint160", "name": "sqrtPriceX96After", "type": "uint160"},
+						map[string]interface{}{"internalType": "uint32", "name": "initializedTicksCrossed", "type": "uint32"},
+						map[string]interface{}{"internalType": "uint256", "name": "gasEstimate", "type": "uint256"},
+					},
+					"stateMutability": "nonpayable",
+					"type":            "function",
+				},
+			},
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName": "quoteExactInputSingle",
+					// ✅ This is the recommended format: JSON array with template variables inside
+					"methodParams": []interface{}{
+						`["{{settings.uniswapv3-pool.token0.id}}", "{{settings.uniswapv3-pool.token1.id}}", "{{settings.amount}}", "{{settings.uniswapv3-pool.feeTier}}", 0]`,
+					},
+				},
+			},
+			"value":    "0",
+			"gasLimit": "210000",
+		}
+
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"chain":   "Sepolia",
+				"amount":  "100000000000000000", // 0.1 ETH in wei
+				"runner":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"chainId": 11155111,
+				"uniswapv3-pool": map[string]interface{}{
+					"id": "0xeb502c739488180b106eded9902b7465a8c12edb",
+					"token0": map[string]interface{}{
+						"id":     "0xfff9976782d46cc05630d1f6ebab18b2324d6b14", // WETH on Sepolia
+						"symbol": "WETH",
+					},
+					"token1": map[string]interface{}{
+						"id":     "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", // USDC on Sepolia
+						"symbol": "USDC",
+					},
+					"feeTier": "3000", // 0.3% fee tier
+				},
+			},
+		}
+
+		// Execute the node
+		result, err := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables, user)
+
+		// Log the result for debugging
+		t.Logf("RunNodeImmediately result: success=%v, error=%v", result["success"], result["error"])
+		if metadata, ok := result["metadata"].([]interface{}); ok && len(metadata) > 0 {
+			if metadataItem, ok := metadata[0].(map[string]interface{}); ok {
+				t.Logf("Metadata: methodName=%v, success=%v, error=%v",
+					metadataItem["methodName"], metadataItem["success"], metadataItem["error"])
+			}
+		}
+
+		// Assertions
+		require.NoError(t, err, "RunNodeImmediately should not return error")
+		assert.NotNil(t, result, "Result should not be nil")
+
+		// Check success flag
+		success, ok := result["success"].(bool)
+		require.True(t, ok, "Result should have success field")
+		assert.True(t, success, "Execution should succeed")
+
+		// Check metadata
+		metadata, ok := result["metadata"].([]interface{})
+		require.True(t, ok, "Result should have metadata array")
+		require.Greater(t, len(metadata), 0, "Metadata should have at least one entry")
+
+		metadataItem, ok := metadata[0].(map[string]interface{})
+		require.True(t, ok, "Metadata item should be a map")
+
+		// Verify method execution
+		assert.Equal(t, "quoteExactInputSingle", metadataItem["methodName"], "Method name should match")
+		assert.True(t, metadataItem["success"].(bool), "Method execution should succeed")
+
+		// Verify that template substitution worked correctly
+		// The backend should have:
+		// 1. Resolved templates to actual values
+		// 2. Parsed the JSON array
+		// 3. Validated tuple element count (5 elements)
+		// 4. Generated calldata successfully
+		assert.Empty(t, metadataItem["error"], "Should not have any errors")
+
+		t.Logf("✅ Tuple parameter with template substitution test passed")
+		t.Logf("   - Templates resolved correctly")
+		t.Logf("   - JSON array parsed successfully")
+		t.Logf("   - Calldata generated for tuple parameter")
+	})
+
+	t.Run("Tuple_Parameter_With_Template_Substitution_JSON_Object", func(t *testing.T) {
+		// Alternative format: JSON object with named fields
+		// The backend will convert this to ordered array based on ABI
+
+		nodeType := "contractWrite"
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
+			"contractAbi":     quoterV2ABI,
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName": "quoteExactInputSingle",
+					// ✅ Alternative format: JSON object (backend converts to array)
+					"methodParams": []interface{}{
+						`{"tokenIn": "{{settings.uniswapv3-pool.token0.id}}", "tokenOut": "{{settings.uniswapv3-pool.token1.id}}", "amountIn": "{{settings.amount}}", "fee": "{{settings.uniswapv3-pool.feeTier}}", "sqrtPriceLimitX96": 0}`,
+					},
+				},
+			},
+			"value":    "0",
+			"gasLimit": "210000",
+		}
+
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"amount": "100000000000000000",
+				"runner": "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"uniswapv3-pool": map[string]interface{}{
+					"token0": map[string]interface{}{
+						"id": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",
+					},
+					"token1": map[string]interface{}{
+						"id": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+					},
+					"feeTier": "3000",
+				},
+			},
+		}
+
+		result, err := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables, user)
+
+		require.NoError(t, err, "RunNodeImmediately should not return error")
+		assert.NotNil(t, result, "Result should not be nil")
+
+		success, ok := result["success"].(bool)
+		require.True(t, ok, "Result should have success field")
+		assert.True(t, success, "Execution should succeed")
+
+		metadata, ok := result["metadata"].([]interface{})
+		require.True(t, ok, "Result should have metadata array")
+		require.Greater(t, len(metadata), 0, "Metadata should have at least one entry")
+
+		metadataItem, ok := metadata[0].(map[string]interface{})
+		require.True(t, ok, "Metadata item should be a map")
+
+		assert.Equal(t, "quoteExactInputSingle", metadataItem["methodName"], "Method name should match")
+		assert.True(t, metadataItem["success"].(bool), "Method execution should succeed")
+		assert.Empty(t, metadataItem["error"], "Should not have any errors")
+
+		t.Logf("✅ Tuple parameter with JSON object format test passed")
+	})
+
+	t.Run("Tuple_Parameter_Missing_Field_Error", func(t *testing.T) {
+		// Test error handling when a required field is missing
+
+		nodeType := "contractWrite"
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
+			"contractAbi":     quoterV2ABI,
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName": "quoteExactInputSingle",
+					// Missing tokenOut field
+					"methodParams": []interface{}{
+						`{"tokenIn": "{{settings.token0}}", "amountIn": "{{settings.amount}}", "fee": "3000", "sqrtPriceLimitX96": 0}`,
+					},
+				},
+			},
+			"value":    "0",
+			"gasLimit": "210000",
+		}
+
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"token0": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",
+				"amount": "100000000000000000",
+				"runner": "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+			},
+		}
+
+		result, _ := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables, user)
+
+		// Should get an error about missing field
+		assert.NotNil(t, result, "Result should not be nil")
+		success, ok := result["success"].(bool)
+		require.True(t, ok, "Result should have success field")
+		assert.False(t, success, "Execution should fail due to missing field")
+
+		metadata, ok := result["metadata"].([]interface{})
+		require.True(t, ok, "Result should have metadata array")
+		require.Greater(t, len(metadata), 0, "Metadata should have at least one entry")
+
+		metadataItem, ok := metadata[0].(map[string]interface{})
+		require.True(t, ok, "Metadata item should be a map")
+
+		assert.False(t, metadataItem["success"].(bool), "Method execution should fail")
+		assert.Contains(t, metadataItem["error"].(string), "tokenOut", "Error should mention missing field")
+
+		t.Logf("✅ Error handling test passed - correctly detected missing field")
+	})
+
+	t.Run("Tuple_Parameter_Wrong_Element_Count_Error", func(t *testing.T) {
+		// Test error handling when array has wrong number of elements
+
+		nodeType := "contractWrite"
+		nodeConfig := map[string]interface{}{
+			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
+			"contractAbi":     quoterV2ABI,
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName": "quoteExactInputSingle",
+					// Only 3 elements instead of 5
+					"methodParams": []interface{}{
+						`["{{settings.token0}}", "{{settings.token1}}", "{{settings.amount}}"]`,
+					},
+				},
+			},
+			"value":    "0",
+			"gasLimit": "210000",
+		}
+
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"token0": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14",
+				"token1": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+				"amount": "100000000000000000",
+				"runner": "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+			},
+		}
+
+		result, _ := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables, user)
+
+		assert.NotNil(t, result, "Result should not be nil")
+		success, ok := result["success"].(bool)
+		require.True(t, ok, "Result should have success field")
+		assert.False(t, success, "Execution should fail due to wrong element count")
+
+		metadata, ok := result["metadata"].([]interface{})
+		require.True(t, ok, "Result should have metadata array")
+		require.Greater(t, len(metadata), 0, "Metadata should have at least one entry")
+
+		metadataItem, ok := metadata[0].(map[string]interface{})
+		require.True(t, ok, "Metadata item should be a map")
+
+		assert.False(t, metadataItem["success"].(bool), "Method execution should fail")
+		errorMsg := metadataItem["error"].(string)
+		assert.True(t, strings.Contains(errorMsg, "expects 5 elements") || strings.Contains(errorMsg, "got 3"),
+			"Error should mention element count mismatch")
+
+		t.Logf("✅ Error handling test passed - correctly detected wrong element count")
+	})
+
+	// Verify ABI parsing works correctly
+	t.Run("Verify_ABI_Structure", func(t *testing.T) {
+		method := parsedABI.Methods["quoteExactInputSingle"]
+		require.NotNil(t, method, "Should find quoteExactInputSingle method")
+		require.Equal(t, 1, len(method.Inputs), "Method should have 1 input")
+		require.Equal(t, abi.TupleTy, method.Inputs[0].Type.T, "Input should be a tuple type")
+		require.Equal(t, 5, len(method.Inputs[0].Type.TupleElems), "Tuple should have 5 elements")
+
+		// Verify field names
+		expectedFields := []string{"tokenIn", "tokenOut", "amountIn", "fee", "sqrtPriceLimitX96"}
+		for i, expected := range expectedFields {
+			assert.Equal(t, expected, method.Inputs[0].Type.TupleRawNames[i],
+				"Field %d name should match", i)
+		}
+
+		t.Logf("✅ ABI structure verified successfully")
+		t.Logf("   - Method: %s", method.Name)
+		t.Logf("   - Input type: %s", method.Inputs[0].Type.String())
+		t.Logf("   - Tuple fields: %v", method.Inputs[0].Type.TupleRawNames)
+	})
+}

--- a/core/taskengine/run_node_integration_test.go
+++ b/core/taskengine/run_node_integration_test.go
@@ -109,7 +109,7 @@ func TestTaskRunLogicAndTemplateVariables(t *testing.T) {
 				}
 			}
 
-			result, err := engine.RunNodeImmediately(nodeType, nodeConfig, tc.templateData)
+			result, err := engine.RunNodeImmediately(nodeType, nodeConfig, tc.templateData, nil)
 
 			if tc.expectError && err == nil {
 				t.Errorf("Expected error for %s, but got none", tc.name)
@@ -155,7 +155,7 @@ func TestSmartTriggerDataFallback(t *testing.T) {
 		"fallbackCamelValue": "fallback_camel_value",
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)

--- a/core/taskengine/run_node_templates_test.go
+++ b/core/taskengine/run_node_templates_test.go
@@ -23,7 +23,7 @@ func TestRunNodeImmediately_RestAPIWithTemplates(t *testing.T) {
 		"test_value": "Hello World",
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 	if err != nil {
 		t.Skipf("Skipping due to network error: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestRunNodeImmediately_SecretsAccess(t *testing.T) {
 		"api_key": "test_secret_123",
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, secrets)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, secrets, nil)
 	if err != nil {
 		t.Skipf("Skipping due to network error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestRunNodeImmediately_SimpleUndefinedVariable(t *testing.T) {
 		},
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, map[string]interface{}{})
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, map[string]interface{}{}, nil)
 	if err != nil {
 		t.Skipf("Skipping due to network error: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestRunNodeImmediately_ClientInputDebug(t *testing.T) {
 		},
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 
 	// Some CI environments block outbound HTTP; tolerate network errors by skipping
 	if err != nil {
@@ -138,7 +138,7 @@ func TestRunNodeImmediately_TemplateProcessingDebug(t *testing.T) {
 		"array": []interface{}{"first_item", "second_item"},
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 	if err != nil {
 		t.Skipf("Skipping due to network error: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestRunNodeImmediately_MissingTemplateVariable(t *testing.T) {
 		"existing_field": "some_value",
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 	if err != nil {
 		t.Skipf("Skipping due to network error: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestRunNodeImmediately_UndefinedVariableReplacement(t *testing.T) {
 		"defined_value": "this_is_defined",
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 	if err != nil {
 		t.Skipf("Skipping due to network error: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestRunNodeImmediately_MalformedTemplateDetection(t *testing.T) {
 		"value": "test_value",
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
@@ -248,7 +248,7 @@ func TestRunNodeImmediately_ValidTemplateAfterFix(t *testing.T) {
 		"message": "Template processing works correctly",
 	}
 
-	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData)
+	result, err := engine.RunNodeImmediately("restAPI", nodeConfig, triggerData, nil)
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)

--- a/core/taskengine/run_node_triggers_test.go
+++ b/core/taskengine/run_node_triggers_test.go
@@ -53,7 +53,7 @@ func TestRunNodeImmediately_TriggerTypes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := engine.RunNodeImmediately("trigger", tc.nodeConfig, map[string]interface{}{})
+			result, err := engine.RunNodeImmediately("trigger", tc.nodeConfig, map[string]interface{}{}, nil)
 
 			if err != nil {
 				t.Errorf("Expected no error for %s, got: %v", tc.name, err)
@@ -77,7 +77,7 @@ func TestRunTriggerRPC_ManualTrigger(t *testing.T) {
 		},
 	}
 
-	result, err := engine.RunNodeImmediately("manualTrigger", nodeConfig, map[string]interface{}{})
+	result, err := engine.RunNodeImmediately("manualTrigger", nodeConfig, map[string]interface{}{}, nil)
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)

--- a/core/taskengine/smart_variable_resolution_test.go
+++ b/core/taskengine/smart_variable_resolution_test.go
@@ -86,7 +86,7 @@ func TestConsistentCamelCaseResolution(t *testing.T) {
 			},
 		}
 
-		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables)
+		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables, nil)
 
 		// Should succeed with direct resolution
 		assert.NoError(t, err)
@@ -133,7 +133,7 @@ func TestConsistentCamelCaseResolution(t *testing.T) {
 			},
 		}
 
-		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables)
+		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables, nil)
 
 		// Should succeed
 		assert.NoError(t, err)
@@ -179,7 +179,7 @@ func TestConsistentCamelCaseResolution(t *testing.T) {
 			},
 		}
 
-		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables)
+		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -221,7 +221,7 @@ func TestConsistentCamelCaseResolution(t *testing.T) {
 			},
 		}
 
-		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables)
+		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -267,7 +267,7 @@ func TestConsistentCamelCaseResolution(t *testing.T) {
 			},
 		}
 
-		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables)
+		result, err := engine.RunNodeImmediately(NodeTypeRestAPI, config, inputVariables, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -333,7 +333,7 @@ func TestCamelCaseVariableSupport(t *testing.T) {
 			},
 		}
 
-		result, err := engine.RunNodeImmediately(NodeTypeCustomCode, config, inputVariables)
+		result, err := engine.RunNodeImmediately(NodeTypeCustomCode, config, inputVariables, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -370,7 +370,7 @@ func TestCamelCaseVariableSupport(t *testing.T) {
 		}
 
 		// Execute REST API node to get output data
-		restResult, err := engine.RunNodeImmediately(NodeTypeRestAPI, restConfig, map[string]interface{}{})
+		restResult, err := engine.RunNodeImmediately(NodeTypeRestAPI, restConfig, map[string]interface{}{}, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, restResult)
 
@@ -399,7 +399,7 @@ func TestCamelCaseVariableSupport(t *testing.T) {
 			},
 		}
 
-		customResult, err := engine.RunNodeImmediately(NodeTypeCustomCode, customCodeConfig, inputVariables)
+		customResult, err := engine.RunNodeImmediately(NodeTypeCustomCode, customCodeConfig, inputVariables, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, customResult)
@@ -456,7 +456,7 @@ func TestCamelCaseDebug(t *testing.T) {
 			},
 		}
 
-		result, err := engine.RunNodeImmediately(NodeTypeCustomCode, config, inputVariables)
+		result, err := engine.RunNodeImmediately(NodeTypeCustomCode, config, inputVariables, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)

--- a/core/taskengine/tenderly_client_test.go
+++ b/core/taskengine/tenderly_client_test.go
@@ -2302,17 +2302,9 @@ func TestEndToEndValuePropagation(t *testing.T) {
 		}
 
 		inputVariables := map[string]interface{}{
-			"workflowContext": map[string]interface{}{
-				"id":           "afc0ea13-35a6-40a5-bcc1-cc26f53cda78",
-				"chainId":      11155111,
-				"name":         "Aug 14, 2025 6:32 PM",
-				"eoaAddress":   "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788",
-				"runner":       "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
-				"startAt":      "2025-08-15T01:50:35.719Z",
-				"expiredAt":    "2025-09-15T01:32:09.000Z",
-				"maxExecution": 0,
-				"status":       "draft",
-				"chain":        "Sepolia",
+			"settings": map[string]interface{}{
+				"runner":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"chainId": 11155111,
 			},
 			"oracle1": map[string]interface{}{
 				"data": map[string]interface{}{
@@ -2332,7 +2324,7 @@ func TestEndToEndValuePropagation(t *testing.T) {
 		t.Logf("   - Node Type: %s", nodeType)
 		t.Logf("   - Contract: %s", nodeConfig["contractAddress"])
 		t.Logf("   - Value: %s wei (0.1 ETH)", nodeConfig["value"])
-		t.Logf("   - Runner: %s", inputVariables["workflowContext"].(map[string]interface{})["runner"])
+		t.Logf("   - Runner: %s", inputVariables["settings"].(map[string]interface{})["runner"])
 
 		// Skip if no Tenderly API key
 		testConfig := testutil.GetTestConfig()
@@ -2345,7 +2337,8 @@ func TestEndToEndValuePropagation(t *testing.T) {
 		}
 
 		// Execute the node using the same flow as the aggregator
-		result, err := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables)
+		user := testutil.TestUser1()
+		result, err := engine.RunNodeImmediately(nodeType, nodeConfig, inputVariables, user)
 
 		// Check for smart wallet validation error
 		// Note: The runner address (0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e) should be the salt:0
@@ -2355,7 +2348,7 @@ func TestEndToEndValuePropagation(t *testing.T) {
 			t.Skipf("⏭️  Skipping E2E test - smart wallet validation failed in test environment. "+
 				"Runner should be salt:0 derivation of EOA on Sepolia (chainId: %v). "+
 				"This appears to be a test environment configuration issue, not a code issue.",
-				inputVariables["workflowContext"].(map[string]interface{})["chainId"])
+				inputVariables["settings"].(map[string]interface{})["chainId"])
 			return
 		}
 

--- a/core/taskengine/tenderly_client_test.go
+++ b/core/taskengine/tenderly_client_test.go
@@ -2303,8 +2303,8 @@ func TestEndToEndValuePropagation(t *testing.T) {
 
 		inputVariables := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"runner":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
-				"chainId": 11155111,
+				"runner":   "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"chain_id": 11155111,
 			},
 			"oracle1": map[string]interface{}{
 				"data": map[string]interface{}{

--- a/core/taskengine/tenderly_client_test.go
+++ b/core/taskengine/tenderly_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -2344,11 +2345,11 @@ func TestEndToEndValuePropagation(t *testing.T) {
 		// Note: The runner address (0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e) should be the salt:0
 		// derivation of the EOA (0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788) on Sepolia chain.
 		// This validation failure suggests a test environment configuration issue.
-		if err != nil && err.Error() == "runner 0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e does not match any existing smart wallet for owner 0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788" {
+		if err != nil && strings.Contains(err.Error(), "does not match any existing smart wallet for owner") {
 			t.Skipf("⏭️  Skipping E2E test - smart wallet validation failed in test environment. "+
-				"Runner should be salt:0 derivation of EOA on Sepolia (chainId: %v). "+
+				"Runner should be salt:0 derivation of EOA on Sepolia (chain_id: %v). "+
 				"This appears to be a test environment configuration issue, not a code issue.",
-				inputVariables["settings"].(map[string]interface{})["chainId"])
+				inputVariables["settings"].(map[string]interface{})["chain_id"])
 			return
 		}
 

--- a/core/taskengine/token_enrichment_integration_test.go
+++ b/core/taskengine/token_enrichment_integration_test.go
@@ -70,7 +70,7 @@ func TestTokenEnrichmentIntegration(t *testing.T) {
 		}
 
 		// Execute EventTrigger immediately
-		result, err := engine.RunNodeImmediately("eventTrigger", configMap, map[string]interface{}{})
+		result, err := engine.RunNodeImmediately("eventTrigger", configMap, map[string]interface{}{}, nil)
 
 		// Even if no events are found, the integration should work without error
 		if err != nil {

--- a/core/taskengine/trigger_data_flattening_test.go
+++ b/core/taskengine/trigger_data_flattening_test.go
@@ -283,7 +283,7 @@ func TestCamelCaseVariableResolutionConsistency(t *testing.T) {
 	}
 
 	t.Run("RunNodeImmediately", func(t *testing.T) {
-		result, err := engine.RunNodeImmediately("customCode", customCodeConfig, inputVariables)
+		result, err := engine.RunNodeImmediately("customCode", customCodeConfig, inputVariables, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 
@@ -409,7 +409,7 @@ func TestBranchNodeCamelCaseResolution(t *testing.T) {
 	}
 
 	t.Run("BranchNodeCamelCaseResolution", func(t *testing.T) {
-		result, err := engine.RunNodeImmediately("branch", branchConfig, inputVariables)
+		result, err := engine.RunNodeImmediately("branch", branchConfig, inputVariables, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 		if result != nil && result["success"] != nil {
@@ -461,7 +461,7 @@ func TestContractReadCamelCaseResolution(t *testing.T) {
 	t.Run("ContractReadCamelCaseResolution", func(t *testing.T) {
 		// This test will fail with RPC connection error, but we can check that the preprocessing worked
 		// by examining the error message - it should contain the resolved address, not the template
-		result, err := engine.RunNodeImmediately("contractRead", contractReadConfig, inputVariables)
+		result, err := engine.RunNodeImmediately("contractRead", contractReadConfig, inputVariables, nil)
 
 		// We expect an error due to RPC connection or template preprocessing issue
 		assert.Error(t, err)

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1714,6 +1714,15 @@ func (v *VM) preprocessTextWithVariableMapping(text string) string {
 			continue
 		}
 
+		// Validate variable names - reject hyphenated keys
+		if strings.Contains(expr, "-") {
+			if v.logger != nil {
+				v.logger.Warn("Template variable contains invalid character (hyphen)", "expression", expr)
+			}
+			result = result[:start] + "undefined" + result[end+2:]
+			continue
+		}
+
 		// Try to resolve the variable with fallback to camelCase
 		exportedValue, resolved := v.resolveVariableWithFallback(jsvm, expr, currentVars)
 		if !resolved {

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1634,6 +1634,31 @@ func (v *VM) runEthTransfer(stepID string, node *avsproto.ETHTransferNode) (*avs
 // convertToCamelCase converts snake_case to camelCase
 // Example: "block_number" -> "blockNumber", "gas_limit" -> "gasLimit"
 
+// isSimpleVariablePath checks if an expression is a simple variable path (e.g., settings.pool.token0)
+// Returns true for: var, var.field, var.nested.field
+// Returns false for: expressions with operators, function calls, string literals, etc.
+func isSimpleVariablePath(expr string) bool {
+	// Check if it contains operators, parentheses, brackets, quotes, or spaces
+	// These indicate it's a complex expression, not just a variable path
+	invalidChars := []string{
+		" ", "+", "*", "/", "%", // Mathematical operators (exclude "-" since we check it separately)
+		"(", ")", // Function calls
+		"[", "]", // Array indexing or computed properties
+		"\"", "'", "`", // String literals
+		"==", "!=", ">", "<", "&&", "||", // Comparison/logical operators
+	}
+
+	for _, char := range invalidChars {
+		if strings.Contains(expr, char) {
+			return false
+		}
+	}
+
+	// If it only contains letters, numbers, dots, and underscores, it's a simple path
+	// (we'll check for hyphens separately)
+	return true
+}
+
 // resolveVariableWithFallback tries to resolve a variable path
 func (v *VM) resolveVariableWithFallback(jsvm *goja.Runtime, varPath string, currentVars map[string]any) (interface{}, bool) {
 	// SECURITY: Validate variable path using centralized security validation
@@ -1714,10 +1739,16 @@ func (v *VM) preprocessTextWithVariableMapping(text string) string {
 			continue
 		}
 
-		// Validate variable names - reject hyphenated keys
-		if strings.Contains(expr, "-") {
+		// Validate variable names - reject hyphenated keys in variable paths only
+		// Allow hyphens in:
+		// - String literals: "hello-world"
+		// - Mathematical expressions: some_var - 10
+		// - Array indexing: array[index-1]
+		// Reject hyphens in:
+		// - Variable names: settings.uniswap-pool (should be settings.uniswap_pool)
+		if isSimpleVariablePath(expr) && strings.Contains(expr, "-") {
 			if v.logger != nil {
-				v.logger.Warn("Template variable contains invalid character (hyphen)", "expression", expr)
+				v.logger.Warn("Template variable path contains invalid character (hyphen)", "expression", expr)
 			}
 			result = result[:start] + "undefined" + result[end+2:]
 			continue

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -372,15 +372,15 @@ func (r *ContractWriteProcessor) executeMethodCall(
 							foundChainID = true
 						}
 					}
-					r.vm.logger.Info("ContractWrite: Found chainId in settings", "chain_id", chainID)
+					r.vm.logger.Debug("ContractWrite: Found chainId in settings", "chain_id", chainID)
 				} else {
-					r.vm.logger.Warn("ContractWrite: chainId not found in settings")
+					r.vm.logger.Debug("ContractWrite: chainId not found in settings")
 				}
 			} else {
-				r.vm.logger.Warn("ContractWrite: settings is not a valid object")
+				r.vm.logger.Debug("ContractWrite: settings is not a valid object")
 			}
 		} else {
-			r.vm.logger.Warn("ContractWrite: settings not found in VM variables")
+			r.vm.logger.Debug("ContractWrite: settings not found in VM variables")
 		}
 
 		if !foundChainID {

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -347,10 +347,10 @@ func (r *ContractWriteProcessor) executeMethodCall(
 		var chainID int64
 		foundChainID := false
 
-		// Get chainId from settings
+		// Get chain_id from settings (snake_case only)
 		if settingsIface, ok := r.vm.vars["settings"]; ok {
 			if settings, ok := settingsIface.(map[string]interface{}); ok {
-				if cid, ok := settings["chainId"]; ok {
+				if cid, ok := settings["chain_id"]; ok {
 					switch v := cid.(type) {
 					case int64:
 						chainID = v
@@ -387,7 +387,7 @@ func (r *ContractWriteProcessor) executeMethodCall(
 			return &avsproto.ContractWriteNode_MethodResult{
 				MethodName: methodName,
 				Success:    false,
-				Error:      "settings.chainId is required for contractWrite",
+				Error:      "settings.chain_id is required for contractWrite",
 			}
 		}
 		r.vm.logger.Debug("ContractWrite: resolved chain id for simulation", "chain_id", chainID)

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -169,7 +169,7 @@ func (r *ContractWriteProcessor) executeMethodCall(
 			return &avsproto.ContractWriteNode_MethodResult{
 				MethodName: methodCall.MethodName,
 				Success:    false,
-				Error:      fmt.Sprintf("template variable resolution failed in parameter %d: '%s' resolved to '%s'. Variables with hyphens (-) are not supported. Use snake_case (e.g., 'uniswapv3_pool' instead of 'uniswapv3-pool')", i, param, resolvedMethodParams[i]),
+				Error:      fmt.Sprintf("template variable resolution failed in parameter %d: '%s' resolved to '%s'", i, param, resolvedMethodParams[i]),
 			}
 		}
 	}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -372,7 +372,7 @@ func (r *ContractWriteProcessor) executeMethodCall(
 			return &avsproto.ContractWriteNode_MethodResult{
 				MethodName: methodName,
 				Success:    false,
-				Error:      "chainId is required for contractWrite (provide in settings.chainId)",
+				Error:      "settings.chainId is required for contractWrite",
 			}
 		}
 		r.vm.logger.Debug("ContractWrite: resolved chain id for simulation", "chain_id", chainID)

--- a/core/taskengine/vm_runner_contract_write_simulation_test.go
+++ b/core/taskengine/vm_runner_contract_write_simulation_test.go
@@ -103,8 +103,8 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		// Provide settings for new backend validation structure
 		triggerData := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"runner":  runnerAddr.Hex(),
-				"chainId": 11155111, // Sepolia
+				"runner":   runnerAddr.Hex(),
+				"chain_id": 11155111, // Sepolia
 			},
 		}
 
@@ -193,8 +193,8 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 				"input": map[string]interface{}{"schedules": []interface{}{"*/5 * * * *"}},
 			},
 			"settings": map[string]interface{}{
-				"runner":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
-				"chainId": 11155111,
+				"runner":   "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"chain_id": 11155111,
 			},
 			// Keep some legacy fields for context but authentication should come from user
 			"workflowMeta": map[string]interface{}{
@@ -319,8 +319,8 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 
 		triggerData := map[string]interface{}{
 			"settings": map[string]interface{}{
-				"runner":  derivedRunner.Hex(),
-				"chainId": 11155111,
+				"runner":   derivedRunner.Hex(),
+				"chain_id": 11155111,
 			},
 			"workflowMeta": map[string]interface{}{
 				"id":    "test-run-node-immediately-transfer",

--- a/core/taskengine/vm_runner_contract_write_simulation_test.go
+++ b/core/taskengine/vm_runner_contract_write_simulation_test.go
@@ -100,16 +100,18 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		factory := testutil.GetAggregatorConfig().SmartWallet.FactoryAddress
 		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: &runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
 
-		// Provide minimal workflowContext to satisfy backend validation
+		// Provide settings for new backend validation structure
 		triggerData := map[string]interface{}{
-			"workflowContext": map[string]interface{}{
-				"eoaAddress": ownerEOA.Hex(),
-				"runner":     runnerAddr.Hex(),
-				"chainId":    11155111, // Sepolia
+			"settings": map[string]interface{}{
+				"runner":  runnerAddr.Hex(),
+				"chainId": 11155111, // Sepolia
 			},
 		}
 
-		result, err := engine.RunNodeImmediately("contractWrite", nodeConfig, triggerData)
+		// Create user for authentication (EOA from the stored wallet)
+		user := &model.User{Address: ownerEOA}
+
+		result, err := engine.RunNodeImmediately("contractWrite", nodeConfig, triggerData, user)
 
 		require.NoError(t, err, "RunNodeImmediately should succeed with Tenderly simulation")
 		require.NotNil(t, result, "Should get simulation result")
@@ -184,18 +186,20 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 			"gasLimit": "210000",
 		}
 
-		// Exact input variables from client request
+		// Updated input variables with new settings structure
 		inputVariables := map[string]interface{}{
 			"timeTrigger": map[string]interface{}{
 				"data":  map[string]interface{}{},
 				"input": map[string]interface{}{"schedules": []interface{}{"*/5 * * * *"}},
 			},
-			"workflowContext": map[string]interface{}{
+			"settings": map[string]interface{}{
+				"runner":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"chainId": 11155111,
+			},
+			// Keep some legacy fields for context but authentication should come from user
+			"workflowMeta": map[string]interface{}{
 				"id":           "7625882c-8d1c-40dc-8d04-13eee0ba8b2f",
-				"chainId":      11155111,
 				"name":         "Recurring Transfer with report",
-				"eoaAddress":   "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788",
-				"runner":       "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
 				"startAt":      "2025-08-14T23:20:37.988Z",
 				"expiredAt":    "2025-09-14T22:23:37.084Z",
 				"maxExecution": 2,
@@ -207,11 +211,14 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		t.Logf("🚀 Testing exact client request:")
 		t.Logf("   Contract: %s", nodeConfig["contractAddress"])
 		t.Logf("   Method: transfer")
-		t.Logf("   From: %s", inputVariables["workflowContext"].(map[string]interface{})["runner"])
+		t.Logf("   From: %s", inputVariables["settings"].(map[string]interface{})["runner"])
 		t.Logf("   To: %s", nodeConfig["methodCalls"].([]interface{})[0].(map[string]interface{})["methodParams"].([]interface{})[0])
 		t.Logf("   Amount: %s", nodeConfig["methodCalls"].([]interface{})[0].(map[string]interface{})["methodParams"].([]interface{})[1])
 
-		result, err := engine.RunNodeImmediately("contractWrite", nodeConfig, inputVariables)
+		// Create user for authentication (EOA from the exact client request)
+		user := &model.User{Address: ownerEOA}
+
+		result, err := engine.RunNodeImmediately("contractWrite", nodeConfig, inputVariables, user)
 
 		if err != nil {
 			t.Logf("❌ RunNodeImmediately failed: %v", err)
@@ -311,18 +318,22 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		}
 
 		triggerData := map[string]interface{}{
-			"workflowContext": map[string]interface{}{
-				"id":         "test-run-node-immediately-transfer",
-				"chainId":    11155111,
-				"name":       "Recurring Transfer with report",
-				"eoaAddress": ownerEOA.Hex(),
-				"runner":     derivedRunner.Hex(),
-				"chain":      "Sepolia",
+			"settings": map[string]interface{}{
+				"runner":  derivedRunner.Hex(),
+				"chainId": 11155111,
+			},
+			"workflowMeta": map[string]interface{}{
+				"id":    "test-run-node-immediately-transfer",
+				"name":  "Recurring Transfer with report",
+				"chain": "Sepolia",
 			},
 			"timeTrigger": map[string]interface{}{"data": map[string]interface{}{}, "input": map[string]interface{}{"schedules": []interface{}{"*/5 * * * *"}}},
 		}
 
-		result, err := engine.RunNodeImmediately("contractWrite", nodeConfig, triggerData)
+		// Create user for authentication (EOA from the derived runner test)
+		user := &model.User{Address: ownerEOA}
+
+		result, err := engine.RunNodeImmediately("contractWrite", nodeConfig, triggerData, user)
 		if err != nil {
 			t.Logf("❌ RunNodeImmediately failed: %v", err)
 		} else {


### PR DESCRIPTION
Changes:
- Remove all backward compatibility for workflowContext.eoaAddress and workflowContext.runner
- All contractWrite operations now require authenticated user context via JWT
- Input format standardized to use 'settings' object with runner and chainId fields

Features:
- Enhanced security: EOA addresses now sourced from authenticated JWT tokens
- Unified RunNodeImmediately signature: (nodeType, nodeConfig, inputVariables, user)
- Clear separation between configuration (settings) and authentication (user)
- Comprehensive validation for missing settings, runner, or user authentication

Core Changes:
- Updated vm_runner_contract_write.go to validate settings.runner and settings.chainId
- Modified run_node_immediately.go to require user authentication for contractWrite nodes
- Removed legacy workflowContext fallback logic throughout codebase
- Updated chainId resolution in contract write simulation to prioritize settings

Tests:
- Added comprehensive test suite (run_node_immediately_settings_test.g- Added comprehe existing test files to use new function signature
- Added tests for authentication failure scenarios
- Added tests for missing settings validation
- All legacy tests updated- All legacy tests updated- All legacy tests updated- All legacy tests updated- Aless- All leg by requiring JWT authentication
- Validate smart wallet runner addresses against authenticated user
- Ensure only authenticated requests can execute contract writes
- Clear error messages for missing authentication or configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require authenticated user and new settings-based config for contractWrite, updating RunNodeImmediately to accept user and removing workflowContext fallback across engine and tests.
> 
> - **Engine/API**:
>   - Update `RunNodeImmediately` to `RunNodeImmediately(nodeType, nodeConfig, inputVariables, user)` and propagate through RPC (`RunNodeImmediatelyRPC`).
>   - For `contractWrite`:
>     - Require authenticated `user` (EOA from JWT) and validate `settings.runner` belongs to `user`’s smart wallets; set `vm.TaskOwner` and `aa_sender` accordingly.
>     - Standardize input to `settings` object (`runner`, `chainId`); remove `workflowContext` fallback and errors now reference `settings.*`.
>     - Read `chainId` from `settings.chainId` in VM runner; update error messages and logging.
>   - Add helper `getMapKeys` and minor log/validation tweaks.
> - **Tests**:
>   - Add `run_node_immediately_settings_test.go` and tuple handling tests for `contractWrite` JSON tuple/object params.
>   - Update all tests to use new `RunNodeImmediately(..., user)` signature and `settings` format; add auth/missing-settings failure cases and E2E updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42716081b1946093f02efa0c7838e93ddb88e631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->