### PR TITLE
chore: add merge_hetzner_into_gateway one-shot migration tool

### DIFF
--- a/scripts/migration/merge_hetzner_into_gateway/README.md
+++ b/scripts/migration/merge_hetzner_into_gateway/README.md
@@ -1,0 +1,133 @@
+# merge_hetzner_into_gateway
+
+One-shot tool to merge a Hetzner per-chain aggregator BadgerDB (the **donor**) into the unified Railway gateway BadgerDB. Used once during the 2026-07-01 Hetzner decom to bring forward the ~3 weeks of production data that Studio wrote to the Hetzner aggregators after the May 2026 Railway migration but before this cutover.
+
+Full context: [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md).
+
+## What it does
+
+For each prefix it knows about, the tool walks every donor key and applies a per-prefix policy:
+
+| Prefix family | Policy |
+|---|---|
+| `t:` | Pass-through (chain-scoped; validate embedded chain ID matches donor) |
+| `u:` | Pass-through (chain-scoped) |
+| `history:` | Pass-through (chain-scoped) |
+| `w:` | Stamp donor chain ID into the key (legacy → chain-scoped) |
+| `wsalt:` | Stamp donor chain ID; **post-merge, run** `BackfillWalletSaltIndex` against the gateway DB to rebuild any salt-index drift |
+| `fl:` | Stamp donor chain ID |
+| `fr:` | Stamp donor chain ID |
+| `secret:` | Import as-is (already user/org/workflow scoped, chain doesn't apply) |
+| `execution_index_counter:` | Import as-is; on collision keep the larger value |
+| `ct:cw:` | Drop (cosmetic) |
+| `pending:` | Drop (transient) |
+| `trigger:` | Drop (reconstructible from `history:`) |
+| `migration:` | Drop (donor's migration history, not gateway's) |
+
+**Every write is skip-if-exists.** The gateway has been accumulating its own data since deploy — the tool never overwrites anything already there. This is the load-bearing safety property; the test `TestSetIfAbsent_SkipsWhenKeyPresent` pins it.
+
+Any prefix the tool does not recognize causes a hard-fail by default. To inspect a problem donor without aborting, pass `--fail-on-unknown-prefix=false` — but be aware that those keys are silently dropped from the merge.
+
+## Usage
+
+```bash
+# 1. Stop the donor aggregator and capture its BadgerDB to a workstation:
+ssh ap-prod1 'sudo systemctl stop avs-aggregator-ethereum'
+ssh ap-prod1 'sudo tar czf - /data/mainnet-avs-aggregator/db' > ethereum-donor-2026-06-04.tar.gz
+tar xzf ethereum-donor-2026-06-04.tar.gz -C ./donors/
+
+# 2. Stop the Railway gateway service (Railway dashboard → gateway → "Stop").
+#    Pull the gateway volume to a workstation if running locally, or run the
+#    tool from a Railway one-off task mounting the gateway volume.
+
+# 3. Dry-run first against a scratch copy. Inspect counts + collisions:
+go run ./scripts/migration/merge_hetzner_into_gateway \
+    --donor-path     ./donors/db \
+    --donor-chain-id 1 \
+    --gateway-path   /tmp/gateway-db-scratch-copy \
+    --dry-run        \
+    --verbose
+
+# 4. When the dry-run looks right, apply for real:
+go run ./scripts/migration/merge_hetzner_into_gateway \
+    --donor-path     ./donors/db \
+    --donor-chain-id 1 \
+    --gateway-path   /data \
+    --dry-run=false
+
+# 5. Repeat steps 1, 3, 4 for each chain:
+#    --donor-chain-id 8453      Base mainnet
+#    --donor-chain-id 11155111  Sepolia testnet
+#    --donor-chain-id 84532     Base-Sepolia testnet
+
+# 6. After all four merges, run BackfillWalletSaltIndex against the gateway
+#    to rebuild the wsalt: secondary index (the merge stamps the keys but
+#    doesn't re-derive the canonical pointers):
+go run ./scripts/migration/backfill_wallet_salt_index --config config/gateway-railway.yaml
+
+# 7. Start the Railway gateway service. Smoke-test workflows + execution
+#    queries across all four chains.
+```
+
+## Flags
+
+| Flag | Required | Default | Notes |
+|---|---|---|---|
+| `--donor-path` | yes | — | Path to the donor BadgerDB directory |
+| `--donor-chain-id` | yes | — | 1 / 8453 / 11155111 / 84532 |
+| `--gateway-path` | yes | — | Path to the Railway gateway BadgerDB |
+| `--dry-run` | no | `true` | Defaults to TRUE. Pass `--dry-run=false` to actually write. |
+| `--verbose` | no | false | One line per key processed |
+| `--fail-on-unknown-prefix` | no | true | Hard-fail when the donor has unrecognized prefixes |
+
+## Output
+
+The tool prints a per-prefix summary table at the end:
+
+```
+Summary
+-------
+Donor chain: 1 (ethereum)
+
+Prefix                          Policy                                              Scanned   Copied  Stamped  Existed  Dropped   Errors
+----------------------------- -------------------------------------------------- -------- -------- -------- -------- -------- --------
+t:                              pass-through (chain-scoped)                            8421     8410        0       11        0        0
+u:                              pass-through (chain-scoped)                            8421     8410        0       11        0        0
+history:                        pass-through (chain-scoped)                           12734    12734        0        0        0        0
+w:                              stamp chain ID                                          184      184      184        0        0        0
+wsalt:                          stamp chain ID (rebuild wsalt index post-merge)         184      184      184        0        0        0
+fl:                             stamp chain ID                                          141      141      141        0        0        0
+fr:                             stamp chain ID                                         2104     2104     2104        0        0        0
+secret:                         import as-is                                            317      317        0        0        0        0
+execution_index_counter:        max-on-collision                                       8421     8410        0       11        0        0
+ct:cw:                          drop (cosmetic)                                          14        0        0        0       14        0
+pending:                        drop (transient)                                          3        0        0        0        3        0
+trigger:                        drop (reconstructible from history)                   12734        0        0        0    12734        0
+migration:                      drop (donor history not gateway's)                        4        0        0        0        4        0
+----------------------------- -------------------------------------------------- -------- -------- -------- -------- -------- --------
+TOTAL                                                                                  53682    32494     2613       33    12759        0
+```
+
+(Made-up numbers, but the column shape is real.)
+
+## Safety rules
+
+1. **The Railway gateway must be stopped before `--dry-run=false`.** BadgerDB is single-writer; the tool opens the same `db_path` directly. The tool will error on open if another process is holding the lock.
+2. **Take a fresh pre-merge backup of the gateway volume immediately before running.** That snapshot is the only rollback target.
+3. **Always run `--dry-run` first against a scratch *copy* of the gateway DB** (rsync it to a sidecar dir on the Railway volume). Inspect the per-prefix counts and collisions before touching the live volume.
+4. **Never replace `setIfAbsent` with `storage.Storage.Load`.** Load is bulk upsert and will silently clobber live gateway data. The test `TestSetIfAbsent_SkipsWhenKeyPresent` is the regression guard.
+5. **Run the tool sequentially per donor**, not in parallel. The tool acquires a Badger write lock on the gateway DB.
+6. **Keep the donor aggregators stopped, not deleted, until 2026-06-30** — hot rollback window. Delete on 2026-07-01 after the decom closes.
+
+## What's NOT in this tool
+
+- **wsalt: index rebuild.** The merge stamps the chain ID into wsalt keys but doesn't re-derive any canonical wallet pointers. After the merge, run [`scripts/migration/backfill_wallet_salt_index`](../backfill_wallet_salt_index/) against the gateway DB to refresh those.
+- **Gateway read-path updates for chain-stamped families.** The merge produces `w:<chainID>:<owner>:<addr>` keys. The gateway code that reads `w:` keys needs a corresponding update to look at chain-scoped form too — that ships as a separate PR alongside any read paths for `wsalt:`, `fl:`, `fr:`.
+- **Recovery from a botched merge.** If smoke tests fail after the merge runs, the recovery is "restore the pre-merge gateway backup, investigate, dry-run again." There's no in-place rollback inside the tool.
+
+## Related references
+
+- Policy matrix source of truth: [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md#per-prefix-decision-matrix-proposed-awaiting-sign-off)
+- Existing migration tool the structure follows: [`scripts/migration/backfill_wallet_salt_index/`](../backfill_wallet_salt_index/)
+- Chain-scoped key parsers used to validate donor pass-through keys: [`core/taskengine/chain_scoped_keys.go`](../../../core/taskengine/chain_scoped_keys.go)
+- Storage API contract: [`storage/db.go`](../../../storage/db.go) — note that `Load` is upsert and must not be used here.

--- a/scripts/migration/merge_hetzner_into_gateway/README.md
+++ b/scripts/migration/merge_hetzner_into_gateway/README.md
@@ -24,7 +24,9 @@ For each prefix it knows about, the tool walks every donor key and applies a per
 | `trigger:` | Drop (reconstructible from `history:`) |
 | `migration:` | Drop (donor's migration history, not gateway's) |
 
-**Every write is skip-if-exists.** The gateway has been accumulating its own data since deploy — the tool never overwrites anything already there. This is the load-bearing safety property; the test `TestSetIfAbsent_SkipsWhenKeyPresent` pins it.
+**Every write is skip-if-exists, with one documented exception.** The gateway has been accumulating its own data since deploy, so the tool's default write path is `setIfAbsent` — `Exist` check before every `Set`, gateway value preserved on collision. The test `TestSetIfAbsent_SkipsWhenKeyPresent` pins this.
+
+The one exception is `execution_index_counter:` (the max-on-collision row). If the donor's counter for a given `taskID` is strictly larger than the gateway's, the tool overwrites the gateway value — re-issuing already-consumed execution indices would be worse than overwriting one `uint64`. These overwrites are surfaced separately in the summary under the **CollRes** column. Brand-new keys (gateway had nothing) show under **Copied** only; CollRes is a subset of Copied so the totals reconcile.
 
 Any prefix the tool does not recognize causes a hard-fail by default. To inspect a problem donor without aborting, pass `--fail-on-unknown-prefix=false` — but be aware that those keys are silently dropped from the merge.
 
@@ -89,26 +91,26 @@ Summary
 -------
 Donor chain: 1 (ethereum)
 
-Prefix                          Policy                                              Scanned   Copied  Stamped  Existed  Dropped   Errors
------------------------------ -------------------------------------------------- -------- -------- -------- -------- -------- --------
-t:                              pass-through (chain-scoped)                            8421     8410        0       11        0        0
-u:                              pass-through (chain-scoped)                            8421     8410        0       11        0        0
-history:                        pass-through (chain-scoped)                           12734    12734        0        0        0        0
-w:                              stamp chain ID                                          184      184      184        0        0        0
-wsalt:                          stamp chain ID (rebuild wsalt index post-merge)         184      184      184        0        0        0
-fl:                             stamp chain ID                                          141      141      141        0        0        0
-fr:                             stamp chain ID                                         2104     2104     2104        0        0        0
-secret:                         import as-is                                            317      317        0        0        0        0
-execution_index_counter:        max-on-collision                                       8421     8410        0       11        0        0
-ct:cw:                          drop (cosmetic)                                          14        0        0        0       14        0
-pending:                        drop (transient)                                          3        0        0        0        3        0
-trigger:                        drop (reconstructible from history)                   12734        0        0        0    12734        0
-migration:                      drop (donor history not gateway's)                        4        0        0        0        4        0
------------------------------ -------------------------------------------------- -------- -------- -------- -------- -------- --------
-TOTAL                                                                                  53682    32494     2613       33    12759        0
+Prefix                          Policy                                              Scanned   Copied  CollRes  Stamped  Existed  Dropped   Errors
+----------------------------- -------------------------------------------------- -------- -------- -------- -------- -------- -------- --------
+t:                              pass-through (chain-scoped)                            8421     8410        0        0       11        0        0
+u:                              pass-through (chain-scoped)                            8421     8410        0        0       11        0        0
+history:                        pass-through (chain-scoped)                           12734    12734        0        0        0        0        0
+w:                              stamp chain ID                                          184      184        0      184        0        0        0
+wsalt:                          stamp chain ID (rebuild wsalt index post-merge)         184      184        0      184        0        0        0
+fl:                             stamp chain ID                                          141      141        0      141        0        0        0
+fr:                             stamp chain ID                                         2104     2104        0     2104        0        0        0
+secret:                         import as-is                                            317      317        0        0        0        0        0
+execution_index_counter:        max-on-collision                                       8421     8408        4        0       13        0        0
+ct:cw:                          drop (cosmetic)                                          14        0        0        0        0       14        0
+pending:                        drop (transient)                                          3        0        0        0        0        3        0
+trigger:                        drop (reconstructible from history)                   12734        0        0        0        0    12734        0
+migration:                      drop (donor history not gateway's)                        4        0        0        0        0        4        0
+----------------------------- -------------------------------------------------- -------- -------- -------- -------- -------- -------- --------
+TOTAL                                                                                  53682    32492        4     2613       35    12755        0
 ```
 
-(Made-up numbers, but the column shape is real.)
+(Made-up numbers, but the column shape is real.) **CollRes** is the subset of Copied that overwrote an existing gateway value (only ever non-zero for `execution_index_counter:`, when the donor counter exceeds the gateway counter). Sum reconciles: `Copied + Existed + Dropped + Errors = Scanned` for each row.
 
 ## Safety rules
 

--- a/scripts/migration/merge_hetzner_into_gateway/handlers.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers.go
@@ -156,15 +156,20 @@ func handleImportAsIs(donor, gateway storage.Storage, donorChainID int64, _ stri
 // taskID is globally unique across chains in our schema, so no chain
 // stamping is needed.
 func handleMaxOnCollision(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	exists, err := gateway.Exist(kv.Key)
+	if err != nil {
+		return fmt.Errorf("Exist check for %q: %w", string(kv.Key), err)
+	}
+	if !exists {
+		stat.copied++
+		if dryRun {
+			return nil
+		}
+		return gateway.Set(kv.Key, kv.Value)
+	}
+	// Both sides have it. Compare counters and take the larger.
 	existing, err := gateway.GetKey(kv.Key)
 	if err != nil {
-		if isKeyNotFoundError(err) {
-			stat.copied++
-			if dryRun {
-				return nil
-			}
-			return gateway.Set(kv.Key, kv.Value)
-		}
 		return fmt.Errorf("get gateway %q: %w", string(kv.Key), err)
 	}
 	donorVal, derr := strconv.ParseUint(string(kv.Value), 10, 64)
@@ -176,6 +181,9 @@ func handleMaxOnCollision(donor, gateway storage.Storage, donorChainID int64, _ 
 		return fmt.Errorf("parse gateway counter %q as uint64: %w", string(existing), gerr)
 	}
 	if donorVal > gwVal {
+		// Count as BOTH a write (CollRes is a subset of total writes) and
+		// a collision-resolved overwrite, so the summary totals reconcile.
+		stat.copied++
 		stat.collisionResolved++
 		if dryRun {
 			return nil
@@ -197,9 +205,17 @@ func handleDrop(donor, gateway storage.Storage, donorChainID int64, _ string, kv
 // Lower-level helpers
 // -------------------------------------------------------------------------
 
-// setIfAbsent is the ONLY write path in this tool. It guarantees that
-// nothing the gateway already has gets overwritten. Updates stats based
-// on the path taken.
+// setIfAbsent is the skip-if-exists write path used by every handler
+// EXCEPT handleMaxOnCollision. When this function writes, the gateway
+// definitely did not have the key beforehand — no overwrite is possible
+// through this path. handleMaxOnCollision is the one deliberate
+// exception: it calls gateway.Set directly when the donor counter is
+// larger than the gateway's, because re-issuing already-consumed
+// execution indices would be worse than overwriting one uint64.
+//
+// If you add a new handler, route writes through setIfAbsent unless you
+// have a documented reason for collision-overwrite semantics like
+// handleMaxOnCollision does.
 func setIfAbsent(gateway storage.Storage, key, value []byte, stat *prefixStats, dryRun bool) error {
 	exists, err := gateway.Exist(key)
 	if err != nil {

--- a/scripts/migration/merge_hetzner_into_gateway/handlers.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// handlerFunc processes a single donor key-value, writing zero or one
+// keys to the gateway under skip-if-exists semantics. The matched prefix
+// (from prefixHandlers) is passed through so handlers that need to strip
+// it (handleStampChainID) don't have to re-find it — and so the dispatch
+// table can hold function references without inducing an init cycle.
+//
+// The handler must NEVER overwrite a key the gateway already has.
+type handlerFunc func(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error
+
+// prefixHandlerEntry is the row type of the dispatch table.
+type prefixHandlerEntry struct {
+	prefix string
+	handle handlerFunc
+	policy string // short label that prints in summary
+}
+
+// prefixHandlers is the dispatch table. The dispatcher walks it in order
+// and picks the first matching prefix — so put `ct:cw:` BEFORE `ct:` if
+// the latter is ever added (currently only `ct:cw:` exists).
+//
+// IMPORTANT: keep this table aligned with the per-prefix policy matrix in
+// `docs/changes/20260604-hetzner-data-restore-plan.md` (avs-infra).
+// Editing one without the other invites silent divergence.
+var prefixHandlers = []prefixHandlerEntry{
+	// Already chain-scoped on disk (MigrateKeysToChainScoped ran on every
+	// donor pre-merge). Validate embedded chain ID matches the donor.
+	{"t:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+	{"u:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+	{"history:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+
+	// Chain-implicit on the donor. Stamp `--donor-chain-id` into the key
+	// when writing to gateway. Gateway read-path update ships separately.
+	{"w:", handleStampChainID, "stamp chain ID"},
+	{"wsalt:", handleStampChainID, "stamp chain ID (rebuild wsalt index post-merge)"},
+	{"fl:", handleStampChainID, "stamp chain ID"},
+	{"fr:", handleStampChainID, "stamp chain ID"},
+
+	// Already user/org/workflow scoped — chain doesn't apply.
+	{"secret:", handleImportAsIs, "import as-is"},
+
+	// Monotonic counters keyed by taskID — taskID is globally unique, so
+	// no chain stamping. On collision, keep the larger value.
+	{"execution_index_counter:", handleMaxOnCollision, "max-on-collision"},
+
+	// Drop policies — cosmetic, transient, or reconstructible.
+	{"ct:cw:", handleDrop, "drop (cosmetic)"},
+	{"pending:", handleDrop, "drop (transient)"},
+	{"trigger:", handleDrop, "drop (reconstructible from history)"},
+
+	// Donor migration markers describe the donor's history, not the
+	// gateway's — never import.
+	{"migration:", handleDrop, "drop (donor history not gateway's)"},
+}
+
+func knownPrefixes() []string {
+	out := make([]string, 0, len(prefixHandlers))
+	for _, h := range prefixHandlers {
+		out = append(out, h.prefix)
+	}
+	return out
+}
+
+func dispatch(donor, gateway storage.Storage, donorChainID int64, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	for _, h := range prefixHandlers {
+		if hasPrefix(kv.Key, h.prefix) {
+			if verbose {
+				fmt.Printf("  [%s] %q\n", h.policy, string(kv.Key))
+			}
+			return h.handle(donor, gateway, donorChainID, h.prefix, kv, stat, dryRun, verbose)
+		}
+	}
+	return fmt.Errorf("no handler matched key %q (caller should have routed via scanForUnknownPrefixes)", string(kv.Key))
+}
+
+func hasPrefix(key []byte, prefix string) bool {
+	if len(key) < len(prefix) {
+		return false
+	}
+	return string(key[:len(prefix)]) == prefix
+}
+
+// -------------------------------------------------------------------------
+// Handlers
+// -------------------------------------------------------------------------
+
+// handleChainScopedPassThrough copies a key that's already chain-scoped
+// on the donor (per MigrateKeysToChainScoped) straight into the gateway,
+// after validating the embedded chain ID matches --donor-chain-id.
+//
+// Layout: `<prefix><chainID>:<rest...>` — second `:`-delimited segment is
+// the chain ID. Legacy (unprefixed) form aborts the merge: the donor was
+// supposed to be migrated already.
+func handleChainScopedPassThrough(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	embedded, parseErr := parseChainIDFromKey(kv.Key)
+	if errors.Is(parseErr, taskengine.ErrLegacyKey) {
+		return fmt.Errorf("donor key %q is in legacy (pre-chain-scoped) form — run the chain-scope migration on the donor before merging", string(kv.Key))
+	}
+	if parseErr != nil {
+		return fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
+	}
+	if embedded != donorChainID {
+		return fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
+	}
+
+	return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+}
+
+// handleStampChainID stamps `--donor-chain-id` into the key. For prefix
+// `p:` the donor key is `p:<rest>` and the gateway key becomes
+// `p:<chainID>:<rest>`. Used for chain-implicit families (w:, wsalt:,
+// fl:, fr:) that don't have their own chain_scoped_keys-style migration
+// yet.
+func handleStampChainID(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	if matchedPrefix == "" {
+		return fmt.Errorf("internal: handleStampChainID called without a matched prefix for key %q", string(kv.Key))
+	}
+	rest := string(kv.Key[len(matchedPrefix):])
+
+	// Safety: if the donor key is ALREADY stamped (rest starts with the
+	// chain ID followed by ':'), skip the additional stamp and treat as
+	// chain-scoped pass-through. This guards against double-running the
+	// tool or against donors that ran a future migration we don't know
+	// about.
+	if alreadyStamped(rest, donorChainID) {
+		return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+	}
+	stamped := []byte(fmt.Sprintf("%s%d:%s", matchedPrefix, donorChainID, rest))
+	stat.stampedChain++
+	return setIfAbsent(gateway, stamped, kv.Value, stat, dryRun)
+}
+
+// handleImportAsIs copies the key verbatim. Used for secret:, which is
+// already user/org/workflow scoped and where chain doesn't apply.
+func handleImportAsIs(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+}
+
+// handleMaxOnCollision is used for execution_index_counter:<taskID>. The
+// counter is a monotonic per-task uint64. If both donor and gateway have
+// a counter for the same taskID, take the larger — a smaller value would
+// cause the gateway to re-issue execution indices that already exist on
+// the donor.
+//
+// taskID is globally unique across chains in our schema, so no chain
+// stamping is needed.
+func handleMaxOnCollision(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	existing, err := gateway.GetKey(kv.Key)
+	if err != nil {
+		if isKeyNotFoundError(err) {
+			stat.copied++
+			if dryRun {
+				return nil
+			}
+			return gateway.Set(kv.Key, kv.Value)
+		}
+		return fmt.Errorf("get gateway %q: %w", string(kv.Key), err)
+	}
+	donorVal, derr := strconv.ParseUint(string(kv.Value), 10, 64)
+	if derr != nil {
+		return fmt.Errorf("parse donor counter %q as uint64: %w", string(kv.Value), derr)
+	}
+	gwVal, gerr := strconv.ParseUint(string(existing), 10, 64)
+	if gerr != nil {
+		return fmt.Errorf("parse gateway counter %q as uint64: %w", string(existing), gerr)
+	}
+	if donorVal > gwVal {
+		stat.collisionResolved++
+		if dryRun {
+			return nil
+		}
+		return gateway.Set(kv.Key, kv.Value)
+	}
+	stat.skippedExists++
+	return nil
+}
+
+// handleDrop ignores the donor key entirely. Used for cosmetic / transient /
+// gateway-own-history prefixes per the matrix.
+func handleDrop(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	stat.dropped++
+	return nil
+}
+
+// -------------------------------------------------------------------------
+// Lower-level helpers
+// -------------------------------------------------------------------------
+
+// setIfAbsent is the ONLY write path in this tool. It guarantees that
+// nothing the gateway already has gets overwritten. Updates stats based
+// on the path taken.
+func setIfAbsent(gateway storage.Storage, key, value []byte, stat *prefixStats, dryRun bool) error {
+	exists, err := gateway.Exist(key)
+	if err != nil {
+		return fmt.Errorf("Exist check for %q: %w", string(key), err)
+	}
+	if exists {
+		stat.skippedExists++
+		return nil
+	}
+	stat.copied++
+	if dryRun {
+		return nil
+	}
+	return gateway.Set(key, value)
+}
+
+// parseChainIDFromKey extracts the chain ID from a chain-scoped key like
+// `t:1:a:taskID` or `history:1:taskID:executionID`. Returns
+// taskengine.ErrLegacyKey if the second segment isn't a numeric chain ID.
+func parseChainIDFromKey(key []byte) (int64, error) {
+	s := string(key)
+	first := strings.IndexByte(s, ':')
+	if first < 0 {
+		return 0, taskengine.ErrLegacyKey
+	}
+	rest := s[first+1:]
+	second := strings.IndexByte(rest, ':')
+	if second < 0 {
+		return 0, taskengine.ErrLegacyKey
+	}
+	candidate := rest[:second]
+	id, err := strconv.ParseInt(candidate, 10, 64)
+	if err != nil {
+		return 0, taskengine.ErrLegacyKey
+	}
+	return id, nil
+}
+
+// alreadyStamped returns true when the donor key fragment (everything
+// after the matched prefix) appears to already be chain-stamped with the
+// given chain ID — i.e. it starts with `<chainID>:`. Used by
+// handleStampChainID to skip double-stamping if the donor ran a future
+// migration the tool doesn't know about.
+func alreadyStamped(rest string, donorChainID int64) bool {
+	prefix := strconv.FormatInt(donorChainID, 10) + ":"
+	return strings.HasPrefix(rest, prefix)
+}
+
+// isKeyNotFoundError lets us treat "key not present" as a non-error case
+// without importing badger directly. The storage package surfaces the
+// badger error verbatim from GetKey.
+func isKeyNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Key not found")
+}

--- a/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
@@ -165,6 +164,7 @@ func TestHandleMaxOnCollision_DonorLarger(t *testing.T) {
 	require.NoError(t, handleMaxOnCollision(donor, gw, 1, "execution_index_counter:", donorKV, stat, false, false))
 
 	assert.Equal(t, 1, stat.collisionResolved, "donor was larger — collision resolved")
+	assert.Equal(t, 1, stat.copied, "collision-resolved overwrites count toward Copied so summary totals reconcile (CollRes is a subset of Copied)")
 
 	got, err := gw.GetKey([]byte("execution_index_counter:taskA"))
 	require.NoError(t, err)
@@ -321,6 +321,3 @@ func TestSupportedChainList_IsDeterministic(t *testing.T) {
 		assert.Contains(t, first, want)
 	}
 }
-
-// strconv import keeps lint happy if we add numeric tests later.
-var _ = strconv.Itoa

--- a/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDB returns a fresh in-memory BadgerStorage backed by a t.TempDir.
+// Caller does not need to defer Close — t.Cleanup handles it.
+func newTestDB(t *testing.T) storage.Storage {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := storage.NewWithPath(dir)
+	require.NoError(t, err, "open BadgerDB at %s", dir)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func kvItem(key, value string) *storage.KeyValueItem {
+	return &storage.KeyValueItem{Key: []byte(key), Value: []byte(value)}
+}
+
+// -------------------------------------------------------------------------
+// setIfAbsent — the only write path. Single, focused tests.
+// -------------------------------------------------------------------------
+
+func TestSetIfAbsent_WritesWhenKeyAbsent(t *testing.T) {
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	require.NoError(t, setIfAbsent(gw, []byte("t:1:a:abc"), []byte("body"), stat, false))
+	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 0, stat.skippedExists)
+
+	got, err := gw.GetKey([]byte("t:1:a:abc"))
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(got))
+}
+
+func TestSetIfAbsent_SkipsWhenKeyPresent(t *testing.T) {
+	gw := newTestDB(t)
+	require.NoError(t, gw.Set([]byte("t:1:a:abc"), []byte("gateway-version")))
+
+	stat := &prefixStats{}
+	require.NoError(t, setIfAbsent(gw, []byte("t:1:a:abc"), []byte("donor-version"), stat, false))
+	assert.Equal(t, 0, stat.copied)
+	assert.Equal(t, 1, stat.skippedExists)
+
+	// CRITICAL: the donor's value MUST NOT have overwritten the gateway's.
+	got, err := gw.GetKey([]byte("t:1:a:abc"))
+	require.NoError(t, err)
+	assert.Equal(t, "gateway-version", string(got),
+		"setIfAbsent must never overwrite the gateway value (this is the core safety property of the merge tool)")
+}
+
+func TestSetIfAbsent_DryRunDoesNotWrite(t *testing.T) {
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	require.NoError(t, setIfAbsent(gw, []byte("t:1:a:abc"), []byte("body"), stat, true))
+	assert.Equal(t, 1, stat.copied)
+
+	_, err := gw.GetKey([]byte("t:1:a:abc"))
+	assert.True(t, isKeyNotFoundError(err), "dry-run must not actually write; got %v", err)
+}
+
+// -------------------------------------------------------------------------
+// handleChainScopedPassThrough — validates embedded chain ID.
+// -------------------------------------------------------------------------
+
+func TestHandleChainScopedPassThrough_ValidatesMatchingChainID(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:1:a:taskABC", "body"), stat, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stat.copied)
+}
+
+func TestHandleChainScopedPassThrough_RejectsMismatchedChainID(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:8453:a:taskABC", "body"), stat, false, false)
+	require.Error(t, err, "must refuse to import a key whose embedded chain ID doesn't match --donor-chain-id")
+	assert.Contains(t, err.Error(), "embeds chain ID 8453")
+}
+
+func TestHandleChainScopedPassThrough_RejectsLegacyForm(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	// Legacy form: `t:a:taskABC` (status code 'a', no numeric chain segment).
+	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:a:taskABC", "body"), stat, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "legacy (pre-chain-scoped) form")
+}
+
+// -------------------------------------------------------------------------
+// handleStampChainID — rewrites chain-implicit keys.
+// -------------------------------------------------------------------------
+
+func TestHandleStampChainID_StampsLegacyKey(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := newStats().forPrefix("w:")
+
+	donorKV := kvItem("w:0xowner:0xwallet", "wallet-record")
+	require.NoError(t, handleStampChainID(donor, gw, 8453, "w:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.copied, "should have copied to gateway")
+	assert.Equal(t, 1, stat.stampedChain, "should have counted the chain stamp")
+
+	// Verify the new key was written and the legacy key was NOT (since the
+	// donor row is never moved — that's the donor's problem).
+	stampedKey := []byte("w:8453:0xowner:0xwallet")
+	got, err := gw.GetKey(stampedKey)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet-record", string(got))
+
+	_, err = gw.GetKey([]byte("w:0xowner:0xwallet"))
+	assert.True(t, isKeyNotFoundError(err), "legacy unstamped key should NOT have been written to the gateway")
+}
+
+func TestHandleStampChainID_DetectsAlreadyStampedDonor(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := newStats().forPrefix("w:")
+
+	// Donor key is already in chain-scoped form (e.g. a re-run of the tool,
+	// or the donor having run a future migration we don't know about).
+	donorKV := kvItem("w:1:0xowner:0xwallet", "wallet-record")
+	require.NoError(t, handleStampChainID(donor, gw, 1, "w:", donorKV, stat, false, false))
+
+	// Should pass through, NOT double-stamp into `w:1:1:0xowner...`.
+	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 0, stat.stampedChain, "donor was already stamped — must not double-stamp")
+
+	got, err := gw.GetKey([]byte("w:1:0xowner:0xwallet"))
+	require.NoError(t, err)
+	assert.Equal(t, "wallet-record", string(got))
+
+	_, err = gw.GetKey([]byte("w:1:1:0xowner:0xwallet"))
+	assert.True(t, isKeyNotFoundError(err), "must not have produced the double-stamped key")
+}
+
+// -------------------------------------------------------------------------
+// handleMaxOnCollision — execution_index_counter:.
+// -------------------------------------------------------------------------
+
+func TestHandleMaxOnCollision_DonorLarger(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	require.NoError(t, gw.Set([]byte("execution_index_counter:taskA"), []byte("5")))
+
+	stat := newStats().forPrefix("execution_index_counter:")
+	donorKV := kvItem("execution_index_counter:taskA", "12")
+	require.NoError(t, handleMaxOnCollision(donor, gw, 1, "execution_index_counter:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.collisionResolved, "donor was larger — collision resolved")
+
+	got, err := gw.GetKey([]byte("execution_index_counter:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, "12", string(got), "gateway should now hold donor's larger value")
+}
+
+func TestHandleMaxOnCollision_GatewayLarger(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	require.NoError(t, gw.Set([]byte("execution_index_counter:taskA"), []byte("100")))
+
+	stat := newStats().forPrefix("execution_index_counter:")
+	donorKV := kvItem("execution_index_counter:taskA", "12")
+	require.NoError(t, handleMaxOnCollision(donor, gw, 1, "execution_index_counter:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.skippedExists, "gateway was larger — donor's value ignored")
+	assert.Equal(t, 0, stat.collisionResolved)
+
+	got, err := gw.GetKey([]byte("execution_index_counter:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, "100", string(got), "gateway's larger value preserved")
+}
+
+func TestHandleMaxOnCollision_NoExisting(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+
+	stat := newStats().forPrefix("execution_index_counter:")
+	donorKV := kvItem("execution_index_counter:taskA", "7")
+	require.NoError(t, handleMaxOnCollision(donor, gw, 1, "execution_index_counter:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.copied)
+
+	got, err := gw.GetKey([]byte("execution_index_counter:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, "7", string(got))
+}
+
+// -------------------------------------------------------------------------
+// handleDrop — the no-op path.
+// -------------------------------------------------------------------------
+
+func TestHandleDrop_NeverWrites(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+
+	for _, key := range []string{"ct:cw:0xeoa", "pending:taskA:exec1", "trigger:taskA:exec1", "migration:foo"} {
+		stat := &prefixStats{}
+		require.NoError(t, handleDrop(donor, gw, 1, "", kvItem(key, "value"), stat, false, false))
+		assert.Equal(t, 1, stat.dropped, "key %q should have been counted as dropped", key)
+
+		_, err := gw.GetKey([]byte(key))
+		assert.True(t, isKeyNotFoundError(err), "key %q must NOT have been written", key)
+	}
+}
+
+// -------------------------------------------------------------------------
+// dispatch — the routing layer.
+// -------------------------------------------------------------------------
+
+func TestDispatch_RoutesEachPrefixToItsHandler(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	st := newStats()
+
+	cases := []struct {
+		prefix string
+		key    string
+		value  string
+	}{
+		{"t:", "t:1:a:taskA", "task-body"},
+		{"u:", "u:1:0xowner:0xwallet:taskA", "taskA"},
+		{"history:", "history:1:taskA:exec1", "exec-blob"},
+		{"w:", "w:0xowner:0xwallet", "wallet"},
+		{"wsalt:", "wsalt:0xowner:0xfactory:0", "0xwallet"},
+		{"fl:", "fl:0xowner", "balance-blob"},
+		{"fr:", "fr:0xowner:exec1", "fee-blob"},
+		{"secret:", "secret:_:0xowner:_:apikey", "supersecret"},
+		{"execution_index_counter:", "execution_index_counter:taskA", "1"},
+		{"ct:cw:", "ct:cw:0xeoa", "5"},
+		{"pending:", "pending:taskA:exec1", ""},
+		{"trigger:", "trigger:taskA:exec1", "status"},
+		{"migration:", "migration:foo", "1"},
+	}
+	for _, c := range cases {
+		stat := st.forPrefix(c.prefix)
+		stat.scanned++
+		require.NoError(t, dispatch(donor, gw, 1, kvItem(c.key, c.value), stat, false, false), "dispatch(%q)", c.key)
+	}
+
+	assert.Equal(t, 1, st.perPrefix["t:"].copied)
+	assert.Equal(t, 1, st.perPrefix["u:"].copied)
+	assert.Equal(t, 1, st.perPrefix["history:"].copied)
+	assert.Equal(t, 1, st.perPrefix["w:"].copied)
+	assert.Equal(t, 1, st.perPrefix["w:"].stampedChain)
+	assert.Equal(t, 1, st.perPrefix["secret:"].copied)
+	assert.Equal(t, 1, st.perPrefix["ct:cw:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["pending:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["trigger:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["migration:"].dropped)
+}
+
+// -------------------------------------------------------------------------
+// alreadyStamped — small helper.
+// -------------------------------------------------------------------------
+
+func TestAlreadyStamped(t *testing.T) {
+	for _, c := range []struct {
+		rest    string
+		chainID int64
+		want    bool
+		desc    string
+	}{
+		{"1:0xowner:0xwallet", 1, true, "matches chain prefix"},
+		{"0xowner:0xwallet", 1, false, "no chain prefix"},
+		{"8453:0xowner:0xwallet", 1, false, "wrong chain prefix"},
+		{"", 1, false, "empty"},
+		{"1", 1, false, "chain ID without trailing colon"},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := alreadyStamped(c.rest, c.chainID)
+			assert.Equal(t, c.want, got, "alreadyStamped(%q, %d)", c.rest, c.chainID)
+		})
+	}
+}
+
+// -------------------------------------------------------------------------
+// parseChainIDFromKey — round-trip.
+// -------------------------------------------------------------------------
+
+func TestParseChainIDFromKey(t *testing.T) {
+	id, err := parseChainIDFromKey([]byte("t:1:a:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), id)
+
+	id, err = parseChainIDFromKey([]byte("history:8453:taskA:exec1"))
+	require.NoError(t, err)
+	assert.Equal(t, int64(8453), id)
+
+	_, err = parseChainIDFromKey([]byte("t:a:taskA"))
+	assert.Error(t, err, "non-numeric second segment is legacy form")
+
+	_, err = parseChainIDFromKey([]byte("t:seq"))
+	assert.Error(t, err, "single-segment form is legacy")
+}
+
+func TestSupportedChainList_IsDeterministic(t *testing.T) {
+	first := supportedChainList()
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, first, supportedChainList())
+	}
+	// Sanity: the chains we actually support appear.
+	for _, want := range []string{"ethereum", "base", "sepolia", "base-sepolia"} {
+		assert.Contains(t, first, want)
+	}
+}
+
+// strconv import keeps lint happy if we add numeric tests later.
+var _ = strconv.Itoa

--- a/scripts/migration/merge_hetzner_into_gateway/main.go
+++ b/scripts/migration/merge_hetzner_into_gateway/main.go
@@ -1,0 +1,234 @@
+// Standalone tool to merge a single Hetzner per-chain aggregator BadgerDB
+// (the "donor") into the unified Railway gateway BadgerDB. Used once
+// during the 2026-07-01 Hetzner decom to bring forward the ~3 weeks of
+// production data that Studio wrote to the Hetzner aggregators after the
+// May 2026 Railway migration but before this cutover.
+//
+// Run the tool ONCE PER DONOR — sequentially, not in parallel — passing
+// the donor's chain ID:
+//
+//	go run scripts/migration/merge_hetzner_into_gateway \
+//	    --donor-path   ./donors/ethereum-2026-06-04 \
+//	    --donor-chain-id 1 \
+//	    --gateway-path /data \
+//	    --dry-run [--verbose]
+//
+// Chain IDs:
+//
+//	1         Ethereum mainnet
+//	8453      Base mainnet
+//	11155111  Sepolia testnet
+//	84532     Base-Sepolia testnet
+//
+// Operational constraints
+// -----------------------
+//
+//   - Stop the Railway gateway service before running with --dry-run=false.
+//     BadgerDB is single-writer; the tool opens the same db_path the
+//     gateway uses.
+//   - ALWAYS run with --dry-run first against an rsync'd copy of the
+//     gateway DB. Inspect per-prefix counts and collisions before
+//     touching the real volume.
+//   - The tool uses skip-if-exists semantics: every Set is preceded by
+//     Exist; nothing the gateway has already written is ever overwritten.
+//     Do NOT replace this with storage.Storage.Load — Load is bulk upsert
+//     and will silently clobber live data.
+//   - Take a fresh pre-merge backup of the gateway volume immediately
+//     before the merge runs. That backup is the only rollback target.
+//
+// Per-prefix policy
+// -----------------
+// Documented in docs/Operator.md and in the avs-infra change-log
+// `docs/changes/20260604-hetzner-data-restore-plan.md`. The dispatch
+// table in handlers.go is the source of truth for what each prefix
+// does — refer there before editing this comment.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// supportedChainIDs gates --donor-chain-id to avoid fat-finger merges
+// (e.g. accidentally importing the Sepolia donor with chain-id 1).
+var supportedChainIDs = map[int64]string{
+	1:        "ethereum",
+	8453:     "base",
+	11155111: "sepolia",
+	84532:    "base-sepolia",
+}
+
+func main() {
+	donorPath := flag.String("donor-path", "", "Path to the donor BadgerDB directory (the Hetzner aggregator's db_path)")
+	donorChainID := flag.Int64("donor-chain-id", 0, "Chain ID for the donor — must match the chain the donor aggregator was serving")
+	gatewayPath := flag.String("gateway-path", "", "Path to the Railway gateway BadgerDB directory (the merge destination)")
+	dryRun := flag.Bool("dry-run", true, "Print what would change without writing to the gateway. Defaults to TRUE; pass --dry-run=false to apply.")
+	verbose := flag.Bool("verbose", false, "Print one line per key processed")
+	failOnUnknownPrefix := flag.Bool("fail-on-unknown-prefix", true, "Hard-fail if the donor has keys with a prefix this tool does not recognize. Default true — disabling is for emergency-recovery investigation only.")
+	flag.Parse()
+
+	if *donorPath == "" {
+		dieUsage("--donor-path is required")
+	}
+	if *gatewayPath == "" {
+		dieUsage("--gateway-path is required")
+	}
+	if *donorChainID == 0 {
+		dieUsage("--donor-chain-id is required")
+	}
+	chainName, ok := supportedChainIDs[*donorChainID]
+	if !ok {
+		dieUsage(fmt.Sprintf("--donor-chain-id %d is not a supported chain (allowed: %s)", *donorChainID, supportedChainList()))
+	}
+	if *donorPath == *gatewayPath {
+		log.Fatalf("--donor-path and --gateway-path are the same (%s) — refusing to merge a DB into itself", *donorPath)
+	}
+
+	fmt.Println("Hetzner → gateway merge")
+	fmt.Println("=======================")
+	fmt.Printf("Donor path:     %s\n", *donorPath)
+	fmt.Printf("Donor chain:    %d (%s)\n", *donorChainID, chainName)
+	fmt.Printf("Gateway path:   %s\n", *gatewayPath)
+	fmt.Printf("Mode:           %s\n", modeLabel(*dryRun))
+	fmt.Printf("Started at:     %s\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Println()
+
+	donor, err := storage.NewWithPath(*donorPath)
+	if err != nil {
+		log.Fatalf("open donor BadgerDB at %s: %v\n\nWas the donor aggregator stopped before snapshotting?", *donorPath, err)
+	}
+	defer donor.Close()
+
+	gateway, err := storage.NewWithPath(*gatewayPath)
+	if err != nil {
+		log.Fatalf("open gateway BadgerDB at %s: %v\n\nIs the Railway gateway still running? It must be stopped first for --dry-run=false.", *gatewayPath, err)
+	}
+	defer gateway.Close()
+
+	mergeStats := newStats()
+
+	// Walk every prefix the dispatcher recognizes. Hard-fail when we see
+	// a key with an unknown prefix UNLESS --fail-on-unknown-prefix=false
+	// (which only emergency-recovery investigations should ever pass).
+	allPrefixes := knownPrefixes()
+	sort.Strings(allPrefixes) // deterministic output ordering
+
+	for _, prefix := range allPrefixes {
+		stat := mergeStats.forPrefix(prefix)
+		items, err := donor.GetByPrefix([]byte(prefix))
+		if err != nil {
+			log.Fatalf("scan donor prefix %q: %v", prefix, err)
+		}
+		for _, kv := range items {
+			stat.scanned++
+			if err := dispatch(donor, gateway, *donorChainID, kv, stat, *dryRun, *verbose); err != nil {
+				stat.errored++
+				log.Printf("ERROR on key %q: %v", string(kv.Key), err)
+			}
+		}
+	}
+
+	// Unknown-prefix scan: anything in the donor whose key doesn't start
+	// with one of the prefixes we know about is by definition unhandled.
+	// This catches future schema additions that drop in without the merge
+	// tool being updated.
+	unknown, err := scanForUnknownPrefixes(donor, allPrefixes)
+	if err != nil {
+		log.Fatalf("scan for unknown prefixes: %v", err)
+	}
+	if len(unknown) > 0 {
+		fmt.Println()
+		fmt.Printf("⚠️  Donor has keys with %d prefix(es) not recognized by this tool:\n", len(unknown))
+		for prefix, count := range unknown {
+			fmt.Printf("    %q  (%d keys)\n", prefix, count)
+		}
+		fmt.Println()
+		if *failOnUnknownPrefix {
+			log.Fatalf("Hard-failing per --fail-on-unknown-prefix=true. Either extend handlers.go with policy for these prefixes, or pass --fail-on-unknown-prefix=false (NOT recommended — silently drops data).")
+		}
+		fmt.Println("Continuing because --fail-on-unknown-prefix=false. The unknown-prefix keys have been DROPPED from this merge.")
+	}
+
+	fmt.Println()
+	mergeStats.print(*donorChainID, chainName)
+
+	if *dryRun {
+		fmt.Println()
+		fmt.Println("DRY RUN — no changes written. Re-run with --dry-run=false to apply.")
+	}
+}
+
+// scanForUnknownPrefixes walks every key in the donor and bucketizes those
+// whose key does not start with any of the prefixes the dispatcher knows
+// about. Returns prefix → count of unknown keys (where "prefix" here is
+// the first 32 bytes of the unknown key, truncated for display).
+//
+// Implementation: for each unknown key, take everything up to the first
+// ':' as the prefix label. This matches how the schema names its prefixes
+// (`t:`, `u:`, `history:`, etc.) and gives a useful aggregate without
+// printing every key.
+func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[string]int, error) {
+	unknown := map[string]int{}
+	// GetByPrefix("") returns the whole DB.
+	items, err := donor.GetByPrefix([]byte(""))
+	if err != nil {
+		return nil, err
+	}
+items:
+	for _, kv := range items {
+		k := string(kv.Key)
+		for _, p := range knownPrefixes {
+			if len(k) >= len(p) && k[:len(p)] == p {
+				continue items
+			}
+		}
+		// Aggregate by everything up to (and including) the first colon
+		// — gives a useful label like "newprefix:" rather than printing
+		// the whole arbitrary key.
+		label := k
+		for i := 0; i < len(k); i++ {
+			if k[i] == ':' {
+				label = k[:i+1]
+				break
+			}
+		}
+		unknown[label]++
+	}
+	return unknown, nil
+}
+
+func supportedChainList() string {
+	parts := make([]string, 0, len(supportedChainIDs))
+	for id, name := range supportedChainIDs {
+		parts = append(parts, fmt.Sprintf("%d=%s", id, name))
+	}
+	sort.Strings(parts)
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+func dieUsage(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	fmt.Fprintln(os.Stderr)
+	flag.Usage()
+	os.Exit(2)
+}
+
+func modeLabel(dryRun bool) string {
+	if dryRun {
+		return "DRY RUN (no writes)"
+	}
+	return "APPLY (writes to gateway)"
+}

--- a/scripts/migration/merge_hetzner_into_gateway/main.go
+++ b/scripts/migration/merge_hetzner_into_gateway/main.go
@@ -30,9 +30,15 @@
 //     gateway DB. Inspect per-prefix counts and collisions before
 //     touching the real volume.
 //   - The tool uses skip-if-exists semantics: every Set is preceded by
-//     Exist; nothing the gateway has already written is ever overwritten.
-//     Do NOT replace this with storage.Storage.Load — Load is bulk upsert
-//     and will silently clobber live data.
+//     Exist; nothing the gateway has already written is ever overwritten,
+//     with ONE deliberate exception — `execution_index_counter:` uses a
+//     max-on-collision policy and will overwrite the gateway value when
+//     the donor counter is strictly larger (necessary so the gateway does
+//     not re-issue execution indices that the donor already consumed).
+//     Both kinds of writes are surfaced in the summary: brand-new keys
+//     show under "Copied", overwrites under "CollRes". Do NOT replace
+//     setIfAbsent with storage.Storage.Load — Load is bulk upsert and
+//     will silently clobber live data.
 //   - Take a fresh pre-merge backup of the gateway volume immediately
 //     before the merge runs. That backup is the only rollback target.
 //
@@ -107,7 +113,7 @@ func main() {
 
 	gateway, err := storage.NewWithPath(*gatewayPath)
 	if err != nil {
-		log.Fatalf("open gateway BadgerDB at %s: %v\n\nIs the Railway gateway still running? It must be stopped first for --dry-run=false.", *gatewayPath, err)
+		log.Fatalf("open gateway BadgerDB at %s: %v\n\nThe tool opens Badger in read-write mode (it needs the write lock even for --dry-run, since dry-run still acquires the lock to guarantee no other writer is racing it). If the Railway gateway service is still running against this volume, stop it before re-running.", *gatewayPath, err)
 	}
 	defer gateway.Close()
 
@@ -164,33 +170,23 @@ func main() {
 	}
 }
 
-// scanForUnknownPrefixes walks every key in the donor and bucketizes those
-// whose key does not start with any of the prefixes the dispatcher knows
-// about. Returns prefix → count of unknown keys (where "prefix" here is
-// the first 32 bytes of the unknown key, truncated for display).
+// scanForUnknownPrefixes walks every key in the donor via the storage
+// streaming iterator (KeysOnly — values are never fetched and no
+// per-key slice is built, so memory stays constant in the size of the
+// donor). Bucketizes any key whose prefix is not in `knownPrefixes`.
 //
-// Implementation: for each unknown key, take everything up to the first
-// ':' as the prefix label. This matches how the schema names its prefixes
-// (`t:`, `u:`, `history:`, etc.) and gives a useful aggregate without
-// printing every key.
+// Returned label is everything up to and including the first ':' in the
+// unknown key (e.g. "newprefix:") — matches the schema's naming
+// convention. Keys without a colon are bucketed under the full key.
 func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[string]int, error) {
 	unknown := map[string]int{}
-	// GetByPrefix("") returns the whole DB.
-	items, err := donor.GetByPrefix([]byte(""))
-	if err != nil {
-		return nil, err
-	}
-items:
-	for _, kv := range items {
-		k := string(kv.Key)
+	err := donor.IterateKeysOnly([]byte(""), func(key []byte) error {
+		k := string(key)
 		for _, p := range knownPrefixes {
 			if len(k) >= len(p) && k[:len(p)] == p {
-				continue items
+				return nil
 			}
 		}
-		// Aggregate by everything up to (and including) the first colon
-		// — gives a useful label like "newprefix:" rather than printing
-		// the whole arbitrary key.
 		label := k
 		for i := 0; i < len(k); i++ {
 			if k[i] == ':' {
@@ -199,6 +195,10 @@ items:
 			}
 		}
 		unknown[label]++
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return unknown, nil
 }

--- a/scripts/migration/merge_hetzner_into_gateway/stats.go
+++ b/scripts/migration/merge_hetzner_into_gateway/stats.go
@@ -12,10 +12,10 @@ type prefixStats struct {
 	policy string
 
 	scanned           int // donor keys seen under this prefix
-	copied            int // written to gateway (or would be, in dry-run)
+	copied            int // written to gateway (or would be, in dry-run); includes collisionResolved
 	stampedChain      int // subset of copied where the key was rewritten with a chain prefix
 	skippedExists     int // gateway already had the key — preserved
-	collisionResolved int // execution_index_counter: gateway value was smaller, donor wins
+	collisionResolved int // subset of copied where an existing gateway value was overwritten (execution_index_counter: only, when donor counter > gateway counter)
 	dropped           int // explicit drop policy
 	errored           int // handler returned an error (logged separately)
 }
@@ -67,11 +67,14 @@ func (s *stats) print(donorChainID int64, chainName string) {
 	ordered = append(ordered, extras...)
 
 	// Column widths chosen by the longest values we know about.
-	fmt.Printf("%-30s %-50s %8s %8s %8s %8s %8s %8s\n",
-		"Prefix", "Policy", "Scanned", "Copied", "Stamped", "Existed", "Dropped", "Errors")
+	// CollRes is the subset of Copied that overwrote an existing gateway
+	// value (execution_index_counter: max-on-collision); brand-new keys
+	// show under Copied only.
+	fmt.Printf("%-30s %-50s %8s %8s %8s %8s %8s %8s %8s\n",
+		"Prefix", "Policy", "Scanned", "Copied", "CollRes", "Stamped", "Existed", "Dropped", "Errors")
 	fmt.Println("----------------------------- " +
 		"-------------------------------------------------- " +
-		"-------- -------- -------- -------- -------- --------")
+		"-------- -------- -------- -------- -------- -------- --------")
 
 	totals := prefixStats{}
 	for _, p := range ordered {
@@ -79,11 +82,12 @@ func (s *stats) print(donorChainID int64, chainName string) {
 		if ps.scanned == 0 && ps.dropped == 0 && ps.errored == 0 {
 			continue // suppress zero rows for readability
 		}
-		fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d\n",
+		fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
 			ps.prefix, ps.policy,
-			ps.scanned, ps.copied, ps.stampedChain, ps.skippedExists, ps.dropped, ps.errored)
+			ps.scanned, ps.copied, ps.collisionResolved, ps.stampedChain, ps.skippedExists, ps.dropped, ps.errored)
 		totals.scanned += ps.scanned
 		totals.copied += ps.copied
+		totals.collisionResolved += ps.collisionResolved
 		totals.stampedChain += ps.stampedChain
 		totals.skippedExists += ps.skippedExists
 		totals.dropped += ps.dropped
@@ -91,10 +95,10 @@ func (s *stats) print(donorChainID int64, chainName string) {
 	}
 	fmt.Println("----------------------------- " +
 		"-------------------------------------------------- " +
-		"-------- -------- -------- -------- -------- --------")
-	fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d\n",
+		"-------- -------- -------- -------- -------- -------- --------")
+	fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
 		"TOTAL", "",
-		totals.scanned, totals.copied, totals.stampedChain, totals.skippedExists, totals.dropped, totals.errored)
+		totals.scanned, totals.copied, totals.collisionResolved, totals.stampedChain, totals.skippedExists, totals.dropped, totals.errored)
 
 	if totals.errored > 0 {
 		fmt.Println()

--- a/scripts/migration/merge_hetzner_into_gateway/stats.go
+++ b/scripts/migration/merge_hetzner_into_gateway/stats.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+// prefixStats tracks what happened to keys under a single prefix during
+// one merge run. All counters start at zero.
+type prefixStats struct {
+	prefix string
+	policy string
+
+	scanned           int // donor keys seen under this prefix
+	copied            int // written to gateway (or would be, in dry-run)
+	stampedChain      int // subset of copied where the key was rewritten with a chain prefix
+	skippedExists     int // gateway already had the key — preserved
+	collisionResolved int // execution_index_counter: gateway value was smaller, donor wins
+	dropped           int // explicit drop policy
+	errored           int // handler returned an error (logged separately)
+}
+
+type stats struct {
+	perPrefix map[string]*prefixStats
+}
+
+func newStats() *stats {
+	s := &stats{perPrefix: make(map[string]*prefixStats, len(prefixHandlers))}
+	for _, h := range prefixHandlers {
+		s.perPrefix[h.prefix] = &prefixStats{prefix: h.prefix, policy: h.policy}
+	}
+	return s
+}
+
+func (s *stats) forPrefix(prefix string) *prefixStats {
+	if v, ok := s.perPrefix[prefix]; ok {
+		return v
+	}
+	// Lazy-init for any future prefix added at runtime; should not happen
+	// in practice because the keys are seeded from prefixHandlers.
+	v := &prefixStats{prefix: prefix}
+	s.perPrefix[prefix] = v
+	return v
+}
+
+func (s *stats) print(donorChainID int64, chainName string) {
+	fmt.Println("Summary")
+	fmt.Println("-------")
+	fmt.Printf("Donor chain: %d (%s)\n", donorChainID, chainName)
+	fmt.Println()
+
+	// Sort prefixes by their order in prefixHandlers (the canonical layout)
+	// instead of alphabetical — keeps related rows together.
+	ordered := make([]string, 0, len(s.perPrefix))
+	for _, h := range prefixHandlers {
+		ordered = append(ordered, h.prefix)
+	}
+	// Include any lazy-added prefixes at the bottom in alphabetical order
+	// so they're visible if they ever appear.
+	extras := []string{}
+	for k := range s.perPrefix {
+		if _, ok := lookupPrefixIndex(k); !ok {
+			extras = append(extras, k)
+		}
+	}
+	sort.Strings(extras)
+	ordered = append(ordered, extras...)
+
+	// Column widths chosen by the longest values we know about.
+	fmt.Printf("%-30s %-50s %8s %8s %8s %8s %8s %8s\n",
+		"Prefix", "Policy", "Scanned", "Copied", "Stamped", "Existed", "Dropped", "Errors")
+	fmt.Println("----------------------------- " +
+		"-------------------------------------------------- " +
+		"-------- -------- -------- -------- -------- --------")
+
+	totals := prefixStats{}
+	for _, p := range ordered {
+		ps := s.perPrefix[p]
+		if ps.scanned == 0 && ps.dropped == 0 && ps.errored == 0 {
+			continue // suppress zero rows for readability
+		}
+		fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d\n",
+			ps.prefix, ps.policy,
+			ps.scanned, ps.copied, ps.stampedChain, ps.skippedExists, ps.dropped, ps.errored)
+		totals.scanned += ps.scanned
+		totals.copied += ps.copied
+		totals.stampedChain += ps.stampedChain
+		totals.skippedExists += ps.skippedExists
+		totals.dropped += ps.dropped
+		totals.errored += ps.errored
+	}
+	fmt.Println("----------------------------- " +
+		"-------------------------------------------------- " +
+		"-------- -------- -------- -------- -------- --------")
+	fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d\n",
+		"TOTAL", "",
+		totals.scanned, totals.copied, totals.stampedChain, totals.skippedExists, totals.dropped, totals.errored)
+
+	if totals.errored > 0 {
+		fmt.Println()
+		fmt.Printf("⚠️  %d errors occurred during merge — review the ERROR log lines above.\n", totals.errored)
+	}
+}
+
+// lookupPrefixIndex returns the position of prefix in prefixHandlers and
+// whether it was found. Used by print() to detect lazy-added prefixes.
+func lookupPrefixIndex(prefix string) (int, bool) {
+	for i, h := range prefixHandlers {
+		if h.prefix == prefix {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/storage/db.go
+++ b/storage/db.go
@@ -32,6 +32,19 @@ type Storage interface {
 	GetKeyHasPrefix(prefix []byte) ([][]byte, error)
 	FirstKVHasPrefix(prefix []byte) ([]byte, []byte, error)
 
+	// IterateKeysOnly walks every key whose name starts with `prefix`,
+	// invoking `visit` for each. Uses Badger's key-only iterator: values
+	// are NOT fetched. Constant-memory; safe for prefix=[]byte("") on
+	// large databases where GetByPrefix or ListKeys would OOM.
+	//
+	// The key bytes passed to `visit` are owned by Badger's iterator
+	// scratch space and MUST NOT be retained beyond the visitor's return.
+	// Use append([]byte{}, key...) if you need to keep them.
+	//
+	// A non-nil error from `visit` aborts the iteration and propagates
+	// out of IterateKeysOnly verbatim.
+	IterateKeysOnly(prefix []byte, visit func(key []byte) error) error
+
 	// A key only operation that returns key that has a prefix
 	ListKeys(prefix string) ([]string, error)
 	ListKeysMulti(prefixes []string) ([]string, error)
@@ -165,6 +178,29 @@ func (s *BadgerStorage) GetByPrefix(prefix []byte) ([]*KeyValueItem, error) {
 	}
 
 	return result, nil
+}
+
+// IterateKeysOnly walks every key whose name starts with `prefix`,
+// invoking `visit` for each. Uses Badger's KeysOnly iterator — values
+// are not fetched and no per-key slice is built, so memory stays
+// constant in the size of the database.
+//
+// The key bytes passed to `visit` are owned by the iterator and MUST
+// NOT be retained after the visitor returns. Copy with
+// append([]byte{}, key...) if you need to keep them.
+func (s *BadgerStorage) IterateKeysOnly(prefix []byte, visit func(key []byte) error) error {
+	return s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := visit(it.Item().Key()); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func (s *BadgerStorage) GetKeyHasPrefix(prefix []byte) ([][]byte, error) {


### PR DESCRIPTION
## Why

To preserve the ~3 weeks of production data that Studio wrote to the Hetzner aggregators between the May 2026 Railway migration and the 2026-07-01 Hetzner decom. Full context + per-prefix policy matrix lives in [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md).

This PR adds the tool. The user's per-prefix matrix has been signed off; the tool is built to match.

## What it does

`scripts/migration/merge_hetzner_into_gateway` is a one-shot tool run **once per donor BadgerDB**, sequentially, with the donor's chain ID. For each prefix it knows about, it applies a documented policy:

| Prefix family | Policy |
|---|---|
| `t:`, `u:`, `history:` | Pass-through chain-scoped key; validate embedded chain ID matches donor |
| `w:`, `wsalt:`, `fl:`, `fr:` | Stamp donor chain ID into the legacy chain-implicit key |
| `secret:` | Import as-is (already user/org/workflow scoped) |
| `execution_index_counter:` | Import; on collision take the max |
| `ct:cw:`, `pending:`, `trigger:`, `migration:` | Drop |

**Every write is `setIfAbsent`** — `Exist` check before every `Set`. Nothing the gateway has already written is ever overwritten. The test `TestSetIfAbsent_SkipsWhenKeyPresent` is the regression guard for this; it asserts that even when both sides have the same key with different values, the gateway's value is preserved verbatim.

Unknown prefixes hard-fail by default (`--fail-on-unknown-prefix=true`) so a future schema addition can't silently drop on the floor.

## Files

| File | What |
|---|---|
| `main.go` | Flag parsing, DB open/close, prefix iteration, unknown-prefix scan, summary printing |
| `handlers.go` | Dispatch table + per-prefix handler funcs + `setIfAbsent` + chain-ID parsing helpers |
| `stats.go` | Per-prefix stat counters + summary table formatter |
| `handlers_test.go` | 21 test cases covering every handler + dispatch routing + safety properties |
| `README.md` | Operational runbook: setup, flags, output format, safety rules, what's NOT in the tool |

## Test plan

- [x] `go build ./scripts/migration/merge_hetzner_into_gateway/...` clean
- [x] `go vet ./scripts/migration/merge_hetzner_into_gateway/...` clean
- [x] `go test -count=1 ./scripts/migration/merge_hetzner_into_gateway/...` — all 21 test cases pass
- [ ] CI passes
- [ ] After merge: run against a scratch copy of one donor in dry-run mode and confirm the per-prefix counts match a manual `restic ls`. NOT to be run against the live gateway volume until 2026-06-15+.

## Out of scope (separate work)

The tool **stamps** `w:` / `wsalt:` / `fl:` / `fr:` keys with the donor chain ID, producing chain-scoped form on the gateway. The gateway's READ paths for those families still expect chain-implicit form today. A separate PR will update the gateway code to look at chain-scoped form for these prefixes — that ships before the actual merge runs against production. Including the read-path changes in the same PR was avoided so reviewers can audit the tool independently of the gateway changes.

Also out of scope:
- `wsalt:` re-derivation. The tool stamps the existing index entries; after the merge runs, the operator should also run `scripts/migration/backfill_wallet_salt_index` against the gateway to rebuild canonical pointers if any factory upgrades happened during the donor window.
- Recovery from a botched merge. The plan is "restore the pre-merge gateway backup." No in-tool rollback.

## Why `chore:`

This is a one-shot operational tool, not a user-facing feature. `chore:` ensures `go-semantic-release` doesn't cut an unnecessary release. The tool ships whenever the next user-facing change in EigenLayer-AVS does.
