### PR TITLE
fix: Tenderly state overrides for simulation balance propagation; include chainId audience claim in JWT

### DIFF
--- a/aggregator/key.go
+++ b/aggregator/key.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/auth"
@@ -44,11 +45,24 @@ func CreateAdminKey(configPath string, opt CreateApiKeyOption) error {
 		roles[i] = auth.ApiRole(v)
 	}
 
+	// The verifier (aggregator/auth.go::verifyAuth) requires the JWT to have an
+	// `aud` claim containing the smart wallet chain ID. r.chainID in the
+	// verifier is sourced from the smart wallet RPC (see rpc_server.go), not
+	// the EigenLayer RPC, so we must use SmartWallet.ChainID here too — using
+	// the EigenLayer chain ID would silently break cross-chain configs (e.g.
+	// EigenLayer on Ethereum + SmartWallet on Base). config.NewConfig already
+	// populated SmartWallet.ChainID at startup, so no extra RPC dial is needed.
+	if nodeConfig.SmartWallet == nil || nodeConfig.SmartWallet.ChainID == 0 {
+		return fmt.Errorf("smart wallet chain ID not populated in config; cannot build audience claim")
+	}
+	audienceChainID := strconv.FormatInt(nodeConfig.SmartWallet.ChainID, 10)
+
 	claims := &auth.APIClaim{
 		RegisteredClaims: &jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 24 * 365 * 10)),
-			Issuer:    "AvaProtocol",
+			Issuer:    auth.Issuer,
 			Subject:   opt.Subject,
+			Audience:  jwt.ClaimStrings{audienceChainID},
 		},
 		Roles: roles,
 	}

--- a/core/auth/user.go
+++ b/core/auth/user.go
@@ -85,10 +85,25 @@ func VerifyJwtKeyForUser(secret []byte, key string, userWallet common.Address) (
 			return true, nil
 		}
 
+		// EOA-subject JWTs (issued by `create-api-key` since #509). Two valid cases:
+		//   1. The JWT carries an admin role → it can manage any wallet.
+		//   2. The JWT subject equals the requesting userWallet → per-wallet key.
 		claimAddress := common.HexToAddress(sub)
+
+		if rolesVal, hasRoles := claims["roles"]; hasRoles {
+			if rolesArray, ok := rolesVal.([]any); ok {
+				for _, v := range rolesArray {
+					if roleStr, ok := v.(string); ok && ApiRole(roleStr) == "admin" {
+						return true, nil
+					}
+				}
+			}
+		}
+
 		if claimAddress != userWallet {
 			return false, fmt.Errorf("Invalid Subject")
 		}
