### PR TITLE
chore: bump version.go semver default from 1.9.6 to 3.0.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,12 @@
 package version
 
 var (
-	// Version can also be set through tag release at build time
-	semver   = "1.9.6"
+	// Bumped manually on each release to match the current main tag — see
+	// docs/Release.md. ldflags overrides this for properly-built Docker
+	// images (publish-prod-docker.yml), but Railway's source-build path
+	// does not pass -ldflags, so this default is what telemetry/health
+	// endpoints report for Railway-deployed services.
+	semver   = "3.0.0"
 	revision = "unknown"
 )
 


### PR DESCRIPTION
## Why

`version/version.go` had `semver = "1.9.6"` as the hardcoded default, last bumped ages ago. That value is what `Get()` returns when no `-ldflags` override is present at build time. The Dockerfile + `publish-prod-docker.yml` pass the right `RELEASE_TAG` build arg, so the official `avaprotocol/ap-avs:v3.0.0` image reports correctly. **But Railway's source-build path doesn't pass the build arg**, so the gateway + workers + operators deployed on Railway all fall back to the hardcoded `"1.9.6"`.

Symptom: today the operator telemetry page at `https://api.avaprotocol.org/telemetry` shows our Ava Protocol mainnet operator (and the gateway) running version `1.9.6` — but they're actually on the v3.0.0 main squash commit (461b8bd). Confusing for operators who look at the page expecting to see the latest release.

## What changed

`semver = "1.9.6"` → `semver = "3.0.0"` (matching the current main release tag), plus a comment in the file explaining the manual-bump-on-release pattern and why it exists.

## Test plan

- [x] `go build ./...` clean
- [ ] CI passes
- [ ] After merge: telemetry HTML at `https://api.avaprotocol.org/telemetry` shows `Aggregator 3.0.0` instead of `1.9.6` (gateway will pick this up on its next Railway build, triggered by the staging→main merge)
- [ ] Operator log on startup shows `🚀 Starting Operator <addr> (v3.0.0)` instead of `(v1.9.6)`

## Maintenance note

This is **Option A** of the three discussed for fixing the version-string mismatch:

| Option | Approach | Trade-off |
|---|---|---|
| **A (this PR)** | Manual bump of `version.go` default on each release | Has to be remembered each release; if forgotten, deploys silently report stale version |
| B | Configure Railway to pass `RELEASE_TAG` as a build arg per service | Per-service config; need to update on each release as well |
| C | Switch Railway services to pull `avaprotocol/ap-avs:vX.Y.Z` from Docker Hub instead of source-building | Loses auto-rebuild on push to main; explicit deploy per version |

If the manual bump becomes a recurring miss, B or C is the longer-term fix.

## Why `chore:` and not `fix:`

`go-semantic-release` treats `chore:` as no-bump, so this commit does not trigger a new release tag — important because we want `version.go` to match the current main release (v3.0.0), not the next one.
