### PR TITLE
feat: chain-scope wallet, wsalt, fl, fr storage keys end-to-end

### DIFF
--- a/cmd/backfillWalletSaltIndex.go
+++ b/cmd/backfillWalletSaltIndex.go
@@ -17,6 +17,7 @@ import (
 var (
 	backfillWalletSaltIndexDryRun  bool
 	backfillWalletSaltIndexVerbose bool
+	backfillWalletSaltIndexChainID int64
 
 	backfillWalletSaltIndexCmd = &cobra.Command{
 		Use:   "backfill-wallet-salt-index",
@@ -58,10 +59,14 @@ Production usage (Docker):
 func init() {
 	backfillWalletSaltIndexCmd.Flags().BoolVar(&backfillWalletSaltIndexDryRun, "dry-run", false, "Print what would change without writing to BadgerDB")
 	backfillWalletSaltIndexCmd.Flags().BoolVar(&backfillWalletSaltIndexVerbose, "verbose", false, "Print one line per wallet processed")
+	backfillWalletSaltIndexCmd.Flags().Int64Var(&backfillWalletSaltIndexChainID, "chain-id", 0, "Chain ID to backfill. Required. Wallet keys are chain-scoped; run the command once per chain the gateway hosts (e.g. 1, 8453, 11155111, 84532).")
 	rootCmd.AddCommand(backfillWalletSaltIndexCmd)
 }
 
 func runBackfillWalletSaltIndex(configPath string) error {
+	if backfillWalletSaltIndexChainID <= 0 {
+		return fmt.Errorf("--chain-id is required (wallet keys are chain-scoped; pass the chain you want to backfill, e.g. 1, 8453, 11155111, 84532)")
+	}
 	nodeConfig, err := avsconfig.NewConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("parse config %s: %w", configPath, err)
@@ -74,6 +79,7 @@ func runBackfillWalletSaltIndex(configPath string) error {
 	}
 
 	fmt.Printf("Config:        %s\n", configPath)
+	fmt.Printf("Chain ID:      %d\n", backfillWalletSaltIndexChainID)
 	fmt.Printf("DB path:       %s\n", nodeConfig.DbPath)
 	// Redact: RPC URLs from Tenderly/Alchemy/Infura embed API keys in
 	// the path or query — printing the raw URL leaks secrets to terminal
@@ -105,7 +111,7 @@ func runBackfillWalletSaltIndex(configPath string) error {
 		return *addr, nil
 	}
 
-	stats, err := taskengine.BackfillWalletSaltIndex(db, deriver, taskengine.WalletSaltIndexBackfillOptions{
+	stats, err := taskengine.BackfillWalletSaltIndex(db, backfillWalletSaltIndexChainID, deriver, taskengine.WalletSaltIndexBackfillOptions{
 		DryRun:  backfillWalletSaltIndexDryRun,
 		Verbose: backfillWalletSaltIndexVerbose,
 		Logf: func(format string, args ...any) {

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -424,6 +424,32 @@ func (n *Engine) defaultChainID() int64 {
 	return 0
 }
 
+// userOwnsWalletOnAnyChain reports whether the user owns the given smart
+// wallet on at least one of the chains this gateway hosts. Used by RPCs
+// that query data across chains (ListWorkflowsByUser, the workflow-count
+// path) — a user with tasks on multiple chains might own a wallet on only
+// one of them, and we want the validation check to succeed for any.
+//
+// Falls through to the default-wallet equality first (the default wallet
+// has the same derived address across chains when factories are aligned).
+// On the first non-nil DB error, returns (false, err) — callers can
+// distinguish "wallet not owned anywhere" from "DB problem."
+func (n *Engine) userOwnsWalletOnAnyChain(user *model.User, walletAddr common.Address) (bool, error) {
+	if user.SmartAccountAddress != nil && user.SmartAccountAddress.Hex() == walletAddr.Hex() {
+		return true, nil
+	}
+	for _, chainID := range n.knownChainIDs() {
+		ok, err := ValidWalletOwner(n.db, chainID, user, walletAddr)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // knownChainIDs returns every chain the aggregator hosts tasks for. In
 // single-chain mode that is the SmartWallet chain; in gateway mode it is
 // every chain registered in chainConfigs plus the SmartWallet default.
@@ -637,35 +663,36 @@ func (n *Engine) MustStart() error {
 // Mark the old record as stale so list responses hide it and future
 // writes can replace the index entry. Index lookup or marking failures
 // are logged but never block the fresh insertion path.
-func (n *Engine) markPreviousCanonicalStaleIfAny(owner common.Address, factoryAddr common.Address, salt *big.Int, freshAddress common.Address) {
-	previousAddr, err := LookupCanonicalWalletAddress(n.db, owner, factoryAddr, salt)
+func (n *Engine) markPreviousCanonicalStaleIfAny(chainID int64, owner common.Address, factoryAddr common.Address, salt *big.Int, freshAddress common.Address) {
+	previousAddr, err := LookupCanonicalWalletAddress(n.db, chainID, owner, factoryAddr, salt)
 	if err == badger.ErrKeyNotFound {
 		return
 	}
 	if err != nil {
-		n.logger.Warn("Failed to look up canonical wallet address by (owner, factory, salt)", "owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt.String(), "error", err)
+		n.logger.Warn("Failed to look up canonical wallet address by (chainID, owner, factory, salt)", "chainID", chainID, "owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt.String(), "error", err)
 		return
 	}
 	if strings.EqualFold(previousAddr.Hex(), freshAddress.Hex()) {
 		return
 	}
 	n.logger.Error("Stale wallet derivation detected — factory implementation likely upgraded",
+		"chainID", chainID,
 		"owner", owner.Hex(),
 		"factory", factoryAddr.Hex(),
 		"salt", salt.String(),
 		"previousAddress", previousAddr.Hex(),
 		"newAddress", freshAddress.Hex(),
 	)
-	if markErr := MarkWalletStale(n.db, owner, previousAddr.Hex()); markErr != nil {
-		n.logger.Warn("Failed to mark previous canonical wallet as stale", "owner", owner.Hex(), "previousAddress", previousAddr.Hex(), "error", markErr)
+	if markErr := MarkWalletStale(n.db, chainID, owner, previousAddr.Hex()); markErr != nil {
+		n.logger.Warn("Failed to mark previous canonical wallet as stale", "chainID", chainID, "owner", owner.Hex(), "previousAddress", previousAddr.Hex(), "error", markErr)
 	}
 }
 
 // storeDefaultWalletForListWallets creates and stores the default wallet (salt:0) for ListWallets.
 // Returns the stored wallet model if successful, or nil if storage failed (but logs the error).
-func (n *Engine) storeDefaultWalletForListWallets(owner common.Address, defaultDerivedAddress *common.Address, defaultSystemFactory common.Address, defaultSalt *big.Int) *model.SmartWallet {
-	n.logger.Info("Default wallet not found in DB for ListWallets, storing it", "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex())
-	n.markPreviousCanonicalStaleIfAny(owner, defaultSystemFactory, defaultSalt, *defaultDerivedAddress)
+func (n *Engine) storeDefaultWalletForListWallets(chainID int64, owner common.Address, defaultDerivedAddress *common.Address, defaultSystemFactory common.Address, defaultSalt *big.Int) *model.SmartWallet {
+	n.logger.Info("Default wallet not found in DB for ListWallets, storing it", "chainID", chainID, "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex())
+	n.markPreviousCanonicalStaleIfAny(chainID, owner, defaultSystemFactory, defaultSalt, *defaultDerivedAddress)
 	newModelWallet := &model.SmartWallet{
 		Owner:    &owner,
 		Address:  defaultDerivedAddress,
@@ -673,8 +700,8 @@ func (n *Engine) storeDefaultWalletForListWallets(owner common.Address, defaultD
 		Salt:     defaultSalt,
 		IsHidden: false,
 	}
-	if storeErr := StoreWallet(n.db, owner, newModelWallet); storeErr != nil {
-		n.logger.Error("Error storing default wallet to DB for ListWallets", "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex(), "error", storeErr)
+	if storeErr := StoreWallet(n.db, chainID, owner, newModelWallet); storeErr != nil {
+		n.logger.Error("Error storing default wallet to DB for ListWallets", "chainID", chainID, "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex(), "error", storeErr)
 		// Continue and return the wallet anyway, but log the error
 		return nil
 	}
@@ -683,7 +710,13 @@ func (n *Engine) storeDefaultWalletForListWallets(owner common.Address, defaultD
 }
 
 // ListWallets corresponds to the ListWallets RPC.
+//
+// Wallet records are chain-scoped. The ListWalletReq proto does not carry a
+// chain_id yet, so this handler queries the gateway's default chain only.
+// Adding multi-chain enumeration (or a chain_id field on ListWalletReq) is
+// a follow-up.
 func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletReq) (*avsproto.ListWalletResp, error) {
+	chainID := n.defaultChainID()
 	walletsToReturnProto := []*avsproto.SmartWallet{}
 	processedAddresses := make(map[string]bool)
 
@@ -716,7 +749,7 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 		}
 
 		if includeThisDefault {
-			modelWallet, dbGetErr := GetWallet(n.db, owner, defaultDerivedAddress.Hex())
+			modelWallet, dbGetErr := GetWallet(n.db, chainID, owner, defaultDerivedAddress.Hex())
 
 			isHidden := false
 			actualSalt := defaultSalt.String()
@@ -740,7 +773,7 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 						maxAllowed = config.HardMaxWalletsPerOwner
 					}
 					// Fetch all wallets for this owner and count unique addresses
-					dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(owner))
+					dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(chainID, owner))
 					if listErr == nil {
 						unique := make(map[string]struct{})
 						for _, item := range dbItems {
@@ -755,13 +788,13 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 							n.logger.Warn("Max wallet count reached for owner in ListWallets, but storing default wallet anyway since it's always returned", "owner", owner.Hex(), "limit", maxAllowed, "currentCount", len(unique))
 						}
 						// Store the default wallet since we're returning it to the client
-						if storedWallet := n.storeDefaultWalletForListWallets(owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
+						if storedWallet := n.storeDefaultWalletForListWallets(chainID, owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
 							modelWallet = storedWallet
 						}
 					}
 				} else {
 					// No config but wallet not in DB - store it anyway
-					if storedWallet := n.storeDefaultWalletForListWallets(owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
+					if storedWallet := n.storeDefaultWalletForListWallets(chainID, owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
 						modelWallet = storedWallet
 					}
 				}
@@ -788,9 +821,9 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 		}
 	}
 
-	dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(owner))
+	dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(chainID, owner))
 	if listErr != nil && listErr != badger.ErrKeyNotFound {
-		n.logger.Error("Error fetching wallets by owner prefix for ListWallets", "owner", owner.Hex(), "error", listErr)
+		n.logger.Error("Error fetching wallets by owner prefix for ListWallets", "owner", owner.Hex(), "chainID", chainID, "error", listErr)
 		if len(walletsToReturnProto) == 0 {
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_UNAVAILABLE), "Error fetching wallets by owner: %v", listErr)
 		}
@@ -854,7 +887,11 @@ func (n *Engine) validateNonZeroAddress(factoryAddr common.Address, methodName, 
 
 // GetWallet is the gRPC handler for the GetWallet RPC.
 // It uses the owner (from auth context), salt, and factory_address from payload to derive the wallet address.
+//
+// Wallet records are chain-scoped. The GetWalletReq proto does not carry a
+// chain_id yet, so this handler reads/writes the gateway's default chain only.
 func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*avsproto.GetWalletResp, error) {
+	chainID := n.defaultChainID()
 	// Allow empty factory address (uses default), but validate non-empty ones
 	if payload.GetFactoryAddress() != "" && !common.IsHexAddress(payload.GetFactoryAddress()) {
 		return nil, status.Errorf(codes.InvalidArgument, InvalidFactoryAddressError)
@@ -909,7 +946,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 		return nil, status.Errorf(codes.InvalidArgument, "Failed to derive sender address or derived address is nil or zero. Error: %v", err)
 	}
 
-	dbModelWallet, err := GetWallet(n.db, user.Address, derivedSenderAddress.Hex())
+	dbModelWallet, err := GetWallet(n.db, chainID, user.Address, derivedSenderAddress.Hex())
 
 	if err != nil && err != badger.ErrKeyNotFound {
 		n.logger.Error("Error fetching wallet from DB for GetWallet", "owner", user.Address.Hex(), "wallet", derivedSenderAddress.Hex(), "error", err)
@@ -928,7 +965,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 				maxAllowed = config.HardMaxWalletsPerOwner
 			}
 			// Fetch all wallets for this owner and count unique addresses
-			dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+			dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(chainID, user.Address))
 			if listErr == nil {
 				unique := make(map[string]struct{})
 				for _, item := range dbItems {
@@ -944,7 +981,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 		}
 
 		n.logger.Info("Wallet not found in DB for GetWallet, creating new entry", "owner", user.Address.Hex(), "walletAddress", derivedSenderAddress.Hex())
-		n.markPreviousCanonicalStaleIfAny(user.Address, factoryAddr, saltBig, *derivedSenderAddress)
+		n.markPreviousCanonicalStaleIfAny(chainID, user.Address, factoryAddr, saltBig, *derivedSenderAddress)
 		newModelWallet := &model.SmartWallet{
 			Owner:    &user.Address,
 			Address:  derivedSenderAddress,
@@ -952,7 +989,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 			Salt:     saltBig,
 			IsHidden: false,
 		}
-		if storeErr := StoreWallet(n.db, user.Address, newModelWallet); storeErr != nil {
+		if storeErr := StoreWallet(n.db, chainID, user.Address, newModelWallet); storeErr != nil {
 			n.logger.Error("Error storing new wallet to DB for GetWallet", "owner", user.Address.Hex(), "walletAddress", derivedSenderAddress.Hex(), "error", storeErr)
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_WRITE_ERROR), "Error storing new wallet: %v", storeErr)
 		}
@@ -980,9 +1017,11 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 	return resp, nil
 }
 
-// GetWalletFromDB retrieves wallet information from database for validation purposes
+// GetWalletFromDB retrieves wallet information from database for validation purposes.
+// Looks up the wallet on the gateway's default chain. Multi-chain wallet
+// validation is a follow-up.
 func (n *Engine) GetWalletFromDB(owner common.Address, smartWalletAddress string) (*model.SmartWallet, error) {
-	return GetWallet(n.db, owner, smartWalletAddress)
+	return GetWallet(n.db, n.defaultChainID(), owner, smartWalletAddress)
 }
 
 // SetWallet is the gRPC handler for the SetWallet RPC.
@@ -1018,7 +1057,7 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.Internal, "Derived wallet address is nil or zero")
 	}
 
-	err = SetWalletHiddenStatus(n.db, owner, derivedWalletAddress.Hex(), payload.GetIsHidden())
+	err = SetWalletHiddenStatus(n.db, n.defaultChainID(), owner, derivedWalletAddress.Hex(), payload.GetIsHidden())
 	if err != nil {
 		if errors.Is(err, badger.ErrKeyNotFound) {
 			n.logger.Warn("Wallet not found for SetWallet", "owner", owner.Hex(), "derivedAddress", derivedWalletAddress.Hex(), "salt", payload.GetSalt(), "factory", payload.GetFactoryAddress())
@@ -1031,7 +1070,7 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.Internal, "Failed to update wallet hidden status: %v", err)
 	}
 
-	updatedModelWallet, getErr := GetWallet(n.db, owner, derivedWalletAddress.Hex())
+	updatedModelWallet, getErr := GetWallet(n.db, n.defaultChainID(), owner, derivedWalletAddress.Hex())
 	if getErr != nil {
 		n.logger.Error("Failed to fetch wallet after SetWallet operation", "owner", owner.Hex(), "wallet", derivedWalletAddress.Hex(), "error", getErr)
 		return nil, status.Errorf(codes.Internal, "Failed to retrieve wallet details after update: %v", getErr)
@@ -1214,15 +1253,6 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		return nil, status.Errorf(codes.InvalidArgument, "EventTrigger template resolution failed: %v", err)
 	}
 
-	// Validate smart wallet ownership. The runner address comes from
-	// inputVariables.settings.runner (via NewTaskFromProtobuf) and is stored
-	// as task.SmartWalletAddress. We must verify the caller owns this wallet.
-	if task.SmartWalletAddress != "" {
-		if valid, _ := ValidWalletOwner(n.db, user, common.HexToAddress(task.SmartWalletAddress)); !valid {
-			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
-		}
-	}
-
 	// Default chain_id to the aggregator's SmartWallet chain when not specified.
 	// In gateway mode the top-level SmartWallet is populated from chains[0]
 	// (mainnet by convention), so a missing chain_id silently routes the task
@@ -1232,6 +1262,10 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 	// the task's intended chain is recorded with no ambiguity. Single-chain
 	// (non-gateway) deployments keep the legacy behavior — there's only one
 	// chain there, so the inference is unambiguous.
+	//
+	// Resolve chain_id BEFORE the wallet-ownership check below — that check
+	// reads `w:<chainID>:<owner>:<wallet>` and would miss the canonical row
+	// if it ran against task.ChainId == 0.
 	if task.ChainId == 0 {
 		if n.config != nil && n.config.IsGateway {
 			return nil, status.Errorf(codes.InvalidArgument,
@@ -1241,6 +1275,16 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		}
 		if n.config != nil && n.config.SmartWallet != nil {
 			task.ChainId = n.config.SmartWallet.ChainID
+		}
+	}
+
+	// Validate smart wallet ownership. The runner address comes from
+	// inputVariables.settings.runner (via NewTaskFromProtobuf) and is stored
+	// as task.SmartWalletAddress. We must verify the caller owns this wallet
+	// on the chain this task targets.
+	if task.SmartWalletAddress != "" {
+		if valid, _ := ValidWalletOwner(n.db, task.ChainId, user, common.HexToAddress(task.SmartWalletAddress)); !valid {
+			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 	}
 
@@ -2375,7 +2419,7 @@ func (n *Engine) ListWorkflowsByUser(user *model.User, payload *avsproto.ListTas
 			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 
-		if valid, _ := ValidWalletOwner(n.db, user, common.HexToAddress(smartWalletAddress)); !valid {
+		if valid, _ := n.userOwnsWalletOnAnyChain(user, common.HexToAddress(smartWalletAddress)); !valid {
 			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 
@@ -4735,7 +4779,7 @@ func (n *Engine) GetWorkflowCount(user *model.User, payload *avsproto.GetWorkflo
 
 		for _, address := range smartWalletAddresses {
 			smartWalletAddress := common.HexToAddress(address)
-			if ok, err := ValidWalletOwner(n.db, user, smartWalletAddress); !ok || err != nil {
+			if ok, err := n.userOwnsWalletOnAnyChain(user, smartWalletAddress); !ok || err != nil {
 				// skip if the address is not a valid smart wallet address or it isn't belong to this user
 				continue
 			}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1283,7 +1283,20 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 	// as task.SmartWalletAddress. We must verify the caller owns this wallet
 	// on the chain this task targets.
 	if task.SmartWalletAddress != "" {
-		if valid, _ := ValidWalletOwner(n.db, task.ChainId, user, common.HexToAddress(task.SmartWalletAddress)); !valid {
+		valid, ownErr := ValidWalletOwner(n.db, task.ChainId, user, common.HexToAddress(task.SmartWalletAddress))
+		if ownErr != nil {
+			// Storage failure on the ownership check is NOT the same as
+			// "wallet not owned" — surfacing it as InvalidArgument would
+			// make a transient DB hiccup look like a malformed request.
+			n.logger.Error("Wallet ownership check failed (storage error)",
+				"owner", user.Address.Hex(),
+				"smart_wallet", task.SmartWalletAddress,
+				"chain_id", task.ChainId,
+				"error", ownErr)
+			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_UNAVAILABLE),
+				"failed to validate smart wallet ownership: %v", ownErr)
+		}
+		if !valid {
 			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 	}
@@ -2419,7 +2432,18 @@ func (n *Engine) ListWorkflowsByUser(user *model.User, payload *avsproto.ListTas
 			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 
-		if valid, _ := n.userOwnsWalletOnAnyChain(user, common.HexToAddress(smartWalletAddress)); !valid {
+		valid, ownErr := n.userOwnsWalletOnAnyChain(user, common.HexToAddress(smartWalletAddress))
+		if ownErr != nil {
+			// Storage failure → surface as STORAGE_UNAVAILABLE; the
+			// caller request is fine, the gateway can't currently answer.
+			n.logger.Error("Wallet ownership check failed (storage error)",
+				"owner", user.Address.Hex(),
+				"smart_wallet", smartWalletAddress,
+				"error", ownErr)
+			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_UNAVAILABLE),
+				"failed to validate smart wallet ownership: %v", ownErr)
+		}
+		if !valid {
 			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 

--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -72,7 +72,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	})
 
 	// Register smart wallet in database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddr,
 		Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/execute_uniswap_approval_test.go
+++ b/core/taskengine/execute_uniswap_approval_test.go
@@ -49,7 +49,7 @@ func TestExecuteTask_UniswapApprovalAndSwap_DifferentApprovalAmounts_Sepolia(t *
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddr,
 		Factory: &config.SmartWallet.FactoryAddress,

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -443,7 +443,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 		smartWalletAddr := common.HexToAddress(task.SmartWalletAddress)
 
 		// Enhanced wallet validation that handles any legitimately derived wallet
-		isValid, err := x.validateWalletOwnership(user, smartWalletAddr)
+		isValid, err := x.validateWalletOwnership(task.ChainId, user, smartWalletAddr)
 		if err != nil {
 			execution.EndAt = time.Now().UnixMilli()
 			execution.Error = fmt.Sprintf("failed to validate wallet ownership for owner %s: %v", owner.Hex(), err)
@@ -465,7 +465,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 
 		// Look up the wallet's salt from DB for auto-deployment of non-salt-0 wallets
 		if x.db != nil {
-			if wallet, walletErr := GetWallet(x.db, owner, task.SmartWalletAddress); walletErr == nil && wallet != nil && wallet.Salt != nil {
+			if wallet, walletErr := GetWallet(x.db, task.ChainId, owner, task.SmartWalletAddress); walletErr == nil && wallet != nil && wallet.Salt != nil {
 				vm.AddVar("aa_salt", wallet.Salt)
 				if x.logger != nil {
 					x.logger.Info("Executor: AA salt resolved from wallet DB", "salt", wallet.Salt.String(), "wallet", task.SmartWalletAddress)
@@ -526,7 +526,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 
 		if creditLimitWei != nil {
 			taskOwner := common.HexToAddress(task.Owner)
-			withinLimit, outstanding, checkErr := x.feeLedger.CheckCreditLimit(taskOwner, creditLimitWei)
+			withinLimit, outstanding, checkErr := x.feeLedger.CheckCreditLimit(task.ChainId, taskOwner, creditLimitWei)
 			if checkErr != nil {
 				x.logger.Warn("Fee ledger check failed, proceeding with execution", "error", checkErr)
 			} else if !withinLimit {
@@ -852,7 +852,7 @@ func sanitizeInterface(x interface{}) interface{} {
 
 // validateWalletOwnership performs comprehensive wallet ownership validation
 // This handles default wallets (salt:0), stored wallets, and legitimately derived wallets
-func (x *WorkflowExecutor) validateWalletOwnership(user *model.User, smartWalletAddr common.Address) (bool, error) {
+func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.User, smartWalletAddr common.Address) (bool, error) {
 	// Step 1: Load the user's default smart wallet address (salt:0) for comparison
 	if x.smartWalletConfig != nil && x.smartWalletConfig.EthRpcUrl != "" {
 		if rpcClient, err := ethclient.Dial(x.smartWalletConfig.EthRpcUrl); err == nil {
@@ -866,7 +866,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(user *model.User, smartWallet
 	}
 
 	// Step 2: Use the standard ValidWalletOwner function (checks default + database)
-	if isValid, err := ValidWalletOwner(x.db, user, smartWalletAddr); err == nil && isValid {
+	if isValid, err := ValidWalletOwner(x.db, chainID, user, smartWalletAddr); err == nil && isValid {
 		return true, nil
 	} else if err != nil {
 		x.logger.Debug("ValidWalletOwner check failed", "owner", user.Address.Hex(),

--- a/core/taskengine/fee_billing_integration_test.go
+++ b/core/taskengine/fee_billing_integration_test.go
@@ -48,12 +48,13 @@ func TestFeeBilling_CreditGating_BlocksOnOutstandingBalance(t *testing.T) {
 
 	// Register the smart wallet for this owner so executor wallet validation passes
 	walletAddr := common.HexToAddress(smartWalletAddr)
-	StoreWallet(db, owner, &model.SmartWallet{Address: &walletAddr})
+	StoreWallet(db, int64(1), owner, &model.SmartWallet{Address: &walletAddr})
 
 	// Create a simple task with manual trigger and custom code node (no on-chain ops)
 	task := &model.Workflow{
 		Task: &avsproto.Task{
 			Id:                 "test-fee-gating",
+			ChainId:            int64(1),
 			Owner:              strings.ToLower(owner.Hex()),
 			SmartWalletAddress: smartWalletAddr,
 			Status:             avsproto.TaskStatus_Enabled,
@@ -109,12 +110,13 @@ func TestFeeBilling_CreditGating_BlocksOnOutstandingBalance(t *testing.T) {
 		Owner:        owner.Hex(),
 		Tier:         "EXECUTION_TIER_1",
 		FeeAmountWei: "1000000000000000", // 0.001 ETH — any non-zero amount
+		ChainID:      int64(1),
 	}
 	err = executor.feeLedger.RecordValueFee(feeRecord)
 	require.NoError(t, err)
 
 	// Verify outstanding balance is now positive
-	outstanding, err := executor.feeLedger.GetOutstandingBalance(owner)
+	outstanding, err := executor.feeLedger.GetOutstandingBalance(int64(1), owner)
 	require.NoError(t, err)
 	assert.True(t, outstanding.Sign() > 0, "Outstanding balance should be positive after recording fee")
 
@@ -159,11 +161,12 @@ func TestFeeBilling_CreditGating_AllowsWithHighCreditLimit(t *testing.T) {
 
 	// Register the smart wallet for this owner
 	walletAddr := common.HexToAddress(smartWalletAddr)
-	StoreWallet(db, owner, &model.SmartWallet{Address: &walletAddr})
+	StoreWallet(db, int64(1), owner, &model.SmartWallet{Address: &walletAddr})
 
 	task := &model.Workflow{
 		Task: &avsproto.Task{
 			Id:                 "test-fee-high-limit",
+			ChainId:            int64(1),
 			Owner:              strings.ToLower(owner.Hex()),
 			SmartWalletAddress: smartWalletAddr,
 			Status:             avsproto.TaskStatus_Enabled,
@@ -202,6 +205,7 @@ func TestFeeBilling_CreditGating_AllowsWithHighCreditLimit(t *testing.T) {
 		TaskID:       task.Id,
 		Owner:        owner.Hex(),
 		FeeAmountWei: "1000000000000000", // 0.001 ETH (~$2.50) — under $100 limit
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 

--- a/core/taskengine/fee_ledger.go
+++ b/core/taskengine/fee_ledger.go
@@ -59,10 +59,10 @@ func NewFeeLedger(db storage.Storage, logger sdklogging.Logger) *FeeLedger {
 	}
 }
 
-// GetOutstandingBalance returns the current outstanding value fee balance for an owner.
-// Returns zero if no ledger entry exists.
-func (fl *FeeLedger) GetOutstandingBalance(owner common.Address) (*big.Int, error) {
-	entry, err := fl.getLedgerEntry(owner)
+// GetOutstandingBalance returns the current outstanding value fee balance for
+// an owner on the given chain. Returns zero if no ledger entry exists.
+func (fl *FeeLedger) GetOutstandingBalance(chainID int64, owner common.Address) (*big.Int, error) {
+	entry, err := fl.getLedgerEntry(chainID, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +77,14 @@ func (fl *FeeLedger) GetOutstandingBalance(owner common.Address) (*big.Int, erro
 	return outstanding, nil
 }
 
-// CheckCreditLimit returns whether the owner is within their credit limit.
-// Returns (withinLimit, outstandingBalance, error).
-func (fl *FeeLedger) CheckCreditLimit(owner common.Address, creditLimitWei *big.Int) (bool, *big.Int, error) {
+// CheckCreditLimit returns whether the owner is within their credit limit on
+// the given chain. Returns (withinLimit, outstandingBalance, error).
+func (fl *FeeLedger) CheckCreditLimit(chainID int64, owner common.Address, creditLimitWei *big.Int) (bool, *big.Int, error) {
 	if creditLimitWei == nil {
 		return true, big.NewInt(0), nil // No limit configured — always within limit
 	}
 
-	outstanding, err := fl.GetOutstandingBalance(owner)
+	outstanding, err := fl.GetOutstandingBalance(chainID, owner)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to get outstanding balance: %w", err)
 	}
@@ -94,17 +94,21 @@ func (fl *FeeLedger) CheckCreditLimit(owner common.Address, creditLimitWei *big.
 	return withinLimit, outstanding, nil
 }
 
-// RecordValueFee records a value fee after successful execution.
-// The mutex serializes the read-check-write sequence to prevent double-recording
-// when concurrent calls arrive with the same ExecutionID.
+// RecordValueFee records a value fee after successful execution. The ledger
+// and fee record are written under the chain ID embedded in record.ChainID.
+// The mutex serializes the read-check-write sequence to prevent
+// double-recording when concurrent calls arrive with the same ExecutionID.
 func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	fl.mu.Lock()
 	defer fl.mu.Unlock()
 
+	if record.ChainID == 0 {
+		return fmt.Errorf("fee record missing chain_id (owner=%s execution=%s)", record.Owner, record.ExecutionID)
+	}
 	owner := common.HexToAddress(record.Owner)
 
 	// Idempotency check: skip if this execution's fee was already recorded
-	existingRecord, _ := fl.db.GetKey(FeeRecordKey(owner, record.ExecutionID))
+	existingRecord, _ := fl.db.GetKey(FeeRecordKey(record.ChainID, owner, record.ExecutionID))
 	if existingRecord != nil {
 		fl.logger.Debug("Fee record already exists, skipping", "execution_id", record.ExecutionID)
 		return nil
@@ -116,7 +120,7 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	}
 
 	// Get or create ledger entry
-	entry, err := fl.getLedgerEntry(owner)
+	entry, err := fl.getLedgerEntry(record.ChainID, owner)
 	if err != nil {
 		return fmt.Errorf("failed to get ledger entry: %w", err)
 	}
@@ -159,8 +163,8 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	}
 
 	updates := map[string][]byte{
-		string(FeeLedgerKey(owner)):                     ledgerData,
-		string(FeeRecordKey(owner, record.ExecutionID)): recordData,
+		string(FeeLedgerKey(record.ChainID, owner)):                     ledgerData,
+		string(FeeRecordKey(record.ChainID, owner, record.ExecutionID)): recordData,
 	}
 
 	if err := fl.db.BatchWrite(updates); err != nil {
@@ -168,6 +172,7 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	}
 
 	fl.logger.Info("Recorded value fee",
+		"chain_id", record.ChainID,
 		"owner", owner.Hex(),
 		"execution_id", record.ExecutionID,
 		"fee_wei", record.FeeAmountWei,
@@ -176,19 +181,20 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	return nil
 }
 
-// getLedgerEntry reads the ledger entry for an owner. Returns nil if not found.
-func (fl *FeeLedger) getLedgerEntry(owner common.Address) (*FeeLedgerEntry, error) {
-	data, err := fl.db.GetKey(FeeLedgerKey(owner))
+// getLedgerEntry reads the ledger entry for an owner on the given chain.
+// Returns nil if not found.
+func (fl *FeeLedger) getLedgerEntry(chainID int64, owner common.Address) (*FeeLedgerEntry, error) {
+	data, err := fl.db.GetKey(FeeLedgerKey(chainID, owner))
 	if err != nil {
 		if err == badger.ErrKeyNotFound {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to read fee ledger for %s: %w", owner.Hex(), err)
+		return nil, fmt.Errorf("failed to read fee ledger for chain=%d owner=%s: %w", chainID, owner.Hex(), err)
 	}
 
 	var entry FeeLedgerEntry
 	if err := json.Unmarshal(data, &entry); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal fee ledger for %s: %w", owner.Hex(), err)
+		return nil, fmt.Errorf("failed to unmarshal fee ledger for chain=%d owner=%s: %w", chainID, owner.Hex(), err)
 	}
 	return &entry, nil
 }

--- a/core/taskengine/fee_ledger_test.go
+++ b/core/taskengine/fee_ledger_test.go
@@ -19,7 +19,7 @@ func TestFeeLedger_GetOutstandingBalance_Empty(t *testing.T) {
 	ledger := NewFeeLedger(db, logger)
 
 	owner := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
-	balance, err := ledger.GetOutstandingBalance(owner)
+	balance, err := ledger.GetOutstandingBalance(int64(1), owner)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), balance, "Empty ledger should return zero balance")
 }
@@ -48,7 +48,7 @@ func TestFeeLedger_RecordValueFee(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check outstanding balance
-	balance, err := ledger.GetOutstandingBalance(owner)
+	balance, err := ledger.GetOutstandingBalance(int64(11155111), owner)
 	require.NoError(t, err)
 
 	expectedFee, _ := new(big.Int).SetString("300000000000000", 10)
@@ -69,6 +69,7 @@ func TestFeeLedger_RecordMultipleFees(t *testing.T) {
 		TaskID:       "task_001",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "100000000000000", // 0.0001 ETH
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
@@ -78,11 +79,12 @@ func TestFeeLedger_RecordMultipleFees(t *testing.T) {
 		TaskID:       "task_001",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "200000000000000", // 0.0002 ETH
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
 	// Balance should be sum of both
-	balance, err := ledger.GetOutstandingBalance(owner)
+	balance, err := ledger.GetOutstandingBalance(int64(1), owner)
 	require.NoError(t, err)
 
 	expectedTotal, _ := new(big.Int).SetString("300000000000000", 10)
@@ -101,7 +103,7 @@ func TestFeeLedger_CheckCreditLimit(t *testing.T) {
 	creditLimit, _ := new(big.Int).SetString("500000000000000", 10)
 
 	// No fees yet — within limit
-	withinLimit, outstanding, err := ledger.CheckCreditLimit(owner, creditLimit)
+	withinLimit, outstanding, err := ledger.CheckCreditLimit(int64(1), owner, creditLimit)
 	require.NoError(t, err)
 	assert.True(t, withinLimit, "Should be within limit when no fees owed")
 	assert.Equal(t, big.NewInt(0), outstanding)
@@ -111,10 +113,11 @@ func TestFeeLedger_CheckCreditLimit(t *testing.T) {
 		ExecutionID:  "exec_001",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "300000000000000", // 0.0003 ETH — under 0.0005 limit
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
-	withinLimit, outstanding, err = ledger.CheckCreditLimit(owner, creditLimit)
+	withinLimit, outstanding, err = ledger.CheckCreditLimit(int64(1), owner, creditLimit)
 	require.NoError(t, err)
 	assert.True(t, withinLimit, "Should be within limit when fees < credit limit")
 
@@ -123,10 +126,11 @@ func TestFeeLedger_CheckCreditLimit(t *testing.T) {
 		ExecutionID:  "exec_002",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "300000000000000", // Total now 0.0006 ETH — over 0.0005 limit
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
-	withinLimit, outstanding, err = ledger.CheckCreditLimit(owner, creditLimit)
+	withinLimit, outstanding, err = ledger.CheckCreditLimit(int64(1), owner, creditLimit)
 	require.NoError(t, err)
 	assert.False(t, withinLimit, "Should exceed credit limit")
 
@@ -148,6 +152,7 @@ func TestFeeLedger_SeparateOwners(t *testing.T) {
 		ExecutionID:  "exec_001",
 		Owner:        owner1.Hex(),
 		FeeAmountWei: "100000000000000",
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
@@ -156,16 +161,17 @@ func TestFeeLedger_SeparateOwners(t *testing.T) {
 		ExecutionID:  "exec_002",
 		Owner:        owner2.Hex(),
 		FeeAmountWei: "200000000000000",
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
 	// Balances should be separate
-	balance1, err := ledger.GetOutstandingBalance(owner1)
+	balance1, err := ledger.GetOutstandingBalance(int64(1), owner1)
 	require.NoError(t, err)
 	expected1, _ := new(big.Int).SetString("100000000000000", 10)
 	assert.Equal(t, expected1, balance1)
 
-	balance2, err := ledger.GetOutstandingBalance(owner2)
+	balance2, err := ledger.GetOutstandingBalance(int64(1), owner2)
 	require.NoError(t, err)
 	expected2, _ := new(big.Int).SetString("200000000000000", 10)
 	assert.Equal(t, expected2, balance2)

--- a/core/taskengine/list_wallets_storage_test.go
+++ b/core/taskengine/list_wallets_storage_test.go
@@ -22,7 +22,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	user := testutil.TestUser1()
 
 	// Verify database is empty initially
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(dbItems), "Database should be empty initially")
 
@@ -42,7 +42,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	require.NotNil(t, defaultWallet, "Default wallet (salt:0) should be in the response")
 
 	// Verify the wallet is now stored in the database
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should contain exactly 1 wallet after ListWallets")
 
@@ -74,7 +74,7 @@ func TestListWalletsDoesNotDuplicateExistingWallet(t *testing.T) {
 	defaultAddress := getResp.Address
 
 	// Verify the wallet is stored
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should contain exactly 1 wallet after GetWallet")
 
@@ -83,7 +83,7 @@ func TestListWalletsDoesNotDuplicateExistingWallet(t *testing.T) {
 	require.NoError(t, err, "ListWallets should succeed")
 
 	// Verify the wallet is still only stored once
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should still contain exactly 1 wallet after ListWallets")
 
@@ -119,7 +119,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NoError(t, err, "First ListWallets call should succeed")
 
 	// Verify salt:0 is stored
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Should have 1 wallet (salt:0) after first ListWallets")
 
@@ -141,7 +141,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NotEqual(t, salt0Address, salt1Address, "Salt:1 address should be different from salt:0")
 
 	// Verify we now have 2 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(dbItems), "Should have 2 wallets (salt:0, salt:1) after GetWallet")
 
@@ -155,7 +155,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NotEqual(t, salt1Address, salt2Address, "Salt:2 address should be different from salt:1")
 
 	// Verify we now have 3 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should have 3 wallets (salt:0, salt:1, salt:2) after second GetWallet")
 
@@ -164,7 +164,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NoError(t, err, "Second ListWallets call should succeed")
 
 	// Verify we still have exactly 3 wallets (no duplicates)
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should still have exactly 3 wallets after second ListWallets")
 
@@ -211,7 +211,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 
 	// Phase 1: Owner with no wallets yet - call ListWallets
 	// This should create and store salt:0
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(dbItems), "Database should be empty initially")
 
@@ -219,7 +219,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NoError(t, err, "ListWallets should succeed when owner has no wallets")
 
 	// Verify salt:0 is now stored
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should contain salt:0 after ListWallets")
 
@@ -233,7 +233,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NotEmpty(t, salt0FromList, "Salt:0 wallet should be in ListWallets response")
 
 	// Verify we can retrieve it directly from the database
-	retrievedWallet, err := GetWallet(db, user.Address, salt0FromList)
+	retrievedWallet, err := GetWallet(db, int64(1), user.Address, salt0FromList)
 	require.NoError(t, err, "Should be able to retrieve salt:0 wallet from database")
 	assert.Equal(t, "0", retrievedWallet.Salt.String(), "Retrieved wallet should have salt 0")
 
@@ -244,7 +244,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NoError(t, err, "GetWallet for salt:1 should succeed")
 
 	// Verify we now have 2 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(dbItems), "Should have 2 wallets after GetWallet for salt:1")
 
@@ -255,7 +255,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NoError(t, err, "GetWallet for salt:2 should succeed")
 
 	// Verify we now have 3 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should have 3 wallets after GetWallet for salt:2")
 
@@ -273,18 +273,18 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	assert.True(t, addressesInResponse[getResp2.Address], "Salt:2 wallet should be in response")
 
 	// Verify database still has exactly 3 wallets (no duplicates created)
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should still have exactly 3 wallets after second ListWallets")
 
 	// Verify all wallets can be retrieved individually
-	_, err = GetWallet(db, user.Address, salt0FromList)
+	_, err = GetWallet(db, int64(1), user.Address, salt0FromList)
 	require.NoError(t, err, "Should be able to retrieve salt:0 from database")
 
-	_, err = GetWallet(db, user.Address, getResp1.Address)
+	_, err = GetWallet(db, int64(1), user.Address, getResp1.Address)
 	require.NoError(t, err, "Should be able to retrieve salt:1 from database")
 
-	_, err = GetWallet(db, user.Address, getResp2.Address)
+	_, err = GetWallet(db, int64(1), user.Address, getResp2.Address)
 	require.NoError(t, err, "Should be able to retrieve salt:2 from database")
 }
 
@@ -300,7 +300,7 @@ func TestListWalletsDatabaseStateVerification(t *testing.T) {
 
 	// Helper function to verify database state
 	verifyDatabaseState := func(t *testing.T, expectedCount int, description string) map[string]*model.SmartWallet {
-		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 		require.NoError(t, err, "Failed to query database: %s", description)
 		assert.Equal(t, expectedCount, len(dbItems), "Database state check failed: %s (expected %d wallets, got %d)", description, expectedCount, len(dbItems))
 

--- a/core/taskengine/migrate_wallet_salt_index.go
+++ b/core/taskengine/migrate_wallet_salt_index.go
@@ -68,31 +68,39 @@ type WalletSaltIndexBackfillStats struct {
 	SkippedDeriveError     int
 }
 
-// BackfillWalletSaltIndex walks every persisted wallet record and either
-// writes a (owner, factory, salt) → address secondary index entry (when
-// the live derivation still matches the stored address), or marks the row
-// stale (when the derivation differs — i.e. the factory's account
-// implementation was upgraded since the row was stored).
+// BackfillWalletSaltIndex walks every persisted wallet record on the given
+// chain and either writes a (chainID, owner, factory, salt) → address
+// secondary index entry (when the live derivation still matches the stored
+// address), or marks the row stale (when the derivation differs — i.e. the
+// factory's account implementation was upgraded since the row was stored).
+//
+// Run the backfill once per chain the gateway hosts. The `derive` callback
+// must produce addresses consistent with the chainID passed in (the caller
+// is responsible for binding the deriver to the right RPC endpoint).
 //
 // The function is the shared core for both the `/ava backfill-wallet-salt-index`
 // CLI subcommand and the standalone scripts/migration/... wrapper. Tests
 // inject a fake deriver to exercise the matrix of canonical / stale /
 // missing / error rows without an RPC.
-func BackfillWalletSaltIndex(db storage.Storage, derive WalletSaltIndexAddressDeriver, opts WalletSaltIndexBackfillOptions) (*WalletSaltIndexBackfillStats, error) {
+func BackfillWalletSaltIndex(db storage.Storage, chainID int64, derive WalletSaltIndexAddressDeriver, opts WalletSaltIndexBackfillOptions) (*WalletSaltIndexBackfillStats, error) {
 	if db == nil {
 		return nil, fmt.Errorf("BackfillWalletSaltIndex: db is required")
 	}
 	if derive == nil {
 		return nil, fmt.Errorf("BackfillWalletSaltIndex: derive callback is required")
 	}
+	if chainID <= 0 {
+		return nil, fmt.Errorf("BackfillWalletSaltIndex: chainID is required (got %d)", chainID)
+	}
 	logf := opts.Logf
 	if logf == nil {
 		logf = func(format string, args ...any) {}
 	}
 
-	items, err := db.GetByPrefix([]byte("w:"))
+	walletPrefix := []byte(fmt.Sprintf("w:%d:", chainID))
+	items, err := db.GetByPrefix(walletPrefix)
 	if err != nil {
-		return nil, fmt.Errorf("scan wallet records: %w", err)
+		return nil, fmt.Errorf("scan wallet records for chain %d: %w", chainID, err)
 	}
 
 	stats := &WalletSaltIndexBackfillStats{}
@@ -140,7 +148,7 @@ func BackfillWalletSaltIndex(db storage.Storage, derive WalletSaltIndexAddressDe
 		if canonical {
 			stats.CanonicalConfirmed++
 
-			indexKey := WalletBySaltKey(owner, factory, wallet.Salt)
+			indexKey := WalletBySaltKey(chainID, owner, factory, wallet.Salt)
 			existing, lookupErr := db.GetKey(indexKey)
 			alreadyCorrect := lookupErr == nil && strings.EqualFold(string(existing), wallet.Address.Hex())
 
@@ -185,7 +193,7 @@ func BackfillWalletSaltIndex(db storage.Storage, derive WalletSaltIndexAddressDe
 		logf("  [stale] %s ≠ live derivation %s (owner=%s factory=%s salt=%s)",
 			wallet.Address.Hex(), derived.Hex(), owner.Hex(), factory.Hex(), wallet.Salt.String())
 		if !opts.DryRun {
-			if markErr := MarkWalletStale(db, owner, wallet.Address.Hex()); markErr != nil {
+			if markErr := MarkWalletStale(db, chainID, owner, wallet.Address.Hex()); markErr != nil {
 				logf("  [err] mark stale: %v", markErr)
 				// Fail-fast: a partially marked stale set would let
 				// zombie rows leak back into ListWallets responses

--- a/core/taskengine/partial_success_test.go
+++ b/core/taskengine/partial_success_test.go
@@ -190,10 +190,11 @@ func TestGetExecutionStatus_StepFailures(t *testing.T) {
 	// Create a test task
 	task := &model.Workflow{
 		Task: &avsproto.Task{
-			Id:     "test-task-id",
-			Owner:  user.Address.Hex(),
-			Status: avsproto.TaskStatus_Enabled,
-			Name:   "Test Task",
+			Id:      "test-task-id",
+			ChainId: int64(1),
+			Owner:   user.Address.Hex(),
+			Status:  avsproto.TaskStatus_Enabled,
+			Name:    "Test Task",
 		},
 	}
 
@@ -278,10 +279,11 @@ func TestGetExecutionStatus_FullSuccess(t *testing.T) {
 	// Create a test task
 	task := &model.Workflow{
 		Task: &avsproto.Task{
-			Id:     "test-task-id",
-			Owner:  user.Address.Hex(),
-			Status: avsproto.TaskStatus_Enabled,
-			Name:   "Test Task",
+			Id:      "test-task-id",
+			ChainId: int64(1),
+			Owner:   user.Address.Hex(),
+			Status:  avsproto.TaskStatus_Enabled,
+			Name:    "Test Task",
 		},
 	}
 
@@ -360,10 +362,11 @@ func TestGetExecutionStatus_FullFailure(t *testing.T) {
 	// Create a test task
 	task := &model.Workflow{
 		Task: &avsproto.Task{
-			Id:     "test-task-id",
-			Owner:  user.Address.Hex(),
-			Status: avsproto.TaskStatus_Enabled,
-			Name:   "Test Task",
+			Id:      "test-task-id",
+			ChainId: int64(1),
+			Owner:   user.Address.Hex(),
+			Status:  avsproto.TaskStatus_Enabled,
+			Name:    "Test Task",
 		},
 	}
 

--- a/core/taskengine/run_node_immediately_missing_dependencies_test.go
+++ b/core/taskengine/run_node_immediately_missing_dependencies_test.go
@@ -47,7 +47,7 @@ func TestRunNodeImmediately_ContractWrite_MissingNodeDependency(t *testing.T) {
 	require.NoError(t, err, "Failed to derive smart wallet address")
 
 	// Seed wallet in DB for validation
-	_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+	_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 		Owner:   &ownerEOA,
 		Address: runnerAddr,
 		Factory: &factory,

--- a/core/taskengine/run_node_immediately_rpc_test.go
+++ b/core/taskengine/run_node_immediately_rpc_test.go
@@ -52,7 +52,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		}
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,
@@ -293,7 +293,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		}
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/run_node_immediately_settings_test.go
+++ b/core/taskengine/run_node_immediately_settings_test.go
@@ -49,7 +49,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 		}
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/run_node_immediately_tuple_test.go
+++ b/core/taskengine/run_node_immediately_tuple_test.go
@@ -85,7 +85,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		// - Templates reference settings.uniswapv3-pool.token0.id etc.
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,
@@ -208,7 +208,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		// The backend will convert this to ordered array based on ABI
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,
@@ -423,7 +423,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		// Note: Mathematical expressions in templates are not supported in RunNodeImmediately
 
 		// Seed wallet in DB
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/run_node_with_inputs_simulation_mode_test.go
+++ b/core/taskengine/run_node_with_inputs_simulation_mode_test.go
@@ -83,7 +83,7 @@ func TestRunNodeWithInputsRespectsIsSimulatedFlag(t *testing.T) {
 			}
 
 			// Seed wallet in DB for validation
-			_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+			_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 				Owner:   &ownerEOA,
 				Address: runnerAddr,
 				Factory: &factory,
@@ -267,7 +267,7 @@ func TestRunNodeWithInputsDefaultsToSimulation(t *testing.T) {
 	user := &model.User{Address: ownerEOA}
 
 	// Seed wallet in DB
-	_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+	_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 		Owner:   &ownerEOA,
 		Address: runnerAddr,
 		Factory: &factory,

--- a/core/taskengine/schema.go
+++ b/core/taskengine/schema.go
@@ -25,44 +25,54 @@ func WorkflowByStatusStoragePrefix(status avsproto.TaskStatus) []byte {
 	return storageschema.WorkflowByStatusStoragePrefix(status)
 }
 
-func WalletByOwnerPrefix(owner common.Address) []byte {
+// WalletByOwnerPrefix returns the storage prefix for all wallets owned by
+// `owner` on chain `chainID`. Used to list wallets for a given user.
+func WalletByOwnerPrefix(chainID int64, owner common.Address) []byte {
 	return []byte(fmt.Sprintf(
-		"w:%s",
+		"w:%d:%s",
+		chainID,
 		strings.ToLower(owner.String()),
 	))
 }
 
-func WalletStorageKey(owner common.Address, smartWalletAddress string) string {
+// WalletStorageKey returns the primary key for a wallet record. The
+// chain ID is the second segment so wallets on different chains
+// (different factory addresses, different derived addresses) never
+// collide in storage.
+func WalletStorageKey(chainID int64, owner common.Address, smartWalletAddress string) string {
 	return fmt.Sprintf(
-		"w:%s:%s",
+		"w:%d:%s:%s",
+		chainID,
 		strings.ToLower(owner.Hex()),
 		strings.ToLower(smartWalletAddress),
 	)
 }
 
 // WalletBySaltKey returns the secondary index key that maps a
-// (owner, factory, salt) tuple to its current canonical wallet address.
+// (chainID, owner, factory, salt) tuple to its current canonical wallet
+// address.
 //
 // The primary wallet record is keyed by the *derived* wallet address
-// (`w:<owner>:<address>`), which means that when a factory's account
-// implementation is upgraded and `factory.getAddress(owner, salt)` starts
-// returning a new address, the new address looks like a brand-new wallet
-// to the primary store and a fresh row gets inserted alongside the old
-// one. This index lets us cheaply ask "for this (owner, factory, salt)
-// triple, which derived address is currently canonical?" so that the write
-// path can detect the upgrade and mark the old row as stale instead of
-// silently accumulating zombies.
+// (`w:<chainID>:<owner>:<address>`), which means that when a factory's
+// account implementation is upgraded and `factory.getAddress(owner, salt)`
+// starts returning a new address, the new address looks like a brand-new
+// wallet to the primary store and a fresh row gets inserted alongside the
+// old one. This index lets us cheaply ask "for this (chainID, owner,
+// factory, salt) tuple, which derived address is currently canonical?"
+// so that the write path can detect the upgrade and mark the old row as
+// stale instead of silently accumulating zombies.
 //
 // Salt is encoded in decimal (matching `(*big.Int).String()`) so the key
 // is stable across encodings. The prefix is `wsalt:` (not `w:`) so it does
 // not collide with `WalletByOwnerPrefix`.
-func WalletBySaltKey(owner common.Address, factory common.Address, salt *big.Int) []byte {
+func WalletBySaltKey(chainID int64, owner common.Address, factory common.Address, salt *big.Int) []byte {
 	saltStr := "0"
 	if salt != nil {
 		saltStr = salt.String()
 	}
 	return []byte(fmt.Sprintf(
-		"wsalt:%s:%s:%s",
+		"wsalt:%d:%s:%s:%s",
+		chainID,
 		strings.ToLower(owner.Hex()),
 		strings.ToLower(factory.Hex()),
 		saltStr,
@@ -70,18 +80,18 @@ func WalletBySaltKey(owner common.Address, factory common.Address, salt *big.Int
 }
 
 // LookupCanonicalWalletAddress returns the wallet address currently
-// registered as canonical for the given (owner, factory, salt) triple, or
-// badger.ErrKeyNotFound if none has been recorded yet.
-func LookupCanonicalWalletAddress(db storage.Storage, owner common.Address, factory common.Address, salt *big.Int) (common.Address, error) {
-	raw, err := db.GetKey(WalletBySaltKey(owner, factory, salt))
+// registered as canonical for the given (chainID, owner, factory, salt)
+// tuple, or badger.ErrKeyNotFound if none has been recorded yet.
+func LookupCanonicalWalletAddress(db storage.Storage, chainID int64, owner common.Address, factory common.Address, salt *big.Int) (common.Address, error) {
+	raw, err := db.GetKey(WalletBySaltKey(chainID, owner, factory, salt))
 	if err != nil {
 		return common.Address{}, err
 	}
 	return common.HexToAddress(string(raw)), nil
 }
 
-func GetWallet(db storage.Storage, owner common.Address, smartWalletAddress string) (*model.SmartWallet, error) {
-	walletKey := WalletStorageKey(owner, smartWalletAddress)
+func GetWallet(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string) (*model.SmartWallet, error) {
+	walletKey := WalletStorageKey(chainID, owner, smartWalletAddress)
 	walletData, err := db.GetKey([]byte(walletKey))
 	if err != nil {
 		return nil, err // Includes badger.ErrKeyNotFound
@@ -95,19 +105,20 @@ func GetWallet(db storage.Storage, owner common.Address, smartWalletAddress stri
 }
 
 // StoreWallet persists the wallet record under its primary key
-// (`w:<owner>:<address>`) and, when the wallet has a non-nil factory and
-// salt and is not flagged stale, also writes the `(owner, factory, salt)`
-// secondary index entry pointing at this wallet's address. Both writes
-// happen in a single BatchWrite so the index can never be left dangling.
+// (`w:<chainID>:<owner>:<address>`) and, when the wallet has a non-nil
+// factory and salt and is not flagged stale, also writes the
+// `(chainID, owner, factory, salt)` secondary index entry pointing at
+// this wallet's address. Both writes happen in a single BatchWrite so
+// the index can never be left dangling.
 //
 // Stale records (StaleDerivation == true) only update the primary entry —
 // the secondary index intentionally continues to point at the new
-// canonical wallet for that triple, not the stale one.
-func StoreWallet(db storage.Storage, owner common.Address, wallet *model.SmartWallet) error {
+// canonical wallet for that tuple, not the stale one.
+func StoreWallet(db storage.Storage, chainID int64, owner common.Address, wallet *model.SmartWallet) error {
 	if wallet.Address == nil {
 		return fmt.Errorf("cannot store wallet with nil address")
 	}
-	walletKey := WalletStorageKey(owner, wallet.Address.String())
+	walletKey := WalletStorageKey(chainID, owner, wallet.Address.String())
 	updatedWalletData, err := wallet.ToJSON()
 	if err != nil {
 		return fmt.Errorf("failed to marshal wallet for storage (key: %s): %w", walletKey, err)
@@ -118,7 +129,7 @@ func StoreWallet(db storage.Storage, owner common.Address, wallet *model.SmartWa
 		return db.Set([]byte(walletKey), updatedWalletData)
 	}
 
-	indexKey := WalletBySaltKey(owner, *wallet.Factory, wallet.Salt)
+	indexKey := WalletBySaltKey(chainID, owner, *wallet.Factory, wallet.Salt)
 	indexValue := []byte(strings.ToLower(wallet.Address.Hex()))
 	return db.BatchWrite(map[string][]byte{
 		walletKey:        updatedWalletData,
@@ -131,14 +142,14 @@ func StoreWallet(db storage.Storage, owner common.Address, wallet *model.SmartWa
 // updated by this call (StoreWallet skips the index for stale records),
 // so callers that want the index to point at a fresh canonical wallet
 // must call StoreWallet on the new wallet *after* this returns.
-func MarkWalletStale(db storage.Storage, owner common.Address, smartWalletAddress string) error {
-	wallet, err := GetWallet(db, owner, smartWalletAddress)
+func MarkWalletStale(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string) error {
+	wallet, err := GetWallet(db, chainID, owner, smartWalletAddress)
 	if err != nil {
 		return fmt.Errorf("failed to load wallet to mark stale (%s): %w", smartWalletAddress, err)
 	}
 	wallet.StaleDerivation = true
 	wallet.IsHidden = true
-	return StoreWallet(db, owner, wallet)
+	return StoreWallet(db, chainID, owner, wallet)
 }
 
 func WorkflowStorageKey(id string, status avsproto.TaskStatus) []byte {
@@ -197,23 +208,6 @@ func ChainTaskExecutionKey(chainID int64, t *model.Workflow, executionID string)
 		chainID,
 		t.Id,
 		executionID,
-	))
-}
-
-func ChainWalletStorageKey(chainID int64, owner common.Address, smartWalletAddress string) string {
-	return fmt.Sprintf(
-		"w:%d:%s:%s",
-		chainID,
-		strings.ToLower(owner.Hex()),
-		strings.ToLower(smartWalletAddress),
-	)
-}
-
-func ChainWalletByOwnerPrefix(chainID int64, owner common.Address) []byte {
-	return []byte(fmt.Sprintf(
-		"w:%d:%s",
-		chainID,
-		strings.ToLower(owner.String()),
 	))
 }
 
@@ -348,8 +342,8 @@ func ContractWriteCounterKey(eoa common.Address) []byte {
 // IsWalletHidden checks if a wallet is marked as hidden.
 // It returns true if hidden, false otherwise. If the wallet is not found or an error occurs,
 // it returns false and the error (except for badger.ErrKeyNotFound where it still returns false for IsHidden).
-func IsWalletHidden(db storage.Storage, owner common.Address, smartWalletAddress string) (bool, error) {
-	wallet, err := GetWallet(db, owner, smartWalletAddress)
+func IsWalletHidden(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string) (bool, error) {
+	wallet, err := GetWallet(db, chainID, owner, smartWalletAddress)
 	if err != nil {
 		if err == badger.ErrKeyNotFound {
 			return false, nil // Wallet doesn't exist, so not hidden by our definition, no error to bubble up for this specific check.
@@ -363,8 +357,8 @@ func IsWalletHidden(db storage.Storage, owner common.Address, smartWalletAddress
 }
 
 // SetWalletHiddenStatus sets the hidden status of a specified wallet.
-func SetWalletHiddenStatus(db storage.Storage, owner common.Address, smartWalletAddress string, hidden bool) error {
-	wallet, err := GetWallet(db, owner, smartWalletAddress)
+func SetWalletHiddenStatus(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string, hidden bool) error {
+	wallet, err := GetWallet(db, chainID, owner, smartWalletAddress)
 	if err != nil {
 		// If wallet not found, and we intend to "unhide" (which is a no-op) or "hide" (which means creating it as hidden).
 		// For simplicity, let's assume for now that SetWalletHiddenStatus operates on existing wallets.
@@ -380,24 +374,27 @@ func SetWalletHiddenStatus(db storage.Storage, owner common.Address, smartWallet
 	}
 
 	wallet.IsHidden = hidden
-	return StoreWallet(db, owner, wallet)
+	return StoreWallet(db, chainID, owner, wallet)
 }
 
 // Fee ledger storage keys
 
-// FeeLedgerKey returns the key for a user's outstanding value fee balance.
-// Format: "fl:<owner_hex>" → JSON-encoded FeeLedgerEntry
-func FeeLedgerKey(owner common.Address) []byte {
-	return []byte(fmt.Sprintf("fl:%s", strings.ToLower(owner.Hex())))
+// FeeLedgerKey returns the key for a user's outstanding value fee balance on
+// a specific chain. Format: "fl:<chainID>:<owner_hex>" → JSON-encoded
+// FeeLedgerEntry. Each chain maintains its own ledger so per-chain billing
+// settlement is unambiguous.
+func FeeLedgerKey(chainID int64, owner common.Address) []byte {
+	return []byte(fmt.Sprintf("fl:%d:%s", chainID, strings.ToLower(owner.Hex())))
 }
 
 // FeeRecordKey returns the key for an individual fee record (audit trail).
-// Format: "fr:<owner_hex>:<execution_id>" → JSON-encoded FeeRecord
-func FeeRecordKey(owner common.Address, executionID string) []byte {
-	return []byte(fmt.Sprintf("fr:%s:%s", strings.ToLower(owner.Hex()), executionID))
+// Format: "fr:<chainID>:<owner_hex>:<execution_id>" → JSON-encoded FeeRecord.
+func FeeRecordKey(chainID int64, owner common.Address, executionID string) []byte {
+	return []byte(fmt.Sprintf("fr:%d:%s:%s", chainID, strings.ToLower(owner.Hex()), executionID))
 }
 
-// FeeRecordPrefix returns the prefix for all fee records for an owner.
-func FeeRecordPrefix(owner common.Address) []byte {
-	return []byte(fmt.Sprintf("fr:%s:", strings.ToLower(owner.Hex())))
+// FeeRecordPrefix returns the prefix for all fee records for an owner on
+// a specific chain.
+func FeeRecordPrefix(chainID int64, owner common.Address) []byte {
+	return []byte(fmt.Sprintf("fr:%d:%s:", chainID, strings.ToLower(owner.Hex())))
 }

--- a/core/taskengine/simulate_sequential_contract_writes_test.go
+++ b/core/taskengine/simulate_sequential_contract_writes_test.go
@@ -79,7 +79,7 @@ func TestSimulateTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	}
 
 	// Register smart wallet in database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddr,
 		Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -79,7 +79,7 @@ func TestSimulateTask_StopLossWorkflow_Sepolia(t *testing.T) {
 		SmartAccountAddress: smartWalletAddr,
 	}
 	require.NoError(t,
-		StoreWallet(db, ownerAddress, &model.SmartWallet{
+		StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 			Owner:   &ownerAddress,
 			Address: smartWalletAddr,
 			Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/stats_test.go
+++ b/core/taskengine/stats_test.go
@@ -34,7 +34,10 @@ func TestTaskStatCount(t *testing.T) {
 	tr1.MaxExecution = 1
 	n.CreateWorkflow(testutil.TestUser1(), tr1)
 
-	statSvc := NewStatService(db)
+	// CreateWorkflow stamps the task with the engine's defaultChainID
+	// (config.SmartWallet.ChainID), so the stat service must scan that
+	// chain — the chain-0 default in NewStatService would miss it.
+	statSvc := NewStatServiceWithChains(db, []int64{config.SmartWallet.ChainID})
 	// Query statistics using the same smart wallet address used for task creation
 	addr := common.HexToAddress(smartWalletAddress)
 	owner := testutil.TestUser1().Address

--- a/core/taskengine/userops_withdraw_all_test.go
+++ b/core/taskengine/userops_withdraw_all_test.go
@@ -192,7 +192,7 @@ func TestWithdrawAllETH_Sepolia(t *testing.T) {
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(0),

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -89,7 +89,7 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(0),
@@ -551,7 +551,7 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(0),

--- a/core/taskengine/utils_calldata_test.go
+++ b/core/taskengine/utils_calldata_test.go
@@ -567,7 +567,7 @@ func TestContractWrite_InvalidNumericValue_ResponseStructure(t *testing.T) {
 	require.NoError(t, err, "Failed to derive smart wallet address")
 
 	// Seed wallet in DB for validation
-	_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+	_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 		Owner:   &ownerEOA,
 		Address: runnerAddr,
 		Factory: &smartWalletConfig.FactoryAddress,

--- a/core/taskengine/validation.go
+++ b/core/taskengine/validation.go
@@ -8,7 +8,12 @@ import (
 
 const TaskIDLength = 26
 
-func ValidWalletOwner(db storage.Storage, u *model.User, smartWalletAddress common.Address) (bool, error) {
+// ValidWalletOwner reports whether the smart wallet at smartWalletAddress is
+// owned by u on the given chain. Wallets are chain-scoped (the factory
+// address differs per chain, so a wallet derived on chain A is not the same
+// record as one on chain B even if the EOA owner matches), so the chainID is
+// part of the ownership question.
+func ValidWalletOwner(db storage.Storage, chainID int64, u *model.User, smartWalletAddress common.Address) (bool, error) {
 	// the smart wallet address is the default one (if SmartAccountAddress is set)
 	// Note: nil check is required because some callers create User objects with only Address field set
 	if u.SmartAccountAddress != nil && u.SmartAccountAddress.Hex() == smartWalletAddress.Hex() {
@@ -16,7 +21,7 @@ func ValidWalletOwner(db storage.Storage, u *model.User, smartWalletAddress comm
 	}
 
 	// not default, look up in our storage
-	exists, err := db.Exist([]byte(WalletStorageKey(u.Address, smartWalletAddress.Hex())))
+	exists, err := db.Exist([]byte(WalletStorageKey(chainID, u.Address, smartWalletAddress.Hex())))
 	if exists {
 		return true, nil
 	}

--- a/core/taskengine/validation_test.go
+++ b/core/taskengine/validation_test.go
@@ -14,7 +14,7 @@ import (
 func TestWalletOwnerReturnTrueForDefaultAddress(t *testing.T) {
 	smartAddress := common.HexToAddress("0x5Df343de7d99fd64b2479189692C1dAb8f46184a")
 
-	result, err := ValidWalletOwner(nil, &model.User{
+	result, err := ValidWalletOwner(nil, int64(1), &model.User{
 		Address:             common.HexToAddress("0xe272b72E51a5bF8cB720fc6D6DF164a4D5E321C5"),
 		SmartAccountAddress: &smartAddress,
 	}, common.HexToAddress("0x5Df343de7d99fd64b2479189692C1dAb8f46184a"))
@@ -32,7 +32,7 @@ func TestWalletOwnerReturnTrueForNonDefaultAddress(t *testing.T) {
 	defaultSmartWallet := common.HexToAddress("0x5Df343de7d99fd64b2479189692C1dAb8f46184a")
 	customSmartWallet := common.HexToAddress("0xdD85693fd14b522a819CC669D6bA388B4FCd158d")
 
-	result, err := ValidWalletOwner(db, &model.User{
+	result, err := ValidWalletOwner(db, int64(1), &model.User{
 		Address:             eoa,
 		SmartAccountAddress: &defaultSmartWallet,
 	}, customSmartWallet)
@@ -41,9 +41,9 @@ func TestWalletOwnerReturnTrueForNonDefaultAddress(t *testing.T) {
 	}
 
 	// setup wallet binding
-	db.Set([]byte(WalletStorageKey(eoa, customSmartWallet.Hex())), []byte("1"))
+	db.Set([]byte(WalletStorageKey(int64(1), eoa, customSmartWallet.Hex())), []byte("1"))
 
-	result, err = ValidWalletOwner(db, &model.User{
+	result, err = ValidWalletOwner(db, int64(1), &model.User{
 		Address:             eoa,
 		SmartAccountAddress: &defaultSmartWallet,
 	}, customSmartWallet)

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1548,7 +1548,7 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 		_, hasSalt := v.vars["aa_salt"]
 		v.mu.Unlock()
 		if !hasSalt && v.db != nil {
-			if wallet, err := GetWallet(v.db, v.TaskOwner, v.task.SmartWalletAddress); err == nil && wallet != nil && wallet.Salt != nil {
+			if wallet, err := GetWallet(v.db, v.task.Task.ChainId, v.TaskOwner, v.task.SmartWalletAddress); err == nil && wallet != nil && wallet.Salt != nil {
 				v.AddVar("aa_salt", wallet.Salt)
 			}
 		}

--- a/core/taskengine/vm_runner_contract_write_data_priority_test.go
+++ b/core/taskengine/vm_runner_contract_write_data_priority_test.go
@@ -49,7 +49,7 @@ func TestContractWriteDataPriority(t *testing.T) {
 		runnerAddr, err := aa.GetSenderAddress(client, ownerEOA, big.NewInt(0))
 		require.NoError(t, err, "Failed to derive smart wallet address")
 
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/vm_runner_contract_write_simulation_test.go
+++ b/core/taskengine/vm_runner_contract_write_simulation_test.go
@@ -104,7 +104,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		runnerAddr, err := aa.GetSenderAddress(client, ownerEOA, big.NewInt(0))
 		require.NoError(t, err, "Failed to derive smart wallet address")
 
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
 
 		// Provide settings for new backend validation structure
 		triggerData := map[string]interface{}{
@@ -171,7 +171,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		require.NoError(t, err, "Failed to derive smart wallet address")
 
 		// Seed wallet for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
 
 		// Full USDC ABI as provided in client request (truncated for readability but key functions included)
 		contractAbi := []interface{}{
@@ -301,7 +301,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		require.NoError(t, derr, "Failed to derive runner")
 
 		// Seed wallet for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: derivedRunner, Factory: &factory, Salt: big.NewInt(0)})
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: derivedRunner, Factory: &factory, Salt: big.NewInt(0)})
 
 		// Minimal ABI for transfer(address,uint256)
 		transferAbi := []interface{}{

--- a/core/taskengine/wallet_count_limit_fix_test.go
+++ b/core/taskengine/wallet_count_limit_fix_test.go
@@ -41,7 +41,7 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		Factory: &factoryAddr,
 		Salt:    big.NewInt(0),
 	}
-	err := StoreWallet(db, user.Address, wallet1)
+	err := StoreWallet(db, int64(1), user.Address, wallet1)
 	require.NoError(t, err)
 
 	addr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -51,16 +51,16 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		Factory: &factoryAddr,
 		Salt:    big.NewInt(1),
 	}
-	err = StoreWallet(db, user.Address, wallet2)
+	err = StoreWallet(db, int64(1), user.Address, wallet2)
 	require.NoError(t, err)
 
 	t.Run("Direct database access to existing wallets should work at limit", func(t *testing.T) {
 		// This is what validateSmartWalletOwnership() does in withdrawFunds
-		retrievedWallet1, err := GetWallet(db, user.Address, wallet1.Address.Hex())
+		retrievedWallet1, err := GetWallet(db, int64(1), user.Address, wallet1.Address.Hex())
 		require.NoError(t, err)
 		assert.Equal(t, wallet1.Address.Hex(), retrievedWallet1.Address.Hex())
 
-		retrievedWallet2, err := GetWallet(db, user.Address, wallet2.Address.Hex())
+		retrievedWallet2, err := GetWallet(db, int64(1), user.Address, wallet2.Address.Hex())
 		require.NoError(t, err)
 		assert.Equal(t, wallet2.Address.Hex(), retrievedWallet2.Address.Hex())
 	})
@@ -93,14 +93,14 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		// Reset the database to have just 1 wallet initially
 		// Clean up any wallets that might have been created by previous subtests (e.g., ListWallets)
 		// by deleting all wallets and recreating just wallet1
-		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 		require.NoError(t, err)
 		for _, item := range dbItems {
 			db.Delete(item.Key)
 		}
 
 		// Recreate wallet1 to ensure clean state
-		err = StoreWallet(db, user.Address, wallet1)
+		err = StoreWallet(db, int64(1), user.Address, wallet1)
 		require.NoError(t, err)
 
 		// Now we have 1 wallet (limit=2), so we can create one more
@@ -115,7 +115,7 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		t.Logf("DEBUG: Created wallet at address: %s", walletAddr)
 
 		// Now add the second wallet back to reach the limit
-		err2 := StoreWallet(db, user.Address, wallet2)
+		err2 := StoreWallet(db, int64(1), user.Address, wallet2)
 		require.NoError(t, err2)
 
 		// Now we have 3 wallets (limit=2), so we're over the limit
@@ -165,7 +165,7 @@ func TestWalletCountLimitReproducesOriginalWithdrawFundsBug(t *testing.T) {
 			Factory: &factoryAddr,
 			Salt:    big.NewInt(int64(i)),
 		}
-		err := StoreWallet(db, user.Address, wallet)
+		err := StoreWallet(db, int64(1), user.Address, wallet)
 		require.NoError(t, err)
 		wallets[i] = wallet
 	}
@@ -202,7 +202,7 @@ func TestWalletCountLimitReproducesOriginalWithdrawFundsBug(t *testing.T) {
 
 		// Access specific wallets
 		for _, wallet := range wallets {
-			retrievedWallet, err := GetWallet(db, user.Address, wallet.Address.Hex())
+			retrievedWallet, err := GetWallet(db, int64(1), user.Address, wallet.Address.Hex())
 			require.NoError(t, err)
 			assert.Equal(t, wallet.Address.Hex(), retrievedWallet.Address.Hex())
 		}

--- a/core/taskengine/wallet_salt_index_test.go
+++ b/core/taskengine/wallet_salt_index_test.go
@@ -55,15 +55,15 @@ func TestStoreWallet_WritesPrimaryAndSecondaryIndex(t *testing.T) {
 	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
 	wallet := mkWallet(owner, factory, addr, 0)
 
-	require.NoError(t, StoreWallet(db, owner, wallet))
+	require.NoError(t, StoreWallet(db, int64(1), owner, wallet))
 
 	// Primary record present.
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.Equal(t, addr.Hex(), got.Address.Hex())
 
 	// Secondary index points at the same address.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), addr.Hex()),
 		"secondary index should point at the canonical wallet address")
@@ -78,7 +78,7 @@ func TestStoreWallet_StaleRecordDoesNotUpdateSecondaryIndex(t *testing.T) {
 
 	// First, persist the canonical wallet — index should point at it.
 	canonicalAddr := common.HexToAddress("0x3333333333333333333333333333333333333333")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, canonicalAddr, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, canonicalAddr, 0)))
 
 	// Now, write a stale wallet with the same (owner, factory, salt).
 	// The secondary index must continue to point at the canonical
@@ -87,15 +87,15 @@ func TestStoreWallet_StaleRecordDoesNotUpdateSecondaryIndex(t *testing.T) {
 	stale := mkWallet(owner, factory, staleAddr, 0)
 	stale.StaleDerivation = true
 	stale.IsHidden = true
-	require.NoError(t, StoreWallet(db, owner, stale))
+	require.NoError(t, StoreWallet(db, int64(1), owner, stale))
 
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), canonicalAddr.Hex()),
 		"index must continue pointing at the canonical wallet, not the stale one")
 
 	// And the stale primary record is still readable.
-	got, err := GetWallet(db, owner, staleAddr.Hex())
+	got, err := GetWallet(db, int64(1), owner, staleAddr.Hex())
 	require.NoError(t, err)
 	assert.True(t, got.StaleDerivation)
 	assert.True(t, got.IsHidden)
@@ -114,9 +114,9 @@ func TestStoreWallet_MissingFactorySkipsSecondaryIndex(t *testing.T) {
 		Address: &addr,
 		Salt:    big.NewInt(0),
 	}
-	require.NoError(t, StoreWallet(db, owner, legacy))
+	require.NoError(t, StoreWallet(db, int64(1), owner, legacy))
 
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.Equal(t, addr.Hex(), got.Address.Hex())
 
@@ -135,7 +135,7 @@ func TestLookupCanonicalWalletAddress_NotFound(t *testing.T) {
 	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
 
-	_, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	_, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	assert.ErrorIs(t, err, badger.ErrKeyNotFound)
 }
 
@@ -146,11 +146,11 @@ func TestMarkWalletStale_FlipsFlagsAndPreservesIndex(t *testing.T) {
 	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
 	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, addr, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, addr, 0)))
 
-	require.NoError(t, MarkWalletStale(db, owner, addr.Hex()))
+	require.NoError(t, MarkWalletStale(db, int64(1), owner, addr.Hex()))
 
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.True(t, got.StaleDerivation)
 	assert.True(t, got.IsHidden)
@@ -158,7 +158,7 @@ func TestMarkWalletStale_FlipsFlagsAndPreservesIndex(t *testing.T) {
 	// The secondary index was written before the wallet was marked
 	// stale, and MarkWalletStale must not erase it (a future fresh
 	// derivation will overwrite it via StoreWallet).
-	indexed, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	indexed, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(indexed.Hex(), addr.Hex()))
 }
@@ -172,6 +172,7 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 
 	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = int64(1)
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
@@ -180,10 +181,10 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	// Era 1: store the wallet that was canonical when the factory
 	// implementation produced this address.
 	era1 := common.HexToAddress("0x5d814Cc9E94B2656f59Ee439D44AA1b6ca21434f")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, era1, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, era1, 0)))
 
 	// Sanity: the index points at era1.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era1.Hex()))
 
@@ -191,10 +192,10 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	// a different address.
 	era2 := common.HexToAddress("0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e")
 
-	engine.markPreviousCanonicalStaleIfAny(owner, factory, big.NewInt(0), era2)
+	engine.markPreviousCanonicalStaleIfAny(int64(1), owner, factory, big.NewInt(0), era2)
 
 	// era1 must now be marked stale.
-	got, err := GetWallet(db, owner, era1.Hex())
+	got, err := GetWallet(db, int64(1), owner, era1.Hex())
 	require.NoError(t, err)
 	assert.True(t, got.StaleDerivation, "era1 wallet should be flagged as stale")
 	assert.True(t, got.IsHidden, "era1 wallet should be force-hidden")
@@ -202,15 +203,15 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	// And the secondary index still points at era1 — until the caller
 	// follows up with StoreWallet on the era2 wallet, which is what
 	// the production GetWallet path does immediately after.
-	canonical, err = LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err = LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era1.Hex()),
 		"index unchanged until the new canonical wallet is stored")
 
 	// Now simulate the StoreWallet that would follow in GetWallet's
 	// not-found branch and verify the index flips to era2.
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, era2, 0)))
-	canonical, err = LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, era2, 0)))
+	canonical, err = LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era2.Hex()),
 		"index should now point at the new canonical wallet")
@@ -221,17 +222,18 @@ func TestMarkPreviousCanonicalStaleIfAny_NoOpWhenIndexMatches(t *testing.T) {
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 
 	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = int64(1)
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
 	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, addr, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, addr, 0)))
 
 	// Same address — no upgrade detected, nothing to mark stale.
-	engine.markPreviousCanonicalStaleIfAny(owner, factory, big.NewInt(0), addr)
+	engine.markPreviousCanonicalStaleIfAny(int64(1), owner, factory, big.NewInt(0), addr)
 
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.False(t, got.StaleDerivation)
 	assert.False(t, got.IsHidden)
@@ -242,6 +244,7 @@ func TestListWallets_HardFiltersStaleRows(t *testing.T) {
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 
 	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = int64(1)
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
@@ -251,11 +254,11 @@ func TestListWallets_HardFiltersStaleRows(t *testing.T) {
 	// it disappears from the list response entirely.
 	a := common.HexToAddress("0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa")
 	b := common.HexToAddress("0xBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbb")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, a, 100)))
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, b, 101)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, a, 100)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, b, 101)))
 
 	// Flag b as stale.
-	require.NoError(t, MarkWalletStale(db, owner, b.Hex()))
+	require.NoError(t, MarkWalletStale(db, int64(1), owner, b.Hex()))
 
 	resp, err := engine.ListWallets(owner, &avsproto.ListWalletReq{})
 	require.NoError(t, err)
@@ -321,12 +324,12 @@ func TestBackfillWalletSaltIndex_AllCanonical(t *testing.T) {
 	w := mkWallet(owner, factory, addr, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, addr.Hex())), body))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, addr.Hex())), body))
 
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), addr)
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Total)
 	assert.Equal(t, 1, stats.CanonicalConfirmed)
@@ -334,7 +337,7 @@ func TestBackfillWalletSaltIndex_AllCanonical(t *testing.T) {
 	assert.Equal(t, 0, stats.NewlyMarkedStale)
 
 	// And the secondary index now exists.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), addr.Hex()))
 }
@@ -356,14 +359,14 @@ func TestBackfillWalletSaltIndex_DetectsAndMarksStale(t *testing.T) {
 		w := mkWallet(owner, factory, addr, 0)
 		body, err := w.ToJSON()
 		require.NoError(t, err)
-		require.NoError(t, db.Set([]byte(WalletStorageKey(owner, addr.Hex())), body))
+		require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, addr.Hex())), body))
 	}
 
 	// Simulate today's factory implementation: salt 0 derives to era3.
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), era3)
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, stats.Total)
 	assert.Equal(t, 1, stats.CanonicalConfirmed, "only the era3 row matches the live derivation")
@@ -372,18 +375,18 @@ func TestBackfillWalletSaltIndex_DetectsAndMarksStale(t *testing.T) {
 
 	// era1 and era2 are now stale.
 	for _, addr := range []common.Address{era1, era2} {
-		got, gerr := GetWallet(db, owner, addr.Hex())
+		got, gerr := GetWallet(db, int64(1), owner, addr.Hex())
 		require.NoError(t, gerr)
 		assert.True(t, got.StaleDerivation, "%s should be stale", addr.Hex())
 		assert.True(t, got.IsHidden, "%s should be hidden", addr.Hex())
 	}
 	// era3 is still canonical.
-	got, err := GetWallet(db, owner, era3.Hex())
+	got, err := GetWallet(db, int64(1), owner, era3.Hex())
 	require.NoError(t, err)
 	assert.False(t, got.StaleDerivation)
 
 	// Secondary index points at era3.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era3.Hex()))
 }
@@ -402,23 +405,23 @@ func TestBackfillWalletSaltIndex_DryRunWritesNothing(t *testing.T) {
 	w := mkWallet(owner, factory, stored, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, stored.Hex())), body))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, stored.Hex())), body))
 
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), live)
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{DryRun: true})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{DryRun: true})
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.NewlyMarkedStale, "dry-run should still report what it would do")
 
 	// But the actual record is unchanged.
-	got, err := GetWallet(db, owner, stored.Hex())
+	got, err := GetWallet(db, int64(1), owner, stored.Hex())
 	require.NoError(t, err)
 	assert.False(t, got.StaleDerivation, "dry-run must not flip the stale flag")
 	assert.False(t, got.IsHidden)
 
 	// And no secondary index entry was written.
-	_, err = LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	_, err = LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	assert.ErrorIs(t, err, badger.ErrKeyNotFound)
 }
 
@@ -435,7 +438,7 @@ func TestBackfillWalletSaltIndex_SkipsLegacyAndDeriveErrors(t *testing.T) {
 	legacy := &model.SmartWallet{Owner: &owner, Address: &legacyAddr, Salt: big.NewInt(0)}
 	legacyBody, err := legacy.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, legacyAddr.Hex())), legacyBody))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, legacyAddr.Hex())), legacyBody))
 
 	// 2. Row whose deriver returns an error — should be counted as
 	//    SkippedDeriveError.
@@ -443,12 +446,12 @@ func TestBackfillWalletSaltIndex_SkipsLegacyAndDeriveErrors(t *testing.T) {
 	errWallet := mkWallet(owner, factory, errAddr, 7)
 	errBody, err := errWallet.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, errAddr.Hex())), errBody))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, errAddr.Hex())), errBody))
 
 	deriver := newFakeDeriver()
 	deriver.errors[deriver.key(owner, factory, big.NewInt(7))] = assertAnError{}
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, stats.Total)
 	assert.Equal(t, 1, stats.SkippedMissingFactory)
@@ -577,7 +580,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnSetError(t *testing.T) {
 	w := mkWallet(owner, factory, addr, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, inner.Set([]byte(WalletStorageKey(owner, addr.Hex())), body))
+	require.NoError(t, inner.Set([]byte(WalletStorageKey(int64(1), owner, addr.Hex())), body))
 
 	// Wrap the DB so the next Set() (the secondary index write) fails.
 	wrapped := &closingDB{Storage: inner, successesAllowed: 0}
@@ -585,7 +588,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnSetError(t *testing.T) {
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), addr) // canonical match
 
-	stats, err := BackfillWalletSaltIndex(wrapped, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(wrapped, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.Error(t, err, "BackfillWalletSaltIndex must surface storage errors instead of swallowing them")
 	assert.Contains(t, err.Error(), "write secondary index")
 	require.NotNil(t, stats, "stats should still be returned alongside the error for diagnostics")
@@ -603,7 +606,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnMarkStaleError(t *testing.T) {
 	w := mkWallet(owner, factory, stored, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, inner.Set([]byte(WalletStorageKey(owner, stored.Hex())), body))
+	require.NoError(t, inner.Set([]byte(WalletStorageKey(int64(1), owner, stored.Hex())), body))
 
 	// MarkWalletStale calls StoreWallet which calls db.Set (since the
 	// stale wallet is not eligible for the secondary index batch path).
@@ -614,7 +617,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnMarkStaleError(t *testing.T) {
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), live) // mismatch -> stale path
 
-	stats, err := BackfillWalletSaltIndex(wrapped, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(wrapped, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.Error(t, err, "BackfillWalletSaltIndex must surface MarkWalletStale errors")
 	assert.Contains(t, err.Error(), "mark wallet stale")
 	require.NotNil(t, stats)

--- a/core/testutil/utils.go
+++ b/core/testutil/utils.go
@@ -478,6 +478,13 @@ func GetAggregatorConfig() *config.Config {
 
 	return &config.Config{
 		SmartWallet: &config.SmartWalletConfig{
+			// ChainID = 1 is the test default. Many tests construct
+			// storage keys manually via StoreWallet(db, int64(1), ...)
+			// alongside engine-mediated calls; both paths must agree on
+			// the chain segment of the chain-scoped key, so we pin the
+			// engine's defaultChainID() to 1 here. Tests that exercise
+			// multi-chain behavior override this on the returned config.
+			ChainID:            1,
 			EthRpcUrl:          GetTestRPCURL(),
 			EthWsUrl:           GetTestWsRPCURL(),
 			FactoryAddress:     common.HexToAddress(GetTestFactoryAddress()),

--- a/scripts/migration/backfill_wallet_salt_index/main.go
+++ b/scripts/migration/backfill_wallet_salt_index/main.go
@@ -49,12 +49,18 @@ type aggregatorYAML struct {
 
 func main() {
 	configPath := flag.String("config", "", "Path to aggregator YAML config (e.g. config/aggregator-base.yaml)")
+	chainID := flag.Int64("chain-id", 0, "Chain ID to backfill. Required. Wallet keys are chain-scoped; run once per chain (e.g. 1, 8453, 11155111, 84532).")
 	dryRun := flag.Bool("dry-run", false, "Print what would change without writing to BadgerDB")
 	verbose := flag.Bool("verbose", false, "Print one line per wallet processed")
 	flag.Parse()
 
 	if *configPath == "" {
 		fmt.Fprintln(os.Stderr, "--config is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *chainID <= 0 {
+		fmt.Fprintln(os.Stderr, "--chain-id is required")
 		flag.Usage()
 		os.Exit(2)
 	}
@@ -71,6 +77,7 @@ func main() {
 	}
 
 	fmt.Printf("Config:        %s\n", *configPath)
+	fmt.Printf("Chain ID:      %d\n", *chainID)
 	fmt.Printf("DB path:       %s\n", cfg.DbPath)
 	// Redact: RPC URLs from Tenderly/Alchemy/Infura embed API keys in
 	// the path or query — printing the raw URL leaks secrets to terminal
@@ -102,7 +109,7 @@ func main() {
 		return *addr, nil
 	}
 
-	stats, err := taskengine.BackfillWalletSaltIndex(db, deriver, taskengine.WalletSaltIndexBackfillOptions{
+	stats, err := taskengine.BackfillWalletSaltIndex(db, *chainID, deriver, taskengine.WalletSaltIndexBackfillOptions{
 		DryRun:  *dryRun,
 		Verbose: *verbose,
 		Logf: func(format string, args ...any) {


### PR DESCRIPTION
## Why

After [PR #542](https://github.com/AvaProtocol/EigenLayer-AVS/pull/542) added the Hetzner → Railway merge tool, the gateway's read paths needed to learn the new chain-scoped key formats for `w:` / `wsalt:` / `fl:` / `fr:`. Otherwise the merge runs cleanly but the gateway can't see any of the data it just received.

This PR is the read-path side of that change, plus the matching writer-side updates so new gateway data is also chain-scoped going forward.

## Key format changes

All four families gain a `<chainID>` segment:

| Family | Before | After |
|---|---|---|
| `w:` | `w:<owner>:<wallet>` | `w:<chainID>:<owner>:<wallet>` |
| `wsalt:` | `wsalt:<owner>:<factory>:<salt>` | `wsalt:<chainID>:<owner>:<factory>:<salt>` |
| `fl:` | `fl:<owner>` | `fl:<chainID>:<owner>` |
| `fr:` | `fr:<owner>:<execID>` | `fr:<chainID>:<owner>:<execID>` |

`fl:` is now **per-chain** instead of cross-chain aggregate. Each chain settles its own value-fee balance for an owner.

## No backwards-compatibility shim

Per signoff: the Railway gateway has no meaningful user data yet, so existing chain-implicit keys are not migrated. Every read/write goes through the chain-scoped helpers cleanly. The merge tool brings the only real data forward already in chain-scoped form.

## What it touches (32 files)

**Production**
- [`core/taskengine/schema.go`](../blob/feat/gateway-chain-scoped-readers/core/taskengine/schema.go) — `GetWallet`, `StoreWallet`, `MarkWalletStale`, `LookupCanonicalWalletAddress`, `IsWalletHidden`, `SetWalletHiddenStatus`, `WalletStorageKey`, `WalletByOwnerPrefix`, `WalletBySaltKey`, `FeeLedgerKey`, `FeeRecordKey`, `FeeRecordPrefix` all take `chainID` as first storage param. Redundant `ChainWalletStorageKey` / `ChainWalletByOwnerPrefix` removed.
- [`core/taskengine/fee_ledger.go`](../blob/feat/gateway-chain-scoped-readers/core/taskengine/fee_ledger.go) — `GetOutstandingBalance(chainID, owner)`, `CheckCreditLimit(chainID, owner, limit)`, `getLedgerEntry(chainID, owner)`. `RecordValueFee(record)` keeps its signature but now requires `record.ChainID` to be non-zero.
- [`core/taskengine/engine.go`](../blob/feat/gateway-chain-scoped-readers/core/taskengine/engine.go) — wallet RPC handlers resolve `chainID` via `n.defaultChainID()` (see "out of scope" below). New `Engine.userOwnsWalletOnAnyChain(user, wallet)` helper for multi-chain ownership checks in `ListWorkflowsByUser` and the workflow-count path. **Important fix**: `CreateWorkflow` now resolves `task.ChainId` default BEFORE `ValidWalletOwner` — previously the wallet-ownership check ran with `task.ChainId == 0` and missed canonical `w:<chainID>:...` keys.
- [`core/taskengine/validation.go`](../blob/feat/gateway-chain-scoped-readers/core/taskengine/validation.go), [`core/taskengine/executor.go`](../blob/feat/gateway-chain-scoped-readers/core/taskengine/executor.go), [`core/taskengine/vm.go`](../blob/feat/gateway-chain-scoped-readers/core/taskengine/vm.go) — thread `task.ChainId` through.

**Migration tools**
- [`core/taskengine/migrate_wallet_salt_index.go`](../blob/feat/gateway-chain-scoped-readers/core/taskengine/migrate_wallet_salt_index.go) — `BackfillWalletSaltIndex(db, chainID, deriver, opts)` iterates one chain at a time.
- [`cmd/backfillWalletSaltIndex.go`](../blob/feat/gateway-chain-scoped-readers/cmd/backfillWalletSaltIndex.go) + [`scripts/migration/backfill_wallet_salt_index/main.go`](../blob/feat/gateway-chain-scoped-readers/scripts/migration/backfill_wallet_salt_index/main.go) gain required `--chain-id` flag. Operator runs once per chain post-merge.

**Test infrastructure**
- [`core/testutil/utils.go`](../blob/feat/gateway-chain-scoped-readers/core/testutil/utils.go) — pins `SmartWallet.ChainID = 1` so engine `defaultChainID()` matches the `int64(1)` used in direct test helper calls.
- 25 test files updated (mechanical: pass `int64(1)` to renamed helpers + set `ChainId: int64(1)` on `model.Workflow` literals where missing).

## Out of scope (separate work)

1. **Add `chain_id` to `ListWalletReq` / `GetWalletReq` / `SetWalletReq` proto messages**, then thread it from REST/gRPC layer (JWT audience). Today these handlers serve only the gateway's primary chain via `n.defaultChainID()`. Multi-chain wallet enumeration needs the proto field first. Documented in code comments on each handler.
2. **One-time backfill migration** of any pre-existing chain-implicit gateway data — not needed since the gateway has no meaningful data yet.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Full `core/taskengine/` test suite passes — 236.7s, all subtests green
- [x] Targeted regression sanity: `TestFeeBilling_CreditGating_*`, `TestGetExecutionStatus_*`, `TestTaskStatCount`, `TestListWallets*`, `TestMarkPreviousCanonicalStaleIfAny_*`, `TestBackfillWalletSaltIndex` all pass
- [ ] CI passes
- [ ] After merge: rehearse the merge tool dry-run against scratch donor + scratch gateway DB to confirm the gateway can now READ everything the merge writes

## Related

- [PR #542](https://github.com/AvaProtocol/EigenLayer-AVS/pull/542) — the merge tool whose output this PR makes readable.
- [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md) — policy matrix.
