### PR TITLE
docs: fix operator setup example to use current mainnet config

### DIFF
--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -21,9 +21,6 @@ operator_address: <operator_address>
 avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
 operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
-eth_rpc_url: https://ethereum-rpc.publicnode.com
-eth_ws_url: wss://ethereum-rpc.publicnode.com
-
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -5,11 +5,11 @@ To run the AVS operator, there are 2 steps
 1. Register to become an EigenLayer operator by following [EigenLayer Operator Guide](https://docs.eigenlayer.xyz/eigenlayer/operator-guides/operator-introduction)
 2. Once become an operator, you can register for Ava Protocol AVS by following the below step
 
-### Run Ava Protocol AVS on Holesky testnet
+### Run Ava Protocol AVS on Ethereum mainnet
 
 Download the latest release from https://github.com/AvaProtocol/EigenLayer-AVS/releases for your platform. You can compile for yourself by simply running `go build` at the root level.
 
-First, Generate Ava Protocol AVS config file. You can put it anywhere. Example `config/operator.yaml` with below content
+First, Generate Ava Protocol AVS config file. You can put it anywhere. Example `config/operator.yaml` with below content:
 
 ```
 # this sets the logger level (true = info, false = debug)
@@ -17,16 +17,19 @@ production: true
 
 operator_address: <operator_address>
 
-avs_registry_coordinator_address: 0x90c6d6f2A78d5Ce22AB8631Ddb142C03AC87De7a
-operator_state_retriever_address: 0xb7bb920538e038DFFEfcB55caBf713652ED2031F
+# Ava Protocol AVS contract addresses on Ethereum mainnet
+avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
+operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
-eth_rpc_url: https://ethereum-sepolia-rpc.publicnode.com
-eth_ws_url: wss://ethereum-sepolia-rpc.publicnode.com
+eth_rpc_url: https://ethereum-rpc.publicnode.com
+eth_ws_url: wss://ethereum-rpc.publicnode.com
 
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 
-aggregator_server_ip_port_address: "aggregator-holesky.avaprotocol.org:2206"
+# Unified aggregator endpoint — serves all mainnet chains (Ethereum, Base, ...)
+# from a single gRPC connection. The gateway routes per-chain internally.
+aggregator_server_ip_port_address: "aggregator.avaprotocol.org:2206"
 
 # avs node spec compliance https://eigen.nethermind.io/docs/spec/intro
 eigen_metrics_ip_port_address: <operator_public_ip>:9090
@@ -34,6 +37,8 @@ enable_metrics: true
 node_api_ip_port_address: <operator_public_ip>:9010
 enable_node_api: true
 ```
+
+> **Note**: Third-party operator support is mainnet-only. Sepolia/Holesky testnet operator coordination is handled internally by Ava Protocol and is not open to external operators.
 
 Configure 2 env var for your ECDSA and BLS password. Recall that these are generated when you onboard your operator to EigenLayer. In case your password contains special characters to the command-line, here we export both variables by disabling history expansion temporarily.
 ```


### PR DESCRIPTION
## Why

`docs/Operator.md` had a Holesky-flavored operator setup example that was internally inconsistent and partially broken:

- Section titled "Run Ava Protocol AVS on Holesky testnet"
- But `eth_rpc_url` used `ethereum-sepolia-rpc.publicnode.com` (Sepolia, not Holesky)
- And `aggregator_server_ip_port_address: "aggregator-holesky.avaprotocol.org:2206"` — a DNS record that **was removed as part of yesterday's [avs-infra DNS cleanup](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260602-aggregator-consolidation-path-b.md)**, so following the doc verbatim today returns NXDOMAIN.

Per the Path B aggregator consolidation, **third-party operator support is now mainnet-only**: testnet operator coordination (Sepolia, Base-Sepolia) is handled internally by Ava Protocol and is not open to external operators. So the example should be a coherent Ethereum mainnet config.

## What changed in this PR

A single block replacement in `docs/Operator.md`. New example uses:

| Field | Old (broken) | New |
|---|---|---|
| Section title | "Run Ava Protocol AVS on Holesky testnet" | "Run Ava Protocol AVS on Ethereum mainnet" |
| `avs_registry_coordinator_address` | `0x90c6...De7a` (Holesky) | `0x8DE3...A44B` (mainnet, matches `config/operator-ethereum-railway.yaml`) |
| `operator_state_retriever_address` | `0xb7bb...2031F` (Holesky) | `0xb3af...2713` (mainnet, matches `config/operator-ethereum-railway.yaml`) |
| `eth_rpc_url` / `eth_ws_url` | sepolia publicnode | mainnet publicnode |
| `aggregator_server_ip_port_address` | `aggregator-holesky.avaprotocol.org:2206` (DNS deleted) | `aggregator.avaprotocol.org:2206` (matches the canonical URL in public docs at avaprotocol.org/docs/run-operator/setup-node) |

Also added a short Note clarifying mainnet-only third-party operator support.

## Test plan

- [x] Mainnet contract addresses verified against `config/operator-ethereum-railway.yaml` (the production Railway operator's actual config)
- [x] Aggregator URL verified against `avaprotocol.org/docs/run-operator/setup-node` (the canonical operator setup docs)
- [x] DNS verified: `dig aggregator.avaprotocol.org` → resolves to the new Lightsail proxy IP
- [ ] CI passes