+		return true, nil
 	}
 
 	return false, fmt.Errorf("Malform JWT Key Claim")

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -2989,7 +2989,7 @@ func (n *Engine) SimulateTask(user *model.User, trigger *avsproto.TaskTrigger, n
 	if shouldContinue {
 		// Inject simulated state overrides so downstream Tenderly simulations see
 		// the balance changes implied by the trigger event.
-		n.logger.Info("SimulateTask: state override check",
+		n.logger.Debug("SimulateTask: state override check",
 			"triggerType", triggerType,
 			"isEventTrigger", triggerType == avsproto.TriggerType_TRIGGER_TYPE_EVENT,
 			"simulationStateNil", vm.simulationState == nil)
@@ -3082,9 +3082,8 @@ func (n *Engine) injectEventTriggerStateOverrides(triggerOutput map[string]inter
 		return
 	}
 
-	n.logger.Info("injectEventTriggerStateOverrides: called",
-		"triggerOutputKeys", GetMapKeys(triggerOutput),
-		"simulationStateEmpty", vm.simulationState.IsEmpty())
+	n.logger.Debug("injectEventTriggerStateOverrides: called",
+		"triggerOutputKeys", GetMapKeys(triggerOutput))
 
 	// Only process if there is parsed event data
 	rawData := triggerOutput["data"]
@@ -3100,7 +3099,7 @@ func (n *Engine) injectEventTriggerStateOverrides(triggerOutput map[string]inter
 	}
 
 	eventName, _ := data["eventName"].(string)
-	n.logger.Info("injectEventTriggerStateOverrides: resolved eventName",
+	n.logger.Debug("injectEventTriggerStateOverrides: resolved eventName",
 		"eventName", eventName,
 		"dataKeys", GetMapKeys(data))
 
@@ -3166,6 +3165,11 @@ func (n *Engine) injectTransferEventState(data map[string]interface{}, vm *VM) {
 	}
 
 	// ERC20 transfer
+	if vm.smartWalletConfig == nil || vm.smartWalletConfig.EthRpcUrl == "" {
+		n.logger.Warn("No smart wallet config for ERC20 balance injection, skipping")
+		return
+	}
+
 	holderAddress := common.HexToAddress(walletAddr)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -2987,6 +2987,16 @@ func (n *Engine) SimulateTask(user *model.User, trigger *avsproto.TaskTrigger, n
 	var nodeEndTime time.Time
 
 	if shouldContinue {
+		// Inject simulated state overrides so downstream Tenderly simulations see
+		// the balance changes implied by the trigger event.
+		n.logger.Info("SimulateTask: state override check",
+			"triggerType", triggerType,
+			"isEventTrigger", triggerType == avsproto.TriggerType_TRIGGER_TYPE_EVENT,
+			"simulationStateNil", vm.simulationState == nil)
+		if triggerType == avsproto.TriggerType_TRIGGER_TYPE_EVENT && vm.simulationState != nil {
+			n.injectEventTriggerStateOverrides(triggerOutput, vm)
+		}
+
 		// Run the workflow nodes
 		runErr = vm.Run()
 		nodeEndTime = time.Now()
@@ -3060,6 +3070,113 @@ func (n *Engine) SimulateTask(user *model.User, trigger *avsproto.TaskTrigger, n
 	}
 
 	return execution, nil
+}
+
+// injectEventTriggerStateOverrides examines the event trigger output and populates
+// the VM's simulation state map with implied balance changes. For Transfer events this
+// means injecting the token balance the smart wallet would have received; for ETH
+// transfers it overrides the ETH balance.
+func (n *Engine) injectEventTriggerStateOverrides(triggerOutput map[string]interface{}, vm *VM) {
+	if vm.simulationState == nil {
+		n.logger.Warn("injectEventTriggerStateOverrides: simulationState is nil, skipping")
+		return
+	}
+
+	n.logger.Info("injectEventTriggerStateOverrides: called",
+		"triggerOutputKeys", GetMapKeys(triggerOutput),
+		"simulationStateEmpty", vm.simulationState.IsEmpty())
+
+	// Only process if there is parsed event data
+	rawData := triggerOutput["data"]
+	n.logger.Debug("injectEventTriggerStateOverrides: raw data field",
+		"type", fmt.Sprintf("%T", rawData),
+		"isNil", rawData == nil)
+
+	data, ok := rawData.(map[string]interface{})
+	if !ok || data == nil {
+		// Flat structure — some paths put fields at the top level
+		n.logger.Debug("injectEventTriggerStateOverrides: data field not a map, using triggerOutput directly")
+		data = triggerOutput
+	}
+
+	eventName, _ := data["eventName"].(string)
+	n.logger.Info("injectEventTriggerStateOverrides: resolved eventName",
+		"eventName", eventName,
+		"dataKeys", GetMapKeys(data))
+
+	switch eventName {
+	case "Transfer":
+		n.injectTransferEventState(data, vm)
+	default:
+		n.logger.Debug("No simulation state injection for event type",
+			"eventName", eventName)
+	}
+}
+
+// injectTransferEventState handles ERC20 Transfer events by computing the balance
+// change implied by the simulated transfer and injecting it as a storage override.
+func (n *Engine) injectTransferEventState(data map[string]interface{}, vm *VM) {
+	n.logger.Info("injectTransferEventState: called",
+		"dataKeys", GetMapKeys(data))
+
+	tokenAddr, _ := data["contractAddress"].(string)
+	walletAddr, _ := data["walletAddress"].(string)
+	valueStr, _ := data["value"].(string)
+
+	n.logger.Info("injectTransferEventState: extracted fields",
+		"tokenAddr", tokenAddr,
+		"walletAddr", walletAddr,
+		"value", valueStr,
+		"direction", data["direction"])
+
+	if tokenAddr == "" || walletAddr == "" || valueStr == "" {
+		n.logger.Warn("Transfer event missing fields for state injection",
+			"tokenAddr", tokenAddr, "walletAddr", walletAddr, "value", valueStr)
+		return
+	}
+
+	transferAmount, ok := new(big.Int).SetString(valueStr, 10)
+	if !ok {
+		n.logger.Warn("Failed to parse transfer amount for state injection", "value", valueStr)
+		return
+	}
+
+	// Determine direction: if the wallet is the sender, balance decreases.
+	// Event enrichment uses "sent"/"received"; older paths may use "outgoing"/"incoming".
+	direction, _ := data["direction"].(string)
+	switch strings.ToLower(direction) {
+	case "outgoing", "sent":
+		transferAmount = new(big.Int).Neg(transferAmount)
+	}
+
+	// Check if this is an ETH transfer (native currency, not ERC20)
+	// ETH transfers have no token contract or a zero address
+	tokenAddress := common.HexToAddress(tokenAddr)
+	if tokenAddress == (common.Address{}) {
+		// Native ETH transfer
+		holderAddress := common.HexToAddress(walletAddr)
+		if vm.smartWalletConfig != nil && vm.smartWalletConfig.EthRpcUrl != "" {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := vm.simulationState.InjectETHBalanceChange(ctx, vm.smartWalletConfig.EthRpcUrl, holderAddress, transferAmount); err != nil {
+				n.logger.Warn("Failed to inject ETH balance override", "error", err)
+			}
+		}
+		return
+	}
+
+	// ERC20 transfer
+	holderAddress := common.HexToAddress(walletAddr)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := vm.simulationState.InjectERC20BalanceChange(ctx, vm.smartWalletConfig, tokenAddress, holderAddress, transferAmount); err != nil {
+		n.logger.Warn("Failed to inject ERC20 balance override for simulation",
+			"error", err,
+			"token", tokenAddr,
+			"holder", walletAddr,
+			"amount", transferAmount.String())
+	}
 }
 
 // shouldContinueWorkflowExecution checks trigger output to determine if workflow should continue

--- a/core/taskengine/manual_trigger_loop_test.go
+++ b/core/taskengine/manual_trigger_loop_test.go
@@ -426,14 +426,15 @@ func TestLoopNode_ContractWrite_InvalidAddress_PartialFailure(t *testing.T) {
 	node.Name = "loopTransfer"
 
 	step, err := vm.RunNodeWithInputs(node, inputVariables)
+	require.NoError(t, err, "loop infrastructure should not fail")
 
-	// Per AvaProtocol/EigenLayer-AVS#511, per-iteration runner failures do not
-	// fail the loop step. The loop ran to completion, so step.Success is true
-	// and the per-iteration outcomes are reflected in the data array (nil for
-	// failed iterations).
+	// When some iterations fail, the loop step reports success=false with a
+	// descriptive error so that AnalyzeExecutionResult detects partial_success.
+	// The loop still ran to completion and preserves OutputData with nil entries
+	// for failed iterations.
 	require.NotNil(t, step, "Execution step should not be nil")
-	assert.True(t, step.Success, "Loop step should succeed when it ran to completion, even if an iteration failed")
-	assert.Empty(t, step.Error, "Loop step error should be empty when loop ran to completion")
+	assert.False(t, step.Success, "Loop step should report failure when iterations failed")
+	assert.Contains(t, step.Error, "1 of 2 iterations failed", "Error should describe the partial failure")
 
 	// The output should still contain results (first iteration data, second nil)
 	loopOutput := step.GetLoop()

--- a/core/taskengine/simulation_state.go
+++ b/core/taskengine/simulation_state.go
@@ -1,0 +1,409 @@
+package taskengine
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// SimulationStateMap tracks accumulated state overrides during workflow simulation.
+// It captures how on-chain state *would* change if each simulated step actually executed,
+// and feeds those changes forward as Tenderly state_objects overrides so subsequent
+// simulation steps see a consistent view of the world.
+type SimulationStateMap struct {
+	mu sync.Mutex
+
+	// storage maps lowercase contract address → storage slot hash → hex value.
+	// These are passed as state_objects[addr].storage in Tenderly API calls.
+	storage map[string]map[string]string
+
+	// ethBalances maps lowercase address → hex balance string.
+	// These are passed as state_objects[addr].balance in Tenderly API calls.
+	ethBalances map[string]string
+
+	// balanceSlotCache maps lowercase token contract address → the uint slot index
+	// used by that token's _balances mapping. Discovered once via probing, then reused.
+	balanceSlotCache map[string]*int64
+
+	logger logger.Logger
+}
+
+// NewSimulationStateMap creates a new empty state map for a simulation run.
+func NewSimulationStateMap(log logger.Logger) *SimulationStateMap {
+	return &SimulationStateMap{
+		storage:          make(map[string]map[string]string),
+		ethBalances:      make(map[string]string),
+		balanceSlotCache: make(map[string]*int64),
+		logger:           log,
+	}
+}
+
+// SetStorageSlot records a storage override for a contract address.
+func (s *SimulationStateMap) SetStorageSlot(contractAddress string, slot string, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	addr := strings.ToLower(contractAddress)
+	if s.storage[addr] == nil {
+		s.storage[addr] = make(map[string]string)
+	}
+	s.storage[addr][slot] = value
+}
+
+// SetETHBalance records an ETH balance override for an address.
+func (s *SimulationStateMap) SetETHBalance(address string, balanceHex string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ethBalances[strings.ToLower(address)] = balanceHex
+}
+
+// MergeRawStateDiff merges Tenderly's raw_state_diff entries into the accumulated state.
+// Each entry has: address, key (storage slot), original, dirty (new value).
+func (s *SimulationStateMap) MergeRawStateDiff(rawStateDiff []interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, entry := range rawStateDiff {
+		entryMap, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		addr, _ := entryMap["address"].(string)
+		key, _ := entryMap["key"].(string)
+		dirty, _ := entryMap["dirty"].(string)
+
+		if addr == "" || key == "" || dirty == "" {
+			continue
+		}
+
+		addr = strings.ToLower(addr)
+		if s.storage[addr] == nil {
+			s.storage[addr] = make(map[string]string)
+		}
+		s.storage[addr][key] = dirty
+	}
+}
+
+// BuildStateObjects constructs the state_objects map for a Tenderly API request,
+// merging accumulated overrides with the existing sender ETH balance override.
+func (s *SimulationStateMap) BuildStateObjects(senderAddress string, senderETHOverride string) map[string]interface{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stateObjects := make(map[string]interface{})
+
+	// Apply accumulated storage overrides
+	for addr, slots := range s.storage {
+		addrObj := s.getOrCreateAddrObj(stateObjects, addr)
+		storageMap := make(map[string]string)
+		for slot, val := range slots {
+			storageMap[slot] = val
+		}
+		addrObj["storage"] = storageMap
+	}
+
+	// Apply accumulated ETH balance overrides
+	for addr, balance := range s.ethBalances {
+		addrObj := s.getOrCreateAddrObj(stateObjects, addr)
+		addrObj["balance"] = balance
+	}
+
+	// Always ensure the sender has enough ETH for gas
+	senderKey := strings.ToLower(senderAddress)
+	senderObj := s.getOrCreateAddrObj(stateObjects, senderKey)
+	if _, hasBalance := senderObj["balance"]; !hasBalance {
+		senderObj["balance"] = senderETHOverride
+	}
+
+	return stateObjects
+}
+
+// getOrCreateAddrObj returns the override object for an address, creating it if needed.
+// Must be called with s.mu held.
+func (s *SimulationStateMap) getOrCreateAddrObj(stateObjects map[string]interface{}, addr string) map[string]interface{} {
+	existing, ok := stateObjects[addr]
+	if ok {
+		if m, ok := existing.(map[string]interface{}); ok {
+			return m
+		}
+	}
+	m := make(map[string]interface{})
+	stateObjects[addr] = m
+	return m
+}
+
+// erc20BalanceSlot computes the keccak256 storage slot for _balances[holder]
+// given the mapping's base slot index in the contract's storage layout.
+func erc20BalanceSlot(holder common.Address, mappingSlot int64) common.Hash {
+	// abi.encode(address, uint256) — each padded to 32 bytes
+	key := common.LeftPadBytes(holder.Bytes(), 32)
+	slot := common.LeftPadBytes(big.NewInt(mappingSlot).Bytes(), 32)
+	return crypto.Keccak256Hash(append(key, slot...))
+}
+
+// Common ERC20 balance mapping slot indices across different implementations.
+var commonBalanceSlots = []int64{0, 1, 2, 3, 9, 51}
+
+// ProbeERC20BalanceSlot discovers which storage slot a token contract uses for
+// its _balances mapping by comparing eth_getStorageAt results against balanceOf.
+// Returns the slot index, or an error if no match is found.
+func (s *SimulationStateMap) ProbeERC20BalanceSlot(
+	ctx context.Context,
+	rpcURL string,
+	tokenContract common.Address,
+	holder common.Address,
+) (int64, error) {
+	tokenKey := strings.ToLower(tokenContract.Hex())
+
+	// Check cache first
+	s.mu.Lock()
+	cached, hasCached := s.balanceSlotCache[tokenKey]
+	s.mu.Unlock()
+	if hasCached {
+		if cached == nil {
+			return -1, fmt.Errorf("previously failed to discover balance slot for %s", tokenKey)
+		}
+		return *cached, nil
+	}
+
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return -1, fmt.Errorf("failed to connect to RPC for slot probing: %w", err)
+	}
+	defer client.Close()
+
+	// Call balanceOf(holder) to get the expected value
+	balanceOfSig := crypto.Keccak256([]byte("balanceOf(address)"))[:4]
+	callData := append(balanceOfSig, common.LeftPadBytes(holder.Bytes(), 32)...)
+
+	result, err := client.CallContract(ctx, ethereum.CallMsg{
+		To:   &tokenContract,
+		Data: callData,
+	}, nil)
+	if err != nil {
+		s.cacheSlotResult(tokenKey, nil)
+		return -1, fmt.Errorf("balanceOf call failed: %w", err)
+	}
+
+	expectedBalance := new(big.Int).SetBytes(result)
+
+	// Only probe with the target holder if they have a non-zero balance.
+	// When balance is 0, every empty storage slot reads as 0 and would
+	// false-match, so we skip straight to the reference-holder approach.
+	if expectedBalance.Sign() > 0 {
+		for _, candidateSlot := range commonBalanceSlots {
+			slotHash := erc20BalanceSlot(holder, candidateSlot)
+			storageValue, err := client.StorageAt(ctx, tokenContract, slotHash, nil)
+			if err != nil {
+				continue
+			}
+
+			storedBalance := new(big.Int).SetBytes(storageValue)
+			if storedBalance.Cmp(expectedBalance) == 0 {
+				if s.logger != nil {
+					s.logger.Info("Discovered ERC20 balance storage slot",
+						"token", tokenContract.Hex(),
+						"slot", candidateSlot,
+						"balance", expectedBalance.String())
+				}
+				discoveredSlot := candidateSlot
+				s.cacheSlotResult(tokenKey, &discoveredSlot)
+				return discoveredSlot, nil
+			}
+		}
+
+		// Non-zero balance but no slot matched — fall through to reference-holder probe
+	}
+
+	// Holder balance is 0: every empty storage slot reads as 0 and would
+	// false-match. Try to find a reference holder with non-zero balance by
+	// checking well-known addresses (e.g. address(1) from test mints).
+	if expectedBalance.Sign() == 0 {
+		if s.logger != nil {
+			s.logger.Info("Holder has zero balance, probing with reference addresses",
+				"token", tokenContract.Hex(),
+				"holder", holder.Hex())
+		}
+
+		referenceAddresses := []common.Address{
+			common.HexToAddress("0x0000000000000000000000000000000000000001"),
+			common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		}
+
+		for _, refAddr := range referenceAddresses {
+			refCallData := append(crypto.Keccak256([]byte("balanceOf(address)"))[:4], common.LeftPadBytes(refAddr.Bytes(), 32)...)
+			refResult, err := client.CallContract(ctx, ethereum.CallMsg{To: &tokenContract, Data: refCallData}, nil)
+			if err != nil {
+				continue
+			}
+			refBalance := new(big.Int).SetBytes(refResult)
+			if refBalance.Sign() == 0 {
+				continue
+			}
+
+			// Found a reference holder with balance — probe slots against it
+			for _, candidateSlot := range commonBalanceSlots {
+				slotHash := erc20BalanceSlot(refAddr, candidateSlot)
+				storageValue, err := client.StorageAt(ctx, tokenContract, slotHash, nil)
+				if err != nil {
+					continue
+				}
+				storedBalance := new(big.Int).SetBytes(storageValue)
+				if storedBalance.Cmp(refBalance) == 0 {
+					if s.logger != nil {
+						s.logger.Info("Discovered ERC20 balance storage slot via reference holder",
+							"token", tokenContract.Hex(),
+							"referenceHolder", refAddr.Hex(),
+							"slot", candidateSlot,
+							"refBalance", refBalance.String())
+					}
+					discoveredSlot := candidateSlot
+					s.cacheSlotResult(tokenKey, &discoveredSlot)
+					return discoveredSlot, nil
+				}
+			}
+		}
+
+		// Last resort: default to slot 9 (USDC-like) since it's the most common
+		// ERC20 proxy pattern and slot 0 rarely works for proxy contracts.
+		defaultSlot := int64(9)
+		if s.logger != nil {
+			s.logger.Warn("Could not discover balance slot via reference holders, using default slot 9",
+				"token", tokenContract.Hex(),
+				"holder", holder.Hex())
+		}
+		s.cacheSlotResult(tokenKey, &defaultSlot)
+		return defaultSlot, nil
+	}
+
+	s.cacheSlotResult(tokenKey, nil)
+	return -1, fmt.Errorf("could not discover balance slot for token %s (tried slots %v)", tokenContract.Hex(), commonBalanceSlots)
+}
+
+func (s *SimulationStateMap) cacheSlotResult(tokenKey string, slot *int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.balanceSlotCache[tokenKey] = slot
+}
+
+// InjectERC20BalanceChange updates the state map to reflect an ERC20 balance change
+// for the given holder on the given token contract. It queries the current on-chain
+// balance via RPC, adds the delta, and sets the storage override.
+func (s *SimulationStateMap) InjectERC20BalanceChange(
+	ctx context.Context,
+	smartWalletConfig *config.SmartWalletConfig,
+	tokenContract common.Address,
+	holder common.Address,
+	delta *big.Int,
+) error {
+	if smartWalletConfig == nil || smartWalletConfig.EthRpcUrl == "" {
+		return fmt.Errorf("no RPC URL available for ERC20 balance probing")
+	}
+
+	rpcURL := smartWalletConfig.EthRpcUrl
+
+	// Discover the balance mapping slot
+	mappingSlot, err := s.ProbeERC20BalanceSlot(ctx, rpcURL, tokenContract, holder)
+	if err != nil {
+		return fmt.Errorf("failed to probe balance slot: %w", err)
+	}
+
+	// Get current on-chain balance
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return fmt.Errorf("failed to connect to RPC: %w", err)
+	}
+	defer client.Close()
+
+	balanceOfSig := crypto.Keccak256([]byte("balanceOf(address)"))[:4]
+	callData := append(balanceOfSig, common.LeftPadBytes(holder.Bytes(), 32)...)
+
+	result, err := client.CallContract(ctx, ethereum.CallMsg{
+		To:   &tokenContract,
+		Data: callData,
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("balanceOf call failed: %w", err)
+	}
+
+	currentBalance := new(big.Int).SetBytes(result)
+	newBalance := new(big.Int).Add(currentBalance, delta)
+	if newBalance.Sign() < 0 {
+		newBalance = big.NewInt(0)
+	}
+
+	// Compute the storage slot and set the override
+	slotHash := erc20BalanceSlot(holder, mappingSlot)
+	valueHex := fmt.Sprintf("0x%064x", newBalance)
+
+	s.SetStorageSlot(tokenContract.Hex(), slotHash.Hex(), valueHex)
+
+	if s.logger != nil {
+		s.logger.Info("Injected ERC20 balance override for simulation",
+			"token", tokenContract.Hex(),
+			"holder", holder.Hex(),
+			"currentBalance", currentBalance.String(),
+			"delta", delta.String(),
+			"newBalance", newBalance.String(),
+			"slot", slotHash.Hex())
+	}
+
+	return nil
+}
+
+// InjectETHBalanceChange updates the state map to reflect an ETH balance change
+// for the given address. It queries the current on-chain balance via RPC and adds the delta.
+func (s *SimulationStateMap) InjectETHBalanceChange(
+	ctx context.Context,
+	rpcURL string,
+	address common.Address,
+	delta *big.Int,
+) error {
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return fmt.Errorf("failed to connect to RPC for ETH balance: %w", err)
+	}
+	defer client.Close()
+
+	currentBalance, err := client.BalanceAt(ctx, address, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get ETH balance: %w", err)
+	}
+
+	newBalance := new(big.Int).Add(currentBalance, delta)
+	if newBalance.Sign() < 0 {
+		newBalance = big.NewInt(0)
+	}
+
+	balanceHex := fmt.Sprintf("0x%x", newBalance)
+	s.SetETHBalance(address.Hex(), balanceHex)
+
+	if s.logger != nil {
+		s.logger.Info("Injected ETH balance override for simulation",
+			"address", address.Hex(),
+			"currentBalance", currentBalance.String(),
+			"delta", delta.String(),
+			"newBalance", newBalance.String())
+	}
+
+	return nil
+}
+
+// IsEmpty returns true if there are no accumulated state overrides.
+func (s *SimulationStateMap) IsEmpty() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.storage) == 0 && len(s.ethBalances) == 0
+}

--- a/core/taskengine/simulation_state.go
+++ b/core/taskengine/simulation_state.go
@@ -154,6 +154,8 @@ func erc20BalanceSlot(holder common.Address, mappingSlot int64) common.Hash {
 }
 
 // Common ERC20 balance mapping slot indices across different implementations.
+// 0: standard OpenZeppelin ERC20, 1-3: various token implementations,
+// 9: USDC (FiatTokenV2 proxy), 51: Compound cToken-style contracts.
 var commonBalanceSlots = []int64{0, 1, 2, 3, 9, 51}
 
 // ProbeERC20BalanceSlot discovers which storage slot a token contract uses for

--- a/core/taskengine/simulation_state_test.go
+++ b/core/taskengine/simulation_state_test.go
@@ -1,0 +1,222 @@
+package taskengine
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimulationStateMap_BasicOperations(t *testing.T) {
+	logger := testutil.GetLogger()
+	state := NewSimulationStateMap(logger)
+
+	t.Run("empty state returns sender-only state_objects", func(t *testing.T) {
+		objects := state.BuildStateObjects("0xABCD", "0x100")
+		require.NotNil(t, objects)
+
+		senderObj, ok := objects["0xabcd"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "0x100", senderObj["balance"])
+	})
+
+	t.Run("storage overrides are included", func(t *testing.T) {
+		state.SetStorageSlot("0xTokenAddr", "0xSlot1", "0xValue1")
+		objects := state.BuildStateObjects("0xSender", "0x100")
+
+		tokenObj, ok := objects["0xtokenaddr"].(map[string]interface{})
+		require.True(t, ok, "token address should be in state_objects")
+
+		storageMap, ok := tokenObj["storage"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "0xValue1", storageMap["0xSlot1"])
+	})
+
+	t.Run("ETH balance overrides are included", func(t *testing.T) {
+		state.SetETHBalance("0xWallet", "0xDE0B6B3A7640000")
+		objects := state.BuildStateObjects("0xSender", "0x100")
+
+		walletObj, ok := objects["0xwallet"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "0xDE0B6B3A7640000", walletObj["balance"])
+	})
+
+	t.Run("merge raw state diff", func(t *testing.T) {
+		state2 := NewSimulationStateMap(logger)
+		rawDiff := []interface{}{
+			map[string]interface{}{
+				"address":  "0xContract1",
+				"key":      "0xSlotA",
+				"original": "0x0000",
+				"dirty":    "0x1234",
+			},
+			map[string]interface{}{
+				"address":  "0xContract1",
+				"key":      "0xSlotB",
+				"original": "0x0000",
+				"dirty":    "0x5678",
+			},
+		}
+		state2.MergeRawStateDiff(rawDiff)
+
+		objects := state2.BuildStateObjects("0xSender", "0x100")
+		contractObj, ok := objects["0xcontract1"].(map[string]interface{})
+		require.True(t, ok)
+		storageMap, ok := contractObj["storage"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "0x1234", storageMap["0xSlotA"])
+		assert.Equal(t, "0x5678", storageMap["0xSlotB"])
+	})
+}
+
+func TestSimulationStateMap_ERC20BalanceSlotComputation(t *testing.T) {
+	// Verify the storage slot computation matches known values
+	holder := common.HexToAddress("0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e")
+	slot := erc20BalanceSlot(holder, 9)
+
+	// The slot should be a 32-byte keccak256 hash — verify it's non-zero
+	assert.NotEqual(t, common.Hash{}, slot, "computed slot should be non-zero")
+
+	// Same inputs should produce same output (deterministic)
+	slot2 := erc20BalanceSlot(holder, 9)
+	assert.Equal(t, slot, slot2, "deterministic: same inputs produce same slot")
+
+	// Different slot index should produce different hash
+	slot3 := erc20BalanceSlot(holder, 0)
+	assert.NotEqual(t, slot, slot3, "different mapping slot should produce different hash")
+}
+
+func TestSimulationStateMap_ContractWriteWithBalanceOverride(t *testing.T) {
+	// Integration test: reproduces the production scenario where a Transfer event
+	// trigger feeds into a loop with contract writes that spend the received tokens.
+	//
+	// Without SimulationStateMap: the contract write reverts with "ERC20: transfer amount exceeds balance"
+	// With SimulationStateMap: the balance override makes the simulation succeed.
+	logger := testutil.GetLogger()
+	testConfig := testutil.GetTestConfig()
+	if testConfig == nil {
+		t.Skip("No test config available")
+	}
+
+	tenderlyClient := NewTenderlyClient(testConfig, logger)
+	if tenderlyClient == nil {
+		t.Skip("No Tenderly client available")
+	}
+
+	smartWalletConfig := testutil.GetTestSmartWalletConfig()
+
+	// Use Sepolia USDC for testing
+	usdcContract := "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+	runner := "0x5a8A8a79DdF433756D4D97DCCE33334D9E218856"
+	recipient := "0x0000000000000000000000000000000000000001"
+	transferAmount := "600000" // 0.6 USDC
+
+	usdcABI := []interface{}{
+		map[string]interface{}{
+			"type":            "function",
+			"name":            "transfer",
+			"stateMutability": "nonpayable",
+			"inputs": []interface{}{
+				map[string]interface{}{"name": "to", "type": "address"},
+				map[string]interface{}{"name": "value", "type": "uint256"},
+			},
+			"outputs": []interface{}{map[string]interface{}{"name": "", "type": "bool"}},
+		},
+	}
+
+	// First, test WITHOUT state override — should fail with "exceeds balance"
+	t.Run("without_state_override_fails", func(t *testing.T) {
+		vm, err := NewVMWithData(nil, nil, smartWalletConfig, nil)
+		require.NoError(t, err)
+		vm.SetSimulation(true)
+		vm.tenderlyClient = tenderlyClient
+
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"runner":   runner,
+				"chain_id": int64(11155111),
+				"chain":    "sepolia",
+			},
+		}
+
+		nodeConfig := map[string]interface{}{
+			"contractAddress": usdcContract,
+			"contractAbi":     usdcABI,
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName":   "transfer",
+					"methodParams": []interface{}{recipient, transferAmount},
+				},
+			},
+		}
+
+		node, err := CreateNodeFromType("contractWrite", nodeConfig, "")
+		require.NoError(t, err)
+		node.Name = "contractWrite1"
+
+		step, _ := vm.RunNodeWithInputs(node, inputVariables)
+		require.NotNil(t, step, "should return a step even on failure")
+
+		// On mainnet/Base USDC, this would fail with "transfer amount exceeds balance".
+		// On Sepolia test USDC, the behavior may differ (some test tokens don't enforce balances).
+		// We just verify the step completed (non-nil) — the important assertion is
+		// in the "with_state_override_succeeds" subtest.
+		t.Logf("without override: success=%v error=%q", step.Success, step.Error)
+	})
+
+	// Then test WITH state override — should succeed
+	t.Run("with_state_override_succeeds", func(t *testing.T) {
+		vm, err := NewVMWithData(nil, nil, smartWalletConfig, nil)
+		require.NoError(t, err)
+		vm.SetSimulation(true)
+		vm.tenderlyClient = tenderlyClient
+
+		// Inject a USDC balance override: give the runner 1.5 USDC (1500000)
+		holderAddress := common.HexToAddress(runner)
+		tokenAddress := common.HexToAddress(usdcContract)
+		simulatedBalance := new(big.Int).SetInt64(1500000) // 1.5 USDC
+
+		// Set the balance at all common slots to cover Sepolia USDC's layout
+		for _, candidateSlot := range commonBalanceSlots {
+			slotHash := erc20BalanceSlot(holderAddress, candidateSlot)
+			valueHex := "0x" + common.Bytes2Hex(common.LeftPadBytes(simulatedBalance.Bytes(), 32))
+			vm.simulationState.SetStorageSlot(tokenAddress.Hex(), slotHash.Hex(), valueHex)
+		}
+
+		inputVariables := map[string]interface{}{
+			"settings": map[string]interface{}{
+				"runner":   runner,
+				"chain_id": int64(11155111),
+				"chain":    "sepolia",
+			},
+		}
+
+		nodeConfig := map[string]interface{}{
+			"contractAddress": usdcContract,
+			"contractAbi":     usdcABI,
+			"methodCalls": []interface{}{
+				map[string]interface{}{
+					"methodName":   "transfer",
+					"methodParams": []interface{}{recipient, transferAmount},
+				},
+			},
+		}
+
+		node, err := CreateNodeFromType("contractWrite", nodeConfig, "")
+		require.NoError(t, err)
+		node.Name = "contractWrite1"
+
+		step, _ := vm.RunNodeWithInputs(node, inputVariables)
+		require.NotNil(t, step, "should return a step")
+
+		assert.True(t, step.Success,
+			"transfer should succeed with balance override; got error: %s", step.Error)
+
+		// Verify state diffs were captured
+		assert.False(t, vm.simulationState.IsEmpty(),
+			"simulation state should have accumulated overrides")
+	})
+}

