### PR TITLE
Migrate from workflowContext to settings for simulations

### DIFF
--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -233,15 +233,9 @@ func (x *TaskExecutor) RunTask(task *model.Task, queueData *QueueExecutionData) 
 		chainIdSource = "tokenEnrichmentService"
 	}
 
-	if chainId > 0 {
-		if x.logger != nil {
-			x.logger.Info("🔗 Executor: Adding chain name to VM", "chainId", chainId, "source", chainIdSource)
-		}
-		vm.WithChainName(chainId)
-	} else {
-		if x.logger != nil {
-			x.logger.Warn("⚠️ Executor: No chainId available for chain name resolution")
-		}
+	// chainId is used by execution context (set in vm.smartWalletConfig.ChainID)
+	if chainId > 0 && x.logger != nil {
+		x.logger.Debug("Executor: Chain ID resolved", "chainId", chainId, "source", chainIdSource)
 	}
 
 	// Debug: Log FilterNode expressions in VM after creation

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2827,19 +2827,6 @@ func (n *Engine) runProcessingNodeWithInputs(user *model.User, nodeType string, 
 	// This allows access to fields like 'value' and 'gasLimit' that aren't in protobuf schema
 	vm.AddVar("nodeConfig", nodeConfig)
 
-	// Add chain name to workflowContext if token enrichment service is available
-	if n.tokenEnrichmentService != nil {
-		chainId := n.tokenEnrichmentService.GetChainID()
-		if n.logger != nil {
-			n.logger.Info("🔗 RunNodeImmediately: Adding chain name to VM", "chainId", chainId)
-		}
-		vm.WithChainName(chainId)
-	} else {
-		if n.logger != nil {
-			n.logger.Warn("⚠️ RunNodeImmediately: No token enrichment service available for chain name")
-		}
-	}
-
 	// Create node from type and config
 	node, err := CreateNodeFromType(nodeType, nodeConfig, "")
 	if err != nil {

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -176,7 +176,7 @@ func (r *ContractWriteProcessor) executeMethodCall(
 			return &avsproto.ContractWriteNode_MethodResult{
 				MethodName: methodCall.MethodName,
 				Success:    false,
-				Error:      fmt.Sprintf("template variable resolution failed in parameter %d: '%s' resolved to '%s'. Variables with hyphens (-) are not supported. Use snake_case (e.g., 'recipient_address' instead of 'recipient-address')", i, param, resolvedMethodParams[i]),
+				Error:      fmt.Sprintf("template variable resolution failed in parameter %d: '%s' resolved to '%s'. This may be due to an undefined variable, incorrect template syntax, or unsupported variable names (e.g., variables with hyphens are not supported; use snake_case such as 'recipient_address' instead of 'recipient-address').", i, param, resolvedMethodParams[i]),
 			}
 		}
 	}


### PR DESCRIPTION
- Remove workflowContext dependency from SimulateTask and RunNodeImmediately
- Use settings.runner exclusively (no fallbacks to workflowContext)
- Remove dead code: WithChainName(), getChainNameFromId()
- Remove unnecessary workflow name extraction from inputVariables
- Clean up chain ID logging in executor (was unused)
- SimulateTask now uses static 'simulation' name

Breaking changes:
- SimulateTask and RunNodeImmediately no longer accept workflowContext in inputVariables
- Must use settings.runner and settings.chain_id instead

Benefits:
- Clean, deterministic code with no fallbacks
- Single source of truth: settings for simulations, Task model for deployed workflows
- Removed ~109 lines of dead/unnecessary code