### PR TITLE
fix: chain_registry non-blocking gRPC dial + retry-on-error RPC client cache

### DIFF
--- a/aggregator/chain_registry.go
+++ b/aggregator/chain_registry.go
@@ -25,27 +25,38 @@ type ChainEntry struct {
 	// ethclient for direct on-chain reads (e.g. ERC-20 balance checks in
 	// the withdraw flow) — not every operation rides through the worker
 	// gRPC channel.
-	rpcOnce sync.Once
-	rpc     *ethclient.Client
-	rpcErr  error
+	//
+	// rpcMu serializes the dial; once `rpc` is non-nil, GetRPC returns it
+	// without taking the lock-critical-section path. Dial failures are NOT
+	// cached: a transient error (RPC node briefly unreachable) leaves
+	// `rpc` nil so the next call retries, instead of permanently disabling
+	// the chain until a full gateway restart. This replaces a prior
+	// sync.Once that pinned the first error forever.
+	rpcMu sync.Mutex
+	rpc   *ethclient.Client
 }
 
 // GetRPC returns a chain-specific ethclient for direct reads against
-// this chain's RPC. Dialed once and cached for the entry's lifetime.
+// this chain's RPC. Successful dials are cached; failed dials are retried
+// on the next call so transient errors don't permanently disable the chain.
 func (e *ChainEntry) GetRPC() (*ethclient.Client, error) {
-	e.rpcOnce.Do(func() {
-		if e.Config == nil || e.Config.SmartWallet == nil || e.Config.SmartWallet.EthRpcUrl == "" {
-			e.rpcErr = fmt.Errorf("chain %d has no eth_rpc_url configured", chainConfigID(e.Config))
-			return
-		}
-		client, err := ethclient.Dial(e.Config.SmartWallet.EthRpcUrl)
-		if err != nil {
-			e.rpcErr = fmt.Errorf("dial chain %d RPC: %w", chainConfigID(e.Config), err)
-			return
-		}
-		e.rpc = client
-	})
-	return e.rpc, e.rpcErr
+	e.rpcMu.Lock()
+	defer e.rpcMu.Unlock()
+
+	if e.rpc != nil {
+		return e.rpc, nil
+	}
+
+	if e.Config == nil || e.Config.SmartWallet == nil || e.Config.SmartWallet.EthRpcUrl == "" {
+		return nil, fmt.Errorf("chain %d has no eth_rpc_url configured", chainConfigID(e.Config))
+	}
+
+	client, err := ethclient.Dial(e.Config.SmartWallet.EthRpcUrl)
+	if err != nil {
+		return nil, fmt.Errorf("dial chain %d RPC: %w", chainConfigID(e.Config), err)
+	}
+	e.rpc = client
+	return e.rpc, nil
 }
 
 func chainConfigID(c *config.ChainConfig) int64 {
@@ -111,6 +122,13 @@ func (r *ChainRegistry) Connect(ctx context.Context) {
 // reconnectLoop periodically retries connections for workers that are not
 // yet connected. It stops when all workers are connected or the context
 // is cancelled (gateway shutdown).
+//
+// Note: since the switch from grpc.DialContext (blocking) to grpc.NewClient
+// (non-blocking), connectEntry never returns a transient error for a
+// reachable URL — it only fails if the URL itself is invalid. The loop now
+// typically runs once, sees all clients populated, and exits. Real worker
+// reconnections are handled by gRPC's internal connection state machine.
+// Kept here for the case of explicit URL-level errors that need re-attempt.
 func (r *ChainRegistry) reconnectLoop(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -151,18 +169,20 @@ func (r *ChainRegistry) reconnectLoop(ctx context.Context) {
 	}
 }
 
-func (r *ChainRegistry) connectEntry(ctx context.Context, entry *ChainEntry) error {
-	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	conn, err := grpc.DialContext(
-		dialCtx,
+// connectEntry creates a non-blocking gRPC client for the worker. The actual
+// TCP connection is established lazily on the first RPC; transient worker
+// outages are handled by gRPC's internal connection state machine. This
+// returns essentially instantly so it is safe to call while holding the
+// registry's write lock (previously this dialed synchronously with
+// grpc.WithBlock() and a 10s timeout, stalling all GetWorker callers
+// waiting on the RLock for up to 10s × number-of-chains on startup).
+func (r *ChainRegistry) connectEntry(_ context.Context, entry *ChainEntry) error {
+	conn, err := grpc.NewClient(
 		entry.Config.WorkerAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
 	)
 	if err != nil {
-		return fmt.Errorf("dialing %s: %w", entry.Config.WorkerAddr, err)
+		return fmt.Errorf("creating client for %s: %w", entry.Config.WorkerAddr, err)
 	}
 
 	entry.conn = conn


### PR DESCRIPTION
Addresses the two high-priority concurrency findings from the [Claude review of #538](https://github.com/AvaProtocol/EigenLayer-AVS/pull/538#issuecomment-claude). Both are in `aggregator/chain_registry.go`. Single-file change, +45/-25 lines, fully isolated.

## 1. Write-lock held across blocking gRPC dials (High Priority #1)

**Before**: `Connect` and `reconnectLoop` hold `r.mu.Lock()` for their entire body while `connectEntry` performs a blocking gRPC dial with `grpc.WithBlock()` and a 10s timeout. In gateway mode with N chains, if workers are unreachable at startup, `Connect` blocks for up to 10s × N with the write lock held — during which every call to `GetWorker` (serving live traffic) queues on `RLock`. Same pattern in `reconnectLoop` every 5s.

**After**: `connectEntry` uses `grpc.NewClient` (non-blocking — the modern replacement for the now-deprecated `grpc.DialContext`). gRPC's internal connection state machine handles the actual TCP connect lazily on first RPC, and transient worker outages are handled by gRPC's reconnect logic. The write lock is now only held briefly enough to swap the client pointer.

The `reconnectLoop` now typically runs once, sees all clients populated, and exits cleanly — real worker reconnections handled internally by gRPC. The loop is preserved (with an updated comment) for the case of explicit URL-level errors that warrant re-attempt; can be removed in a follow-up if you want to fully lean on gRPC's reconnect.

## 2. Error cached permanently in `ChainEntry.GetRPC` (High Priority #2)

**Before**: `GetRPC` uses `sync.Once` + a stored `rpcErr` field. A transient dial failure at startup (RPC node momentarily unreachable) permanently disables the per-chain RPC client — `Once` never re-runs, so the only recovery is a full gateway restart.

**After**: replaced `sync.Once`/`rpcErr` with `sync.Mutex` + lazy-dial pattern. Successful dials are cached; failed dials are NOT cached, so the next call retries. Worst-case under contention: multiple concurrent first-time callers serialize through the mutex with a single dial attempt at a time — negligible cost per-chain.

## Side benefit (Low Priority #8 from the review)

`grpc.DialContext` is deprecated in modern gRPC-Go. This PR moves to the recommended `grpc.NewClient` API as part of the High #1 fix. No additional code change for #8 — it's swept in for free.

## Test plan

- [x] `go build ./aggregator/...` clean
- [x] `go vet ./aggregator/...` clean
- [x] `go test ./aggregator/...` — all existing tests pass (`aggregator`, `aggregator/rest`, `aggregator/rest/mapping`)
- [ ] CI runs the full test suite

Did not add a new test for the GetRPC retry behavior — `ethclient.Dial` opens a real connection, so testing the retry-on-error path requires either a temp HTTP server returning errors then recovering, or dependency-injection of the dialer. Reviewers should feel free to ask for a test if you want one; the fix itself is small enough to review by eye.