--- a/core/taskengine/summarizer_context_memory.go
+++ b/core/taskengine/summarizer_context_memory.go
@@ -436,10 +436,35 @@ func (c *ContextMemorySummarizer) buildRequest(vm *VM, currentStepName string) (
 				}
 			}
 
+			// Fallback for LOOP steps: check runner.config for contractAddress and methodName
+			if contractAddress == "" && methodName == "" {
+				if runner, ok := configMap["runner"].(map[string]interface{}); ok {
+					if runnerConfig, ok := runner["config"].(map[string]interface{}); ok {
+						if addr, ok := runnerConfig["contractAddress"].(string); ok {
+							contractAddress = addr
+						}
+						if methodCalls, ok := runnerConfig["methodCalls"].([]interface{}); ok && len(methodCalls) > 0 {
+							if firstCall, ok := methodCalls[0].(map[string]interface{}); ok {
+								if name, ok := firstCall["methodName"].(string); ok {
+									methodName = name
+								}
+							}
+						}
+					}
+				}
+			}
+
 			// If contractAddress is a template variable, try to extract resolved address from metadata
 			resolvedContractAddress := contractAddress
 			if strings.Contains(contractAddress, "{{") || contractAddress == "" {
 				resolvedContractAddress = extractResolvedContractAddress(log)
+
+				// Fallback for LOOP steps: step-level metadata is nil, but the
+				// iteration output may contain metadata with the resolved address.
+				// Loop output is []interface{} where each element has a "metadata" key.
+				if resolvedContractAddress == "" {
+					resolvedContractAddress = extractResolvedContractAddressFromLoopOutput(log)
+				}
 			}
 
 			// Look up token metadata for the contract address (for ERC20 tokens only)
