### PR TITLE
refactor: factor out whitelist cache loader + lowercase token ids

### DIFF
--- a/core/taskengine/token_metadata.go
+++ b/core/taskengine/token_metadata.go
@@ -188,12 +188,27 @@ func (t *TokenEnrichmentService) LoadWhitelist() error {
 		return fmt.Errorf("failed to parse whitelist file %s: %w", whitelistPath, err)
 	}
 
-	// Load tokens into cache (normalize addresses to lowercase). Surface
-	// malformed entries (empty id, decimals=0) at startup rather than letting
-	// them silently degrade balance lookups — once cached, GetTokenMetadata
-	// short-circuits the RPC fallback that would otherwise fix the metadata.
+	loaded, skipped := t.loadTokensIntoCache(tokens, whitelistPath)
+
+	if t.logger != nil {
+		t.logger.Debug("Loaded token whitelist",
+			"file", whitelistPath,
+			"loaded", loaded,
+			"skipped", skipped,
+			"chainID", t.chainID)
+	}
+
+	return nil
+}
+
+// loadTokensIntoCache copies parsed whitelist tokens into t.cache, lowercasing
+// addresses and surfacing malformed entries. Returns counts for caller logging.
+// decimals=0 is a heuristic — some legitimate ERC20s (e.g. WBTC variants) use
+// non-18 decimals and a handful intentionally use 0; the warning is
+// informational and does not skip the entry.
+func (t *TokenEnrichmentService) loadTokensIntoCache(tokens []TokenMetadata, whitelistPath string) (loaded, skipped int) {
 	t.cacheMux.Lock()
-	skipped := 0
+	defer t.cacheMux.Unlock()
 	for _, token := range tokens {
 		normalizedAddr := strings.ToLower(token.Id)
 		if normalizedAddr == "" {
@@ -204,9 +219,11 @@ func (t *TokenEnrichmentService) LoadWhitelist() error {
 			}
 			continue
 		}
-		if token.Decimals == 0 && t.logger != nil {
-			t.logger.Warn("Whitelist entry has decimals=0; balance lookups will use 0-decimal formatting unless populated",
-				"file", whitelistPath, "id", normalizedAddr, "symbol", token.Symbol)
+		if token.Decimals == 0 {
+			if t.logger != nil {
+				t.logger.Warn("Whitelist entry has decimals=0; balance lookups will use 0-decimal formatting unless populated",
+					"file", whitelistPath, "id", normalizedAddr, "symbol", token.Symbol)
+			}
 		}
 		t.cache[normalizedAddr] = &TokenMetadata{
 			Id:       normalizedAddr,
@@ -216,18 +233,7 @@ func (t *TokenEnrichmentService) LoadWhitelist() error {
 			Source:   "whitelist",
 		}
 	}
-	t.cacheMux.Unlock()
-
-	if t.logger != nil {
-		t.logger.Debug("Loaded token whitelist",
-			"file", whitelistPath,
-			"tokenCount", len(tokens),
-			"loaded", len(tokens)-skipped,
-			"skipped", skipped,
-			"chainID", t.chainID)
-	}
-
-	return nil
+	return len(tokens) - skipped, skipped
 }
 
 // GetTokenMetadata retrieves token metadata, checking cache first, then RPC

--- a/core/taskengine/token_metadata_test.go
+++ b/core/taskengine/token_metadata_test.go
@@ -114,6 +114,46 @@ func TestIsNativeToken(t *testing.T) {
 	}
 }
 
+// warnCapturingLogger records Warn calls for assertions.
+type warnCapturingLogger struct {
+	MockLogger
+	warns []string
+}
+
+func (l *warnCapturingLogger) Warn(msg string, keysAndValues ...interface{}) {
+	l.warns = append(l.warns, msg)
+}
+
+func TestLoadTokensIntoCacheValidation(t *testing.T) {
+	logger := &warnCapturingLogger{}
+	service := &TokenEnrichmentService{
+		cache:  make(map[string]*TokenMetadata),
+		logger: logger,
+	}
+
+	tokens := []TokenMetadata{
+		{Id: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", Name: "Valid", Symbol: "VAL", Decimals: 18},
+		{Id: "", Name: "MissingId", Symbol: "BAD", Decimals: 18},
+		{Id: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", Name: "ZeroDec", Symbol: "ZD", Decimals: 0},
+	}
+
+	loaded, skipped := service.loadTokensIntoCache(tokens, "test.json")
+
+	assert.Equal(t, 2, loaded)
+	assert.Equal(t, 1, skipped)
+
+	// Empty-id entry skipped; the two valid entries are cached with lowercased ids.
+	assert.Len(t, service.cache, 2)
+	assert.Contains(t, service.cache, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	assert.Contains(t, service.cache, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	assert.NotContains(t, service.cache, "")
+
+	// One warn for missing id, one for decimals=0.
+	require.Len(t, logger.warns, 2)
+	assert.Contains(t, logger.warns[0], "missing id")
+	assert.Contains(t, logger.warns[1], "decimals=0")
+}
+
 func TestGetNativeTokenMetadata(t *testing.T) {
 	metadata := getNativeTokenMetadata()
 

--- a/token_whitelist/base.json
+++ b/token_whitelist/base.json
@@ -3,97 +3,97 @@
     "name": "Aave",
     "symbol": "AAVE",
     "decimals": 18,
-    "id": "0x63706e401c06ac8513145b7687A14804d17f814b"
+    "id": "0x63706e401c06ac8513145b7687a14804d17f814b"
   },
   {
     "name": "Aerodrome",
     "symbol": "AERO",
     "decimals": 18,
-    "id": "0x940181a94A35A4569E4529A3CDfB74e38FD98631"
+    "id": "0x940181a94a35a4569e4529a3cdfb74e38fd98631"
   },
   {
     "name": "Balancer",
     "symbol": "BAL",
     "decimals": 18,
-    "id": "0x7c6b91D9Be155A6Db01f749217d76fF02A7227F2"
+    "id": "0x7c6b91d9be155a6db01f749217d76ff02a7227f2"
   },
   {
     "name": "Brett",
     "symbol": "BRETT",
     "decimals": 18,
-    "id": "0x532f27101965dd16442E59d40670FaF5eBB142E4"
+    "id": "0x532f27101965dd16442e59d40670faf5ebb142e4"
   },
   {
     "name": "Dai",
     "symbol": "DAI",
     "decimals": 18,
-    "id": "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"
+    "id": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb"
   },
   {
     "name": "Degen",
     "symbol": "DEGEN",
     "decimals": 18,
-    "id": "0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed"
+    "id": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed"
   },
   {
     "name": "Chainlink",
     "symbol": "LINK",
     "decimals": 18,
-    "id": "0x88Fb150BDc53A65fe94Dea0c9BA0a6dAf8C6e196"
+    "id": "0x88fb150bdc53a65fe94dea0c9ba0a6daf8c6e196"
   },
   {
     "name": "Morpho Token",
     "symbol": "MORPHO",
     "decimals": 18,
-    "id": "0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842"
+    "id": "0xbaa5cc21fd487b8fcc2f632f3f4e8d37262a0842"
   },
   {
     "name": "Reserve Rights",
     "symbol": "RSR",
     "decimals": 18,
-    "id": "0xaB36452DbAC151bE02b16Ca17d8919826072f64a"
+    "id": "0xab36452dbac151be02b16ca17d8919826072f64a"
   },
   {
     "name": "Toshi",
     "symbol": "TOSHI",
     "decimals": 18,
-    "id": "0xAC1Bd2486aAf3B5C0fc3Fd868558b082a531B2B4"
+    "id": "0xac1bd2486aaf3b5c0fc3fd868558b082a531b2b4"
   },
   {
     "name": "Uniswap",
     "symbol": "UNI",
     "decimals": 18,
-    "id": "0xc3De830EA07524a0761646a6a4e4be0e114a3C83"
+    "id": "0xc3de830ea07524a0761646a6a4e4be0e114a3c83"
   },
   {
     "name": "USD Coin",
     "symbol": "USDC",
     "decimals": 6,
-    "id": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    "id": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
   },
   {
     "name": "Bridged Tether USD",
     "symbol": "USDT",
     "decimals": 6,
-    "id": "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2"
+    "id": "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2"
   },
   {
     "name": "USD Base Coin",
     "symbol": "USDbC",
     "decimals": 6,
-    "id": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA"
+    "id": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca"
   },
   {
     "name": "Virtual Protocol",
     "symbol": "VIRTUAL",
     "decimals": 18,
-    "id": "0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b"
+    "id": "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b"
   },
   {
     "name": "WELL",
     "symbol": "WELL",
     "decimals": 18,
-    "id": "0xA88594D404727625A9437C3f886C7643872296AE"
+    "id": "0xa88594d404727625a9437c3f886c7643872296ae"
   },
   {
     "name": "Wrapped Ether",
@@ -105,36 +105,36 @@
     "name": "yearn.finance",
     "symbol": "YFI",
     "decimals": 18,
-    "id": "0x9EaF8C1E34F05a589EDa6BAfdF391Cf6Ad3CB239"
+    "id": "0x9eaf8c1e34f05a589eda6bafdf391cf6ad3cb239"
   },
   {
     "name": "Axelar Wrapped USDC",
     "symbol": "axlUSDC",
     "decimals": 6,
-    "id": "0xEB466342C4d449BC9f53A865D5Cb90586f405215"
+    "id": "0xeb466342c4d449bc9f53a865d5cb90586f405215"
   },
   {
     "name": "Coinbase Wrapped BTC",
     "symbol": "cbBTC",
     "decimals": 8,
-    "id": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    "id": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
   },
   {
     "name": "Coinbase Wrapped Staked ETH",
     "symbol": "cbETH",
     "decimals": 18,
-    "id": "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22"
+    "id": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22"
   },
   {
     "name": "Rocket Pool ETH",
     "symbol": "rETH",
     "decimals": 18,
-    "id": "0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c"
+    "id": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c"
   },
   {
     "name": "Wrapped liquid staked Ether 2.0",
     "symbol": "wstETH",
     "decimals": 18,
-    "id": "0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452"
+    "id": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452"
   }
 ]

--- a/token_whitelist/ethereum.json
+++ b/token_whitelist/ethereum.json
@@ -3,181 +3,181 @@
     "name": "Aave",
     "symbol": "AAVE",
     "decimals": 18,
-    "id": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+    "id": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"
   },
   {
     "name": "Arbitrum",
     "symbol": "ARB",
     "decimals": 18,
-    "id": "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1"
+    "id": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1"
   },
   {
     "name": "Compound",
     "symbol": "COMP",
     "decimals": 18,
-    "id": "0xc00e94Cb662C3520282E6f5717214004A7f26888"
+    "id": "0xc00e94cb662c3520282e6f5717214004a7f26888"
   },
   {
     "name": "Curve DAO Token",
     "symbol": "CRV",
     "decimals": 18,
-    "id": "0xD533a949740bb3306d119CC777fa900bA034cd52"
+    "id": "0xd533a949740bb3306d119cc777fa900ba034cd52"
   },
   {
     "name": "Dai",
     "symbol": "DAI",
     "decimals": 18,
-    "id": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+    "id": "0x6b175474e89094c44da98b954eedeac495271d0f"
   },
   {
     "name": "dYdX",
     "symbol": "DYDX",
     "decimals": 18,
-    "id": "0x92D6C1e31e14520e676a687F0a93788B716BEff5"
+    "id": "0x92d6c1e31e14520e676a687f0a93788b716beff5"
   },
   {
     "name": "Eigen",
     "symbol": "EIGEN",
     "decimals": 18,
-    "id": "0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83"
+    "id": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83"
   },
   {
     "name": "ENA",
     "symbol": "ENA",
     "decimals": 18,
-    "id": "0x57e114B691Db790C35207b2e685D4A43181e6061"
+    "id": "0x57e114b691db790c35207b2e685d4a43181e6061"
   },
   {
     "name": "Ethereum Name Service",
     "symbol": "ENS",
     "decimals": 18,
-    "id": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+    "id": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72"
   },
   {
     "name": "Fetch.ai",
     "symbol": "FET",
     "decimals": 18,
-    "id": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85"
+    "id": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85"
   },
   {
     "name": "Frax",
     "symbol": "FRAX",
     "decimals": 18,
-    "id": "0x853d955aCEf822Db058eb8505911ED77F175b99e"
+    "id": "0x853d955acef822db058eb8505911ed77f175b99e"
   },
   {
     "name": "The Graph",
     "symbol": "GRT",
     "decimals": 18,
-    "id": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7"
+    "id": "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
   },
   {
     "name": "Lido DAO",
     "symbol": "LDO",
     "decimals": 18,
-    "id": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"
+    "id": "0x5a98fcbea516cf06857215779fd812ca3bef1b32"
   },
   {
     "name": "Chainlink",
     "symbol": "LINK",
     "decimals": 18,
-    "id": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+    "id": "0x514910771af9ca656af840dff83e8264ecf986ca"
   },
   {
     "name": "Maker",
     "symbol": "MKR",
     "decimals": 18,
-    "id": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+    "id": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2"
   },
   {
     "name": "PAX Gold",
     "symbol": "PAXG",
     "decimals": 18,
-    "id": "0x45804880De22913dAFE09f4980848ECE6EcbAf78"
+    "id": "0x45804880de22913dafe09f4980848ece6ecbaf78"
   },
   {
     "name": "Pendle",
     "symbol": "PENDLE",
     "decimals": 18,
-    "id": "0x808507121B80c02388fAd14726482e061B8da827"
+    "id": "0x808507121b80c02388fad14726482e061b8da827"
   },
   {
     "name": "Pepe",
     "symbol": "PEPE",
     "decimals": 18,
-    "id": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"
+    "id": "0x6982508145454ce325ddbe47a25d4ec3d2311933"
   },
   {
     "name": "PayPal USD",
     "symbol": "PYUSD",
     "decimals": 6,
-    "id": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    "id": "0x6c3ea9036406852006290770bedfcaba0e23a0e8"
   },
   {
     "name": "Render Token",
     "symbol": "RNDR",
     "decimals": 18,
-    "id": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24"
+    "id": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24"
   },
   {
     "name": "Rocket Pool",
     "symbol": "RPL",
     "decimals": 18,
-    "id": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f"
+    "id": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f"
   },
   {
     "name": "SHIBA INU",
     "symbol": "SHIB",
     "decimals": 18,
-    "id": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
+    "id": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
   },
   {
     "name": "Synthetix",
     "symbol": "SNX",
     "decimals": 18,
-    "id": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F"
+    "id": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f"
   },
   {
     "name": "Uniswap",
     "symbol": "UNI",
     "decimals": 18,
-    "id": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+    "id": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
   },
   {
     "name": "USD Coin",
     "symbol": "USDC",
     "decimals": 6,
-    "id": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    "id": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
   },
   {
     "name": "Tether",
     "symbol": "USDT",
     "decimals": 6,
-    "id": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    "id": "0xdac17f958d2ee523a2206206994597c13d831ec7"
   },
   {
     "name": "Wrapped BTC",
     "symbol": "WBTC",
     "decimals": 8,
-    "id": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+    "id": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
   },
   {
     "name": "Wrapped Ether",
     "symbol": "WETH",
     "decimals": 18,
-    "id": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    "id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
   },
   {
     "name": "stETH",
     "symbol": "stETH",
     "decimals": 18,
-    "id": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+    "id": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"
   },
   {
     "name": "Wrapped liquid staked Ether 2.0",
     "symbol": "wstETH",
     "decimals": 18,
-    "id": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+    "id": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
   },
   {
     "name": "BNB",

--- a/token_whitelist/sepolia.json
+++ b/token_whitelist/sepolia.json
@@ -21,7 +21,7 @@
     "name": "USD Coin",
     "symbol": "USDC",
     "decimals": 6,
-    "id": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+    "id": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238"
   },
   {
     "name": "Tether USD",
@@ -33,6 +33,6 @@
     "name": "Wrapped Ether",
     "symbol": "WETH",
     "decimals": 18,
-    "id": "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14"
+    "id": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14"
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to PR #536 addressing actionable items from Claude's code review.

- Extract `loadTokensIntoCache` helper from `LoadWhitelist` so the cache-load logic is unit testable without touching the filesystem. Add `TestLoadTokensIntoCacheValidation` covering the empty-id and decimals=0 paths.
- Drop redundant `tokenCount` field from the load debug log; `loaded + skipped` already conveys it.
- Align the nil-logger guard around the decimals=0 warning to the same nested style used for the empty-id warning.
- Document that `decimals=0` is a heuristic — some legitimate ERC20s use non-18 (and rarely 0) decimals, so the warning is informational and does not skip the entry.
- Normalize all `id` addresses in `token_whitelist/{ethereum,sepolia,base}.json` to lowercase. Loader already lowercases at runtime, so behavior is unchanged; this just makes the source match the runtime representation and simplifies manual audits.

`base-sepolia.json` was already all-lowercase.

## Test plan

- [x] `go test ./core/taskengine/ -run TestLoadTokensIntoCacheValidation -v` passes locally
- [x] `go vet ./core/taskengine/` clean
- [ ] CI passes on the merge commit

Generated with Claude Code (https://claude.com/claude-code)
