### PR TITLE
fix: accept EOA-subject admin keys in legacy VerifyJwtKeyForUser

### DIFF
--- a/core/auth/user.go
+++ b/core/auth/user.go
@@ -85,10 +85,25 @@ func VerifyJwtKeyForUser(secret []byte, key string, userWallet common.Address) (
 			return true, nil
 		}
 
+		// EOA-subject JWTs (issued by `create-api-key` since #509). Two valid cases:
+		//   1. The JWT carries an admin role → it can manage any wallet.
+		//   2. The JWT subject equals the requesting userWallet → per-wallet key.
 		claimAddress := common.HexToAddress(sub)
+
+		if rolesVal, hasRoles := claims["roles"]; hasRoles {
+			if rolesArray, ok := rolesVal.([]any); ok {
+				for _, v := range rolesArray {
+					if roleStr, ok := v.(string); ok && ApiRole(roleStr) == "admin" {
+						return true, nil
+					}
+				}
+			}
+		}
+
 		if claimAddress != userWallet {
 			return false, fmt.Errorf("Invalid Subject")
 		}
+		return true, nil
 	}
 
 	return false, fmt.Errorf("Malform JWT Key Claim")


### PR DESCRIPTION
## Summary
Follow-up to #513. The audience-claim fix unblocked the modern verifier, but `GetKey` (used by SDK `authWithAPIKey`) calls `VerifyJwtKeyForUser` in `core/auth/user.go`, which had two bugs:

1. Only treated literal `sub == "apikey"` as admin, but #509 changed `CreateAdminKey` to require an EOA address as the subject.
2. For EOA-subject JWTs, even when `claimAddress == userWallet`, fell through to `Malform JWT Key Claim` because the address-match branch was missing a `return true, nil`.

Add an EOA-subject branch mirroring the modern `verifyAuth` contract: admin-role keys may manage any wallet; non-admin keys are valid only when `subject == userWallet`.

Discovered re-running ava-sdk-js#209 CI after #513 merged — the API key length grew (proving `aud` was now embedded) but `tests/core/auth.test.ts` still failed against this legacy path.

## Test plan
- [x] `go build ./...` clean
- [ ] ava-sdk-js #210 `test:core` passes after a fresh `:latest` rebuild