@@ -674,6 +699,43 @@ func extractResolvedContractAddressFromMetadata(metadataInterface interface{}) s
 						}
 					}
 				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// extractResolvedContractAddressFromLoopOutput extracts the resolved contract address
+// from a LOOP step's output data. Loop iterations store metadata.contractAddress
+// (propagated from the iteration's receipt.to during execution).
+func extractResolvedContractAddressFromLoopOutput(log *avsproto.Execution_Step) string {
+	if log == nil {
+		return ""
+	}
+
+	// Loop output is stored as the Loop output type
+	loopOutput := log.GetLoop()
+	if loopOutput == nil || loopOutput.Data == nil {
+		return ""
+	}
+
+	// Loop output data is an array of iteration results
+	outputInterface := loopOutput.Data.AsInterface()
+	iterations, ok := outputInterface.([]interface{})
+	if !ok || len(iterations) == 0 {
+		return ""
+	}
+
+	// Check the first successful iteration for metadata.contractAddress
+	for _, iter := range iterations {
+		iterMap, ok := iter.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if meta, ok := iterMap["metadata"].(map[string]interface{}); ok {
+			if addr, ok := meta["contractAddress"].(string); ok && common.IsHexAddress(addr) {
+				return addr
 			}
 		}
 	}

--- a/core/taskengine/summarizer_context_memory_test.go
+++ b/core/taskengine/summarizer_context_memory_test.go
@@ -7,6 +7,7 @@ import (
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // TestBuildRequest_SettingsTokens verifies that settings.tokens addresses
@@ -160,4 +161,210 @@ func TestBuildRequest_SettingsTokensDeduplication(t *testing.T) {
 	require.NotNil(t, usdcMeta, "USDC metadata should be present")
 	assert.Equal(t, "USDC", usdcMeta.Symbol)
 	assert.Equal(t, uint32(6), usdcMeta.Decimals)
+}
+
+// TestBuildRequest_LoopNodeTokenMetadata verifies that a LOOP step with a contractWrite
+// runner extracts token metadata from the nested runner config, resolving the contract
+// address from execution metadata when the config uses a template variable.
+func TestBuildRequest_LoopNodeTokenMetadata(t *testing.T) {
+	usdcAddr := "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+	daiAddr := "0x50c5725949a6f0c72e6c4a641f24049a917db0cb"
+
+	oldService := GetTokenEnrichmentService()
+	service := &TokenEnrichmentService{
+		cache: map[string]*TokenMetadata{
+			strings.ToLower(usdcAddr): {Symbol: "USDC", Decimals: 6, Name: "USD Coin"},
+			strings.ToLower(daiAddr):  {Symbol: "DAI", Decimals: 18, Name: "Dai Stablecoin"},
+		},
+	}
+	SetTokenEnrichmentService(service)
+	defer SetTokenEnrichmentService(oldService)
+
+	// Build loop output data: array of iteration results with metadata.contractAddress
+	// This matches what wrapResultWithMetadata produces during execution.
+	loopOutputData, err := structpb.NewValue([]interface{}{
+		map[string]interface{}{
+			"transfer": map[string]interface{}{
+				"from":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"to":    "0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557",
+				"value": "2000000",
+			},
+			"metadata": map[string]interface{}{
+				"transactionHash": "0xe3c082af67cba0cc7ece21a4211567726834f9c8577e303e834b2196c528764e",
+				"contractAddress": usdcAddr,
+			},
+		},
+		map[string]interface{}{
+			"transfer": map[string]interface{}{
+				"from":  "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+				"to":    "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788",
+				"value": "3000000",
+			},
+			"metadata": map[string]interface{}{
+				"transactionHash": "0x9e2c0483e8b2afcd4a50d1711ed9e5ebda4c4e314209f1d483d5cba83d50dfb1",
+				"contractAddress": usdcAddr,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	vm := NewVM()
+	vm.mu.Lock()
+	vm.vars = map[string]interface{}{
+		"settings": map[string]interface{}{
+			"name":   "Automatically Split Incoming USDC Payments",
+			"chain":  "base",
+			"runner": "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+			"tokens": []interface{}{usdcAddr, daiAddr},
+		},
+	}
+	vm.TaskNodes = map[string]*avsproto.TaskNode{
+		"trigger0": {Id: "trigger0", Name: "eventTrigger"},
+		"split1":   {Id: "split1", Name: "split1"},
+		"loop1": {
+			Id:   "loop1",
+			Name: "loop1",
+			TaskType: &avsproto.TaskNode_Loop{
+				Loop: &avsproto.LoopNode{
+					Config: &avsproto.LoopNode_Config{
+						InputVariable: "{{split1.data}}",
+						IterVal:       "value",
+						IterKey:       "index",
+					},
+					Runner: &avsproto.LoopNode_ContractWrite{
+						ContractWrite: &avsproto.ContractWriteNode{
+							Config: &avsproto.ContractWriteNode_Config{
+								ContractAddress: "{{value.tokenAddress}}",
+								MethodCalls: []*avsproto.ContractWriteNode_MethodCall{
+									{MethodName: "transfer", MethodParams: []string{"{{value.recipient}}", "{{value.amount}}"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"telegram1": {Id: "telegram1", Name: "telegram1"},
+	}
+	vm.ExecutionLogs = []*avsproto.Execution_Step{
+		{Id: "trigger0", Name: "eventTrigger", Type: "eventTrigger", Success: true},
+		{Id: "split1", Name: "split1", Type: "customCode", Success: true},
+		{
+			Id:      "loop1",
+			Name:    "loop1",
+			Type:    "loop",
+			Success: true,
+			// Loop step metadata is nil in practice — the contract address
+			// is resolved from the loop output data (iteration metadata.contractAddress).
+			Metadata: nil,
+			OutputData: &avsproto.Execution_Step_Loop{
+				Loop: &avsproto.LoopNode_Output{
+					Data: loopOutputData,
+				},
+			},
+		},
+		{Id: "telegram1", Name: "telegram1", Type: "restApi", Success: true},
+	}
+	vm.mu.Unlock()
+
+	summarizer := &ContextMemorySummarizer{baseURL: "http://localhost", authToken: "test"}
+	req, err := summarizer.buildRequest(vm, "telegram1")
+	require.NoError(t, err)
+
+	// The loop step (index 2) should have per-step tokenMetadata populated with USDC
+	loopStep := req.Steps[2]
+	require.NotNil(t, loopStep.TokenMetadata, "loop step should have per-step tokenMetadata")
+	assert.Equal(t, "USDC", loopStep.TokenMetadata.Symbol)
+	assert.Equal(t, uint32(6), loopStep.TokenMetadata.Decimals)
+
+	// The request-level tokenMetadata should include USDC (from per-step + settings.tokens)
+	usdcMeta := req.TokenMetadata[strings.ToLower(usdcAddr)]
+	require.NotNil(t, usdcMeta, "USDC should be in request-level tokenMetadata")
+	assert.Equal(t, "USDC", usdcMeta.Symbol)
+	assert.Equal(t, uint32(6), usdcMeta.Decimals)
+
+	// DAI should also be present (from settings.tokens)
+	daiMeta := req.TokenMetadata[strings.ToLower(daiAddr)]
+	require.NotNil(t, daiMeta, "DAI should be in request-level tokenMetadata")
+	assert.Equal(t, "DAI", daiMeta.Symbol)
+	assert.Equal(t, uint32(18), daiMeta.Decimals)
+}
+
+// TestBuildRequest_LoopNodeTokenMetadata_NoMetadataFallback verifies that when a LOOP
+// step has no execution metadata (e.g., simulation or failed run), the per-step
+// tokenMetadata remains nil without panicking.
+func TestBuildRequest_LoopNodeTokenMetadata_NoMetadataFallback(t *testing.T) {
+	usdcAddr := "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+	daiAddr := "0x50c5725949a6f0c72e6c4a641f24049a917db0cb"
+
+	oldService := GetTokenEnrichmentService()
+	service := &TokenEnrichmentService{
+		cache: map[string]*TokenMetadata{
+			strings.ToLower(usdcAddr): {Symbol: "USDC", Decimals: 6, Name: "USD Coin"},
+			strings.ToLower(daiAddr):  {Symbol: "DAI", Decimals: 18, Name: "Dai Stablecoin"},
+		},
+	}
+	SetTokenEnrichmentService(service)
+	defer SetTokenEnrichmentService(oldService)
+
+	vm := NewVM()
+	vm.mu.Lock()
+	vm.vars = map[string]interface{}{
+		"settings": map[string]interface{}{
+			"name":   "Automatically Split Incoming USDC Payments",
+			"chain":  "base",
+			"runner": "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e",
+			"tokens": []interface{}{usdcAddr, daiAddr},
+		},
+	}
+	vm.TaskNodes = map[string]*avsproto.TaskNode{
+		"trigger0": {Id: "trigger0", Name: "eventTrigger"},
+		"loop1": {
+			Id:   "loop1",
+			Name: "loop1",
+			TaskType: &avsproto.TaskNode_Loop{
+				Loop: &avsproto.LoopNode{
+					Config: &avsproto.LoopNode_Config{
+						InputVariable: "{{split1.data}}",
+						IterVal:       "value",
+						IterKey:       "index",
+					},
+					Runner: &avsproto.LoopNode_ContractWrite{
+						ContractWrite: &avsproto.ContractWriteNode{
+							Config: &avsproto.ContractWriteNode_Config{
+								ContractAddress: "{{value.tokenAddress}}",
+								MethodCalls: []*avsproto.ContractWriteNode_MethodCall{
+									{MethodName: "transfer", MethodParams: []string{"{{value.recipient}}", "{{value.amount}}"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	vm.ExecutionLogs = []*avsproto.Execution_Step{
+		{Id: "trigger0", Name: "eventTrigger", Type: "eventTrigger", Success: true},
+		{
+			Id:       "loop1",
+			Name:     "loop1",
+			Type:     "loop",
+			Success:  true,
+			Metadata: nil, // No metadata — simulates a failed or simulation execution
+		},
+	}
+	vm.mu.Unlock()
+
+	summarizer := &ContextMemorySummarizer{baseURL: "http://localhost", authToken: "test"}
+	req, err := summarizer.buildRequest(vm, "loop1")
+	require.NoError(t, err)
+
+	// Loop step should NOT have per-step tokenMetadata (no metadata to resolve from)
+	loopStep := req.Steps[1]
+	assert.Nil(t, loopStep.TokenMetadata, "loop step tokenMetadata should be nil when no metadata available")
+
+	// Request-level tokenMetadata should still have tokens from settings.tokens
+	assert.Len(t, req.TokenMetadata, 2, "settings.tokens should still populate request-level tokenMetadata")
+	assert.NotNil(t, req.TokenMetadata[strings.ToLower(usdcAddr)])
+	assert.NotNil(t, req.TokenMetadata[strings.ToLower(daiAddr)])
 }

--- a/core/taskengine/tenderly_client.go
+++ b/core/taskengine/tenderly_client.go
@@ -623,7 +623,7 @@ func (tc *TenderlyClient) createMockTransferLog(contractAddress string, from, to
 }
 
 // SimulateContractWrite simulates a contract write operation using Tenderly
-func (tc *TenderlyClient) SimulateContractWrite(ctx context.Context, contractAddress string, callData string, contractABI string, methodName string, chainID int64, fromAddress string, value string) (*ContractWriteSimulationResult, error) {
+func (tc *TenderlyClient) SimulateContractWrite(ctx context.Context, contractAddress string, callData string, contractABI string, methodName string, chainID int64, fromAddress string, value string, simulationState *SimulationStateMap) (*ContractWriteSimulationResult, error) {
 	tc.logger.Info("Simulating contract write via Tenderly",
 		"contract", contractAddress,
 		"method", methodName,
@@ -651,36 +651,42 @@ func (tc *TenderlyClient) SimulateContractWrite(ctx context.Context, contractAdd
 		apiValue = "0"
 	}
 
-	body := map[string]interface{}{
-		"network_id":      fmt.Sprintf("%d", chainID),
-		"from":            fromAddress,
-		"to":              contractAddress,
-		"gas":             8000000,
-		"gas_price":       0,
-		"value":           apiValue, // Use the provided value parameter, defaulting empty to "0"
-		"input":           callData,
-		"simulation_type": "full", // Use "full" instead of "quick" for more accurate state (ensures latest allowances are visible)
-		// Optional conveniences kept compatible
-		"state_objects": map[string]interface{}{
+	// Build state_objects: merge accumulated simulation state overrides with
+	// the mandatory sender ETH balance override so gas checks pass.
+	var stateObjects map[string]interface{}
+	if simulationState != nil && !simulationState.IsEmpty() {
+		stateObjects = simulationState.BuildStateObjects(fromAddress, balanceOverride)
+	} else {
+		stateObjects = map[string]interface{}{
 			strings.ToLower(fromAddress): map[string]interface{}{
 				"balance": balanceOverride,
 			},
-		},
+		}
 	}
 
-	// Set ETH balance for the sender so gas checks don't fail in simulation
-	// Tenderly uses the latest block state by default, which includes all on-chain approvals
-	// So we don't need to set token allowances here - they're already on-chain
+	// Ensure sender always has enough ETH for gas
 	if common.IsHexAddress(fromAddress) {
-		stateObjects := body["state_objects"].(map[string]interface{})
 		senderKey := strings.ToLower(fromAddress)
 		senderOverrides, ok := stateObjects[senderKey].(map[string]interface{})
 		if !ok || senderOverrides == nil {
 			senderOverrides = map[string]interface{}{}
 			stateObjects[senderKey] = senderOverrides
 		}
-		// Set 10 ETH balance (0x8AC7230489E80000 = 10 * 10^18)
-		senderOverrides["balance"] = "0x8AC7230489E80000"
+		if _, hasBalance := senderOverrides["balance"]; !hasBalance {
+			senderOverrides["balance"] = "0x8AC7230489E80000"
+		}
+	}
+
+	body := map[string]interface{}{
+		"network_id":      fmt.Sprintf("%d", chainID),
+		"from":            fromAddress,
+		"to":              contractAddress,
+		"gas":             8000000,
+		"gas_price":       0,
+		"value":           apiValue,
+		"input":           callData,
+		"simulation_type": "full",
+		"state_objects":   stateObjects,
 	}
 
 	tc.logger.Info("📡 Making Tenderly HTTP simulation call for contract write", "url", simURL)
@@ -728,9 +734,19 @@ func (tc *TenderlyClient) SimulateContractWrite(ctx context.Context, contractAdd
 		if slug == "invalid_state_storage" {
 			tc.logger.Info("🔄 Retrying Tenderly simulation without storage overrides due to invalid_state_storage error")
 
-			// Remove the storage overrides and try again
+			// Strip all storage overrides from state_objects but keep ETH
+			// balance overrides (needed for gas). The invalid override may be
+			// on any address (e.g. an ERC20 token), not just the target contract.
 			if stateObjects, ok := body["state_objects"].(map[string]interface{}); ok {
-				delete(stateObjects, strings.ToLower(contractAddress))
+				for addr, obj := range stateObjects {
+					if addrObj, ok := obj.(map[string]interface{}); ok {
+						delete(addrObj, "storage")
+						// Remove the address entry entirely if only storage was set
+						if len(addrObj) == 0 {
+							delete(stateObjects, addr)
+						}
+					}
+				}
 			}
 
 			// Retry the HTTP request without storage overrides
@@ -1011,6 +1027,20 @@ func (tc *TenderlyClient) SimulateContractWrite(ctx context.Context, contractAdd
 			}
 		}
 
+		// Extract raw_state_diff for simulation state propagation.
+		// Lives at transaction.transaction_info.raw_state_diff in the Tenderly response.
+		if m, ok := resultForExtraction.(map[string]interface{}); ok {
+			if tx, ok := m["transaction"].(map[string]interface{}); ok {
+				if txInfo, ok := tx["transaction_info"].(map[string]interface{}); ok {
+					if rawSD, ok := txInfo["raw_state_diff"].([]interface{}); ok && len(rawSD) > 0 {
+						result.RawStateDiff = rawSD
+						tc.logger.Debug("Extracted raw_state_diff from Tenderly response",
+							"entries", len(rawSD))
+					}
+				}
+			}
+		}
+
 		// Propagate revert status from Tenderly into result.Success/Error
 		// Also extract detailed error messages from call traces for better debugging
 		if m, ok := resultForExtraction.(map[string]interface{}); ok {
@@ -1251,6 +1281,9 @@ type ContractWriteSimulationResult struct {
 	GasUsed      string `json:"gas_used,omitempty"`
 	GasPrice     string `json:"gas_price,omitempty"`
 	TotalGasCost string `json:"total_gas_cost,omitempty"`
+	// RawStateDiff contains the raw storage changes from the Tenderly simulation.
+	// Each entry has address, key, original, and dirty fields.
+	RawStateDiff []interface{} `json:"raw_state_diff,omitempty"`
 }
 
 // ContractWriteTransactionData represents transaction information for simulated writes

--- a/core/taskengine/tenderly_client_test.go
+++ b/core/taskengine/tenderly_client_test.go
@@ -2173,6 +2173,7 @@ func TestContractWriteWithValueParameter(t *testing.T) {
 					11155111,
 					runnerAddress,
 					tc.value,
+					nil, // no simulation state overrides
 				)
 
 				if tc.expectedError {

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -4904,14 +4904,19 @@ func (v *VM) executeLoopWithQueue(stepID string, taskNode *avsproto.TaskNode, no
 		}
 	}
 
-	if iterationFailCount > 0 && firstError != nil {
+	if iterationFailCount > 0 {
 		// Some or all iterations failed — mark the loop step as failed so
 		// AnalyzeExecutionResult can detect partial_success at the execution level.
 		// Pass the error via the `err` parameter (not `errorMessage`) so that
 		// finalizeStep uses err.Error() directly without wrapping it in
 		// NewInvalidRequestError which adds an "invalid request: " prefix.
-		innerMsg := strings.TrimPrefix(firstError.Error(), "invalid request: ")
-		errorMsg := fmt.Sprintf("%d of %d iterations failed: %s", iterationFailCount, len(results), innerMsg)
+		var errorMsg string
+		if firstError != nil {
+			innerMsg := strings.TrimPrefix(firstError.Error(), "invalid request: ")
+			errorMsg = fmt.Sprintf("%d of %d iterations failed: %s", iterationFailCount, len(results), innerMsg)
+		} else {
+			errorMsg = fmt.Sprintf("%d of %d iterations failed", iterationFailCount, len(results))
+		}
 		loopErr := NewStructuredError(
 			avsproto.ErrorCode_INVALID_REQUEST,
 			errorMsg,

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -4840,14 +4840,42 @@ func (v *VM) executeLoopWithQueue(stepID string, taskNode *avsproto.TaskNode, no
 	}
 
 	// Only treat infrastructure failures (queue submit errors, iteration timeouts)
-	// as a hard step failure. Per-iteration runner errors (e.g. a contract call
-	// reverting in one iteration of a Loop > ContractRead) are reflected as nil
-	// entries in the results array — the loop ran to completion, so we preserve
-	// OutputData and return success so the client can inspect partial results.
-	// See AvaProtocol/EigenLayer-AVS#511.
+	// as a hard step failure.
 	if infraFailure && firstError != nil {
 		finalizeStep(s, false, nil, firstError.Error(), log.String())
 		return s, firstError
+	}
+
+	// Count successful vs failed iterations to determine step status.
+	// Per-iteration runner errors (e.g. a contract call reverting) are reflected
+	// as nil entries in the results array. The loop ran to completion, so we
+	// always preserve OutputData for the client to inspect partial results.
+	// See AvaProtocol/EigenLayer-AVS#511.
+	iterationFailCount := 0
+	for _, result := range results {
+		if result == nil {
+			iterationFailCount++
+		}
+	}
+
+	if iterationFailCount > 0 && firstError != nil {
+		// Some or all iterations failed — mark the loop step as failed so
+		// AnalyzeExecutionResult can detect partial_success at the execution level.
+		// Pass the error via the `err` parameter (not `errorMessage`) so that
+		// finalizeStep uses err.Error() directly without wrapping it in
+		// NewInvalidRequestError which adds an "invalid request: " prefix.
+		innerMsg := strings.TrimPrefix(firstError.Error(), "invalid request: ")
+		errorMsg := fmt.Sprintf("%d of %d iterations failed: %s", iterationFailCount, len(results), innerMsg)
+		loopErr := NewStructuredError(
+			avsproto.ErrorCode_INVALID_REQUEST,
+			errorMsg,
+			map[string]interface{}{
+				"failed_iterations": iterationFailCount,
+				"total_iterations":  len(results),
+			},
+		)
+		finalizeStep(s, false, loopErr, "", log.String())
+		return s, nil // return nil error: the loop itself ran to completion
 	}
 
 	finalizeStep(s, success, nil, "", log.String())

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -252,6 +252,11 @@ type VM struct {
 	// Shared clients
 	tenderlyClient *TenderlyClient
 
+	// simulationState accumulates on-chain state overrides during workflow simulation.
+	// Each Tenderly simulation's state diffs are merged here so subsequent steps
+	// see a consistent view. Nil when not in simulation mode.
+	simulationState *SimulationStateMap
+
 	// executionFeeWei is the platform fee (converted from USD to WEI) to be collected
 	// atomically in the UserOp. Set by executor before node execution. Nil = no fee.
 	executionFeeWei *big.Int
@@ -277,6 +282,11 @@ func NewVM() *VM {
 // SetSimulation sets whether this VM is executing in simulation context.
 func (v *VM) SetSimulation(isSimulation bool) *VM {
 	v.IsSimulation = isSimulation
+	if isSimulation {
+		v.simulationState = NewSimulationStateMap(v.logger)
+	} else {
+		v.simulationState = nil
+	}
 	return v
 }
 
@@ -4272,10 +4282,11 @@ func (eq *ExecutionQueue) extractResultData(step *avsproto.Execution_Step) inter
 			}
 		}
 
-		// Extract transactionHash from step.Metadata (results array with receipts)
-		// and attach it so loop iteration output includes metadata for the summarizer.
+		// Extract transactionHash and contractAddress from step.Metadata (results array with receipts)
+		// and attach them so loop iteration output includes metadata for the summarizer.
 		txHash := extractTxHashFromMetadata(step.Metadata)
-		return wrapResultWithTxHash(resultData, txHash)
+		contractAddr := extractContractAddressFromMetadata(step.Metadata)
+		return wrapResultWithMetadata(resultData, txHash, contractAddr)
 	}
 	if ethTransferOutput := step.GetEthTransfer(); ethTransferOutput != nil && ethTransferOutput.Data != nil {
 		resultData := ethTransferOutput.Data.AsInterface()
@@ -4289,7 +4300,13 @@ func (eq *ExecutionQueue) extractResultData(step *avsproto.Execution_Step) inter
 // wrapResultWithTxHash attaches a transactionHash to the result data under a metadata key.
 // If txHash is empty, the original resultData is returned unchanged.
 func wrapResultWithTxHash(resultData interface{}, txHash string) interface{} {
-	if txHash == "" {
+	return wrapResultWithMetadata(resultData, txHash, "")
+}
+
+// wrapResultWithMetadata attaches transactionHash and contractAddress to the result data
+// under a metadata key. If both are empty, the original resultData is returned unchanged.
+func wrapResultWithMetadata(resultData interface{}, txHash string, contractAddress string) interface{} {
+	if txHash == "" && contractAddress == "" {
 		return resultData
 	}
 	resultMap := make(map[string]interface{})
@@ -4300,9 +4317,14 @@ func wrapResultWithTxHash(resultData interface{}, txHash string) interface{} {
 	} else if resultData != nil {
 		resultMap["data"] = resultData
 	}
-	resultMap["metadata"] = map[string]interface{}{
-		"transactionHash": txHash,
+	meta := map[string]interface{}{}
+	if txHash != "" {
+		meta["transactionHash"] = txHash
 	}
+	if contractAddress != "" {
+		meta["contractAddress"] = contractAddress
+	}
+	resultMap["metadata"] = meta
 	return resultMap
 }
 
@@ -4320,6 +4342,30 @@ func extractTxHashFromMetadata(metadata *structpb.Value) string {
 					if receiptStruct := receiptVal.GetStructValue(); receiptStruct != nil {
 						if hashVal := receiptStruct.Fields["transactionHash"]; hashVal != nil {
 							return hashVal.GetStringValue()
+						}
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// extractContractAddressFromMetadata extracts the contract address (receipt.to) from
+// a contractWrite step's Metadata field. Used to propagate the resolved contract address
+// into loop iteration output so the summarizer can identify the token.
+func extractContractAddressFromMetadata(metadata *structpb.Value) string {
+	if metadata == nil {
+		return ""
+	}
+	// Metadata is an array of method results: [{receipt: {to: "0x..."}, ...}]
+	if listVal := metadata.GetListValue(); listVal != nil {
+		for _, item := range listVal.GetValues() {
+			if m := item.GetStructValue(); m != nil {
+				if receiptVal := m.Fields["receipt"]; receiptVal != nil {
+					if receiptStruct := receiptVal.GetStructValue(); receiptStruct != nil {
+						if toVal := receiptStruct.Fields["to"]; toVal != nil {
+							return toVal.GetStringValue()
 						}
 					}
 				}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -468,6 +468,7 @@ func (r *ContractWriteProcessor) executeMethodCall(
 			chainID,
 			senderAddress.Hex(), // Use runner (smart wallet) address for simulation
 			transactionValue,    // Pass the transaction value
+			r.vm.simulationState,
 		)
 
 		if err != nil {
@@ -478,6 +479,15 @@ func (r *ContractWriteProcessor) executeMethodCall(
 				Success:    false,
 				Error:      fmt.Sprintf("tenderly simulation failed: %v", err),
 			}
+		}
+
+		// Merge state diffs from this simulation into the accumulated state map
+		// so subsequent simulation steps see a consistent view of on-chain state.
+		if r.vm.simulationState != nil && simulationResult != nil && simulationResult.Success && len(simulationResult.RawStateDiff) > 0 {
+			r.vm.simulationState.MergeRawStateDiff(simulationResult.RawStateDiff)
+			r.vm.logger.Debug("Merged simulation state diff into accumulator",
+				"method", methodName,
+				"diffEntries", len(simulationResult.RawStateDiff))
 		}
 
 		// Convert Tenderly simulation result to legacy protobuf format


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the aggregator, authentication, simulation, and summarization components. The most significant changes are the addition of simulation state injection for event triggers (especially for ERC20 transfers), enhancements to loop step error handling, and improved extraction of contract addresses in summarization logic. Comprehensive tests for simulation state management and ERC20 balance overrides have also been added.

**Simulation and State Injection Enhancements:**

- Added the `injectEventTriggerStateOverrides` and `injectTransferEventState` methods in `core/taskengine/engine.go` to automatically inject balance changes into the simulation state when a Transfer event is detected, ensuring downstream contract write simulations reflect the correct balances. This fixes issues where simulated contract writes would incorrectly fail due to missing balance updates. [[1]](diffhunk://#diff-77494b7116e328f80878e42128327bd124ab4ef1d7394c1d51109a5a5e93c4bcR2990-R2999) [[2]](diffhunk://#diff-77494b7116e328f80878e42128327bd124ab4ef1d7394c1d51109a5a5e93c4bcR3075-R3181)

- Introduced `core/taskengine/simulation_state_test.go` with detailed tests for simulation state map operations, ERC20 balance slot computation, and integration scenarios where balance overrides are required for successful contract write simulations.

**Authentication and JWT Handling:**

- Modified JWT creation in `aggregator/key.go` to ensure the `aud` claim uses the smart wallet chain ID, aligning with the verifier's expectations and supporting cross-chain configurations. Also updated the issuer to use a constant. [[1]](diffhunk://#diff-9027ff066628974ef1b91b0ed2ec94b0935848c03bdbcbeb9f35df2a085282d4R5) [[2]](diffhunk://#diff-9027ff066628974ef1b91b0ed2ec94b0935848c03bdbcbeb9f35df2a085282d4R48-R65)

- Updated JWT verification logic in `core/auth/user.go` to allow admin-role JWTs to manage any wallet and to clarify subject matching for per-wallet keys.

**Loop Step and Summarization Improvements:**

- Changed loop step result handling in `core/taskengine/manual_trigger_loop_test.go` so that partial iteration failures cause the step to report `success=false` with a descriptive error, supporting better detection of partial successes.

- Improved contract address and method name extraction in summarization logic for LOOP steps in `core/taskengine/summarizer_context_memory.go`, including a fallback that checks iteration-level metadata. Added `extractResolvedContractAddressFromLoopOutput` for robust address extraction from loop outputs. [[1]](diffhunk://#diff-89ff5bda3460c7f0195ccee4a50900f1de180fda6bdf85f725123bc319e9aadbR439-R467) [[2]](diffhunk://#diff-89ff5bda3460c7f0195ccee4a50900f1de180fda6bdf85f725123bc319e9aadbR708-R744)

**Other:**

- Added a missing import for `structpb` in summarizer context memory tests.