### PR TITLE
feat: chain-scoped gateway storage + Hetzner→Railway migration pipeline + env-var hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ config/*.yaml
 !config/operator.example.yaml
 !config/*-dev.yaml
 !config/*-railway.yaml
+!config/*-rehearsal.yaml
 # Snapshot of tracked configs taken before any restructure; safety net.
 !config/_legacy/
 !config/_legacy/*.yaml
@@ -77,3 +78,13 @@ EigenLayer-AVS
 
 # VS Code workspace files
 *.code-workspace
+# Hetzner donor snapshots + rehearsal scratch gateway DB (local only)
+donors/
+tmp/rehearsal-gateway-db/
+tmp/rehearsal-gateway-backup/
+# Stale build artifacts at repo root from manual go run
+/dev
+/merge_hetzner_into_gateway
+
+# Local Claude Code agent state (session locks, project-local skills, etc.)
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -294,3 +294,44 @@ dev-stack: build
 ## clean: cleanup storage data
 clean:
 	rm -rf /tmp/ap-avs /tmp/ap.sock
+
+## hetzner-snapshot: pull fresh BadgerDB tarballs from each Hetzner aggregator
+##                   into ./donors/<chain>/db/. Brief docker-stop per chain.
+##                   Pass CHAIN=sepolia (etc.) to limit scope.
+.PHONY: hetzner-snapshot
+hetzner-snapshot:
+	@scripts/dev/snapshot-hetzner-donors.sh $(CHAIN)
+
+## migration-rehearse: run the Hetzner->gateway merge tool sequentially
+##                     against each donor in ./donors/, default dry-run.
+##                     Pass APPLY=1 to actually write to the scratch
+##                     gateway DB at /tmp/rehearsal-gateway-db.
+##                     Pass CHAIN=sepolia (etc.) to limit scope.
+.PHONY: migration-rehearse
+migration-rehearse:
+	@scripts/dev/run-merge-rehearsal.sh $(if $(APPLY),--apply) $(CHAIN)
+
+## dev-stack-rehearsal: start the dev gateway against the post-merge
+##                      scratch DB at /tmp/rehearsal-gateway-db. Use
+##                      after `make migration-rehearse APPLY=1` to
+##                      validate read-path queries via the SDK.
+.PHONY: dev-stack-rehearsal
+dev-stack-rehearsal: build
+	@mkdir -p logs
+	@echo "🚀 Starting rehearsal gateway against /tmp/rehearsal-gateway-db"
+	@echo "   gateway      → REST :8080, gRPC :2206  (logs/gateway-rehearsal.log)"
+	@echo "   worker:sep   → gRPC :50051            (logs/worker-sepolia.log)"
+	@echo "   worker:bsep  → gRPC :50052            (logs/worker-base-sepolia.log)"
+	@echo ""
+	@echo "   Validate with the ava-sdk-js CLI:"
+	@echo "     cd ../ava-sdk-js/examples"
+	@echo "     yarn start listWorkflows           # expect post-merge workflow count"
+	@echo "     yarn start getWorkflow <task_id>   # ground-truth single-task fetch"
+	@echo ""
+	@set -m; \
+		trap 'echo; echo "🛑 Stopping rehearsal stack..."; kill 0 2>/dev/null; exit 0' INT TERM; \
+		./out/ap worker --config=config/worker-sepolia-dev.yaml      > logs/worker-sepolia.log      2>&1 & \
+		./out/ap worker --config=config/worker-base-sepolia-dev.yaml > logs/worker-base-sepolia.log 2>&1 & \
+		sleep 1; \
+		./out/ap aggregator --config=config/gateway-dev-rehearsal.yaml > logs/gateway-rehearsal.log 2>&1 & \
+		wait

--- a/aggregator/chain_registry.go
+++ b/aggregator/chain_registry.go
@@ -25,27 +25,38 @@ type ChainEntry struct {
 	// ethclient for direct on-chain reads (e.g. ERC-20 balance checks in
 	// the withdraw flow) — not every operation rides through the worker
 	// gRPC channel.
-	rpcOnce sync.Once
-	rpc     *ethclient.Client
-	rpcErr  error
+	//
+	// rpcMu serializes the dial; once `rpc` is non-nil, GetRPC returns it
+	// without taking the lock-critical-section path. Dial failures are NOT
+	// cached: a transient error (RPC node briefly unreachable) leaves
+	// `rpc` nil so the next call retries, instead of permanently disabling
+	// the chain until a full gateway restart. This replaces a prior
+	// sync.Once that pinned the first error forever.
+	rpcMu sync.Mutex
+	rpc   *ethclient.Client
 }
 
 // GetRPC returns a chain-specific ethclient for direct reads against
-// this chain's RPC. Dialed once and cached for the entry's lifetime.
+// this chain's RPC. Successful dials are cached; failed dials are retried
+// on the next call so transient errors don't permanently disable the chain.
 func (e *ChainEntry) GetRPC() (*ethclient.Client, error) {
-	e.rpcOnce.Do(func() {
-		if e.Config == nil || e.Config.SmartWallet == nil || e.Config.SmartWallet.EthRpcUrl == "" {
-			e.rpcErr = fmt.Errorf("chain %d has no eth_rpc_url configured", chainConfigID(e.Config))
-			return
-		}
-		client, err := ethclient.Dial(e.Config.SmartWallet.EthRpcUrl)
-		if err != nil {
-			e.rpcErr = fmt.Errorf("dial chain %d RPC: %w", chainConfigID(e.Config), err)
-			return
-		}
-		e.rpc = client
-	})
-	return e.rpc, e.rpcErr
+	e.rpcMu.Lock()
+	defer e.rpcMu.Unlock()
+
+	if e.rpc != nil {
+		return e.rpc, nil
+	}
+
+	if e.Config == nil || e.Config.SmartWallet == nil || e.Config.SmartWallet.EthRpcUrl == "" {
+		return nil, fmt.Errorf("chain %d has no eth_rpc_url configured", chainConfigID(e.Config))
+	}
+
+	client, err := ethclient.Dial(e.Config.SmartWallet.EthRpcUrl)
+	if err != nil {
+		return nil, fmt.Errorf("dial chain %d RPC: %w", chainConfigID(e.Config), err)
+	}
+	e.rpc = client
+	return e.rpc, nil
 }
 
 func chainConfigID(c *config.ChainConfig) int64 {
@@ -111,6 +122,13 @@ func (r *ChainRegistry) Connect(ctx context.Context) {
 // reconnectLoop periodically retries connections for workers that are not
 // yet connected. It stops when all workers are connected or the context
 // is cancelled (gateway shutdown).
+//
+// Note: since the switch from grpc.DialContext (blocking) to grpc.NewClient
+// (non-blocking), connectEntry never returns a transient error for a
+// reachable URL — it only fails if the URL itself is invalid. The loop now
+// typically runs once, sees all clients populated, and exits. Real worker
+// reconnections are handled by gRPC's internal connection state machine.
+// Kept here for the case of explicit URL-level errors that need re-attempt.
 func (r *ChainRegistry) reconnectLoop(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -151,18 +169,20 @@ func (r *ChainRegistry) reconnectLoop(ctx context.Context) {
 	}
 }
 
-func (r *ChainRegistry) connectEntry(ctx context.Context, entry *ChainEntry) error {
-	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	conn, err := grpc.DialContext(
-		dialCtx,
+// connectEntry creates a non-blocking gRPC client for the worker. The actual
+// TCP connection is established lazily on the first RPC; transient worker
+// outages are handled by gRPC's internal connection state machine. This
+// returns essentially instantly so it is safe to call while holding the
+// registry's write lock (previously this dialed synchronously with
+// grpc.WithBlock() and a 10s timeout, stalling all GetWorker callers
+// waiting on the RLock for up to 10s × number-of-chains on startup).
+func (r *ChainRegistry) connectEntry(_ context.Context, entry *ChainEntry) error {
+	conn, err := grpc.NewClient(
 		entry.Config.WorkerAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
 	)
 	if err != nil {
-		return fmt.Errorf("dialing %s: %w", entry.Config.WorkerAddr, err)
+		return fmt.Errorf("creating client for %s: %w", entry.Config.WorkerAddr, err)
 	}
 
 	entry.conn = conn

--- a/cmd/backfillWalletSaltIndex.go
+++ b/cmd/backfillWalletSaltIndex.go
@@ -17,6 +17,7 @@ import (
 var (
 	backfillWalletSaltIndexDryRun  bool
 	backfillWalletSaltIndexVerbose bool
+	backfillWalletSaltIndexChainID int64
 
 	backfillWalletSaltIndexCmd = &cobra.Command{
 		Use:   "backfill-wallet-salt-index",
@@ -58,10 +59,14 @@ Production usage (Docker):
 func init() {
 	backfillWalletSaltIndexCmd.Flags().BoolVar(&backfillWalletSaltIndexDryRun, "dry-run", false, "Print what would change without writing to BadgerDB")
 	backfillWalletSaltIndexCmd.Flags().BoolVar(&backfillWalletSaltIndexVerbose, "verbose", false, "Print one line per wallet processed")
+	backfillWalletSaltIndexCmd.Flags().Int64Var(&backfillWalletSaltIndexChainID, "chain-id", 0, "Chain ID to backfill. Required. Wallet keys are chain-scoped; run the command once per chain the gateway hosts (e.g. 1, 8453, 11155111, 84532).")
 	rootCmd.AddCommand(backfillWalletSaltIndexCmd)
 }
 
 func runBackfillWalletSaltIndex(configPath string) error {
+	if backfillWalletSaltIndexChainID <= 0 {
+		return fmt.Errorf("--chain-id is required (wallet keys are chain-scoped; pass the chain you want to backfill, e.g. 1, 8453, 11155111, 84532)")
+	}
 	nodeConfig, err := avsconfig.NewConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("parse config %s: %w", configPath, err)
@@ -74,6 +79,7 @@ func runBackfillWalletSaltIndex(configPath string) error {
 	}
 
 	fmt.Printf("Config:        %s\n", configPath)
+	fmt.Printf("Chain ID:      %d\n", backfillWalletSaltIndexChainID)
 	fmt.Printf("DB path:       %s\n", nodeConfig.DbPath)
 	// Redact: RPC URLs from Tenderly/Alchemy/Infura embed API keys in
 	// the path or query — printing the raw URL leaks secrets to terminal
@@ -105,7 +111,7 @@ func runBackfillWalletSaltIndex(configPath string) error {
 		return *addr, nil
 	}
 
-	stats, err := taskengine.BackfillWalletSaltIndex(db, deriver, taskengine.WalletSaltIndexBackfillOptions{
+	stats, err := taskengine.BackfillWalletSaltIndex(db, backfillWalletSaltIndexChainID, deriver, taskengine.WalletSaltIndexBackfillOptions{
 		DryRun:  backfillWalletSaltIndexDryRun,
 		Verbose: backfillWalletSaltIndexVerbose,
 		Logf: func(format string, args ...any) {

--- a/config/gateway-dev-rehearsal.yaml
+++ b/config/gateway-dev-rehearsal.yaml
@@ -1,0 +1,130 @@
+# Gateway configuration for the Hetzner -> Railway migration rehearsal.
+#
+# Differs from gateway-dev.yaml in two ways:
+#
+#  1. db_path points at ./tmp/rehearsal-gateway-db -- the scratch DB the
+#     merge tool populates via `make migration-rehearse APPLY=1`. Path is
+#     relative to the project root so it lives inside the repo workspace
+#     (already in .gitignore) and matches the script in
+#     scripts/dev/run-merge-rehearsal.sh. Keeping this separate from
+#     /tmp/ap-avs/gateway (the normal dev DB) means you can flip between
+#     the two stacks without clobbering either.
+#
+#  2. All four production chains (sepolia, base-sepolia, base, ethereum)
+#     are registered. After a full-suite merge, the gateway can serve
+#     read queries for tasks/executions/wallets/secrets on any of them
+#     via the SDK's listWorkflows / getWorkflow / getExecution / etc.
+#
+# Workers: only sepolia + base-sepolia run locally by default (see
+# `make dev-stack-rehearsal`). Mainnet workers are listed below but not
+# expected to be reachable -- the rehearsal validates the gateway's
+# READ-path against the merged DB, not UserOp execution against
+# mainnet (which would cost real ETH and isn't the purpose here).
+# Triggering a task on a chain with no live worker returns
+# WORKER_UNAVAILABLE; that's expected.
+#
+# CREDENTIALS: Every secret in this file is `${VAR}` -- exported by your
+# shell or supplied via a `.env` file you keep locally. Nothing real
+# lives in git. The rehearsal does NOT execute UserOps, so all
+# controller / bundler / paymaster references are inert (the gateway
+# probes the paymaster's owner() function at startup but never signs);
+# the values below can stay as test-only placeholders unless you also
+# want to drive trigger->worker flows on testnets. See
+# scripts/dev/README.md for the env-var checklist.
+environment: development
+
+db_path: ./tmp/rehearsal-gateway-db
+backup_dir: ./tmp/rehearsal-gateway-backup
+
+ecdsa_private_key: ${REHEARSAL_ECDSA_PRIVATE_KEY}
+
+# EigenLayer contracts live on Sepolia (the AVS registration chain)
+eth_rpc_url: ${REHEARSAL_AVS_RPC}
+eth_ws_url: ${REHEARSAL_AVS_WS}
+
+# Top-level smart_wallet is required by the aa package + startup probes
+# even in gateway mode. Mirrors the AVS chain (sepolia) below.
+smart_wallet:
+  eth_rpc_url: ${REHEARSAL_SEPOLIA_RPC}
+  eth_ws_url: ${REHEARSAL_SEPOLIA_WS}
+  bundler_url: ${REHEARSAL_SEPOLIA_BUNDLER_URL}
+  controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+  paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
+  max_wallets_per_owner: 2000
+
+rpc_bind_address: "0.0.0.0:2206"
+http_bind_address: "0.0.0.0:8080"
+
+avs_registry_coordinator_address: 0xcA95381802FD1398d5BF2D01243210cFb3a2b3BD
+operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
+
+jwt_secret: ${REHEARSAL_JWT_SECRET}
+
+rest_rate_limit_per_second: 200
+rest_rate_limit_burst: 1000
+
+server_name: "gateway-dev-rehearsal"
+sentry_dsn: ""  # rehearsal traffic shouldn't pollute Sentry
+
+tenderly_account: "chrisli"
+tenderly_project: "default"
+tenderly_access_key: ${REHEARSAL_TENDERLY_ACCESS_KEY}
+
+chains:
+  - chain_id: 11155111
+    name: sepolia
+    worker_addr: "127.0.0.1:50051"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_SEPOLIA_RPC}
+      eth_ws_url: ${REHEARSAL_SEPOLIA_WS}
+      bundler_url: ${REHEARSAL_SEPOLIA_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
+      max_wallets_per_owner: 2000
+
+  - chain_id: 84532
+    name: base-sepolia
+    worker_addr: "127.0.0.1:50052"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_BASE_SEPOLIA_RPC}
+      eth_ws_url: ${REHEARSAL_BASE_SEPOLIA_WS}
+      bundler_url: ${REHEARSAL_BASE_SEPOLIA_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
+      max_wallets_per_owner: 3
+
+  # Mainnet chains. Use the per-chain paymaster from docs/Contract.md
+  # (0xf023eA...19D6f is the mainnet paymaster; the testnet
+  # 0xd856f...d92 has no bytecode on either mainnet).
+  - chain_id: 1
+    name: ethereum
+    worker_addr: "127.0.0.1:50053"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_ETHEREUM_RPC}
+      eth_ws_url: ${REHEARSAL_ETHEREUM_WS}
+      bundler_url: ${REHEARSAL_ETHEREUM_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f
+      max_wallets_per_owner: 3
+
+  - chain_id: 8453
+    name: base
+    worker_addr: "127.0.0.1:50054"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_BASE_RPC}
+      eth_ws_url: ${REHEARSAL_BASE_WS}
+      bundler_url: ${REHEARSAL_BASE_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f
+      max_wallets_per_owner: 3
+
+macros:
+  secrets:
+    ap_notify_bot_token: ${REHEARSAL_TELEGRAM_BOT_TOKEN}
+    sendgrid_key: ""
+    thegraph_api_key: ${REHEARSAL_THEGRAPH_API_KEY}
+    moralis_api_key: ${REHEARSAL_MORALIS_API_KEY}
+
+notifications:
+  summary:
+    enabled: false  # rehearsal must not send real notifications

--- a/config/gateway-railway.yaml
+++ b/config/gateway-railway.yaml
@@ -17,11 +17,15 @@
 #       variables so the topology auto-resolves and survives service
 #       renames, e.g.:
 #         WORKER_ETHEREUM = ${{worker-ethereum.RAILWAY_PRIVATE_DOMAIN}}:50051
-#   ETHEREUM_DWELLIR_RPC / ETHEREUM_DWELLIR_WS  — AVS chain RPC
-#   SEPOLIA_DWELLIR_RPC  / SEPOLIA_DWELLIR_WS   — sepolia chain RPC
-#   BASE_DWELLIR_RPC     / BASE_DWELLIR_WS
-#   BASE_SEPOLIA_DWELLIR_RPC / BASE_SEPOLIA_DWELLIR_WS
-#   BNB_DWELLIR_RPC      / BNB_DWELLIR_WS       — BNB Smart Chain mainnet
+#   ETHEREUM_RPC          — Ethereum mainnet HTTPS RPC (WS derived in code)
+#   SEPOLIA_RPC           — Sepolia HTTPS RPC
+#   BASE_RPC              — Base mainnet HTTPS RPC
+#   BASE_SEPOLIA_RPC      — Base-Sepolia HTTPS RPC
+#   BNB_RPC               — BNB Smart Chain mainnet HTTPS RPC
+# (WebSocket URLs are auto-derived from the HTTPS URL by core/config —
+# every supported provider serves both transports at the same host+path
+# with only the scheme differing. Set the explicit eth_ws_url in the
+# YAML only if a chain genuinely needs a separate WS endpoint.)
 #   ETHEREUM_BUNDLER_URL, SEPOLIA_BUNDLER_URL,
 #   BASE_BUNDLER_URL,     BASE_SEPOLIA_BUNDLER_URL
 #   BNB_BUNDLER_URL      — optional; connectivity-only rollout leaves it unset
@@ -43,8 +47,7 @@ ecdsa_private_key: ${GATEWAY_ECDSA_PRIVATE_KEY}
 # disabled, so one gateway can serve operators from any AVS chain. We
 # point this at Sepolia AVS to match the existing testnet operator;
 # flip to Ethereum mainnet AVS when enforceAuth is turned on.
-eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+eth_rpc_url: ${SEPOLIA_RPC}
 
 rpc_bind_address: "0.0.0.0:2206"
 http_bind_address: "0.0.0.0:8080"
@@ -82,8 +85,7 @@ tenderly_access_key: ${TENDERLY_ACCESS_KEY}
 # execution still routes via chains[] below — the top-level only
 # matters for package-globals + tooling.
 smart_wallet:
-  eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-  eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+  eth_rpc_url: ${SEPOLIA_RPC}
   bundler_url: ${SEPOLIA_BUNDLER_URL}
   controller_private_key: ${CONTROLLER_PRIVATE_KEY}
   paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
@@ -102,8 +104,7 @@ chains:
     name: ethereum
     worker_addr: ${WORKER_ETHEREUM}
     smart_wallet:
-      eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-      eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+      eth_rpc_url: ${ETHEREUM_RPC}
       bundler_url: ${ETHEREUM_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_MAINNET}
@@ -116,8 +117,7 @@ chains:
     name: base
     worker_addr: ${WORKER_BASE}
     smart_wallet:
-      eth_rpc_url: ${BASE_DWELLIR_RPC}
-      eth_ws_url: ${BASE_DWELLIR_WS}
+      eth_rpc_url: ${BASE_RPC}
       bundler_url: ${BASE_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_MAINNET}
@@ -128,8 +128,7 @@ chains:
     name: sepolia
     worker_addr: ${WORKER_SEPOLIA}
     smart_wallet:
-      eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-      eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+      eth_rpc_url: ${SEPOLIA_RPC}
       bundler_url: ${SEPOLIA_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
@@ -139,8 +138,7 @@ chains:
     name: base-sepolia
     worker_addr: ${WORKER_BASE_SEPOLIA}
     smart_wallet:
-      eth_rpc_url: ${BASE_SEPOLIA_DWELLIR_RPC}
-      eth_ws_url: ${BASE_SEPOLIA_DWELLIR_WS}
+      eth_rpc_url: ${BASE_SEPOLIA_RPC}
       bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
@@ -156,8 +154,7 @@ chains:
     name: bnb-mainnet
     worker_addr: ${WORKER_BNB}
     smart_wallet:
-      eth_rpc_url: ${BNB_DWELLIR_RPC}
-      eth_ws_url: ${BNB_DWELLIR_WS}
+      eth_rpc_url: ${BNB_RPC}
       bundler_url: ${BNB_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}

--- a/config/operator-ethereum-railway.yaml
+++ b/config/operator-ethereum-railway.yaml
@@ -4,7 +4,7 @@
 # layout but points at the Railway gateway over private networking.
 # Secrets are injected via Railway sealed environment variables — set
 # these on the `operator-ethereum` service:
-#   ETHEREUM_DWELLIR_RPC, ETHEREUM_DWELLIR_WS
+#   ETHEREUM_RPC (HTTPS; WS derived in code)
 #   ECDSA_KEY_JSON, BLS_KEY_JSON  (operator-entrypoint.sh writes these
 #                                   to /app/keys/ at startup)
 #   OPERATOR_BLS_KEY_PASSWORD, OPERATOR_ECDSA_KEY_PASSWORD
@@ -17,8 +17,7 @@ avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
 operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
 # EigenLayer chain RPC (Ethereum mainnet)
-eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+eth_rpc_url: ${ETHEREUM_RPC}
 
 # Key files — written at startup by scripts/operator-entrypoint.sh
 ecdsa_private_key_store_path: /app/keys/ecdsa.key.json
@@ -46,8 +45,7 @@ server_name: "operator-ethereum-railway"
 
 # Destination chain — Ethereum mainnet
 target_chain:
-  eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-  eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+  eth_rpc_url: ${ETHEREUM_RPC}
 
 enabled_features:
   event_trigger: true

--- a/config/operator-railway.yaml
+++ b/config/operator-railway.yaml
@@ -10,9 +10,8 @@ operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
 
 # EigenLayer chain RPC (Sepolia) — driven by env var so the key can
 # be rotated without redeploying. Set on the operator service:
-#   SEPOLIA_DWELLIR_RPC, SEPOLIA_DWELLIR_WS
-eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+#   SEPOLIA_RPC (HTTPS; WS derived in code)
+eth_rpc_url: ${SEPOLIA_RPC}
 
 # Key files — written at startup by scripts/operator-entrypoint.sh
 # Set ECDSA_KEY_JSON and BLS_KEY_JSON env vars in Railway
@@ -41,8 +40,7 @@ server_name: "operator-railway"
 
 # Destination chain - Sepolia
 target_chain:
-  eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-  eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+  eth_rpc_url: ${SEPOLIA_RPC}
 
 enabled_features:
   event_trigger: true

--- a/config/worker-base-railway.yaml
+++ b/config/worker-base-railway.yaml
@@ -3,7 +3,7 @@
 # Secrets are injected via Railway sealed environment variables and
 # expanded at startup (see core/config.ReadYamlConfig). Set these on
 # the `worker-base` Railway service:
-#   BASE_DWELLIR_RPC, BASE_DWELLIR_WS
+#   BASE_RPC (HTTPS; WS derived in code)
 #   BASE_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -24,8 +24,7 @@ health_address: "0.0.0.0:8080"
 # dials in. Workers only listen on `listen_address`.
 
 # Chain RPC endpoints (Base mainnet)
-eth_rpc_url: ${BASE_DWELLIR_RPC}
-eth_ws_url: ${BASE_DWELLIR_WS}
+eth_rpc_url: ${BASE_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${BASE_BUNDLER_URL}

--- a/config/worker-base-sepolia-railway.yaml
+++ b/config/worker-base-sepolia-railway.yaml
@@ -2,7 +2,7 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-base-sepolia` service:
-#   BASE_SEPOLIA_DWELLIR_RPC, BASE_SEPOLIA_DWELLIR_WS
+#   BASE_SEPOLIA_RPC (HTTPS; WS derived in code)
 #   BASE_SEPOLIA_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -22,8 +22,7 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints (Base Sepolia)
-eth_rpc_url: ${BASE_SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${BASE_SEPOLIA_DWELLIR_WS}
+eth_rpc_url: ${BASE_SEPOLIA_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}

--- a/config/worker-bnb-mainnet-railway.yaml
+++ b/config/worker-bnb-mainnet-railway.yaml
@@ -11,7 +11,7 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-bnb-mainnet` service:
-#   BNB_DWELLIR_RPC, BNB_DWELLIR_WS
+#   BNB_RPC (HTTPS; WS derived in code)
 #   BNB_BUNDLER_URL          — optional for connectivity-only; can be
 #                              left unset (the YAML expansion will
 #                              produce an empty string and bundler
@@ -35,8 +35,7 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints
-eth_rpc_url: ${BNB_DWELLIR_RPC}
-eth_ws_url: ${BNB_DWELLIR_WS}
+eth_rpc_url: ${BNB_RPC}
 
 # Bundler — left as an env var expansion. Unset in connectivity-only
 # mode; populate once a 4337 bundler provider with BNB support is in

--- a/config/worker-ethereum-railway.yaml
+++ b/config/worker-ethereum-railway.yaml
@@ -3,7 +3,7 @@
 # Secrets are injected via Railway sealed environment variables and
 # expanded at startup (see core/config.ReadYamlConfig). Set these on
 # the `worker-ethereum` Railway service:
-#   ETHEREUM_DWELLIR_RPC, ETHEREUM_DWELLIR_WS
+#   ETHEREUM_RPC (HTTPS; WS derived in code)
 #   ETHEREUM_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -24,8 +24,7 @@ health_address: "0.0.0.0:8080"
 # and dials in. Workers only listen on `listen_address`.
 
 # Chain RPC endpoints (Ethereum mainnet)
-eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+eth_rpc_url: ${ETHEREUM_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${ETHEREUM_BUNDLER_URL}

--- a/config/worker-sepolia-railway.yaml
+++ b/config/worker-sepolia-railway.yaml
@@ -2,7 +2,7 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-sepolia` service:
-#   SEPOLIA_DWELLIR_RPC, SEPOLIA_DWELLIR_WS
+#   SEPOLIA_RPC (HTTPS; WS derived in code)
 #   SEPOLIA_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -22,8 +22,7 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints
-eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+eth_rpc_url: ${SEPOLIA_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${SEPOLIA_BUNDLER_URL}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -332,6 +332,21 @@ func NewConfig(configFilePath string) (*Config, error) {
 		}
 	}
 
+	// Derive eth_ws_url from eth_rpc_url when not explicitly set. Both
+	// endpoints typically live at the same host+path on every supported
+	// provider (Dwellir, Tenderly, Alchemy, …) — only the scheme
+	// differs. Letting one URL drive both halves the number of env
+	// vars an operator has to keep in sync and avoids the easy mistake
+	// of rotating one without the other. An explicit eth_ws_url still
+	// wins when set, for the rare case where the WS endpoint really
+	// is a separate URL.
+	if configRaw.EthWsUrl == "" {
+		configRaw.EthWsUrl = DeriveWsURL(configRaw.EthRpcUrl)
+	}
+	if configRaw.SmartWallet.EthWsUrl == "" {
+		configRaw.SmartWallet.EthWsUrl = DeriveWsURL(configRaw.SmartWallet.EthRpcUrl)
+	}
+
 	// Only create WebSocket client if URL is provided
 	var ethWsClient *eth.InstrumentedClient
 	if configRaw.EthWsUrl != "" {
@@ -602,6 +617,40 @@ func newLogger(env sdklogging.LogLevel, serviceName string) (sdklogging.Logger, 
 	return pkglogger.NewSentryLogger(zapLogger, serviceName), nil
 }
 
+// DeriveWsURL turns an HTTP(S) RPC URL into the equivalent WebSocket URL
+// by flipping the scheme. Returns "" when given "" (so callers can use
+// it unconditionally — empty in, empty out, fall back to the existing
+// "no WebSocket" code path).
+//
+// Every RPC provider we ship configs for (Dwellir, Tenderly, Alchemy,
+// Infura, mainnet.base.org, etc.) serves HTTP and WebSocket from the
+// same host + path with only the scheme changing. So:
+//
+//	https://api-ethereum-mainnet.n.dwellir.com/<key>
+//	wss://api-ethereum-mainnet.n.dwellir.com/<key>
+//
+// are the same endpoint via different transports. Letting one URL drive
+// both halves the env-var count an operator manages, and makes it
+// impossible to rotate one without the other.
+//
+// If a provider ever splits the two (different host or different path
+// for WS), set eth_ws_url explicitly — that value still wins.
+func DeriveWsURL(rpcURL string) string {
+	switch {
+	case rpcURL == "":
+		return ""
+	case strings.HasPrefix(rpcURL, "https://"):
+		return "wss://" + strings.TrimPrefix(rpcURL, "https://")
+	case strings.HasPrefix(rpcURL, "http://"):
+		return "ws://" + strings.TrimPrefix(rpcURL, "http://")
+	default:
+		// Not an http(s) URL — return as-is and let the WS client
+		// surface a clear "scheme not supported" error rather than
+		// silently mangling something we don't recognize.
+		return rpcURL
+	}
+}
+
 // firstNonEmpty returns the first non-empty string among the arguments.
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
@@ -746,13 +795,21 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 		maxWallets = HardMaxWalletsPerOwner
 	}
 
+	// Derive WS URL from RPC URL if not explicit (same provider, same
+	// path, scheme swap). See the top-level derivation block in
+	// NewConfig for rationale.
+	wsURL := sw.EthWsUrl
+	if wsURL == "" {
+		wsURL = DeriveWsURL(sw.EthRpcUrl)
+	}
+
 	chainCfg := &ChainConfig{
 		ChainID:    raw.ChainID,
 		Name:       raw.Name,
 		WorkerAddr: raw.WorkerAddr,
 		SmartWallet: &SmartWalletConfig{
 			EthRpcUrl:            sw.EthRpcUrl,
-			EthWsUrl:             sw.EthWsUrl,
+			EthWsUrl:             wsURL,
 			BundlerURL:           sw.BundlerURL,
 			FactoryAddress:       common.HexToAddress(firstNonEmpty(sw.FactoryAddress, DefaultFactoryProxyAddressHex)),
 			EntrypointAddress:    common.HexToAddress(firstNonEmpty(sw.EntrypointAddress, DefaultEntrypointAddressHex)),

--- a/core/config/derive_ws_url_test.go
+++ b/core/config/derive_ws_url_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestDeriveWsURL(t *testing.T) {
+	cases := []struct {
+		in, want, name string
+	}{
+		{"https://api-ethereum-mainnet.n.dwellir.com/<key>", "wss://api-ethereum-mainnet.n.dwellir.com/<key>", "https → wss (dwellir mainnet)"},
+		{"https://sepolia.gateway.tenderly.co/abc", "wss://sepolia.gateway.tenderly.co/abc", "https → wss (tenderly)"},
+		{"http://localhost:8545", "ws://localhost:8545", "http → ws (local dev)"},
+		{"", "", "empty in → empty out (caller skips WS init)"},
+		// Unknown scheme passes through unchanged — the WS client will
+		// surface a clear error rather than us silently mangling.
+		{"ipc:///tmp/geth.ipc", "ipc:///tmp/geth.ipc", "unknown scheme preserved"},
+		{"foo-bar", "foo-bar", "no scheme preserved"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DeriveWsURL(c.in)
+			if got != c.want {
+				t.Fatalf("DeriveWsURL(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -624,7 +624,14 @@ func (n *Engine) MustStart() error {
 			task := &model.Workflow{
 				Task: &avsproto.Task{},
 			}
-			err := protojson.Unmarshal(item.Value, task)
+			// DiscardUnknown: schema evolution over time has renamed/
+			// removed proto fields (e.g. `expression`, `epochs`,
+			// `totalExecution`, `interval`, `input`). Strict decode
+			// would silently skip any task whose body retains those
+			// old fields (the `if err == nil` branch below swallows
+			// errors). Tolerate unknowns at load — re-marshal on the
+			// next write drops them permanently.
+			err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, task)
 			if err == nil {
 				if initErr := task.EnsureInitialized(); initErr != nil {
 					n.logger.Warn("Task failed initialization after loading from storage",
@@ -3677,7 +3684,11 @@ func (n *Engine) ListExecutions(user *model.User, payload *avsproto.ListExecutio
 			}
 
 			exec := &avsproto.Execution{}
-			if err := protojson.Unmarshal(executionValue, exec); err == nil {
+			// DiscardUnknown: tolerate proto fields renamed/removed
+			// since this execution was written. The merge tool re-
+			// serializes bodies on import so this matters mainly for
+			// data that was never touched by a merge run.
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(executionValue, exec); err == nil {
 				executioResp.Items = append(executioResp.Items, exec)
 				total += 1
 			}
@@ -3713,7 +3724,11 @@ func (n *Engine) ListExecutions(user *model.User, payload *avsproto.ListExecutio
 			}
 
 			exec := &avsproto.Execution{}
-			if err := protojson.Unmarshal(executionValue, exec); err == nil {
+			// DiscardUnknown: tolerate proto fields renamed/removed
+			// since this execution was written. The merge tool re-
+			// serializes bodies on import so this matters mainly for
+			// data that was never touched by a merge run.
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(executionValue, exec); err == nil {
 				executioResp.Items = append(executioResp.Items, exec)
 				total += 1
 			}
@@ -3780,7 +3795,10 @@ func (n *Engine) GetExecution(user *model.User, payload *avsproto.ExecutionReq) 
 	rawExecution, err := n.db.GetKey(ChainTaskExecutionKey(task.ChainId, task, payload.ExecutionId))
 	if err == nil {
 		exec := &avsproto.Execution{}
-		err = protojson.Unmarshal(rawExecution, exec)
+		// DiscardUnknown: tolerate proto fields renamed/removed since
+		// the execution was written; otherwise GetExecution/
+		// GetExecutionStatus would error 500 on any older row.
+		err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(rawExecution, exec)
 		if err != nil {
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_TASK_DATA_CORRUPTED), TaskStorageCorruptedError)
 		}
@@ -3843,7 +3861,10 @@ func (n *Engine) GetExecutionStatus(user *model.User, payload *avsproto.Executio
 	rawExecution, err := n.db.GetKey(ChainTaskExecutionKey(task.ChainId, task, payload.ExecutionId))
 	if err == nil {
 		exec := &avsproto.Execution{}
-		err = protojson.Unmarshal(rawExecution, exec)
+		// DiscardUnknown: tolerate proto fields renamed/removed since
+		// the execution was written; otherwise GetExecution/
+		// GetExecutionStatus would error 500 on any older row.
+		err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(rawExecution, exec)
 		if err != nil {
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_TASK_DATA_CORRUPTED), TaskStorageCorruptedError)
 		}
@@ -4751,7 +4772,10 @@ func (n *Engine) GetExecutionStats(user *model.User, payload *avsproto.GetExecut
 
 		for _, item := range items {
 			execution := &avsproto.Execution{}
-			if err := protojson.Unmarshal(item.Value, execution); err != nil {
+			// DiscardUnknown: same rationale as elsewhere — tolerate
+			// proto fields renamed/removed since the execution was
+			// written.
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, execution); err != nil {
 				n.logger.Error("error unmarshalling execution", "error", err)
 				continue
 			}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -424,6 +424,32 @@ func (n *Engine) defaultChainID() int64 {
 	return 0
 }
 
+// userOwnsWalletOnAnyChain reports whether the user owns the given smart
+// wallet on at least one of the chains this gateway hosts. Used by RPCs
+// that query data across chains (ListWorkflowsByUser, the workflow-count
+// path) — a user with tasks on multiple chains might own a wallet on only
+// one of them, and we want the validation check to succeed for any.
+//
+// Falls through to the default-wallet equality first (the default wallet
+// has the same derived address across chains when factories are aligned).
+// On the first non-nil DB error, returns (false, err) — callers can
+// distinguish "wallet not owned anywhere" from "DB problem."
+func (n *Engine) userOwnsWalletOnAnyChain(user *model.User, walletAddr common.Address) (bool, error) {
+	if user.SmartAccountAddress != nil && user.SmartAccountAddress.Hex() == walletAddr.Hex() {
+		return true, nil
+	}
+	for _, chainID := range n.knownChainIDs() {
+		ok, err := ValidWalletOwner(n.db, chainID, user, walletAddr)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // knownChainIDs returns every chain the aggregator hosts tasks for. In
 // single-chain mode that is the SmartWallet chain; in gateway mode it is
 // every chain registered in chainConfigs plus the SmartWallet default.
@@ -637,35 +663,36 @@ func (n *Engine) MustStart() error {
 // Mark the old record as stale so list responses hide it and future
 // writes can replace the index entry. Index lookup or marking failures
 // are logged but never block the fresh insertion path.
-func (n *Engine) markPreviousCanonicalStaleIfAny(owner common.Address, factoryAddr common.Address, salt *big.Int, freshAddress common.Address) {
-	previousAddr, err := LookupCanonicalWalletAddress(n.db, owner, factoryAddr, salt)
+func (n *Engine) markPreviousCanonicalStaleIfAny(chainID int64, owner common.Address, factoryAddr common.Address, salt *big.Int, freshAddress common.Address) {
+	previousAddr, err := LookupCanonicalWalletAddress(n.db, chainID, owner, factoryAddr, salt)
 	if err == badger.ErrKeyNotFound {
 		return
 	}
 	if err != nil {
-		n.logger.Warn("Failed to look up canonical wallet address by (owner, factory, salt)", "owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt.String(), "error", err)
+		n.logger.Warn("Failed to look up canonical wallet address by (chainID, owner, factory, salt)", "chainID", chainID, "owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt.String(), "error", err)
 		return
 	}
 	if strings.EqualFold(previousAddr.Hex(), freshAddress.Hex()) {
 		return
 	}
 	n.logger.Error("Stale wallet derivation detected — factory implementation likely upgraded",
+		"chainID", chainID,
 		"owner", owner.Hex(),
 		"factory", factoryAddr.Hex(),
 		"salt", salt.String(),
 		"previousAddress", previousAddr.Hex(),
 		"newAddress", freshAddress.Hex(),
 	)
-	if markErr := MarkWalletStale(n.db, owner, previousAddr.Hex()); markErr != nil {
-		n.logger.Warn("Failed to mark previous canonical wallet as stale", "owner", owner.Hex(), "previousAddress", previousAddr.Hex(), "error", markErr)
+	if markErr := MarkWalletStale(n.db, chainID, owner, previousAddr.Hex()); markErr != nil {
+		n.logger.Warn("Failed to mark previous canonical wallet as stale", "chainID", chainID, "owner", owner.Hex(), "previousAddress", previousAddr.Hex(), "error", markErr)
 	}
 }
 
 // storeDefaultWalletForListWallets creates and stores the default wallet (salt:0) for ListWallets.
 // Returns the stored wallet model if successful, or nil if storage failed (but logs the error).
-func (n *Engine) storeDefaultWalletForListWallets(owner common.Address, defaultDerivedAddress *common.Address, defaultSystemFactory common.Address, defaultSalt *big.Int) *model.SmartWallet {
-	n.logger.Info("Default wallet not found in DB for ListWallets, storing it", "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex())
-	n.markPreviousCanonicalStaleIfAny(owner, defaultSystemFactory, defaultSalt, *defaultDerivedAddress)
+func (n *Engine) storeDefaultWalletForListWallets(chainID int64, owner common.Address, defaultDerivedAddress *common.Address, defaultSystemFactory common.Address, defaultSalt *big.Int) *model.SmartWallet {
+	n.logger.Info("Default wallet not found in DB for ListWallets, storing it", "chainID", chainID, "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex())
+	n.markPreviousCanonicalStaleIfAny(chainID, owner, defaultSystemFactory, defaultSalt, *defaultDerivedAddress)
 	newModelWallet := &model.SmartWallet{
 		Owner:    &owner,
 		Address:  defaultDerivedAddress,
@@ -673,8 +700,8 @@ func (n *Engine) storeDefaultWalletForListWallets(owner common.Address, defaultD
 		Salt:     defaultSalt,
 		IsHidden: false,
 	}
-	if storeErr := StoreWallet(n.db, owner, newModelWallet); storeErr != nil {
-		n.logger.Error("Error storing default wallet to DB for ListWallets", "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex(), "error", storeErr)
+	if storeErr := StoreWallet(n.db, chainID, owner, newModelWallet); storeErr != nil {
+		n.logger.Error("Error storing default wallet to DB for ListWallets", "chainID", chainID, "owner", owner.Hex(), "walletAddress", defaultDerivedAddress.Hex(), "error", storeErr)
 		// Continue and return the wallet anyway, but log the error
 		return nil
 	}
@@ -683,7 +710,13 @@ func (n *Engine) storeDefaultWalletForListWallets(owner common.Address, defaultD
 }
 
 // ListWallets corresponds to the ListWallets RPC.
+//
+// Wallet records are chain-scoped. The ListWalletReq proto does not carry a
+// chain_id yet, so this handler queries the gateway's default chain only.
+// Adding multi-chain enumeration (or a chain_id field on ListWalletReq) is
+// a follow-up.
 func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletReq) (*avsproto.ListWalletResp, error) {
+	chainID := n.defaultChainID()
 	walletsToReturnProto := []*avsproto.SmartWallet{}
 	processedAddresses := make(map[string]bool)
 
@@ -716,7 +749,7 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 		}
 
 		if includeThisDefault {
-			modelWallet, dbGetErr := GetWallet(n.db, owner, defaultDerivedAddress.Hex())
+			modelWallet, dbGetErr := GetWallet(n.db, chainID, owner, defaultDerivedAddress.Hex())
 
 			isHidden := false
 			actualSalt := defaultSalt.String()
@@ -740,7 +773,7 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 						maxAllowed = config.HardMaxWalletsPerOwner
 					}
 					// Fetch all wallets for this owner and count unique addresses
-					dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(owner))
+					dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(chainID, owner))
 					if listErr == nil {
 						unique := make(map[string]struct{})
 						for _, item := range dbItems {
@@ -755,13 +788,13 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 							n.logger.Warn("Max wallet count reached for owner in ListWallets, but storing default wallet anyway since it's always returned", "owner", owner.Hex(), "limit", maxAllowed, "currentCount", len(unique))
 						}
 						// Store the default wallet since we're returning it to the client
-						if storedWallet := n.storeDefaultWalletForListWallets(owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
+						if storedWallet := n.storeDefaultWalletForListWallets(chainID, owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
 							modelWallet = storedWallet
 						}
 					}
 				} else {
 					// No config but wallet not in DB - store it anyway
-					if storedWallet := n.storeDefaultWalletForListWallets(owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
+					if storedWallet := n.storeDefaultWalletForListWallets(chainID, owner, defaultDerivedAddress, defaultSystemFactory, defaultSalt); storedWallet != nil {
 						modelWallet = storedWallet
 					}
 				}
@@ -788,9 +821,9 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 		}
 	}
 
-	dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(owner))
+	dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(chainID, owner))
 	if listErr != nil && listErr != badger.ErrKeyNotFound {
-		n.logger.Error("Error fetching wallets by owner prefix for ListWallets", "owner", owner.Hex(), "error", listErr)
+		n.logger.Error("Error fetching wallets by owner prefix for ListWallets", "owner", owner.Hex(), "chainID", chainID, "error", listErr)
 		if len(walletsToReturnProto) == 0 {
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_UNAVAILABLE), "Error fetching wallets by owner: %v", listErr)
 		}
@@ -854,7 +887,11 @@ func (n *Engine) validateNonZeroAddress(factoryAddr common.Address, methodName, 
 
 // GetWallet is the gRPC handler for the GetWallet RPC.
 // It uses the owner (from auth context), salt, and factory_address from payload to derive the wallet address.
+//
+// Wallet records are chain-scoped. The GetWalletReq proto does not carry a
+// chain_id yet, so this handler reads/writes the gateway's default chain only.
 func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*avsproto.GetWalletResp, error) {
+	chainID := n.defaultChainID()
 	// Allow empty factory address (uses default), but validate non-empty ones
 	if payload.GetFactoryAddress() != "" && !common.IsHexAddress(payload.GetFactoryAddress()) {
 		return nil, status.Errorf(codes.InvalidArgument, InvalidFactoryAddressError)
@@ -909,7 +946,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 		return nil, status.Errorf(codes.InvalidArgument, "Failed to derive sender address or derived address is nil or zero. Error: %v", err)
 	}
 
-	dbModelWallet, err := GetWallet(n.db, user.Address, derivedSenderAddress.Hex())
+	dbModelWallet, err := GetWallet(n.db, chainID, user.Address, derivedSenderAddress.Hex())
 
 	if err != nil && err != badger.ErrKeyNotFound {
 		n.logger.Error("Error fetching wallet from DB for GetWallet", "owner", user.Address.Hex(), "wallet", derivedSenderAddress.Hex(), "error", err)
@@ -928,7 +965,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 				maxAllowed = config.HardMaxWalletsPerOwner
 			}
 			// Fetch all wallets for this owner and count unique addresses
-			dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+			dbItems, listErr := n.db.GetByPrefix(WalletByOwnerPrefix(chainID, user.Address))
 			if listErr == nil {
 				unique := make(map[string]struct{})
 				for _, item := range dbItems {
@@ -944,7 +981,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 		}
 
 		n.logger.Info("Wallet not found in DB for GetWallet, creating new entry", "owner", user.Address.Hex(), "walletAddress", derivedSenderAddress.Hex())
-		n.markPreviousCanonicalStaleIfAny(user.Address, factoryAddr, saltBig, *derivedSenderAddress)
+		n.markPreviousCanonicalStaleIfAny(chainID, user.Address, factoryAddr, saltBig, *derivedSenderAddress)
 		newModelWallet := &model.SmartWallet{
 			Owner:    &user.Address,
 			Address:  derivedSenderAddress,
@@ -952,7 +989,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 			Salt:     saltBig,
 			IsHidden: false,
 		}
-		if storeErr := StoreWallet(n.db, user.Address, newModelWallet); storeErr != nil {
+		if storeErr := StoreWallet(n.db, chainID, user.Address, newModelWallet); storeErr != nil {
 			n.logger.Error("Error storing new wallet to DB for GetWallet", "owner", user.Address.Hex(), "walletAddress", derivedSenderAddress.Hex(), "error", storeErr)
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_WRITE_ERROR), "Error storing new wallet: %v", storeErr)
 		}
@@ -980,9 +1017,11 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 	return resp, nil
 }
 
-// GetWalletFromDB retrieves wallet information from database for validation purposes
+// GetWalletFromDB retrieves wallet information from database for validation purposes.
+// Looks up the wallet on the gateway's default chain. Multi-chain wallet
+// validation is a follow-up.
 func (n *Engine) GetWalletFromDB(owner common.Address, smartWalletAddress string) (*model.SmartWallet, error) {
-	return GetWallet(n.db, owner, smartWalletAddress)
+	return GetWallet(n.db, n.defaultChainID(), owner, smartWalletAddress)
 }
 
 // SetWallet is the gRPC handler for the SetWallet RPC.
@@ -1018,7 +1057,7 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.Internal, "Derived wallet address is nil or zero")
 	}
 
-	err = SetWalletHiddenStatus(n.db, owner, derivedWalletAddress.Hex(), payload.GetIsHidden())
+	err = SetWalletHiddenStatus(n.db, n.defaultChainID(), owner, derivedWalletAddress.Hex(), payload.GetIsHidden())
 	if err != nil {
 		if errors.Is(err, badger.ErrKeyNotFound) {
 			n.logger.Warn("Wallet not found for SetWallet", "owner", owner.Hex(), "derivedAddress", derivedWalletAddress.Hex(), "salt", payload.GetSalt(), "factory", payload.GetFactoryAddress())
@@ -1031,7 +1070,7 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.Internal, "Failed to update wallet hidden status: %v", err)
 	}
 
-	updatedModelWallet, getErr := GetWallet(n.db, owner, derivedWalletAddress.Hex())
+	updatedModelWallet, getErr := GetWallet(n.db, n.defaultChainID(), owner, derivedWalletAddress.Hex())
 	if getErr != nil {
 		n.logger.Error("Failed to fetch wallet after SetWallet operation", "owner", owner.Hex(), "wallet", derivedWalletAddress.Hex(), "error", getErr)
 		return nil, status.Errorf(codes.Internal, "Failed to retrieve wallet details after update: %v", getErr)
@@ -1214,15 +1253,6 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		return nil, status.Errorf(codes.InvalidArgument, "EventTrigger template resolution failed: %v", err)
 	}
 
-	// Validate smart wallet ownership. The runner address comes from
-	// inputVariables.settings.runner (via NewTaskFromProtobuf) and is stored
-	// as task.SmartWalletAddress. We must verify the caller owns this wallet.
-	if task.SmartWalletAddress != "" {
-		if valid, _ := ValidWalletOwner(n.db, user, common.HexToAddress(task.SmartWalletAddress)); !valid {
-			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
-		}
-	}
-
 	// Default chain_id to the aggregator's SmartWallet chain when not specified.
 	// In gateway mode the top-level SmartWallet is populated from chains[0]
 	// (mainnet by convention), so a missing chain_id silently routes the task
@@ -1232,6 +1262,10 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 	// the task's intended chain is recorded with no ambiguity. Single-chain
 	// (non-gateway) deployments keep the legacy behavior — there's only one
 	// chain there, so the inference is unambiguous.
+	//
+	// Resolve chain_id BEFORE the wallet-ownership check below — that check
+	// reads `w:<chainID>:<owner>:<wallet>` and would miss the canonical row
+	// if it ran against task.ChainId == 0.
 	if task.ChainId == 0 {
 		if n.config != nil && n.config.IsGateway {
 			return nil, status.Errorf(codes.InvalidArgument,
@@ -1241,6 +1275,29 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		}
 		if n.config != nil && n.config.SmartWallet != nil {
 			task.ChainId = n.config.SmartWallet.ChainID
+		}
+	}
+
+	// Validate smart wallet ownership. The runner address comes from
+	// inputVariables.settings.runner (via NewTaskFromProtobuf) and is stored
+	// as task.SmartWalletAddress. We must verify the caller owns this wallet
+	// on the chain this task targets.
+	if task.SmartWalletAddress != "" {
+		valid, ownErr := ValidWalletOwner(n.db, task.ChainId, user, common.HexToAddress(task.SmartWalletAddress))
+		if ownErr != nil {
+			// Storage failure on the ownership check is NOT the same as
+			// "wallet not owned" — surfacing it as InvalidArgument would
+			// make a transient DB hiccup look like a malformed request.
+			n.logger.Error("Wallet ownership check failed (storage error)",
+				"owner", user.Address.Hex(),
+				"smart_wallet", task.SmartWalletAddress,
+				"chain_id", task.ChainId,
+				"error", ownErr)
+			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_UNAVAILABLE),
+				"failed to validate smart wallet ownership: %v", ownErr)
+		}
+		if !valid {
+			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 	}
 
@@ -2375,7 +2432,18 @@ func (n *Engine) ListWorkflowsByUser(user *model.User, payload *avsproto.ListTas
 			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 
-		if valid, _ := ValidWalletOwner(n.db, user, common.HexToAddress(smartWalletAddress)); !valid {
+		valid, ownErr := n.userOwnsWalletOnAnyChain(user, common.HexToAddress(smartWalletAddress))
+		if ownErr != nil {
+			// Storage failure → surface as STORAGE_UNAVAILABLE; the
+			// caller request is fine, the gateway can't currently answer.
+			n.logger.Error("Wallet ownership check failed (storage error)",
+				"owner", user.Address.Hex(),
+				"smart_wallet", smartWalletAddress,
+				"error", ownErr)
+			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_STORAGE_UNAVAILABLE),
+				"failed to validate smart wallet ownership: %v", ownErr)
+		}
+		if !valid {
 			return nil, status.Errorf(codes.InvalidArgument, InvalidSmartAccountAddressError)
 		}
 
@@ -4735,7 +4803,7 @@ func (n *Engine) GetWorkflowCount(user *model.User, payload *avsproto.GetWorkflo
 
 		for _, address := range smartWalletAddresses {
 			smartWalletAddress := common.HexToAddress(address)
-			if ok, err := ValidWalletOwner(n.db, user, smartWalletAddress); !ok || err != nil {
+			if ok, err := n.userOwnsWalletOnAnyChain(user, smartWalletAddress); !ok || err != nil {
 				// skip if the address is not a valid smart wallet address or it isn't belong to this user
 				continue
 			}

--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -72,7 +72,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	})
 
 	// Register smart wallet in database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddr,
 		Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/execute_uniswap_approval_test.go
+++ b/core/taskengine/execute_uniswap_approval_test.go
@@ -49,7 +49,7 @@ func TestExecuteTask_UniswapApprovalAndSwap_DifferentApprovalAmounts_Sepolia(t *
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddr,
 		Factory: &config.SmartWallet.FactoryAddress,

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -443,7 +443,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 		smartWalletAddr := common.HexToAddress(task.SmartWalletAddress)
 
 		// Enhanced wallet validation that handles any legitimately derived wallet
-		isValid, err := x.validateWalletOwnership(user, smartWalletAddr)
+		isValid, err := x.validateWalletOwnership(task.ChainId, user, smartWalletAddr)
 		if err != nil {
 			execution.EndAt = time.Now().UnixMilli()
 			execution.Error = fmt.Sprintf("failed to validate wallet ownership for owner %s: %v", owner.Hex(), err)
@@ -465,7 +465,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 
 		// Look up the wallet's salt from DB for auto-deployment of non-salt-0 wallets
 		if x.db != nil {
-			if wallet, walletErr := GetWallet(x.db, owner, task.SmartWalletAddress); walletErr == nil && wallet != nil && wallet.Salt != nil {
+			if wallet, walletErr := GetWallet(x.db, task.ChainId, owner, task.SmartWalletAddress); walletErr == nil && wallet != nil && wallet.Salt != nil {
 				vm.AddVar("aa_salt", wallet.Salt)
 				if x.logger != nil {
 					x.logger.Info("Executor: AA salt resolved from wallet DB", "salt", wallet.Salt.String(), "wallet", task.SmartWalletAddress)
@@ -526,7 +526,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 
 		if creditLimitWei != nil {
 			taskOwner := common.HexToAddress(task.Owner)
-			withinLimit, outstanding, checkErr := x.feeLedger.CheckCreditLimit(taskOwner, creditLimitWei)
+			withinLimit, outstanding, checkErr := x.feeLedger.CheckCreditLimit(task.ChainId, taskOwner, creditLimitWei)
 			if checkErr != nil {
 				x.logger.Warn("Fee ledger check failed, proceeding with execution", "error", checkErr)
 			} else if !withinLimit {
@@ -852,7 +852,7 @@ func sanitizeInterface(x interface{}) interface{} {
 
 // validateWalletOwnership performs comprehensive wallet ownership validation
 // This handles default wallets (salt:0), stored wallets, and legitimately derived wallets
-func (x *WorkflowExecutor) validateWalletOwnership(user *model.User, smartWalletAddr common.Address) (bool, error) {
+func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.User, smartWalletAddr common.Address) (bool, error) {
 	// Step 1: Load the user's default smart wallet address (salt:0) for comparison
 	if x.smartWalletConfig != nil && x.smartWalletConfig.EthRpcUrl != "" {
 		if rpcClient, err := ethclient.Dial(x.smartWalletConfig.EthRpcUrl); err == nil {
@@ -866,7 +866,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(user *model.User, smartWallet
 	}
 
 	// Step 2: Use the standard ValidWalletOwner function (checks default + database)
-	if isValid, err := ValidWalletOwner(x.db, user, smartWalletAddr); err == nil && isValid {
+	if isValid, err := ValidWalletOwner(x.db, chainID, user, smartWalletAddr); err == nil && isValid {
 		return true, nil
 	} else if err != nil {
 		x.logger.Debug("ValidWalletOwner check failed", "owner", user.Address.Hex(),

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -127,7 +127,12 @@ func (x *WorkflowExecutor) GetTask(id string) (*model.Workflow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("storage access failed for key '%s': %w", string(storageKey), err)
 	}
-	err = protojson.Unmarshal(item, task)
+	// DiscardUnknown: tolerate proto fields renamed/removed since the
+	// task was written. Without this, any task whose body carries
+	// old fields like `expression`/`epochs`/`totalExecution` would
+	// fail strict decode here and the executor would falsely report
+	// the task as "data may be corrupted".
+	err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item, task)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse task data from storage (data may be corrupted): %w", err)
 	}

--- a/core/taskengine/fee_billing_integration_test.go
+++ b/core/taskengine/fee_billing_integration_test.go
@@ -48,12 +48,13 @@ func TestFeeBilling_CreditGating_BlocksOnOutstandingBalance(t *testing.T) {
 
 	// Register the smart wallet for this owner so executor wallet validation passes
 	walletAddr := common.HexToAddress(smartWalletAddr)
-	StoreWallet(db, owner, &model.SmartWallet{Address: &walletAddr})
+	StoreWallet(db, int64(1), owner, &model.SmartWallet{Address: &walletAddr})
 
 	// Create a simple task with manual trigger and custom code node (no on-chain ops)
 	task := &model.Workflow{
 		Task: &avsproto.Task{
 			Id:                 "test-fee-gating",
+			ChainId:            int64(1),
 			Owner:              strings.ToLower(owner.Hex()),
 			SmartWalletAddress: smartWalletAddr,
 			Status:             avsproto.TaskStatus_Enabled,
@@ -109,12 +110,13 @@ func TestFeeBilling_CreditGating_BlocksOnOutstandingBalance(t *testing.T) {
 		Owner:        owner.Hex(),
 		Tier:         "EXECUTION_TIER_1",
 		FeeAmountWei: "1000000000000000", // 0.001 ETH — any non-zero amount
+		ChainID:      int64(1),
 	}
 	err = executor.feeLedger.RecordValueFee(feeRecord)
 	require.NoError(t, err)
 
 	// Verify outstanding balance is now positive
-	outstanding, err := executor.feeLedger.GetOutstandingBalance(owner)
+	outstanding, err := executor.feeLedger.GetOutstandingBalance(int64(1), owner)
 	require.NoError(t, err)
 	assert.True(t, outstanding.Sign() > 0, "Outstanding balance should be positive after recording fee")
 
@@ -159,11 +161,12 @@ func TestFeeBilling_CreditGating_AllowsWithHighCreditLimit(t *testing.T) {
 
 	// Register the smart wallet for this owner
 	walletAddr := common.HexToAddress(smartWalletAddr)
-	StoreWallet(db, owner, &model.SmartWallet{Address: &walletAddr})
+	StoreWallet(db, int64(1), owner, &model.SmartWallet{Address: &walletAddr})
 
 	task := &model.Workflow{
 		Task: &avsproto.Task{
 			Id:                 "test-fee-high-limit",
+			ChainId:            int64(1),
 			Owner:              strings.ToLower(owner.Hex()),
 			SmartWalletAddress: smartWalletAddr,
 			Status:             avsproto.TaskStatus_Enabled,
@@ -202,6 +205,7 @@ func TestFeeBilling_CreditGating_AllowsWithHighCreditLimit(t *testing.T) {
 		TaskID:       task.Id,
 		Owner:        owner.Hex(),
 		FeeAmountWei: "1000000000000000", // 0.001 ETH (~$2.50) — under $100 limit
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 

--- a/core/taskengine/fee_ledger.go
+++ b/core/taskengine/fee_ledger.go
@@ -59,10 +59,10 @@ func NewFeeLedger(db storage.Storage, logger sdklogging.Logger) *FeeLedger {
 	}
 }
 
-// GetOutstandingBalance returns the current outstanding value fee balance for an owner.
-// Returns zero if no ledger entry exists.
-func (fl *FeeLedger) GetOutstandingBalance(owner common.Address) (*big.Int, error) {
-	entry, err := fl.getLedgerEntry(owner)
+// GetOutstandingBalance returns the current outstanding value fee balance for
+// an owner on the given chain. Returns zero if no ledger entry exists.
+func (fl *FeeLedger) GetOutstandingBalance(chainID int64, owner common.Address) (*big.Int, error) {
+	entry, err := fl.getLedgerEntry(chainID, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +77,14 @@ func (fl *FeeLedger) GetOutstandingBalance(owner common.Address) (*big.Int, erro
 	return outstanding, nil
 }
 
-// CheckCreditLimit returns whether the owner is within their credit limit.
-// Returns (withinLimit, outstandingBalance, error).
-func (fl *FeeLedger) CheckCreditLimit(owner common.Address, creditLimitWei *big.Int) (bool, *big.Int, error) {
+// CheckCreditLimit returns whether the owner is within their credit limit on
+// the given chain. Returns (withinLimit, outstandingBalance, error).
+func (fl *FeeLedger) CheckCreditLimit(chainID int64, owner common.Address, creditLimitWei *big.Int) (bool, *big.Int, error) {
 	if creditLimitWei == nil {
 		return true, big.NewInt(0), nil // No limit configured — always within limit
 	}
 
-	outstanding, err := fl.GetOutstandingBalance(owner)
+	outstanding, err := fl.GetOutstandingBalance(chainID, owner)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to get outstanding balance: %w", err)
 	}
@@ -94,17 +94,21 @@ func (fl *FeeLedger) CheckCreditLimit(owner common.Address, creditLimitWei *big.
 	return withinLimit, outstanding, nil
 }
 
-// RecordValueFee records a value fee after successful execution.
-// The mutex serializes the read-check-write sequence to prevent double-recording
-// when concurrent calls arrive with the same ExecutionID.
+// RecordValueFee records a value fee after successful execution. The ledger
+// and fee record are written under the chain ID embedded in record.ChainID.
+// The mutex serializes the read-check-write sequence to prevent
+// double-recording when concurrent calls arrive with the same ExecutionID.
 func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	fl.mu.Lock()
 	defer fl.mu.Unlock()
 
+	if record.ChainID == 0 {
+		return fmt.Errorf("fee record missing chain_id (owner=%s execution=%s)", record.Owner, record.ExecutionID)
+	}
 	owner := common.HexToAddress(record.Owner)
 
 	// Idempotency check: skip if this execution's fee was already recorded
-	existingRecord, _ := fl.db.GetKey(FeeRecordKey(owner, record.ExecutionID))
+	existingRecord, _ := fl.db.GetKey(FeeRecordKey(record.ChainID, owner, record.ExecutionID))
 	if existingRecord != nil {
 		fl.logger.Debug("Fee record already exists, skipping", "execution_id", record.ExecutionID)
 		return nil
@@ -116,7 +120,7 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	}
 
 	// Get or create ledger entry
-	entry, err := fl.getLedgerEntry(owner)
+	entry, err := fl.getLedgerEntry(record.ChainID, owner)
 	if err != nil {
 		return fmt.Errorf("failed to get ledger entry: %w", err)
 	}
@@ -159,8 +163,8 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	}
 
 	updates := map[string][]byte{
-		string(FeeLedgerKey(owner)):                     ledgerData,
-		string(FeeRecordKey(owner, record.ExecutionID)): recordData,
+		string(FeeLedgerKey(record.ChainID, owner)):                     ledgerData,
+		string(FeeRecordKey(record.ChainID, owner, record.ExecutionID)): recordData,
 	}
 
 	if err := fl.db.BatchWrite(updates); err != nil {
@@ -168,6 +172,7 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	}
 
 	fl.logger.Info("Recorded value fee",
+		"chain_id", record.ChainID,
 		"owner", owner.Hex(),
 		"execution_id", record.ExecutionID,
 		"fee_wei", record.FeeAmountWei,
@@ -176,19 +181,20 @@ func (fl *FeeLedger) RecordValueFee(record *FeeRecord) error {
 	return nil
 }
 
-// getLedgerEntry reads the ledger entry for an owner. Returns nil if not found.
-func (fl *FeeLedger) getLedgerEntry(owner common.Address) (*FeeLedgerEntry, error) {
-	data, err := fl.db.GetKey(FeeLedgerKey(owner))
+// getLedgerEntry reads the ledger entry for an owner on the given chain.
+// Returns nil if not found.
+func (fl *FeeLedger) getLedgerEntry(chainID int64, owner common.Address) (*FeeLedgerEntry, error) {
+	data, err := fl.db.GetKey(FeeLedgerKey(chainID, owner))
 	if err != nil {
 		if err == badger.ErrKeyNotFound {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to read fee ledger for %s: %w", owner.Hex(), err)
+		return nil, fmt.Errorf("failed to read fee ledger for chain=%d owner=%s: %w", chainID, owner.Hex(), err)
 	}
 
 	var entry FeeLedgerEntry
 	if err := json.Unmarshal(data, &entry); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal fee ledger for %s: %w", owner.Hex(), err)
+		return nil, fmt.Errorf("failed to unmarshal fee ledger for chain=%d owner=%s: %w", chainID, owner.Hex(), err)
 	}
 	return &entry, nil
 }

--- a/core/taskengine/fee_ledger_test.go
+++ b/core/taskengine/fee_ledger_test.go
@@ -19,7 +19,7 @@ func TestFeeLedger_GetOutstandingBalance_Empty(t *testing.T) {
 	ledger := NewFeeLedger(db, logger)
 
 	owner := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
-	balance, err := ledger.GetOutstandingBalance(owner)
+	balance, err := ledger.GetOutstandingBalance(int64(1), owner)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), balance, "Empty ledger should return zero balance")
 }
@@ -48,7 +48,7 @@ func TestFeeLedger_RecordValueFee(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check outstanding balance
-	balance, err := ledger.GetOutstandingBalance(owner)
+	balance, err := ledger.GetOutstandingBalance(int64(11155111), owner)
 	require.NoError(t, err)
 
 	expectedFee, _ := new(big.Int).SetString("300000000000000", 10)
@@ -69,6 +69,7 @@ func TestFeeLedger_RecordMultipleFees(t *testing.T) {
 		TaskID:       "task_001",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "100000000000000", // 0.0001 ETH
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
@@ -78,11 +79,12 @@ func TestFeeLedger_RecordMultipleFees(t *testing.T) {
 		TaskID:       "task_001",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "200000000000000", // 0.0002 ETH
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
 	// Balance should be sum of both
-	balance, err := ledger.GetOutstandingBalance(owner)
+	balance, err := ledger.GetOutstandingBalance(int64(1), owner)
 	require.NoError(t, err)
 
 	expectedTotal, _ := new(big.Int).SetString("300000000000000", 10)
@@ -101,7 +103,7 @@ func TestFeeLedger_CheckCreditLimit(t *testing.T) {
 	creditLimit, _ := new(big.Int).SetString("500000000000000", 10)
 
 	// No fees yet — within limit
-	withinLimit, outstanding, err := ledger.CheckCreditLimit(owner, creditLimit)
+	withinLimit, outstanding, err := ledger.CheckCreditLimit(int64(1), owner, creditLimit)
 	require.NoError(t, err)
 	assert.True(t, withinLimit, "Should be within limit when no fees owed")
 	assert.Equal(t, big.NewInt(0), outstanding)
@@ -111,10 +113,11 @@ func TestFeeLedger_CheckCreditLimit(t *testing.T) {
 		ExecutionID:  "exec_001",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "300000000000000", // 0.0003 ETH — under 0.0005 limit
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
-	withinLimit, outstanding, err = ledger.CheckCreditLimit(owner, creditLimit)
+	withinLimit, outstanding, err = ledger.CheckCreditLimit(int64(1), owner, creditLimit)
 	require.NoError(t, err)
 	assert.True(t, withinLimit, "Should be within limit when fees < credit limit")
 
@@ -123,10 +126,11 @@ func TestFeeLedger_CheckCreditLimit(t *testing.T) {
 		ExecutionID:  "exec_002",
 		Owner:        owner.Hex(),
 		FeeAmountWei: "300000000000000", // Total now 0.0006 ETH — over 0.0005 limit
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
-	withinLimit, outstanding, err = ledger.CheckCreditLimit(owner, creditLimit)
+	withinLimit, outstanding, err = ledger.CheckCreditLimit(int64(1), owner, creditLimit)
 	require.NoError(t, err)
 	assert.False(t, withinLimit, "Should exceed credit limit")
 
@@ -148,6 +152,7 @@ func TestFeeLedger_SeparateOwners(t *testing.T) {
 		ExecutionID:  "exec_001",
 		Owner:        owner1.Hex(),
 		FeeAmountWei: "100000000000000",
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
@@ -156,16 +161,17 @@ func TestFeeLedger_SeparateOwners(t *testing.T) {
 		ExecutionID:  "exec_002",
 		Owner:        owner2.Hex(),
 		FeeAmountWei: "200000000000000",
+		ChainID:      int64(1),
 	})
 	require.NoError(t, err)
 
 	// Balances should be separate
-	balance1, err := ledger.GetOutstandingBalance(owner1)
+	balance1, err := ledger.GetOutstandingBalance(int64(1), owner1)
 	require.NoError(t, err)
 	expected1, _ := new(big.Int).SetString("100000000000000", 10)
 	assert.Equal(t, expected1, balance1)
 
-	balance2, err := ledger.GetOutstandingBalance(owner2)
+	balance2, err := ledger.GetOutstandingBalance(int64(1), owner2)
 	require.NoError(t, err)
 	expected2, _ := new(big.Int).SetString("200000000000000", 10)
 	assert.Equal(t, expected2, balance2)

--- a/core/taskengine/list_wallets_storage_test.go
+++ b/core/taskengine/list_wallets_storage_test.go
@@ -22,7 +22,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	user := testutil.TestUser1()
 
 	// Verify database is empty initially
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(dbItems), "Database should be empty initially")
 
@@ -42,7 +42,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	require.NotNil(t, defaultWallet, "Default wallet (salt:0) should be in the response")
 
 	// Verify the wallet is now stored in the database
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should contain exactly 1 wallet after ListWallets")
 
@@ -74,7 +74,7 @@ func TestListWalletsDoesNotDuplicateExistingWallet(t *testing.T) {
 	defaultAddress := getResp.Address
 
 	// Verify the wallet is stored
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should contain exactly 1 wallet after GetWallet")
 
@@ -83,7 +83,7 @@ func TestListWalletsDoesNotDuplicateExistingWallet(t *testing.T) {
 	require.NoError(t, err, "ListWallets should succeed")
 
 	// Verify the wallet is still only stored once
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should still contain exactly 1 wallet after ListWallets")
 
@@ -119,7 +119,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NoError(t, err, "First ListWallets call should succeed")
 
 	// Verify salt:0 is stored
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Should have 1 wallet (salt:0) after first ListWallets")
 
@@ -141,7 +141,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NotEqual(t, salt0Address, salt1Address, "Salt:1 address should be different from salt:0")
 
 	// Verify we now have 2 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(dbItems), "Should have 2 wallets (salt:0, salt:1) after GetWallet")
 
@@ -155,7 +155,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NotEqual(t, salt1Address, salt2Address, "Salt:2 address should be different from salt:1")
 
 	// Verify we now have 3 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should have 3 wallets (salt:0, salt:1, salt:2) after second GetWallet")
 
@@ -164,7 +164,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	require.NoError(t, err, "Second ListWallets call should succeed")
 
 	// Verify we still have exactly 3 wallets (no duplicates)
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should still have exactly 3 wallets after second ListWallets")
 
@@ -211,7 +211,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 
 	// Phase 1: Owner with no wallets yet - call ListWallets
 	// This should create and store salt:0
-	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(dbItems), "Database should be empty initially")
 
@@ -219,7 +219,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NoError(t, err, "ListWallets should succeed when owner has no wallets")
 
 	// Verify salt:0 is now stored
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(dbItems), "Database should contain salt:0 after ListWallets")
 
@@ -233,7 +233,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NotEmpty(t, salt0FromList, "Salt:0 wallet should be in ListWallets response")
 
 	// Verify we can retrieve it directly from the database
-	retrievedWallet, err := GetWallet(db, user.Address, salt0FromList)
+	retrievedWallet, err := GetWallet(db, int64(1), user.Address, salt0FromList)
 	require.NoError(t, err, "Should be able to retrieve salt:0 wallet from database")
 	assert.Equal(t, "0", retrievedWallet.Salt.String(), "Retrieved wallet should have salt 0")
 
@@ -244,7 +244,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NoError(t, err, "GetWallet for salt:1 should succeed")
 
 	// Verify we now have 2 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(dbItems), "Should have 2 wallets after GetWallet for salt:1")
 
@@ -255,7 +255,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NoError(t, err, "GetWallet for salt:2 should succeed")
 
 	// Verify we now have 3 wallets
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should have 3 wallets after GetWallet for salt:2")
 
@@ -273,18 +273,18 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	assert.True(t, addressesInResponse[getResp2.Address], "Salt:2 wallet should be in response")
 
 	// Verify database still has exactly 3 wallets (no duplicates created)
-	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+	dbItems, err = db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(dbItems), "Should still have exactly 3 wallets after second ListWallets")
 
 	// Verify all wallets can be retrieved individually
-	_, err = GetWallet(db, user.Address, salt0FromList)
+	_, err = GetWallet(db, int64(1), user.Address, salt0FromList)
 	require.NoError(t, err, "Should be able to retrieve salt:0 from database")
 
-	_, err = GetWallet(db, user.Address, getResp1.Address)
+	_, err = GetWallet(db, int64(1), user.Address, getResp1.Address)
 	require.NoError(t, err, "Should be able to retrieve salt:1 from database")
 
-	_, err = GetWallet(db, user.Address, getResp2.Address)
+	_, err = GetWallet(db, int64(1), user.Address, getResp2.Address)
 	require.NoError(t, err, "Should be able to retrieve salt:2 from database")
 }
 
@@ -300,7 +300,7 @@ func TestListWalletsDatabaseStateVerification(t *testing.T) {
 
 	// Helper function to verify database state
 	verifyDatabaseState := func(t *testing.T, expectedCount int, description string) map[string]*model.SmartWallet {
-		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 		require.NoError(t, err, "Failed to query database: %s", description)
 		assert.Equal(t, expectedCount, len(dbItems), "Database state check failed: %s (expected %d wallets, got %d)", description, expectedCount, len(dbItems))
 

--- a/core/taskengine/migrate_wallet_salt_index.go
+++ b/core/taskengine/migrate_wallet_salt_index.go
@@ -68,31 +68,39 @@ type WalletSaltIndexBackfillStats struct {
 	SkippedDeriveError     int
 }
 
-// BackfillWalletSaltIndex walks every persisted wallet record and either
-// writes a (owner, factory, salt) → address secondary index entry (when
-// the live derivation still matches the stored address), or marks the row
-// stale (when the derivation differs — i.e. the factory's account
-// implementation was upgraded since the row was stored).
+// BackfillWalletSaltIndex walks every persisted wallet record on the given
+// chain and either writes a (chainID, owner, factory, salt) → address
+// secondary index entry (when the live derivation still matches the stored
+// address), or marks the row stale (when the derivation differs — i.e. the
+// factory's account implementation was upgraded since the row was stored).
+//
+// Run the backfill once per chain the gateway hosts. The `derive` callback
+// must produce addresses consistent with the chainID passed in (the caller
+// is responsible for binding the deriver to the right RPC endpoint).
 //
 // The function is the shared core for both the `/ava backfill-wallet-salt-index`
 // CLI subcommand and the standalone scripts/migration/... wrapper. Tests
 // inject a fake deriver to exercise the matrix of canonical / stale /
 // missing / error rows without an RPC.
-func BackfillWalletSaltIndex(db storage.Storage, derive WalletSaltIndexAddressDeriver, opts WalletSaltIndexBackfillOptions) (*WalletSaltIndexBackfillStats, error) {
+func BackfillWalletSaltIndex(db storage.Storage, chainID int64, derive WalletSaltIndexAddressDeriver, opts WalletSaltIndexBackfillOptions) (*WalletSaltIndexBackfillStats, error) {
 	if db == nil {
 		return nil, fmt.Errorf("BackfillWalletSaltIndex: db is required")
 	}
 	if derive == nil {
 		return nil, fmt.Errorf("BackfillWalletSaltIndex: derive callback is required")
 	}
+	if chainID <= 0 {
+		return nil, fmt.Errorf("BackfillWalletSaltIndex: chainID is required (got %d)", chainID)
+	}
 	logf := opts.Logf
 	if logf == nil {
 		logf = func(format string, args ...any) {}
 	}
 
-	items, err := db.GetByPrefix([]byte("w:"))
+	walletPrefix := []byte(fmt.Sprintf("w:%d:", chainID))
+	items, err := db.GetByPrefix(walletPrefix)
 	if err != nil {
-		return nil, fmt.Errorf("scan wallet records: %w", err)
+		return nil, fmt.Errorf("scan wallet records for chain %d: %w", chainID, err)
 	}
 
 	stats := &WalletSaltIndexBackfillStats{}
@@ -140,7 +148,7 @@ func BackfillWalletSaltIndex(db storage.Storage, derive WalletSaltIndexAddressDe
 		if canonical {
 			stats.CanonicalConfirmed++
 
-			indexKey := WalletBySaltKey(owner, factory, wallet.Salt)
+			indexKey := WalletBySaltKey(chainID, owner, factory, wallet.Salt)
 			existing, lookupErr := db.GetKey(indexKey)
 			alreadyCorrect := lookupErr == nil && strings.EqualFold(string(existing), wallet.Address.Hex())
 
@@ -185,7 +193,7 @@ func BackfillWalletSaltIndex(db storage.Storage, derive WalletSaltIndexAddressDe
 		logf("  [stale] %s ≠ live derivation %s (owner=%s factory=%s salt=%s)",
 			wallet.Address.Hex(), derived.Hex(), owner.Hex(), factory.Hex(), wallet.Salt.String())
 		if !opts.DryRun {
-			if markErr := MarkWalletStale(db, owner, wallet.Address.Hex()); markErr != nil {
+			if markErr := MarkWalletStale(db, chainID, owner, wallet.Address.Hex()); markErr != nil {
 				logf("  [err] mark stale: %v", markErr)
 				// Fail-fast: a partially marked stale set would let
 				// zombie rows leak back into ListWallets responses

--- a/core/taskengine/partial_success_test.go
+++ b/core/taskengine/partial_success_test.go
@@ -190,10 +190,11 @@ func TestGetExecutionStatus_StepFailures(t *testing.T) {
 	// Create a test task
 	task := &model.Workflow{
 		Task: &avsproto.Task{
-			Id:     "test-task-id",
-			Owner:  user.Address.Hex(),
-			Status: avsproto.TaskStatus_Enabled,
-			Name:   "Test Task",
+			Id:      "test-task-id",
+			ChainId: int64(1),
+			Owner:   user.Address.Hex(),
+			Status:  avsproto.TaskStatus_Enabled,
+			Name:    "Test Task",
 		},
 	}
 
@@ -278,10 +279,11 @@ func TestGetExecutionStatus_FullSuccess(t *testing.T) {
 	// Create a test task
 	task := &model.Workflow{
 		Task: &avsproto.Task{
-			Id:     "test-task-id",
-			Owner:  user.Address.Hex(),
-			Status: avsproto.TaskStatus_Enabled,
-			Name:   "Test Task",
+			Id:      "test-task-id",
+			ChainId: int64(1),
+			Owner:   user.Address.Hex(),
+			Status:  avsproto.TaskStatus_Enabled,
+			Name:    "Test Task",
 		},
 	}
 
@@ -360,10 +362,11 @@ func TestGetExecutionStatus_FullFailure(t *testing.T) {
 	// Create a test task
 	task := &model.Workflow{
 		Task: &avsproto.Task{
-			Id:     "test-task-id",
-			Owner:  user.Address.Hex(),
-			Status: avsproto.TaskStatus_Enabled,
-			Name:   "Test Task",
+			Id:      "test-task-id",
+			ChainId: int64(1),
+			Owner:   user.Address.Hex(),
+			Status:  avsproto.TaskStatus_Enabled,
+			Name:    "Test Task",
 		},
 	}
 

--- a/core/taskengine/run_node_immediately_missing_dependencies_test.go
+++ b/core/taskengine/run_node_immediately_missing_dependencies_test.go
@@ -47,7 +47,7 @@ func TestRunNodeImmediately_ContractWrite_MissingNodeDependency(t *testing.T) {
 	require.NoError(t, err, "Failed to derive smart wallet address")
 
 	// Seed wallet in DB for validation
-	_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+	_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 		Owner:   &ownerEOA,
 		Address: runnerAddr,
 		Factory: &factory,

--- a/core/taskengine/run_node_immediately_rpc_test.go
+++ b/core/taskengine/run_node_immediately_rpc_test.go
@@ -52,7 +52,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		}
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,
@@ -293,7 +293,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		}
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/run_node_immediately_settings_test.go
+++ b/core/taskengine/run_node_immediately_settings_test.go
@@ -49,7 +49,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 		}
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/run_node_immediately_tuple_test.go
+++ b/core/taskengine/run_node_immediately_tuple_test.go
@@ -85,7 +85,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		// - Templates reference settings.uniswapv3-pool.token0.id etc.
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,
@@ -208,7 +208,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		// The backend will convert this to ordered array based on ABI
 
 		// Seed wallet in DB for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,
@@ -423,7 +423,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		// Note: Mathematical expressions in templates are not supported in RunNodeImmediately
 
 		// Seed wallet in DB
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/run_node_with_inputs_simulation_mode_test.go
+++ b/core/taskengine/run_node_with_inputs_simulation_mode_test.go
@@ -83,7 +83,7 @@ func TestRunNodeWithInputsRespectsIsSimulatedFlag(t *testing.T) {
 			}
 
 			// Seed wallet in DB for validation
-			_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+			_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 				Owner:   &ownerEOA,
 				Address: runnerAddr,
 				Factory: &factory,
@@ -267,7 +267,7 @@ func TestRunNodeWithInputsDefaultsToSimulation(t *testing.T) {
 	user := &model.User{Address: ownerEOA}
 
 	// Seed wallet in DB
-	_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+	_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 		Owner:   &ownerEOA,
 		Address: runnerAddr,
 		Factory: &factory,

--- a/core/taskengine/schema.go
+++ b/core/taskengine/schema.go
@@ -25,44 +25,54 @@ func WorkflowByStatusStoragePrefix(status avsproto.TaskStatus) []byte {
 	return storageschema.WorkflowByStatusStoragePrefix(status)
 }
 
-func WalletByOwnerPrefix(owner common.Address) []byte {
+// WalletByOwnerPrefix returns the storage prefix for all wallets owned by
+// `owner` on chain `chainID`. Used to list wallets for a given user.
+func WalletByOwnerPrefix(chainID int64, owner common.Address) []byte {
 	return []byte(fmt.Sprintf(
-		"w:%s",
+		"w:%d:%s",
+		chainID,
 		strings.ToLower(owner.String()),
 	))
 }
 
-func WalletStorageKey(owner common.Address, smartWalletAddress string) string {
+// WalletStorageKey returns the primary key for a wallet record. The
+// chain ID is the second segment so wallets on different chains
+// (different factory addresses, different derived addresses) never
+// collide in storage.
+func WalletStorageKey(chainID int64, owner common.Address, smartWalletAddress string) string {
 	return fmt.Sprintf(
-		"w:%s:%s",
+		"w:%d:%s:%s",
+		chainID,
 		strings.ToLower(owner.Hex()),
 		strings.ToLower(smartWalletAddress),
 	)
 }
 
 // WalletBySaltKey returns the secondary index key that maps a
-// (owner, factory, salt) tuple to its current canonical wallet address.
+// (chainID, owner, factory, salt) tuple to its current canonical wallet
+// address.
 //
 // The primary wallet record is keyed by the *derived* wallet address
-// (`w:<owner>:<address>`), which means that when a factory's account
-// implementation is upgraded and `factory.getAddress(owner, salt)` starts
-// returning a new address, the new address looks like a brand-new wallet
-// to the primary store and a fresh row gets inserted alongside the old
-// one. This index lets us cheaply ask "for this (owner, factory, salt)
-// triple, which derived address is currently canonical?" so that the write
-// path can detect the upgrade and mark the old row as stale instead of
-// silently accumulating zombies.
+// (`w:<chainID>:<owner>:<address>`), which means that when a factory's
+// account implementation is upgraded and `factory.getAddress(owner, salt)`
+// starts returning a new address, the new address looks like a brand-new
+// wallet to the primary store and a fresh row gets inserted alongside the
+// old one. This index lets us cheaply ask "for this (chainID, owner,
+// factory, salt) tuple, which derived address is currently canonical?"
+// so that the write path can detect the upgrade and mark the old row as
+// stale instead of silently accumulating zombies.
 //
 // Salt is encoded in decimal (matching `(*big.Int).String()`) so the key
 // is stable across encodings. The prefix is `wsalt:` (not `w:`) so it does
 // not collide with `WalletByOwnerPrefix`.
-func WalletBySaltKey(owner common.Address, factory common.Address, salt *big.Int) []byte {
+func WalletBySaltKey(chainID int64, owner common.Address, factory common.Address, salt *big.Int) []byte {
 	saltStr := "0"
 	if salt != nil {
 		saltStr = salt.String()
 	}
 	return []byte(fmt.Sprintf(
-		"wsalt:%s:%s:%s",
+		"wsalt:%d:%s:%s:%s",
+		chainID,
 		strings.ToLower(owner.Hex()),
 		strings.ToLower(factory.Hex()),
 		saltStr,
@@ -70,18 +80,18 @@ func WalletBySaltKey(owner common.Address, factory common.Address, salt *big.Int
 }
 
 // LookupCanonicalWalletAddress returns the wallet address currently
-// registered as canonical for the given (owner, factory, salt) triple, or
-// badger.ErrKeyNotFound if none has been recorded yet.
-func LookupCanonicalWalletAddress(db storage.Storage, owner common.Address, factory common.Address, salt *big.Int) (common.Address, error) {
-	raw, err := db.GetKey(WalletBySaltKey(owner, factory, salt))
+// registered as canonical for the given (chainID, owner, factory, salt)
+// tuple, or badger.ErrKeyNotFound if none has been recorded yet.
+func LookupCanonicalWalletAddress(db storage.Storage, chainID int64, owner common.Address, factory common.Address, salt *big.Int) (common.Address, error) {
+	raw, err := db.GetKey(WalletBySaltKey(chainID, owner, factory, salt))
 	if err != nil {
 		return common.Address{}, err
 	}
 	return common.HexToAddress(string(raw)), nil
 }
 
-func GetWallet(db storage.Storage, owner common.Address, smartWalletAddress string) (*model.SmartWallet, error) {
-	walletKey := WalletStorageKey(owner, smartWalletAddress)
+func GetWallet(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string) (*model.SmartWallet, error) {
+	walletKey := WalletStorageKey(chainID, owner, smartWalletAddress)
 	walletData, err := db.GetKey([]byte(walletKey))
 	if err != nil {
 		return nil, err // Includes badger.ErrKeyNotFound
@@ -95,19 +105,20 @@ func GetWallet(db storage.Storage, owner common.Address, smartWalletAddress stri
 }
 
 // StoreWallet persists the wallet record under its primary key
-// (`w:<owner>:<address>`) and, when the wallet has a non-nil factory and
-// salt and is not flagged stale, also writes the `(owner, factory, salt)`
-// secondary index entry pointing at this wallet's address. Both writes
-// happen in a single BatchWrite so the index can never be left dangling.
+// (`w:<chainID>:<owner>:<address>`) and, when the wallet has a non-nil
+// factory and salt and is not flagged stale, also writes the
+// `(chainID, owner, factory, salt)` secondary index entry pointing at
+// this wallet's address. Both writes happen in a single BatchWrite so
+// the index can never be left dangling.
 //
 // Stale records (StaleDerivation == true) only update the primary entry —
 // the secondary index intentionally continues to point at the new
-// canonical wallet for that triple, not the stale one.
-func StoreWallet(db storage.Storage, owner common.Address, wallet *model.SmartWallet) error {
+// canonical wallet for that tuple, not the stale one.
+func StoreWallet(db storage.Storage, chainID int64, owner common.Address, wallet *model.SmartWallet) error {
 	if wallet.Address == nil {
 		return fmt.Errorf("cannot store wallet with nil address")
 	}
-	walletKey := WalletStorageKey(owner, wallet.Address.String())
+	walletKey := WalletStorageKey(chainID, owner, wallet.Address.String())
 	updatedWalletData, err := wallet.ToJSON()
 	if err != nil {
 		return fmt.Errorf("failed to marshal wallet for storage (key: %s): %w", walletKey, err)
@@ -118,7 +129,7 @@ func StoreWallet(db storage.Storage, owner common.Address, wallet *model.SmartWa
 		return db.Set([]byte(walletKey), updatedWalletData)
 	}
 
-	indexKey := WalletBySaltKey(owner, *wallet.Factory, wallet.Salt)
+	indexKey := WalletBySaltKey(chainID, owner, *wallet.Factory, wallet.Salt)
 	indexValue := []byte(strings.ToLower(wallet.Address.Hex()))
 	return db.BatchWrite(map[string][]byte{
 		walletKey:        updatedWalletData,
@@ -131,14 +142,14 @@ func StoreWallet(db storage.Storage, owner common.Address, wallet *model.SmartWa
 // updated by this call (StoreWallet skips the index for stale records),
 // so callers that want the index to point at a fresh canonical wallet
 // must call StoreWallet on the new wallet *after* this returns.
-func MarkWalletStale(db storage.Storage, owner common.Address, smartWalletAddress string) error {
-	wallet, err := GetWallet(db, owner, smartWalletAddress)
+func MarkWalletStale(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string) error {
+	wallet, err := GetWallet(db, chainID, owner, smartWalletAddress)
 	if err != nil {
 		return fmt.Errorf("failed to load wallet to mark stale (%s): %w", smartWalletAddress, err)
 	}
 	wallet.StaleDerivation = true
 	wallet.IsHidden = true
-	return StoreWallet(db, owner, wallet)
+	return StoreWallet(db, chainID, owner, wallet)
 }
 
 func WorkflowStorageKey(id string, status avsproto.TaskStatus) []byte {
@@ -197,23 +208,6 @@ func ChainTaskExecutionKey(chainID int64, t *model.Workflow, executionID string)
 		chainID,
 		t.Id,
 		executionID,
-	))
-}
-
-func ChainWalletStorageKey(chainID int64, owner common.Address, smartWalletAddress string) string {
-	return fmt.Sprintf(
-		"w:%d:%s:%s",
-		chainID,
-		strings.ToLower(owner.Hex()),
-		strings.ToLower(smartWalletAddress),
-	)
-}
-
-func ChainWalletByOwnerPrefix(chainID int64, owner common.Address) []byte {
-	return []byte(fmt.Sprintf(
-		"w:%d:%s",
-		chainID,
-		strings.ToLower(owner.String()),
 	))
 }
 
@@ -348,8 +342,8 @@ func ContractWriteCounterKey(eoa common.Address) []byte {
 // IsWalletHidden checks if a wallet is marked as hidden.
 // It returns true if hidden, false otherwise. If the wallet is not found or an error occurs,
 // it returns false and the error (except for badger.ErrKeyNotFound where it still returns false for IsHidden).
-func IsWalletHidden(db storage.Storage, owner common.Address, smartWalletAddress string) (bool, error) {
-	wallet, err := GetWallet(db, owner, smartWalletAddress)
+func IsWalletHidden(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string) (bool, error) {
+	wallet, err := GetWallet(db, chainID, owner, smartWalletAddress)
 	if err != nil {
 		if err == badger.ErrKeyNotFound {
 			return false, nil // Wallet doesn't exist, so not hidden by our definition, no error to bubble up for this specific check.
@@ -363,8 +357,8 @@ func IsWalletHidden(db storage.Storage, owner common.Address, smartWalletAddress
 }
 
 // SetWalletHiddenStatus sets the hidden status of a specified wallet.
-func SetWalletHiddenStatus(db storage.Storage, owner common.Address, smartWalletAddress string, hidden bool) error {
-	wallet, err := GetWallet(db, owner, smartWalletAddress)
+func SetWalletHiddenStatus(db storage.Storage, chainID int64, owner common.Address, smartWalletAddress string, hidden bool) error {
+	wallet, err := GetWallet(db, chainID, owner, smartWalletAddress)
 	if err != nil {
 		// If wallet not found, and we intend to "unhide" (which is a no-op) or "hide" (which means creating it as hidden).
 		// For simplicity, let's assume for now that SetWalletHiddenStatus operates on existing wallets.
@@ -380,24 +374,27 @@ func SetWalletHiddenStatus(db storage.Storage, owner common.Address, smartWallet
 	}
 
 	wallet.IsHidden = hidden
-	return StoreWallet(db, owner, wallet)
+	return StoreWallet(db, chainID, owner, wallet)
 }
 
 // Fee ledger storage keys
 
-// FeeLedgerKey returns the key for a user's outstanding value fee balance.
-// Format: "fl:<owner_hex>" → JSON-encoded FeeLedgerEntry
-func FeeLedgerKey(owner common.Address) []byte {
-	return []byte(fmt.Sprintf("fl:%s", strings.ToLower(owner.Hex())))
+// FeeLedgerKey returns the key for a user's outstanding value fee balance on
+// a specific chain. Format: "fl:<chainID>:<owner_hex>" → JSON-encoded
+// FeeLedgerEntry. Each chain maintains its own ledger so per-chain billing
+// settlement is unambiguous.
+func FeeLedgerKey(chainID int64, owner common.Address) []byte {
+	return []byte(fmt.Sprintf("fl:%d:%s", chainID, strings.ToLower(owner.Hex())))
 }
 
 // FeeRecordKey returns the key for an individual fee record (audit trail).
-// Format: "fr:<owner_hex>:<execution_id>" → JSON-encoded FeeRecord
-func FeeRecordKey(owner common.Address, executionID string) []byte {
-	return []byte(fmt.Sprintf("fr:%s:%s", strings.ToLower(owner.Hex()), executionID))
+// Format: "fr:<chainID>:<owner_hex>:<execution_id>" → JSON-encoded FeeRecord.
+func FeeRecordKey(chainID int64, owner common.Address, executionID string) []byte {
+	return []byte(fmt.Sprintf("fr:%d:%s:%s", chainID, strings.ToLower(owner.Hex()), executionID))
 }
 
-// FeeRecordPrefix returns the prefix for all fee records for an owner.
-func FeeRecordPrefix(owner common.Address) []byte {
-	return []byte(fmt.Sprintf("fr:%s:", strings.ToLower(owner.Hex())))
+// FeeRecordPrefix returns the prefix for all fee records for an owner on
+// a specific chain.
+func FeeRecordPrefix(chainID int64, owner common.Address) []byte {
+	return []byte(fmt.Sprintf("fr:%d:%s:", chainID, strings.ToLower(owner.Hex())))
 }

--- a/core/taskengine/simulate_sequential_contract_writes_test.go
+++ b/core/taskengine/simulate_sequential_contract_writes_test.go
@@ -79,7 +79,7 @@ func TestSimulateTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	}
 
 	// Register smart wallet in database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddr,
 		Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -79,7 +79,7 @@ func TestSimulateTask_StopLossWorkflow_Sepolia(t *testing.T) {
 		SmartAccountAddress: smartWalletAddr,
 	}
 	require.NoError(t,
-		StoreWallet(db, ownerAddress, &model.SmartWallet{
+		StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 			Owner:   &ownerAddress,
 			Address: smartWalletAddr,
 			Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/stats_test.go
+++ b/core/taskengine/stats_test.go
@@ -34,7 +34,10 @@ func TestTaskStatCount(t *testing.T) {
 	tr1.MaxExecution = 1
 	n.CreateWorkflow(testutil.TestUser1(), tr1)
 
-	statSvc := NewStatService(db)
+	// CreateWorkflow stamps the task with the engine's defaultChainID
+	// (config.SmartWallet.ChainID), so the stat service must scan that
+	// chain — the chain-0 default in NewStatService would miss it.
+	statSvc := NewStatServiceWithChains(db, []int64{config.SmartWallet.ChainID})
 	// Query statistics using the same smart wallet address used for task creation
 	addr := common.HexToAddress(smartWalletAddress)
 	owner := testutil.TestUser1().Address

--- a/core/taskengine/userops_withdraw_all_test.go
+++ b/core/taskengine/userops_withdraw_all_test.go
@@ -192,7 +192,7 @@ func TestWithdrawAllETH_Sepolia(t *testing.T) {
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(0),

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -89,7 +89,7 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(0),
@@ -551,7 +551,7 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(0),

--- a/core/taskengine/utils_calldata_test.go
+++ b/core/taskengine/utils_calldata_test.go
@@ -567,7 +567,7 @@ func TestContractWrite_InvalidNumericValue_ResponseStructure(t *testing.T) {
 	require.NoError(t, err, "Failed to derive smart wallet address")
 
 	// Seed wallet in DB for validation
-	_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+	_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 		Owner:   &ownerEOA,
 		Address: runnerAddr,
 		Factory: &smartWalletConfig.FactoryAddress,

--- a/core/taskengine/validation.go
+++ b/core/taskengine/validation.go
@@ -8,7 +8,12 @@ import (
 
 const TaskIDLength = 26
 
-func ValidWalletOwner(db storage.Storage, u *model.User, smartWalletAddress common.Address) (bool, error) {
+// ValidWalletOwner reports whether the smart wallet at smartWalletAddress is
+// owned by u on the given chain. Wallets are chain-scoped (the factory
+// address differs per chain, so a wallet derived on chain A is not the same
+// record as one on chain B even if the EOA owner matches), so the chainID is
+// part of the ownership question.
+func ValidWalletOwner(db storage.Storage, chainID int64, u *model.User, smartWalletAddress common.Address) (bool, error) {
 	// the smart wallet address is the default one (if SmartAccountAddress is set)
 	// Note: nil check is required because some callers create User objects with only Address field set
 	if u.SmartAccountAddress != nil && u.SmartAccountAddress.Hex() == smartWalletAddress.Hex() {
@@ -16,7 +21,7 @@ func ValidWalletOwner(db storage.Storage, u *model.User, smartWalletAddress comm
 	}
 
 	// not default, look up in our storage
-	exists, err := db.Exist([]byte(WalletStorageKey(u.Address, smartWalletAddress.Hex())))
+	exists, err := db.Exist([]byte(WalletStorageKey(chainID, u.Address, smartWalletAddress.Hex())))
 	if exists {
 		return true, nil
 	}

--- a/core/taskengine/validation_test.go
+++ b/core/taskengine/validation_test.go
@@ -14,7 +14,7 @@ import (
 func TestWalletOwnerReturnTrueForDefaultAddress(t *testing.T) {
 	smartAddress := common.HexToAddress("0x5Df343de7d99fd64b2479189692C1dAb8f46184a")
 
-	result, err := ValidWalletOwner(nil, &model.User{
+	result, err := ValidWalletOwner(nil, int64(1), &model.User{
 		Address:             common.HexToAddress("0xe272b72E51a5bF8cB720fc6D6DF164a4D5E321C5"),
 		SmartAccountAddress: &smartAddress,
 	}, common.HexToAddress("0x5Df343de7d99fd64b2479189692C1dAb8f46184a"))
@@ -32,7 +32,7 @@ func TestWalletOwnerReturnTrueForNonDefaultAddress(t *testing.T) {
 	defaultSmartWallet := common.HexToAddress("0x5Df343de7d99fd64b2479189692C1dAb8f46184a")
 	customSmartWallet := common.HexToAddress("0xdD85693fd14b522a819CC669D6bA388B4FCd158d")
 
-	result, err := ValidWalletOwner(db, &model.User{
+	result, err := ValidWalletOwner(db, int64(1), &model.User{
 		Address:             eoa,
 		SmartAccountAddress: &defaultSmartWallet,
 	}, customSmartWallet)
@@ -41,9 +41,9 @@ func TestWalletOwnerReturnTrueForNonDefaultAddress(t *testing.T) {
 	}
 
 	// setup wallet binding
-	db.Set([]byte(WalletStorageKey(eoa, customSmartWallet.Hex())), []byte("1"))
+	db.Set([]byte(WalletStorageKey(int64(1), eoa, customSmartWallet.Hex())), []byte("1"))
 
-	result, err = ValidWalletOwner(db, &model.User{
+	result, err = ValidWalletOwner(db, int64(1), &model.User{
 		Address:             eoa,
 		SmartAccountAddress: &defaultSmartWallet,
 	}, customSmartWallet)

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1548,7 +1548,7 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 		_, hasSalt := v.vars["aa_salt"]
 		v.mu.Unlock()
 		if !hasSalt && v.db != nil {
-			if wallet, err := GetWallet(v.db, v.TaskOwner, v.task.SmartWalletAddress); err == nil && wallet != nil && wallet.Salt != nil {
+			if wallet, err := GetWallet(v.db, v.task.Task.ChainId, v.TaskOwner, v.task.SmartWalletAddress); err == nil && wallet != nil && wallet.Salt != nil {
 				v.AddVar("aa_salt", wallet.Salt)
 			}
 		}

--- a/core/taskengine/vm_runner_contract_write_data_priority_test.go
+++ b/core/taskengine/vm_runner_contract_write_data_priority_test.go
@@ -49,7 +49,7 @@ func TestContractWriteDataPriority(t *testing.T) {
 		runnerAddr, err := aa.GetSenderAddress(client, ownerEOA, big.NewInt(0))
 		require.NoError(t, err, "Failed to derive smart wallet address")
 
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
 			Owner:   &ownerEOA,
 			Address: runnerAddr,
 			Factory: &factory,

--- a/core/taskengine/vm_runner_contract_write_simulation_test.go
+++ b/core/taskengine/vm_runner_contract_write_simulation_test.go
@@ -104,7 +104,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		runnerAddr, err := aa.GetSenderAddress(client, ownerEOA, big.NewInt(0))
 		require.NoError(t, err, "Failed to derive smart wallet address")
 
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
 
 		// Provide settings for new backend validation structure
 		triggerData := map[string]interface{}{
@@ -171,7 +171,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		require.NoError(t, err, "Failed to derive smart wallet address")
 
 		// Seed wallet for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: runnerAddr, Factory: &factory, Salt: big.NewInt(0)})
 
 		// Full USDC ABI as provided in client request (truncated for readability but key functions included)
 		contractAbi := []interface{}{
@@ -301,7 +301,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		require.NoError(t, derr, "Failed to derive runner")
 
 		// Seed wallet for validation
-		_ = StoreWallet(db, ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: derivedRunner, Factory: &factory, Salt: big.NewInt(0)})
+		_ = StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{Owner: &ownerEOA, Address: derivedRunner, Factory: &factory, Salt: big.NewInt(0)})
 
 		// Minimal ABI for transfer(address,uint256)
 		transferAbi := []interface{}{

--- a/core/taskengine/wallet_count_limit_fix_test.go
+++ b/core/taskengine/wallet_count_limit_fix_test.go
@@ -41,7 +41,7 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		Factory: &factoryAddr,
 		Salt:    big.NewInt(0),
 	}
-	err := StoreWallet(db, user.Address, wallet1)
+	err := StoreWallet(db, int64(1), user.Address, wallet1)
 	require.NoError(t, err)
 
 	addr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -51,16 +51,16 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		Factory: &factoryAddr,
 		Salt:    big.NewInt(1),
 	}
-	err = StoreWallet(db, user.Address, wallet2)
+	err = StoreWallet(db, int64(1), user.Address, wallet2)
 	require.NoError(t, err)
 
 	t.Run("Direct database access to existing wallets should work at limit", func(t *testing.T) {
 		// This is what validateSmartWalletOwnership() does in withdrawFunds
-		retrievedWallet1, err := GetWallet(db, user.Address, wallet1.Address.Hex())
+		retrievedWallet1, err := GetWallet(db, int64(1), user.Address, wallet1.Address.Hex())
 		require.NoError(t, err)
 		assert.Equal(t, wallet1.Address.Hex(), retrievedWallet1.Address.Hex())
 
-		retrievedWallet2, err := GetWallet(db, user.Address, wallet2.Address.Hex())
+		retrievedWallet2, err := GetWallet(db, int64(1), user.Address, wallet2.Address.Hex())
 		require.NoError(t, err)
 		assert.Equal(t, wallet2.Address.Hex(), retrievedWallet2.Address.Hex())
 	})
@@ -93,14 +93,14 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		// Reset the database to have just 1 wallet initially
 		// Clean up any wallets that might have been created by previous subtests (e.g., ListWallets)
 		// by deleting all wallets and recreating just wallet1
-		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(user.Address))
+		dbItems, err := db.GetByPrefix(WalletByOwnerPrefix(int64(1), user.Address))
 		require.NoError(t, err)
 		for _, item := range dbItems {
 			db.Delete(item.Key)
 		}
 
 		// Recreate wallet1 to ensure clean state
-		err = StoreWallet(db, user.Address, wallet1)
+		err = StoreWallet(db, int64(1), user.Address, wallet1)
 		require.NoError(t, err)
 
 		// Now we have 1 wallet (limit=2), so we can create one more
@@ -115,7 +115,7 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 		t.Logf("DEBUG: Created wallet at address: %s", walletAddr)
 
 		// Now add the second wallet back to reach the limit
-		err2 := StoreWallet(db, user.Address, wallet2)
+		err2 := StoreWallet(db, int64(1), user.Address, wallet2)
 		require.NoError(t, err2)
 
 		// Now we have 3 wallets (limit=2), so we're over the limit
@@ -165,7 +165,7 @@ func TestWalletCountLimitReproducesOriginalWithdrawFundsBug(t *testing.T) {
 			Factory: &factoryAddr,
 			Salt:    big.NewInt(int64(i)),
 		}
-		err := StoreWallet(db, user.Address, wallet)
+		err := StoreWallet(db, int64(1), user.Address, wallet)
 		require.NoError(t, err)
 		wallets[i] = wallet
 	}
@@ -202,7 +202,7 @@ func TestWalletCountLimitReproducesOriginalWithdrawFundsBug(t *testing.T) {
 
 		// Access specific wallets
 		for _, wallet := range wallets {
-			retrievedWallet, err := GetWallet(db, user.Address, wallet.Address.Hex())
+			retrievedWallet, err := GetWallet(db, int64(1), user.Address, wallet.Address.Hex())
 			require.NoError(t, err)
 			assert.Equal(t, wallet.Address.Hex(), retrievedWallet.Address.Hex())
 		}

--- a/core/taskengine/wallet_salt_index_test.go
+++ b/core/taskengine/wallet_salt_index_test.go
@@ -55,15 +55,15 @@ func TestStoreWallet_WritesPrimaryAndSecondaryIndex(t *testing.T) {
 	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
 	wallet := mkWallet(owner, factory, addr, 0)
 
-	require.NoError(t, StoreWallet(db, owner, wallet))
+	require.NoError(t, StoreWallet(db, int64(1), owner, wallet))
 
 	// Primary record present.
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.Equal(t, addr.Hex(), got.Address.Hex())
 
 	// Secondary index points at the same address.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), addr.Hex()),
 		"secondary index should point at the canonical wallet address")
@@ -78,7 +78,7 @@ func TestStoreWallet_StaleRecordDoesNotUpdateSecondaryIndex(t *testing.T) {
 
 	// First, persist the canonical wallet — index should point at it.
 	canonicalAddr := common.HexToAddress("0x3333333333333333333333333333333333333333")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, canonicalAddr, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, canonicalAddr, 0)))
 
 	// Now, write a stale wallet with the same (owner, factory, salt).
 	// The secondary index must continue to point at the canonical
@@ -87,15 +87,15 @@ func TestStoreWallet_StaleRecordDoesNotUpdateSecondaryIndex(t *testing.T) {
 	stale := mkWallet(owner, factory, staleAddr, 0)
 	stale.StaleDerivation = true
 	stale.IsHidden = true
-	require.NoError(t, StoreWallet(db, owner, stale))
+	require.NoError(t, StoreWallet(db, int64(1), owner, stale))
 
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), canonicalAddr.Hex()),
 		"index must continue pointing at the canonical wallet, not the stale one")
 
 	// And the stale primary record is still readable.
-	got, err := GetWallet(db, owner, staleAddr.Hex())
+	got, err := GetWallet(db, int64(1), owner, staleAddr.Hex())
 	require.NoError(t, err)
 	assert.True(t, got.StaleDerivation)
 	assert.True(t, got.IsHidden)
@@ -114,9 +114,9 @@ func TestStoreWallet_MissingFactorySkipsSecondaryIndex(t *testing.T) {
 		Address: &addr,
 		Salt:    big.NewInt(0),
 	}
-	require.NoError(t, StoreWallet(db, owner, legacy))
+	require.NoError(t, StoreWallet(db, int64(1), owner, legacy))
 
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.Equal(t, addr.Hex(), got.Address.Hex())
 
@@ -135,7 +135,7 @@ func TestLookupCanonicalWalletAddress_NotFound(t *testing.T) {
 	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
 
-	_, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	_, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	assert.ErrorIs(t, err, badger.ErrKeyNotFound)
 }
 
@@ -146,11 +146,11 @@ func TestMarkWalletStale_FlipsFlagsAndPreservesIndex(t *testing.T) {
 	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
 	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, addr, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, addr, 0)))
 
-	require.NoError(t, MarkWalletStale(db, owner, addr.Hex()))
+	require.NoError(t, MarkWalletStale(db, int64(1), owner, addr.Hex()))
 
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.True(t, got.StaleDerivation)
 	assert.True(t, got.IsHidden)
@@ -158,7 +158,7 @@ func TestMarkWalletStale_FlipsFlagsAndPreservesIndex(t *testing.T) {
 	// The secondary index was written before the wallet was marked
 	// stale, and MarkWalletStale must not erase it (a future fresh
 	// derivation will overwrite it via StoreWallet).
-	indexed, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	indexed, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(indexed.Hex(), addr.Hex()))
 }
@@ -172,6 +172,7 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 
 	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = int64(1)
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
@@ -180,10 +181,10 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	// Era 1: store the wallet that was canonical when the factory
 	// implementation produced this address.
 	era1 := common.HexToAddress("0x5d814Cc9E94B2656f59Ee439D44AA1b6ca21434f")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, era1, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, era1, 0)))
 
 	// Sanity: the index points at era1.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era1.Hex()))
 
@@ -191,10 +192,10 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	// a different address.
 	era2 := common.HexToAddress("0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e")
 
-	engine.markPreviousCanonicalStaleIfAny(owner, factory, big.NewInt(0), era2)
+	engine.markPreviousCanonicalStaleIfAny(int64(1), owner, factory, big.NewInt(0), era2)
 
 	// era1 must now be marked stale.
-	got, err := GetWallet(db, owner, era1.Hex())
+	got, err := GetWallet(db, int64(1), owner, era1.Hex())
 	require.NoError(t, err)
 	assert.True(t, got.StaleDerivation, "era1 wallet should be flagged as stale")
 	assert.True(t, got.IsHidden, "era1 wallet should be force-hidden")
@@ -202,15 +203,15 @@ func TestMarkPreviousCanonicalStaleIfAny_DetectsUpgrade(t *testing.T) {
 	// And the secondary index still points at era1 — until the caller
 	// follows up with StoreWallet on the era2 wallet, which is what
 	// the production GetWallet path does immediately after.
-	canonical, err = LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err = LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era1.Hex()),
 		"index unchanged until the new canonical wallet is stored")
 
 	// Now simulate the StoreWallet that would follow in GetWallet's
 	// not-found branch and verify the index flips to era2.
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, era2, 0)))
-	canonical, err = LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, era2, 0)))
+	canonical, err = LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era2.Hex()),
 		"index should now point at the new canonical wallet")
@@ -221,17 +222,18 @@ func TestMarkPreviousCanonicalStaleIfAny_NoOpWhenIndexMatches(t *testing.T) {
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 
 	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = int64(1)
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
 	addr := common.HexToAddress("0x3333333333333333333333333333333333333333")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, addr, 0)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, addr, 0)))
 
 	// Same address — no upgrade detected, nothing to mark stale.
-	engine.markPreviousCanonicalStaleIfAny(owner, factory, big.NewInt(0), addr)
+	engine.markPreviousCanonicalStaleIfAny(int64(1), owner, factory, big.NewInt(0), addr)
 
-	got, err := GetWallet(db, owner, addr.Hex())
+	got, err := GetWallet(db, int64(1), owner, addr.Hex())
 	require.NoError(t, err)
 	assert.False(t, got.StaleDerivation)
 	assert.False(t, got.IsHidden)
@@ -242,6 +244,7 @@ func TestListWallets_HardFiltersStaleRows(t *testing.T) {
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 
 	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = int64(1)
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
@@ -251,11 +254,11 @@ func TestListWallets_HardFiltersStaleRows(t *testing.T) {
 	// it disappears from the list response entirely.
 	a := common.HexToAddress("0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa")
 	b := common.HexToAddress("0xBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbb")
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, a, 100)))
-	require.NoError(t, StoreWallet(db, owner, mkWallet(owner, factory, b, 101)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, a, 100)))
+	require.NoError(t, StoreWallet(db, int64(1), owner, mkWallet(owner, factory, b, 101)))
 
 	// Flag b as stale.
-	require.NoError(t, MarkWalletStale(db, owner, b.Hex()))
+	require.NoError(t, MarkWalletStale(db, int64(1), owner, b.Hex()))
 
 	resp, err := engine.ListWallets(owner, &avsproto.ListWalletReq{})
 	require.NoError(t, err)
@@ -321,12 +324,12 @@ func TestBackfillWalletSaltIndex_AllCanonical(t *testing.T) {
 	w := mkWallet(owner, factory, addr, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, addr.Hex())), body))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, addr.Hex())), body))
 
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), addr)
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Total)
 	assert.Equal(t, 1, stats.CanonicalConfirmed)
@@ -334,7 +337,7 @@ func TestBackfillWalletSaltIndex_AllCanonical(t *testing.T) {
 	assert.Equal(t, 0, stats.NewlyMarkedStale)
 
 	// And the secondary index now exists.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), addr.Hex()))
 }
@@ -356,14 +359,14 @@ func TestBackfillWalletSaltIndex_DetectsAndMarksStale(t *testing.T) {
 		w := mkWallet(owner, factory, addr, 0)
 		body, err := w.ToJSON()
 		require.NoError(t, err)
-		require.NoError(t, db.Set([]byte(WalletStorageKey(owner, addr.Hex())), body))
+		require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, addr.Hex())), body))
 	}
 
 	// Simulate today's factory implementation: salt 0 derives to era3.
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), era3)
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, stats.Total)
 	assert.Equal(t, 1, stats.CanonicalConfirmed, "only the era3 row matches the live derivation")
@@ -372,18 +375,18 @@ func TestBackfillWalletSaltIndex_DetectsAndMarksStale(t *testing.T) {
 
 	// era1 and era2 are now stale.
 	for _, addr := range []common.Address{era1, era2} {
-		got, gerr := GetWallet(db, owner, addr.Hex())
+		got, gerr := GetWallet(db, int64(1), owner, addr.Hex())
 		require.NoError(t, gerr)
 		assert.True(t, got.StaleDerivation, "%s should be stale", addr.Hex())
 		assert.True(t, got.IsHidden, "%s should be hidden", addr.Hex())
 	}
 	// era3 is still canonical.
-	got, err := GetWallet(db, owner, era3.Hex())
+	got, err := GetWallet(db, int64(1), owner, era3.Hex())
 	require.NoError(t, err)
 	assert.False(t, got.StaleDerivation)
 
 	// Secondary index points at era3.
-	canonical, err := LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	canonical, err := LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	require.NoError(t, err)
 	assert.True(t, strings.EqualFold(canonical.Hex(), era3.Hex()))
 }
@@ -402,23 +405,23 @@ func TestBackfillWalletSaltIndex_DryRunWritesNothing(t *testing.T) {
 	w := mkWallet(owner, factory, stored, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, stored.Hex())), body))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, stored.Hex())), body))
 
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), live)
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{DryRun: true})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{DryRun: true})
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.NewlyMarkedStale, "dry-run should still report what it would do")
 
 	// But the actual record is unchanged.
-	got, err := GetWallet(db, owner, stored.Hex())
+	got, err := GetWallet(db, int64(1), owner, stored.Hex())
 	require.NoError(t, err)
 	assert.False(t, got.StaleDerivation, "dry-run must not flip the stale flag")
 	assert.False(t, got.IsHidden)
 
 	// And no secondary index entry was written.
-	_, err = LookupCanonicalWalletAddress(db, owner, factory, big.NewInt(0))
+	_, err = LookupCanonicalWalletAddress(db, int64(1), owner, factory, big.NewInt(0))
 	assert.ErrorIs(t, err, badger.ErrKeyNotFound)
 }
 
@@ -435,7 +438,7 @@ func TestBackfillWalletSaltIndex_SkipsLegacyAndDeriveErrors(t *testing.T) {
 	legacy := &model.SmartWallet{Owner: &owner, Address: &legacyAddr, Salt: big.NewInt(0)}
 	legacyBody, err := legacy.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, legacyAddr.Hex())), legacyBody))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, legacyAddr.Hex())), legacyBody))
 
 	// 2. Row whose deriver returns an error — should be counted as
 	//    SkippedDeriveError.
@@ -443,12 +446,12 @@ func TestBackfillWalletSaltIndex_SkipsLegacyAndDeriveErrors(t *testing.T) {
 	errWallet := mkWallet(owner, factory, errAddr, 7)
 	errBody, err := errWallet.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, db.Set([]byte(WalletStorageKey(owner, errAddr.Hex())), errBody))
+	require.NoError(t, db.Set([]byte(WalletStorageKey(int64(1), owner, errAddr.Hex())), errBody))
 
 	deriver := newFakeDeriver()
 	deriver.errors[deriver.key(owner, factory, big.NewInt(7))] = assertAnError{}
 
-	stats, err := BackfillWalletSaltIndex(db, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(db, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, stats.Total)
 	assert.Equal(t, 1, stats.SkippedMissingFactory)
@@ -577,7 +580,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnSetError(t *testing.T) {
 	w := mkWallet(owner, factory, addr, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, inner.Set([]byte(WalletStorageKey(owner, addr.Hex())), body))
+	require.NoError(t, inner.Set([]byte(WalletStorageKey(int64(1), owner, addr.Hex())), body))
 
 	// Wrap the DB so the next Set() (the secondary index write) fails.
 	wrapped := &closingDB{Storage: inner, successesAllowed: 0}
@@ -585,7 +588,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnSetError(t *testing.T) {
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), addr) // canonical match
 
-	stats, err := BackfillWalletSaltIndex(wrapped, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(wrapped, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.Error(t, err, "BackfillWalletSaltIndex must surface storage errors instead of swallowing them")
 	assert.Contains(t, err.Error(), "write secondary index")
 	require.NotNil(t, stats, "stats should still be returned alongside the error for diagnostics")
@@ -603,7 +606,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnMarkStaleError(t *testing.T) {
 	w := mkWallet(owner, factory, stored, 0)
 	body, err := w.ToJSON()
 	require.NoError(t, err)
-	require.NoError(t, inner.Set([]byte(WalletStorageKey(owner, stored.Hex())), body))
+	require.NoError(t, inner.Set([]byte(WalletStorageKey(int64(1), owner, stored.Hex())), body))
 
 	// MarkWalletStale calls StoreWallet which calls db.Set (since the
 	// stale wallet is not eligible for the secondary index batch path).
@@ -614,7 +617,7 @@ func TestBackfillWalletSaltIndex_FailsFastOnMarkStaleError(t *testing.T) {
 	deriver := newFakeDeriver()
 	deriver.set(owner, factory, big.NewInt(0), live) // mismatch -> stale path
 
-	stats, err := BackfillWalletSaltIndex(wrapped, deriver.derive, WalletSaltIndexBackfillOptions{})
+	stats, err := BackfillWalletSaltIndex(wrapped, int64(1), deriver.derive, WalletSaltIndexBackfillOptions{})
 	require.Error(t, err, "BackfillWalletSaltIndex must surface MarkWalletStale errors")
 	assert.Contains(t, err.Error(), "mark wallet stale")
 	require.NotNil(t, stats)

--- a/core/testutil/utils.go
+++ b/core/testutil/utils.go
@@ -478,6 +478,13 @@ func GetAggregatorConfig() *config.Config {
 
 	return &config.Config{
 		SmartWallet: &config.SmartWalletConfig{
+			// ChainID = 1 is the test default. Many tests construct
+			// storage keys manually via StoreWallet(db, int64(1), ...)
+			// alongside engine-mediated calls; both paths must agree on
+			// the chain segment of the chain-scoped key, so we pin the
+			// engine's defaultChainID() to 1 here. Tests that exercise
+			// multi-chain behavior override this on the returned config.
+			ChainID:            1,
 			EthRpcUrl:          GetTestRPCURL(),
 			EthWsUrl:           GetTestWsRPCURL(),
 			FactoryAddress:     common.HexToAddress(GetTestFactoryAddress()),

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -21,9 +21,6 @@ operator_address: <operator_address>
 avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
 operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
-eth_rpc_url: https://ethereum-rpc.publicnode.com
-eth_ws_url: wss://ethereum-rpc.publicnode.com
-
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -5,11 +5,11 @@ To run the AVS operator, there are 2 steps
 1. Register to become an EigenLayer operator by following [EigenLayer Operator Guide](https://docs.eigenlayer.xyz/eigenlayer/operator-guides/operator-introduction)
 2. Once become an operator, you can register for Ava Protocol AVS by following the below step
 
-### Run Ava Protocol AVS on Holesky testnet
+### Run Ava Protocol AVS on Ethereum mainnet
 
 Download the latest release from https://github.com/AvaProtocol/EigenLayer-AVS/releases for your platform. You can compile for yourself by simply running `go build` at the root level.
 
-First, Generate Ava Protocol AVS config file. You can put it anywhere. Example `config/operator.yaml` with below content
+First, Generate Ava Protocol AVS config file. You can put it anywhere. Example `config/operator.yaml` with below content:
 
 ```
 # this sets the logger level (true = info, false = debug)
@@ -17,16 +17,19 @@ production: true
 
 operator_address: <operator_address>
 
-avs_registry_coordinator_address: 0x90c6d6f2A78d5Ce22AB8631Ddb142C03AC87De7a
-operator_state_retriever_address: 0xb7bb920538e038DFFEfcB55caBf713652ED2031F
+# Ava Protocol AVS contract addresses on Ethereum mainnet
+avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
+operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
-eth_rpc_url: https://ethereum-sepolia-rpc.publicnode.com
-eth_ws_url: wss://ethereum-sepolia-rpc.publicnode.com
+eth_rpc_url: https://ethereum-rpc.publicnode.com
+eth_ws_url: wss://ethereum-rpc.publicnode.com
 
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 
-aggregator_server_ip_port_address: "aggregator-holesky.avaprotocol.org:2206"
+# Unified aggregator endpoint — serves all mainnet chains (Ethereum, Base, ...)
+# from a single gRPC connection. The gateway routes per-chain internally.
+aggregator_server_ip_port_address: "aggregator.avaprotocol.org:2206"
 
 # avs node spec compliance https://eigen.nethermind.io/docs/spec/intro
 eigen_metrics_ip_port_address: <operator_public_ip>:9090
@@ -34,6 +37,8 @@ enable_metrics: true
 node_api_ip_port_address: <operator_public_ip>:9010
 enable_node_api: true
 ```
+
+> **Note**: Third-party operator support is mainnet-only. Sepolia/Holesky testnet operator coordination is handled internally by Ava Protocol and is not open to external operators.
 
 Configure 2 env var for your ECDSA and BLS password. Recall that these are generated when you onboard your operator to EigenLayer. In case your password contains special characters to the command-line, here we export both variables by disabling history expansion temporarily.
 ```

--- a/operator/derive_ws_url_test.go
+++ b/operator/derive_ws_url_test.go
@@ -1,0 +1,87 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+// Operator-side mirror of the test that lives in core/config: when the
+// operator YAML omits eth_ws_url at any of its three layers (top-level,
+// target_chain, per-chain entry in Chains), NewOperatorFromConfig
+// derives it from the matching eth_rpc_url via config.DeriveWsURL.
+//
+// Regression guard for the Railway env-var rename in #546 — without
+// derivation, removing eth_ws_url from operator-railway.yaml would
+// leave c.EthWsUrl empty and operator/operator.go:NewOperator would
+// fail the WebSocket dial at startup. Surfaced by the Copilot review.
+func TestOperatorConfig_DerivesWsURLWhenMissing(t *testing.T) {
+	cfg := OperatorConfig{
+		EthRpcUrl: "https://api-ethereum-mainnet.example.com/key",
+		// EthWsUrl intentionally left empty
+	}
+	cfg.TargetChain.EthRpcUrl = "https://api-base-mainnet.example.com/key"
+	// TargetChain.EthWsUrl intentionally left empty
+	cfg.Chains = []OperatorChainConfig{
+		{ChainID: 1, Name: "ethereum", EthRpcUrl: "https://api-ethereum-mainnet.example.com/key"},
+		{ChainID: 8453, Name: "base", EthRpcUrl: "https://api-base-mainnet.example.com/key"},
+	}
+
+	// We don't want to actually build the full Operator (needs ECDSA
+	// keystore, AVS contracts, etc.) — just exercise the derivation
+	// block at the top of NewOperatorFromConfig. Replicate that block
+	// here against an exported helper to keep the test fast.
+	applyWsDerivation(&cfg)
+
+	if got, want := cfg.EthWsUrl, "wss://api-ethereum-mainnet.example.com/key"; got != want {
+		t.Errorf("top-level EthWsUrl = %q, want %q", got, want)
+	}
+	if got, want := cfg.TargetChain.EthWsUrl, "wss://api-base-mainnet.example.com/key"; got != want {
+		t.Errorf("TargetChain.EthWsUrl = %q, want %q", got, want)
+	}
+	if got, want := cfg.Chains[0].EthWsUrl, "wss://api-ethereum-mainnet.example.com/key"; got != want {
+		t.Errorf("Chains[0].EthWsUrl = %q, want %q", got, want)
+	}
+	if got, want := cfg.Chains[1].EthWsUrl, "wss://api-base-mainnet.example.com/key"; got != want {
+		t.Errorf("Chains[1].EthWsUrl = %q, want %q", got, want)
+	}
+}
+
+// Explicit eth_ws_url values must win over derivation — operators that
+// genuinely need a separate WS endpoint can still set it.
+func TestOperatorConfig_PreservesExplicitWsURL(t *testing.T) {
+	cfg := OperatorConfig{
+		EthRpcUrl: "https://eth-rpc.example.com/key",
+		EthWsUrl:  "wss://eth-ws.different-host.example.com/key",
+	}
+	cfg.TargetChain.EthRpcUrl = "https://target-rpc.example.com/key"
+	cfg.TargetChain.EthWsUrl = "wss://target-ws.different-host.example.com/key"
+
+	applyWsDerivation(&cfg)
+
+	if got, want := cfg.EthWsUrl, "wss://eth-ws.different-host.example.com/key"; got != want {
+		t.Errorf("explicit top-level EthWsUrl overwritten: got %q, want %q", got, want)
+	}
+	if got, want := cfg.TargetChain.EthWsUrl, "wss://target-ws.different-host.example.com/key"; got != want {
+		t.Errorf("explicit TargetChain.EthWsUrl overwritten: got %q, want %q", got, want)
+	}
+}
+
+// applyWsDerivation is the exact block inlined at the top of
+// NewOperatorFromConfig. Extracted here so tests can exercise it
+// without building the full Operator. If you change the derivation
+// rules in NewOperatorFromConfig, update this in lockstep — these
+// tests are the regression guard.
+func applyWsDerivation(c *OperatorConfig) {
+	if c.EthWsUrl == "" {
+		c.EthWsUrl = config.DeriveWsURL(c.EthRpcUrl)
+	}
+	if c.TargetChain.EthWsUrl == "" {
+		c.TargetChain.EthWsUrl = config.DeriveWsURL(c.TargetChain.EthRpcUrl)
+	}
+	for i := range c.Chains {
+		if c.Chains[i].EthWsUrl == "" {
+			c.Chains[i].EthWsUrl = config.DeriveWsURL(c.Chains[i].EthRpcUrl)
+		}
+	}
+}

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -422,6 +422,24 @@ func NewOperatorFromConfigFile(configPath string) (*Operator, error) {
 
 // take the config in core (which is shared with aggregator and challenger)
 func NewOperatorFromConfig(c OperatorConfig) (*Operator, error) {
+	// Derive WebSocket URLs from their RPC counterparts when not set
+	// explicitly. Mirrors what core/config does for the aggregator/gateway
+	// config: every supported RPC provider serves HTTP and WS at the same
+	// host+path with only the scheme differing, so letting one URL drive
+	// both halves the env-var count and prevents the "rotate RPC but
+	// forget WS" mistake. See core/config.DeriveWsURL for the helper.
+	if c.EthWsUrl == "" {
+		c.EthWsUrl = config.DeriveWsURL(c.EthRpcUrl)
+	}
+	if c.TargetChain.EthWsUrl == "" {
+		c.TargetChain.EthWsUrl = config.DeriveWsURL(c.TargetChain.EthRpcUrl)
+	}
+	for i := range c.Chains {
+		if c.Chains[i].EthWsUrl == "" {
+			c.Chains[i].EthWsUrl = config.DeriveWsURL(c.Chains[i].EthRpcUrl)
+		}
+	}
+
 	elapsing := timekeeper.NewElapsing()
 
 	// Backward compatibility: Handle old 'production' boolean field

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -1,0 +1,170 @@
+# scripts/dev — migration rehearsal tooling
+
+End-to-end test of the Hetzner → Railway-gateway data merge on a local
+dev machine, without touching production Railway. Lets you snapshot the
+live Hetzner aggregator BadgerDBs, run the merge tool against scratch
+gateway storage, and verify the gateway can serve read queries against
+the merged data via the SDK.
+
+## Env vars required by `make dev-stack-rehearsal`
+
+`config/gateway-dev-rehearsal.yaml` references everything secret via
+`${REHEARSAL_*}` env vars so nothing real lives in git. Export these
+in your shell (or a local untracked `.env` you `source` before the
+make target) before starting the rehearsal gateway:
+
+```bash
+# Sepolia is the AVS registration chain — used by EigenLayer code paths
+# at startup. The Tenderly key is read-only so it's fine to reuse.
+export REHEARSAL_AVS_RPC=https://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_AVS_WS=wss://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_SEPOLIA_RPC=https://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_SEPOLIA_WS=wss://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_SEPOLIA_BUNDLER_URL=https://api.pimlico.io/v2/11155111/rpc?apikey=<pim_key>
+
+export REHEARSAL_BASE_SEPOLIA_RPC=https://api-base-sepolia-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_SEPOLIA_WS=wss://api-base-sepolia-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_SEPOLIA_BUNDLER_URL=https://api.pimlico.io/v2/84532/rpc?apikey=<pim_key>
+
+export REHEARSAL_ETHEREUM_RPC=https://api-ethereum-mainnet.n.dwellir.com/<key>
+export REHEARSAL_ETHEREUM_WS=wss://api-ethereum-mainnet.n.dwellir.com/<key>
+export REHEARSAL_ETHEREUM_BUNDLER_URL=https://api.pimlico.io/v2/1/rpc?apikey=<pim_key>
+
+export REHEARSAL_BASE_RPC=https://api-base-mainnet-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_WS=wss://api-base-mainnet-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_BUNDLER_URL=https://api.pimlico.io/v2/8453/rpc?apikey=<pim_key>
+
+# Cryptographic material — placeholders are fine since the rehearsal
+# never signs or submits UserOps. Any 32-byte hex works.
+export REHEARSAL_ECDSA_PRIVATE_KEY=<32-byte-hex>
+export REHEARSAL_CONTROLLER_PRIVATE_KEY=<32-byte-hex>
+export REHEARSAL_JWT_SECRET=<any-string>
+
+# Optional — only used by Tenderly-simulated nodes and notification
+# flows. Leave unset and those features degrade gracefully.
+export REHEARSAL_TENDERLY_ACCESS_KEY=<tenderly-key>
+export REHEARSAL_TELEGRAM_BOT_TOKEN=<bot-token>
+export REHEARSAL_THEGRAPH_API_KEY=<thegraph-key>
+export REHEARSAL_MORALIS_API_KEY=<moralis-jwt>
+```
+
+`make hetzner-snapshot` and `make migration-rehearse` (the steps that
+actually validate the merge) do NOT need any of these — they read
+donor BadgerDBs and write the gateway BadgerDB directly, no RPC or
+auth involved. The env vars are only required when you bring up the
+gateway to query the merged data via the SDK.
+
+## Quick start
+
+```bash
+# 1) Pull fresh donor DBs from all 4 Hetzner aggregators.
+#    Brief docker-stop per chain (~30-90s each).
+make hetzner-snapshot
+
+# 2) Dry-run the merge for all 4 chains — no writes.
+#    Inspect the per-prefix counts printed at the end of each chain.
+make migration-rehearse
+
+# 3) When the dry-run output looks right, actually merge.
+make migration-rehearse APPLY=1
+
+# 4) Start the gateway against the post-merge scratch DB.
+#    Runs the gateway on REST :8080 / gRPC :2206 plus 2 testnet workers.
+#    Mainnet workers are listed in the config but not started here;
+#    triggering a task on ethereum/base returns WORKER_UNAVAILABLE.
+make dev-stack-rehearsal
+
+# 5) In another terminal, query the SDK to confirm reads work.
+#    Compare counts to the live aggregators' output before they were
+#    snapshotted.
+cd ../ava-sdk-js/examples
+yarn start listWorkflows
+yarn start getWorkflow <task-id-from-the-list>
+```
+
+## What the rehearsal validates
+
+- The merge tool dispatch matrix matches the actual on-disk shape of
+  each donor (no unknown prefixes, no parse errors)
+- Chain-scoped keys (`w:<chain>:`, `wsalt:<chain>:`, `fl:<chain>:`,
+  `fr:<chain>:`, `t:<chain>:`, `u:<chain>:`, `history:<chain>:`) are
+  written correctly and the gateway can READ each family for each
+  chain
+- Aggregate counts (workflows, executions, wallets, secrets) match
+  the donor totals — nothing was silently dropped or duplicated
+- `execution_index_counter:` max-on-collision picks the right value
+  when both donor and gateway have entries for the same task
+- `wsalt:` index is consistent post-merge — `LookupCanonicalWalletAddress`
+  on a (chainID, owner, factory, salt) tuple returns the same wallet
+  the primary `w:<chain>:<owner>:<wallet>` record points to
+
+## What it does NOT validate
+
+- Real UserOp execution against mainnet (would cost real ETH; out of
+  scope, the merge tool does not change the execution path)
+- Operator-side trigger evaluation (operators aren't part of the
+  rehearsal stack)
+- The Railway gateway's actual storage volume — the rehearsal runs
+  against `/tmp/rehearsal-gateway-db` only. Promote to production by
+  taking a fresh pre-merge backup of the Railway gateway volume, then
+  running the same merge sequence in the production maintenance window.
+
+## Iterating without re-downloading
+
+`make hetzner-snapshot` always pulls fresh and overwrites `./donors/`.
+The merge rehearsal is non-destructive to the donor data — only the
+scratch gateway DB at `/tmp/rehearsal-gateway-db` gets reset on each
+`make migration-rehearse APPLY=1` run.
+
+So a tight iteration loop is:
+
+```bash
+make hetzner-snapshot       # once per day, when fresh data matters
+make migration-rehearse     # dry-run, iterate on dispatch matrix
+make migration-rehearse APPLY=1  # apply, then validate via SDK
+```
+
+To only snapshot or rehearse one chain:
+
+```bash
+make hetzner-snapshot CHAIN=sepolia
+make migration-rehearse CHAIN=sepolia
+make migration-rehearse CHAIN=sepolia APPLY=1
+```
+
+## File map
+
+| File | What |
+|---|---|
+| `snapshot-hetzner-donors.sh` | SSH + docker-stop + tarball each Hetzner aggregator. Extracts to `./donors/<chain>/db/`. |
+| `run-merge-rehearsal.sh` | Runs the merge tool sequentially per donor against `/tmp/rehearsal-gateway-db`. Calls `count-gateway-keys.go` at the end. |
+| `count-gateway-keys.go` | One-shot scan of the gateway DB that prints per-prefix per-chain key counts. Helps spot unexpected key distributions after the merge. |
+| `../../config/gateway-dev-rehearsal.yaml` | Gateway config pointing at the rehearsal scratch DB with all 4 chains registered. Used by `make dev-stack-rehearsal`. |
+
+## Disk + downtime budget
+
+| Chain | DB size (2026-06-04) | Hetzner downtime per snapshot |
+|---|---|---|
+| sepolia | 34 MB | ~5s |
+| base-sepolia | 26 MB | ~5s |
+| ethereum | 1.0 GB | ~30s |
+| base | 1.2 GB | ~30s |
+| **total** | **~2.3 GB** | **~70s total wall** |
+
+`make hetzner-snapshot` runs chains sequentially per host but
+mainnet/testnet hosts are independent — the two pairs could be
+parallelized in a future revision if the downtime budget becomes
+tight.
+
+## Cleanup
+
+```bash
+rm -rf donors/                          # delete all snapshotted donor data
+rm -rf /tmp/rehearsal-gateway-db        # delete the scratch gateway DB
+rm -rf /tmp/rehearsal-gateway-backup    # and its backup dir
+```
+
+## Related
+
+- [`scripts/migration/merge_hetzner_into_gateway/`](../migration/merge_hetzner_into_gateway/) — the merge tool itself
+- [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md) — the policy matrix the merge tool implements

--- a/scripts/dev/count-gateway-keys.go
+++ b/scripts/dev/count-gateway-keys.go
@@ -1,0 +1,107 @@
+// count-gateway-keys — print per-prefix key counts for a BadgerDB
+// directory. Used by run-merge-rehearsal.sh to verify what the merge
+// tool wrote and let the operator compare counts against the live SDK
+// queries (yarn start listWorkflows / getExecution).
+//
+// Usage:
+//
+//	go run scripts/dev/count-gateway-keys.go --gateway-path /tmp/...
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+func main() {
+	gatewayPath := flag.String("gateway-path", "", "Path to the gateway BadgerDB directory")
+	flag.Parse()
+	if *gatewayPath == "" {
+		log.Fatalf("--gateway-path is required")
+	}
+
+	db, err := storage.NewWithPath(*gatewayPath)
+	if err != nil {
+		log.Fatalf("open BadgerDB at %s: %v", *gatewayPath, err)
+	}
+	defer db.Close()
+
+	// Bucket every key by its prefix (everything up to first ':') and
+	// then by chain (next segment if numeric) so the post-merge
+	// distribution is visible at a glance.
+	type bucket struct {
+		prefix  string
+		chainID string // "_" when not present or non-numeric
+		count   int64
+	}
+	counts := map[string]*bucket{}
+
+	if err := db.IterateKeysOnly([]byte(""), func(key []byte) error {
+		s := string(key)
+		prefix := s
+		rest := ""
+		for i, c := range s {
+			if c == ':' {
+				prefix = s[:i+1]
+				rest = s[i+1:]
+				break
+			}
+		}
+		chainID := "_"
+		// Chain segment is everything up to the next ':' if it parses
+		// as an integer.
+		for i, c := range rest {
+			if c == ':' {
+				cand := rest[:i]
+				ok := len(cand) > 0
+				for _, ch := range cand {
+					if ch < '0' || ch > '9' {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					chainID = cand
+				}
+				break
+			}
+		}
+		bucketKey := prefix + "|" + chainID
+		b, found := counts[bucketKey]
+		if !found {
+			b = &bucket{prefix: prefix, chainID: chainID}
+			counts[bucketKey] = b
+		}
+		b.count++
+		return nil
+	}); err != nil {
+		log.Fatalf("iterate keys: %v", err)
+	}
+
+	// Sort by prefix, then chain
+	type row struct{ b *bucket }
+	rows := make([]row, 0, len(counts))
+	for _, b := range counts {
+		rows = append(rows, row{b})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].b.prefix != rows[j].b.prefix {
+			return rows[i].b.prefix < rows[j].b.prefix
+		}
+		return rows[i].b.chainID < rows[j].b.chainID
+	})
+
+	fmt.Printf("%-30s %-12s %12s\n", "Prefix", "ChainID", "Count")
+	fmt.Println("----------------------------- ------------ ------------")
+	var total int64
+	for _, r := range rows {
+		fmt.Printf("%-30s %-12s %12d\n", r.b.prefix, r.b.chainID, r.b.count)
+		total += r.b.count
+	}
+	fmt.Println("----------------------------- ------------ ------------")
+	fmt.Printf("%-30s %-12s %12d\n", "TOTAL", "", total)
+}

--- a/scripts/dev/run-merge-rehearsal.sh
+++ b/scripts/dev/run-merge-rehearsal.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# run-merge-rehearsal.sh — exercise the Hetzner→gateway merge tool against
+# locally-snapshotted donor BadgerDBs.
+#
+# Reads ./donors/<chain>/db/, runs the merge tool sequentially per chain
+# into a scratch gateway DB, prints a per-chain summary table, then
+# reports aggregate counts the operator can compare to the live SDK
+# output afterwards.
+#
+# Usage:
+#   scripts/dev/run-merge-rehearsal.sh                    # all 4 chains
+#   scripts/dev/run-merge-rehearsal.sh sepolia            # one chain
+#   scripts/dev/run-merge-rehearsal.sh sepolia base-sepolia
+#
+# Run order matters when multiple chains are requested: sepolia, base-
+# sepolia, base, ethereum (smallest first → catch issues before paying
+# the wall-clock cost of mainnet). Override the order by passing chains
+# in your preferred sequence.
+#
+# Prereqs:
+#   - Donor data already at ./donors/<chain>/db/ (run snapshot-hetzner-donors.sh first)
+#   - Local Go toolchain (`go run ./scripts/migration/merge_hetzner_into_gateway/...`)
+#
+# Exit codes:
+#   0  every requested chain merged + summary printed
+#   1  prereq missing or donor data not snapshotted
+#   2  the merge tool errored on one or more chains
+#
+# This is the DRY-RUN by default. To actually write to the scratch
+# gateway DB, pass --apply as the first arg:
+#
+#   scripts/dev/run-merge-rehearsal.sh --apply
+#   scripts/dev/run-merge-rehearsal.sh --apply sepolia
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DONORS_DIR="${ROOT_DIR}/donors"
+GATEWAY_DB="${ROOT_DIR}/tmp/rehearsal-gateway-db"
+
+declare -A CHAIN_IDS
+CHAIN_IDS[sepolia]="11155111"
+CHAIN_IDS[base-sepolia]="84532"
+CHAIN_IDS[ethereum]="1"
+CHAIN_IDS[base]="8453"
+
+DRY_RUN="true"
+if [[ "${1:-}" == "--apply" ]]; then
+    DRY_RUN="false"
+    shift
+fi
+
+# Default ordering: smallest first so iteration cycles are short
+DEFAULT_ORDER="sepolia base-sepolia base ethereum"
+
+if [[ $# -eq 0 ]]; then
+    CHAINS="${DEFAULT_ORDER}"
+else
+    CHAINS="$*"
+fi
+
+for chain in ${CHAINS}; do
+    if [[ -z "${CHAIN_IDS[${chain}]:-}" ]]; then
+        echo "ERROR: unknown chain '${chain}' — pick from: ${DEFAULT_ORDER}" >&2
+        exit 1
+    fi
+    if [[ ! -d "${DONORS_DIR}/${chain}/db" ]]; then
+        echo "ERROR: no donor snapshot for ${chain} at ${DONORS_DIR}/${chain}/db" >&2
+        echo "       run: scripts/dev/snapshot-hetzner-donors.sh ${chain}" >&2
+        exit 1
+    fi
+done
+
+# Fresh scratch gateway DB every rehearsal — we want to know exactly
+# what each merge contributed, not what stacked on top of a prior run.
+echo "Resetting scratch gateway DB: ${GATEWAY_DB}"
+rm -rf "${GATEWAY_DB}"
+mkdir -p "${GATEWAY_DB}"
+
+echo
+echo "Mode:    $([[ "${DRY_RUN}" == "true" ]] && echo "DRY RUN (no writes)" || echo "APPLY (writes to scratch gateway)")"
+echo "Chains:  ${CHAINS}"
+echo
+
+FAILED=()
+
+for chain in ${CHAINS}; do
+    chain_id="${CHAIN_IDS[${chain}]}"
+    donor_path="${DONORS_DIR}/${chain}/db"
+
+    echo "================================================================"
+    echo "MERGE: ${chain} (chain_id=${chain_id})"
+    echo "================================================================"
+
+    if ! ( cd "${ROOT_DIR}" && go run ./scripts/migration/merge_hetzner_into_gateway \
+        --donor-path     "${donor_path}" \
+        --donor-chain-id "${chain_id}" \
+        --gateway-path   "${GATEWAY_DB}" \
+        --dry-run="${DRY_RUN}" ); then
+        echo "FAIL: merge tool errored on ${chain}" >&2
+        FAILED+=("${chain}")
+    fi
+    echo
+done
+
+if [[ "${DRY_RUN}" == "false" ]]; then
+    echo "================================================================"
+    echo "POST-MERGE KEY COUNTS (gateway DB: ${GATEWAY_DB})"
+    echo "================================================================"
+    # Print per-prefix counts using badger info (if available) or a
+    # one-shot Go scan via the merge tool's IterateKeysOnly.
+    ( cd "${ROOT_DIR}" && go run scripts/dev/count-gateway-keys.go --gateway-path "${GATEWAY_DB}" ) || \
+        echo "(count tool not available — skip)"
+fi
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "FAILED CHAINS: ${FAILED[*]}" >&2
+    exit 2
+fi
+
+echo
+echo "Rehearsal complete."
+echo
+if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "This was a DRY RUN. Re-run with --apply to actually write to ${GATEWAY_DB}."
+    echo "Then start the dev gateway against that DB with:"
+    echo "  make dev-stack-rehearsal"
+fi

--- a/scripts/dev/snapshot-hetzner-donors.sh
+++ b/scripts/dev/snapshot-hetzner-donors.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# snapshot-hetzner-donors.sh — pull a fresh BadgerDB tarball from each
+# Hetzner aggregator and extract it to ./donors/<chain>/db/.
+#
+# Used by the migration rehearsal flow (see scripts/dev/run-merge-rehearsal.sh
+# and `make migration-rehearse`). Captures the live aggregator state with a
+# brief docker-stop so the BadgerDB on-disk snapshot is internally
+# consistent.
+#
+# Usage:
+#   scripts/dev/snapshot-hetzner-donors.sh                    # all 4 chains
+#   scripts/dev/snapshot-hetzner-donors.sh sepolia            # one chain
+#   scripts/dev/snapshot-hetzner-donors.sh sepolia base-sepolia
+#
+# Each chain's data lands at ./donors/<chain>/db/ (relative to the
+# project root). Existing data is overwritten — the script always pulls
+# fresh.
+#
+# Downtime: each aggregator is stopped for the duration of its tarball
+# (~30s for testnets, ~60-90s for mainnets). Mainnet downtime moves into
+# the actual maintenance window after this rehearsal succeeds.
+#
+# Prereqs:
+#   - SSH access to ap-prod1 (mainnet) and ap-staging1 (testnet)
+#   - ~/.ssh/config aliases set up
+#   - docker available on each host
+#
+# Exit codes:
+#   0  every requested chain snapshotted + extracted OK
+#   1  prereq missing (ssh, tar, etc.)
+#   2  one or more chains failed — partial download left in ./donors/
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DONORS_DIR="${ROOT_DIR}/donors"
+
+# Chain → (host, container) map. Container name is also the chain folder.
+declare -A HOSTS
+HOSTS[sepolia]="ap-staging1"
+HOSTS[base-sepolia]="ap-staging1"
+HOSTS[ethereum]="ap-prod1"
+HOSTS[base]="ap-prod1"
+
+ALL_CHAINS="sepolia base-sepolia ethereum base"
+
+# Pick which chains to snapshot
+if [[ $# -eq 0 ]]; then
+    CHAINS="${ALL_CHAINS}"
+else
+    CHAINS="$*"
+fi
+
+# Validate every chain is known before doing any work
+for chain in ${CHAINS}; do
+    if [[ -z "${HOSTS[${chain}]:-}" ]]; then
+        echo "ERROR: unknown chain '${chain}' — pick from: ${ALL_CHAINS}" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "${DONORS_DIR}"
+echo "Snapshot destination: ${DONORS_DIR}"
+echo "Chains:               ${CHAINS}"
+echo
+
+FAILED=()
+
+for chain in ${CHAINS}; do
+    host="${HOSTS[${chain}]}"
+    container="aggregator-${chain}"
+    out_dir="${DONORS_DIR}/${chain}"
+    tar_file="${DONORS_DIR}/${chain}.tar.gz"
+
+    echo "=== ${chain} (${host}:${container}) ==="
+
+    # Stop, tarball via docker exec on a temporary alpine container that
+    # mounts the same volume, restart. The trap-on-EXIT ensures the
+    # aggregator restarts even if tar fails mid-stream.
+    #
+    # We use --volumes-from on a throwaway alpine container so we don't
+    # rely on the host-side mount path (which differs between ap-prod1
+    # and ap-staging1).
+    echo "  -> stop, tarball via --volumes-from, restart"
+    if ! ssh -o BatchMode=yes "${host}" "
+        set -e
+        docker stop ${container} >/dev/null
+        trap 'docker start ${container} >/dev/null' EXIT
+        docker run --rm --volumes-from ${container} alpine \
+            tar czf - -C /tmp/ap-avs db
+    " > "${tar_file}" 2>/dev/null; then
+        echo "  FAIL: ssh+tar pipeline failed for ${chain}" >&2
+        FAILED+=("${chain}")
+        rm -f "${tar_file}"
+        continue
+    fi
+
+    size=$(du -h "${tar_file}" | cut -f1)
+    echo "  -> tarball: ${tar_file} (${size})"
+
+    # Extract into ./donors/<chain>/ — wipe any prior extraction first
+    rm -rf "${out_dir}"
+    mkdir -p "${out_dir}"
+    if ! tar xzf "${tar_file}" -C "${out_dir}"; then
+        echo "  FAIL: tar extract failed for ${chain}" >&2
+        FAILED+=("${chain}")
+        continue
+    fi
+
+    db_size=$(du -sh "${out_dir}/db" 2>/dev/null | cut -f1)
+    echo "  -> extracted: ${out_dir}/db (${db_size})"
+
+    # Drop the intermediate tarball — the extracted dir is what the
+    # merge tool reads. Keeping both wastes disk.
+    rm -f "${tar_file}"
+
+    echo "  OK"
+    echo
+done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "FAILED: ${FAILED[*]}" >&2
+    exit 2
+fi
+
+echo "All snapshots complete."
+echo
+echo "Next: scripts/dev/run-merge-rehearsal.sh"

--- a/scripts/migration/backfill_wallet_salt_index/main.go
+++ b/scripts/migration/backfill_wallet_salt_index/main.go
@@ -49,12 +49,18 @@ type aggregatorYAML struct {
 
 func main() {
 	configPath := flag.String("config", "", "Path to aggregator YAML config (e.g. config/aggregator-base.yaml)")
+	chainID := flag.Int64("chain-id", 0, "Chain ID to backfill. Required. Wallet keys are chain-scoped; run once per chain (e.g. 1, 8453, 11155111, 84532).")
 	dryRun := flag.Bool("dry-run", false, "Print what would change without writing to BadgerDB")
 	verbose := flag.Bool("verbose", false, "Print one line per wallet processed")
 	flag.Parse()
 
 	if *configPath == "" {
 		fmt.Fprintln(os.Stderr, "--config is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *chainID <= 0 {
+		fmt.Fprintln(os.Stderr, "--chain-id is required")
 		flag.Usage()
 		os.Exit(2)
 	}
@@ -71,6 +77,7 @@ func main() {
 	}
 
 	fmt.Printf("Config:        %s\n", *configPath)
+	fmt.Printf("Chain ID:      %d\n", *chainID)
 	fmt.Printf("DB path:       %s\n", cfg.DbPath)
 	// Redact: RPC URLs from Tenderly/Alchemy/Infura embed API keys in
 	// the path or query — printing the raw URL leaks secrets to terminal
@@ -102,7 +109,7 @@ func main() {
 		return *addr, nil
 	}
 
-	stats, err := taskengine.BackfillWalletSaltIndex(db, deriver, taskengine.WalletSaltIndexBackfillOptions{
+	stats, err := taskengine.BackfillWalletSaltIndex(db, *chainID, deriver, taskengine.WalletSaltIndexBackfillOptions{
 		DryRun:  *dryRun,
 		Verbose: *verbose,
 		Logf: func(format string, args ...any) {

--- a/scripts/migration/merge_hetzner_into_gateway/README.md
+++ b/scripts/migration/merge_hetzner_into_gateway/README.md
@@ -1,0 +1,135 @@
+# merge_hetzner_into_gateway
+
+One-shot tool to merge a Hetzner per-chain aggregator BadgerDB (the **donor**) into the unified Railway gateway BadgerDB. Used once during the 2026-07-01 Hetzner decom to bring forward the ~3 weeks of production data that Studio wrote to the Hetzner aggregators after the May 2026 Railway migration but before this cutover.
+
+Full context: [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md).
+
+## What it does
+
+For each prefix it knows about, the tool walks every donor key and applies a per-prefix policy:
+
+| Prefix family | Policy |
+|---|---|
+| `t:` | Pass-through (chain-scoped; validate embedded chain ID matches donor) |
+| `u:` | Pass-through (chain-scoped) |
+| `history:` | Pass-through (chain-scoped) |
+| `w:` | Stamp donor chain ID into the key (legacy → chain-scoped) |
+| `wsalt:` | Stamp donor chain ID; **post-merge, run** `BackfillWalletSaltIndex` against the gateway DB to rebuild any salt-index drift |
+| `fl:` | Stamp donor chain ID |
+| `fr:` | Stamp donor chain ID |
+| `secret:` | Import as-is (already user/org/workflow scoped, chain doesn't apply) |
+| `execution_index_counter:` | Import as-is; on collision keep the larger value |
+| `ct:cw:` | Drop (cosmetic) |
+| `pending:` | Drop (transient) |
+| `trigger:` | Drop (reconstructible from `history:`) |
+| `migration:` | Drop (donor's migration history, not gateway's) |
+
+**Every write is skip-if-exists, with one documented exception.** The gateway has been accumulating its own data since deploy, so the tool's default write path is `setIfAbsent` — `Exist` check before every `Set`, gateway value preserved on collision. The test `TestSetIfAbsent_SkipsWhenKeyPresent` pins this.
+
+The one exception is `execution_index_counter:` (the max-on-collision row). If the donor's counter for a given `taskID` is strictly larger than the gateway's, the tool overwrites the gateway value — re-issuing already-consumed execution indices would be worse than overwriting one `uint64`. These overwrites are surfaced separately in the summary under the **CollRes** column. Brand-new keys (gateway had nothing) show under **Copied** only; CollRes is a subset of Copied so the totals reconcile.
+
+Any prefix the tool does not recognize causes a hard-fail by default. To inspect a problem donor without aborting, pass `--fail-on-unknown-prefix=false` — but be aware that those keys are silently dropped from the merge.
+
+## Usage
+
+```bash
+# 1. Stop the donor aggregator and capture its BadgerDB to a workstation:
+ssh ap-prod1 'sudo systemctl stop avs-aggregator-ethereum'
+ssh ap-prod1 'sudo tar czf - /data/mainnet-avs-aggregator/db' > ethereum-donor-2026-06-04.tar.gz
+tar xzf ethereum-donor-2026-06-04.tar.gz -C ./donors/
+
+# 2. Stop the Railway gateway service (Railway dashboard → gateway → "Stop").
+#    Pull the gateway volume to a workstation if running locally, or run the
+#    tool from a Railway one-off task mounting the gateway volume.
+
+# 3. Dry-run first against a scratch copy. Inspect counts + collisions:
+go run ./scripts/migration/merge_hetzner_into_gateway \
+    --donor-path     ./donors/db \
+    --donor-chain-id 1 \
+    --gateway-path   /tmp/gateway-db-scratch-copy \
+    --dry-run        \
+    --verbose
+
+# 4. When the dry-run looks right, apply for real:
+go run ./scripts/migration/merge_hetzner_into_gateway \
+    --donor-path     ./donors/db \
+    --donor-chain-id 1 \
+    --gateway-path   /data \
+    --dry-run=false
+
+# 5. Repeat steps 1, 3, 4 for each chain:
+#    --donor-chain-id 8453      Base mainnet
+#    --donor-chain-id 11155111  Sepolia testnet
+#    --donor-chain-id 84532     Base-Sepolia testnet
+
+# 6. After all four merges, run BackfillWalletSaltIndex against the gateway
+#    to rebuild the wsalt: secondary index (the merge stamps the keys but
+#    doesn't re-derive the canonical pointers):
+go run ./scripts/migration/backfill_wallet_salt_index --config config/gateway-railway.yaml
+
+# 7. Start the Railway gateway service. Smoke-test workflows + execution
+#    queries across all four chains.
+```
+
+## Flags
+
+| Flag | Required | Default | Notes |
+|---|---|---|---|
+| `--donor-path` | yes | — | Path to the donor BadgerDB directory |
+| `--donor-chain-id` | yes | — | 1 / 8453 / 11155111 / 84532 |
+| `--gateway-path` | yes | — | Path to the Railway gateway BadgerDB |
+| `--dry-run` | no | `true` | Defaults to TRUE. Pass `--dry-run=false` to actually write. |
+| `--verbose` | no | false | One line per key processed |
+| `--fail-on-unknown-prefix` | no | true | Hard-fail when the donor has unrecognized prefixes |
+
+## Output
+
+The tool prints a per-prefix summary table at the end:
+
+```
+Summary
+-------
+Donor chain: 1 (ethereum)
+
+Prefix                          Policy                                              Scanned   Copied  CollRes  Stamped  Existed  Dropped   Errors
+----------------------------- -------------------------------------------------- -------- -------- -------- -------- -------- -------- --------
+t:                              pass-through (chain-scoped)                            8421     8410        0        0       11        0        0
+u:                              pass-through (chain-scoped)                            8421     8410        0        0       11        0        0
+history:                        pass-through (chain-scoped)                           12734    12734        0        0        0        0        0
+w:                              stamp chain ID                                          184      184        0      184        0        0        0
+wsalt:                          stamp chain ID (rebuild wsalt index post-merge)         184      184        0      184        0        0        0
+fl:                             stamp chain ID                                          141      141        0      141        0        0        0
+fr:                             stamp chain ID                                         2104     2104        0     2104        0        0        0
+secret:                         import as-is                                            317      317        0        0        0        0        0
+execution_index_counter:        max-on-collision                                       8421     8408        4        0       13        0        0
+ct:cw:                          drop (cosmetic)                                          14        0        0        0        0       14        0
+pending:                        drop (transient)                                          3        0        0        0        0        3        0
+trigger:                        drop (reconstructible from history)                   12734        0        0        0        0    12734        0
+migration:                      drop (donor history not gateway's)                        4        0        0        0        0        4        0
+----------------------------- -------------------------------------------------- -------- -------- -------- -------- -------- -------- --------
+TOTAL                                                                                  53682    32492        4     2613       35    12755        0
+```
+
+(Made-up numbers, but the column shape is real.) **CollRes** is the subset of Copied that overwrote an existing gateway value (only ever non-zero for `execution_index_counter:`, when the donor counter exceeds the gateway counter). Sum reconciles: `Copied + Existed + Dropped + Errors = Scanned` for each row.
+
+## Safety rules
+
+1. **The Railway gateway must be stopped before `--dry-run=false`.** BadgerDB is single-writer; the tool opens the same `db_path` directly. The tool will error on open if another process is holding the lock.
+2. **Take a fresh pre-merge backup of the gateway volume immediately before running.** That snapshot is the only rollback target.
+3. **Always run `--dry-run` first against a scratch *copy* of the gateway DB** (rsync it to a sidecar dir on the Railway volume). Inspect the per-prefix counts and collisions before touching the live volume.
+4. **Never replace `setIfAbsent` with `storage.Storage.Load`.** Load is bulk upsert and will silently clobber live gateway data. The test `TestSetIfAbsent_SkipsWhenKeyPresent` is the regression guard.
+5. **Run the tool sequentially per donor**, not in parallel. The tool acquires a Badger write lock on the gateway DB.
+6. **Keep the donor aggregators stopped, not deleted, until 2026-06-30** — hot rollback window. Delete on 2026-07-01 after the decom closes.
+
+## What's NOT in this tool
+
+- **wsalt: index rebuild.** The merge stamps the chain ID into wsalt keys but doesn't re-derive any canonical wallet pointers. After the merge, run [`scripts/migration/backfill_wallet_salt_index`](../backfill_wallet_salt_index/) against the gateway DB to refresh those.
+- **Gateway read-path updates for chain-stamped families.** The merge produces `w:<chainID>:<owner>:<addr>` keys. The gateway code that reads `w:` keys needs a corresponding update to look at chain-scoped form too — that ships as a separate PR alongside any read paths for `wsalt:`, `fl:`, `fr:`.
+- **Recovery from a botched merge.** If smoke tests fail after the merge runs, the recovery is "restore the pre-merge gateway backup, investigate, dry-run again." There's no in-place rollback inside the tool.
+
+## Related references
+
+- Policy matrix source of truth: [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md#per-prefix-decision-matrix-proposed-awaiting-sign-off)
+- Existing migration tool the structure follows: [`scripts/migration/backfill_wallet_salt_index/`](../backfill_wallet_salt_index/)
+- Chain-scoped key parsers used to validate donor pass-through keys: [`core/taskengine/chain_scoped_keys.go`](../../../core/taskengine/chain_scoped_keys.go)
+- Storage API contract: [`storage/db.go`](../../../storage/db.go) — note that `Load` is upsert and must not be used here.

--- a/scripts/migration/merge_hetzner_into_gateway/handlers.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // handlerFunc processes a single donor key-value, writing zero or one
@@ -27,25 +30,52 @@ type prefixHandlerEntry struct {
 }
 
 // prefixHandlers is the dispatch table. The dispatcher walks it in order
-// and picks the first matching prefix — so put `ct:cw:` BEFORE `ct:` if
-// the latter is ever added (currently only `ct:cw:` exists).
+// and picks the first matching prefix — so the order matters when one
+// prefix is the prefix of another. In particular, `t:seq` (Badger
+// sequence counter) is listed BEFORE `t:` so the generic t-handler
+// doesn't try to chain-stamp the sequence-counter key, and `q:seq:`
+// before `q:` for the same reason.
 //
 // IMPORTANT: keep this table aligned with the per-prefix policy matrix in
 // `docs/changes/20260604-hetzner-data-restore-plan.md` (avs-infra).
 // Editing one without the other invites silent divergence.
 var prefixHandlers = []prefixHandlerEntry{
-	// Already chain-scoped on disk (MigrateKeysToChainScoped ran on every
-	// donor pre-merge). Validate embedded chain ID matches the donor.
-	{"t:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
-	{"u:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
-	{"history:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+	// Per-DB Badger sequence counters. Per-aggregator operational state;
+	// the gateway maintains its own sequences. Must be matched BEFORE
+	// the generic `t:` / `q:` handlers below — otherwise handleStampChainID
+	// would corrupt them into `t:<chainID>:seq` etc.
+	{"t:seq", handleDrop, "drop (Badger sequence counter, per-aggregator)"},
+	{"q:seq:", handleDrop, "drop (Badger sequence counter, per-aggregator)"},
+
+	// Workflow + execution history. On every Hetzner donor (which predates
+	// chain-scoped storage) these are in legacy form (t:<status>:<task>,
+	// history:<task>:<execution>). We:
+	//
+	//   1. stamp the chain ID into the KEY (the equivalent of running
+	//      MigrateKeysToChainScoped on the donor, folded into the merge)
+	//   2. decode the VALUE with protojson DiscardUnknown:true to tolerate
+	//      proto fields that were renamed/removed over time
+	//      (expression/epochs/totalExecution/interval/input — surfaced by
+	//      the 2026-06-04 rehearsal where ~46% of mainnet tasks
+	//      would have failed strict decode)
+	//   3. set the body's chain_id field to the donor chain ID (Task
+	//      proto only) so subsequent updates don't default it to the
+	//      gateway's defaultChainID and silently re-key the task
+	//   4. re-marshal with the current proto schema, which drops the
+	//      unknown fields permanently — one-time data cleanup
+	//
+	// `u:` is just a status byte slice (no body to clean) and stays on
+	// the plain key-stamp handler.
+	{"t:", handleStampTaskBody, "stamp chain ID + clean Task body (drop unknown proto fields, set chain_id)"},
+	{"u:", handleStampChainID, "stamp chain ID (status byte slice, no body)"},
+	{"history:", handleStampExecutionBody, "stamp chain ID + clean Execution body (drop unknown proto fields)"},
 
 	// Chain-implicit on the donor. Stamp `--donor-chain-id` into the key
-	// when writing to gateway. Gateway read-path update ships separately.
+	// when writing to gateway.
 	{"w:", handleStampChainID, "stamp chain ID"},
 	{"wsalt:", handleStampChainID, "stamp chain ID (rebuild wsalt index post-merge)"},
 	{"fl:", handleStampChainID, "stamp chain ID"},
-	{"fr:", handleStampChainID, "stamp chain ID"},
+	{"fr:", handleStampFeeRecordBody, "stamp chain ID + set FeeRecord.ChainID"},
 
 	// Already user/org/workflow scoped — chain doesn't apply.
 	{"secret:", handleImportAsIs, "import as-is"},
@@ -54,10 +84,13 @@ var prefixHandlers = []prefixHandlerEntry{
 	// no chain stamping. On collision, keep the larger value.
 	{"execution_index_counter:", handleMaxOnCollision, "max-on-collision"},
 
-	// Drop policies — cosmetic, transient, or reconstructible.
+	// Drop policies — cosmetic, transient, reconstructible, or
+	// per-aggregator operational state.
 	{"ct:cw:", handleDrop, "drop (cosmetic)"},
 	{"pending:", handleDrop, "drop (transient)"},
 	{"trigger:", handleDrop, "drop (reconstructible from history)"},
+	{"operator:", handleDrop, "drop (per-aggregator operator pool registry)"},
+	{"q:", handleDrop, "drop (per-aggregator async execution queue)"},
 
 	// Donor migration markers describe the donor's history, not the
 	// gateway's — never import.
@@ -95,47 +128,185 @@ func hasPrefix(key []byte, prefix string) bool {
 // Handlers
 // -------------------------------------------------------------------------
 
-// handleChainScopedPassThrough copies a key that's already chain-scoped
-// on the donor (per MigrateKeysToChainScoped) straight into the gateway,
-// after validating the embedded chain ID matches --donor-chain-id.
+// stampedKey applies the same key-stamping rules handleStampChainID uses,
+// returning either the original kv.Key (when already chain-scoped on the
+// donor) or a new key with `<donorChainID>:` inserted after matchedPrefix
+// (when legacy). The bool says whether stamping happened (so callers can
+// increment stat.stampedChain only when the key actually changed).
 //
-// Layout: `<prefix><chainID>:<rest...>` — second `:`-delimited segment is
-// the chain ID. Legacy (unprefixed) form aborts the merge: the donor was
-// supposed to be migrated already.
-func handleChainScopedPassThrough(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+// Returns a wrong-chain-mis-stamp error when the donor key is already
+// chain-scoped but with a chain ID that disagrees with --donor-chain-id.
+func stampedKey(donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem) (newKey []byte, stamped bool, err error) {
+	if matchedPrefix == "" {
+		return nil, false, fmt.Errorf("internal: stampedKey called without a matched prefix for key %q", string(kv.Key))
+	}
 	embedded, parseErr := parseChainIDFromKey(kv.Key)
-	if errors.Is(parseErr, taskengine.ErrLegacyKey) {
-		return fmt.Errorf("donor key %q is in legacy (pre-chain-scoped) form — run the chain-scope migration on the donor before merging", string(kv.Key))
+	if parseErr == nil {
+		if embedded != donorChainID {
+			return nil, false, fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
+		}
+		return kv.Key, false, nil
 	}
-	if parseErr != nil {
-		return fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
+	if !errors.Is(parseErr, taskengine.ErrLegacyKey) {
+		return nil, false, fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
 	}
-	if embedded != donorChainID {
-		return fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
-	}
-
-	return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+	rest := string(kv.Key[len(matchedPrefix):])
+	return []byte(fmt.Sprintf("%s%d:%s", matchedPrefix, donorChainID, rest)), true, nil
 }
 
-// handleStampChainID stamps `--donor-chain-id` into the key. For prefix
-// `p:` the donor key is `p:<rest>` and the gateway key becomes
-// `p:<chainID>:<rest>`. Used for chain-implicit families (w:, wsalt:,
-// fl:, fr:) that don't have their own chain_scoped_keys-style migration
-// yet.
+// cleanTaskBody decodes a stored Task with DiscardUnknown=true so old
+// proto fields (renamed/removed: expression, epochs, totalExecution,
+// interval, input, …) don't reject the whole task, then sets the body's
+// chain_id field to donorChainID and re-marshals. Drops the unknown
+// fields permanently. Returns the cleaned body or an error if even the
+// loose decoder couldn't make sense of it (rare — a handful of
+// genuinely malformed rows out of 200-400 per chain).
+func cleanTaskBody(value []byte, donorChainID int64) ([]byte, error) {
+	var task avsproto.Task
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(value, &task); err != nil {
+		return nil, fmt.Errorf("decode task with DiscardUnknown: %w", err)
+	}
+	task.ChainId = donorChainID
+	out, err := protojson.Marshal(&task)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal cleaned task: %w", err)
+	}
+	return out, nil
+}
+
+// cleanExecutionBody mirrors cleanTaskBody for the Execution proto. The
+// Execution message has no chain_id field of its own (chain is implicit
+// in the history:<chainID>:<taskID>:<executionID> key), so this is
+// purely a re-serialize that drops unknown fields like "success" (which
+// got moved into Step) and others.
+func cleanExecutionBody(value []byte) ([]byte, error) {
+	var execution avsproto.Execution
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(value, &execution); err != nil {
+		return nil, fmt.Errorf("decode execution with DiscardUnknown: %w", err)
+	}
+	out, err := protojson.Marshal(&execution)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal cleaned execution: %w", err)
+	}
+	return out, nil
+}
+
+// cleanFeeRecordBody decodes the donor's FeeRecord (stdlib json), sets
+// ChainID to donorChainID (it may have been 0 on old donors since
+// FeeRecord.ChainID was added later), and re-marshals. RecordValueFee
+// now requires ChainID != 0 to write the chain-scoped fl:/fr: keys.
+func cleanFeeRecordBody(value []byte, donorChainID int64) ([]byte, error) {
+	// We intentionally use stdlib json (not protojson) because FeeRecord
+	// is a plain Go struct, not a proto message. stdlib json ignores
+	// unknown fields by default, which is the behavior we want here too.
+	var record taskengine.FeeRecord
+	if err := json.Unmarshal(value, &record); err != nil {
+		return nil, fmt.Errorf("decode fee record: %w", err)
+	}
+	record.ChainID = donorChainID
+	out, err := json.Marshal(&record)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal cleaned fee record: %w", err)
+	}
+	return out, nil
+}
+
+// handleStampTaskBody stamps the chain ID into the key AND rewrites the
+// stored Task body via cleanTaskBody (drops unknown proto fields + sets
+// task.chain_id = donorChainID). See the dispatch-table comment on
+// prefixHandlers for the rationale; see cleanTaskBody for what's
+// dropped.
+func handleStampTaskBody(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	newKey, stamped, err := stampedKey(donorChainID, matchedPrefix, kv)
+	if err != nil {
+		return err
+	}
+	cleaned, err := cleanTaskBody(kv.Value, donorChainID)
+	if err != nil {
+		return err
+	}
+	if stamped {
+		stat.stampedChain++
+	}
+	return setIfAbsent(gateway, newKey, cleaned, stat, dryRun)
+}
+
+// handleStampExecutionBody is the Execution-body analogue.
+func handleStampExecutionBody(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	newKey, stamped, err := stampedKey(donorChainID, matchedPrefix, kv)
+	if err != nil {
+		return err
+	}
+	cleaned, err := cleanExecutionBody(kv.Value)
+	if err != nil {
+		return err
+	}
+	if stamped {
+		stat.stampedChain++
+	}
+	return setIfAbsent(gateway, newKey, cleaned, stat, dryRun)
+}
+
+// handleStampFeeRecordBody is the FeeRecord-body analogue. fr: keys are
+// always chain-implicit on the donor (chain-scoped form didn't exist
+// before this rewrite), so the key is always stamped and the body's
+// ChainID is always populated.
+func handleStampFeeRecordBody(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	newKey, stamped, err := stampedKey(donorChainID, matchedPrefix, kv)
+	if err != nil {
+		return err
+	}
+	cleaned, err := cleanFeeRecordBody(kv.Value, donorChainID)
+	if err != nil {
+		return err
+	}
+	if stamped {
+		stat.stampedChain++
+	}
+	return setIfAbsent(gateway, newKey, cleaned, stat, dryRun)
+}
+
+// handleStampChainID handles both legacy (chain-implicit) and already-
+// chain-scoped donor keys:
+//
+//   - If the second `:`-delimited segment parses as a numeric chain ID,
+//     the key is already chain-scoped. Validate it matches the donor's
+//     chain ID and pass it through untouched.
+//   - If the second segment is non-numeric (or absent), the key is in
+//     legacy form. Insert `<donorChainID>:` right after the matched
+//     prefix and write the stamped key.
+//
+// This is the equivalent of running MigrateKeysToChainScoped on the
+// donor — folded into the merge so we don't have to mutate donor data
+// before merging, and so donors that have a MIX of legacy and chain-
+// scoped keys (because an in-place migration ran partway) still merge
+// correctly.
+//
+// Wrong-chain mis-stamp protection: a donor key like `t:8453:c:taskID`
+// merged with --donor-chain-id=1 will hard-fail, not get re-stamped
+// into `t:1:8453:c:taskID`.
 func handleStampChainID(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
 	if matchedPrefix == "" {
 		return fmt.Errorf("internal: handleStampChainID called without a matched prefix for key %q", string(kv.Key))
 	}
-	rest := string(kv.Key[len(matchedPrefix):])
 
-	// Safety: if the donor key is ALREADY stamped (rest starts with the
-	// chain ID followed by ':'), skip the additional stamp and treat as
-	// chain-scoped pass-through. This guards against double-running the
-	// tool or against donors that ran a future migration we don't know
-	// about.
-	if alreadyStamped(rest, donorChainID) {
+	embedded, parseErr := parseChainIDFromKey(kv.Key)
+	if parseErr == nil {
+		// Already chain-scoped. Refuse to merge a donor key whose
+		// embedded chain ID disagrees with --donor-chain-id (e.g.
+		// somebody pointed the wrong chain's DB at the wrong --donor-
+		// chain-id flag).
+		if embedded != donorChainID {
+			return fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
+		}
 		return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
 	}
+	if !errors.Is(parseErr, taskengine.ErrLegacyKey) {
+		return fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
+	}
+
+	// Legacy form — stamp the donor chain ID inline.
+	rest := string(kv.Key[len(matchedPrefix):])
 	stamped := []byte(fmt.Sprintf("%s%d:%s", matchedPrefix, donorChainID, rest))
 	stat.stampedChain++
 	return setIfAbsent(gateway, stamped, kv.Value, stat, dryRun)
@@ -252,16 +423,6 @@ func parseChainIDFromKey(key []byte) (int64, error) {
 		return 0, taskengine.ErrLegacyKey
 	}
 	return id, nil
-}
-
-// alreadyStamped returns true when the donor key fragment (everything
-// after the matched prefix) appears to already be chain-stamped with the
-// given chain ID — i.e. it starts with `<chainID>:`. Used by
-// handleStampChainID to skip double-stamping if the donor ran a future
-// migration the tool doesn't know about.
-func alreadyStamped(rest string, donorChainID int64) bool {
-	prefix := strconv.FormatInt(donorChainID, 10) + ":"
-	return strings.HasPrefix(rest, prefix)
 }
 
 // isKeyNotFoundError lets us treat "key not present" as a non-error case

--- a/scripts/migration/merge_hetzner_into_gateway/handlers.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// handlerFunc processes a single donor key-value, writing zero or one
+// keys to the gateway under skip-if-exists semantics. The matched prefix
+// (from prefixHandlers) is passed through so handlers that need to strip
+// it (handleStampChainID) don't have to re-find it — and so the dispatch
+// table can hold function references without inducing an init cycle.
+//
+// The handler must NEVER overwrite a key the gateway already has.
+type handlerFunc func(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error
+
+// prefixHandlerEntry is the row type of the dispatch table.
+type prefixHandlerEntry struct {
+	prefix string
+	handle handlerFunc
+	policy string // short label that prints in summary
+}
+
+// prefixHandlers is the dispatch table. The dispatcher walks it in order
+// and picks the first matching prefix — so put `ct:cw:` BEFORE `ct:` if
+// the latter is ever added (currently only `ct:cw:` exists).
+//
+// IMPORTANT: keep this table aligned with the per-prefix policy matrix in
+// `docs/changes/20260604-hetzner-data-restore-plan.md` (avs-infra).
+// Editing one without the other invites silent divergence.
+var prefixHandlers = []prefixHandlerEntry{
+	// Already chain-scoped on disk (MigrateKeysToChainScoped ran on every
+	// donor pre-merge). Validate embedded chain ID matches the donor.
+	{"t:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+	{"u:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+	{"history:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+
+	// Chain-implicit on the donor. Stamp `--donor-chain-id` into the key
+	// when writing to gateway. Gateway read-path update ships separately.
+	{"w:", handleStampChainID, "stamp chain ID"},
+	{"wsalt:", handleStampChainID, "stamp chain ID (rebuild wsalt index post-merge)"},
+	{"fl:", handleStampChainID, "stamp chain ID"},
+	{"fr:", handleStampChainID, "stamp chain ID"},
+
+	// Already user/org/workflow scoped — chain doesn't apply.
+	{"secret:", handleImportAsIs, "import as-is"},
+
+	// Monotonic counters keyed by taskID — taskID is globally unique, so
+	// no chain stamping. On collision, keep the larger value.
+	{"execution_index_counter:", handleMaxOnCollision, "max-on-collision"},
+
+	// Drop policies — cosmetic, transient, or reconstructible.
+	{"ct:cw:", handleDrop, "drop (cosmetic)"},
+	{"pending:", handleDrop, "drop (transient)"},
+	{"trigger:", handleDrop, "drop (reconstructible from history)"},
+
+	// Donor migration markers describe the donor's history, not the
+	// gateway's — never import.
+	{"migration:", handleDrop, "drop (donor history not gateway's)"},
+}
+
+func knownPrefixes() []string {
+	out := make([]string, 0, len(prefixHandlers))
+	for _, h := range prefixHandlers {
+		out = append(out, h.prefix)
+	}
+	return out
+}
+
+func dispatch(donor, gateway storage.Storage, donorChainID int64, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	for _, h := range prefixHandlers {
+		if hasPrefix(kv.Key, h.prefix) {
+			if verbose {
+				fmt.Printf("  [%s] %q\n", h.policy, string(kv.Key))
+			}
+			return h.handle(donor, gateway, donorChainID, h.prefix, kv, stat, dryRun, verbose)
+		}
+	}
+	return fmt.Errorf("no handler matched key %q (caller should have routed via scanForUnknownPrefixes)", string(kv.Key))
+}
+
+func hasPrefix(key []byte, prefix string) bool {
+	if len(key) < len(prefix) {
+		return false
+	}
+	return string(key[:len(prefix)]) == prefix
+}
+
+// -------------------------------------------------------------------------
+// Handlers
+// -------------------------------------------------------------------------
+
+// handleChainScopedPassThrough copies a key that's already chain-scoped
+// on the donor (per MigrateKeysToChainScoped) straight into the gateway,
+// after validating the embedded chain ID matches --donor-chain-id.
+//
+// Layout: `<prefix><chainID>:<rest...>` — second `:`-delimited segment is
+// the chain ID. Legacy (unprefixed) form aborts the merge: the donor was
+// supposed to be migrated already.
+func handleChainScopedPassThrough(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	embedded, parseErr := parseChainIDFromKey(kv.Key)
+	if errors.Is(parseErr, taskengine.ErrLegacyKey) {
+		return fmt.Errorf("donor key %q is in legacy (pre-chain-scoped) form — run the chain-scope migration on the donor before merging", string(kv.Key))
+	}
+	if parseErr != nil {
+		return fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
+	}
+	if embedded != donorChainID {
+		return fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
+	}
+
+	return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+}
+
+// handleStampChainID stamps `--donor-chain-id` into the key. For prefix
+// `p:` the donor key is `p:<rest>` and the gateway key becomes
+// `p:<chainID>:<rest>`. Used for chain-implicit families (w:, wsalt:,
+// fl:, fr:) that don't have their own chain_scoped_keys-style migration
+// yet.
+func handleStampChainID(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	if matchedPrefix == "" {
+		return fmt.Errorf("internal: handleStampChainID called without a matched prefix for key %q", string(kv.Key))
+	}
+	rest := string(kv.Key[len(matchedPrefix):])
+
+	// Safety: if the donor key is ALREADY stamped (rest starts with the
+	// chain ID followed by ':'), skip the additional stamp and treat as
+	// chain-scoped pass-through. This guards against double-running the
+	// tool or against donors that ran a future migration we don't know
+	// about.
+	if alreadyStamped(rest, donorChainID) {
+		return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+	}
+	stamped := []byte(fmt.Sprintf("%s%d:%s", matchedPrefix, donorChainID, rest))
+	stat.stampedChain++
+	return setIfAbsent(gateway, stamped, kv.Value, stat, dryRun)
+}
+
+// handleImportAsIs copies the key verbatim. Used for secret:, which is
+// already user/org/workflow scoped and where chain doesn't apply.
+func handleImportAsIs(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+}
+
+// handleMaxOnCollision is used for execution_index_counter:<taskID>. The
+// counter is a monotonic per-task uint64. If both donor and gateway have
+// a counter for the same taskID, take the larger — a smaller value would
+// cause the gateway to re-issue execution indices that already exist on
+// the donor.
+//
+// taskID is globally unique across chains in our schema, so no chain
+// stamping is needed.
+func handleMaxOnCollision(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	exists, err := gateway.Exist(kv.Key)
+	if err != nil {
+		return fmt.Errorf("Exist check for %q: %w", string(kv.Key), err)
+	}
+	if !exists {
+		stat.copied++
+		if dryRun {
+			return nil
+		}
+		return gateway.Set(kv.Key, kv.Value)
+	}
+	// Both sides have it. Compare counters and take the larger.
+	existing, err := gateway.GetKey(kv.Key)
+	if err != nil {
+		return fmt.Errorf("get gateway %q: %w", string(kv.Key), err)
+	}
+	donorVal, derr := strconv.ParseUint(string(kv.Value), 10, 64)
+	if derr != nil {
+		return fmt.Errorf("parse donor counter %q as uint64: %w", string(kv.Value), derr)
+	}
+	gwVal, gerr := strconv.ParseUint(string(existing), 10, 64)
+	if gerr != nil {
+		return fmt.Errorf("parse gateway counter %q as uint64: %w", string(existing), gerr)
+	}
+	if donorVal > gwVal {
+		// Count as BOTH a write (CollRes is a subset of total writes) and
+		// a collision-resolved overwrite, so the summary totals reconcile.
+		stat.copied++
+		stat.collisionResolved++
+		if dryRun {
+			return nil
+		}
+		return gateway.Set(kv.Key, kv.Value)
+	}
+	stat.skippedExists++
+	return nil
+}
+
+// handleDrop ignores the donor key entirely. Used for cosmetic / transient /
+// gateway-own-history prefixes per the matrix.
+func handleDrop(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	stat.dropped++
+	return nil
+}
+
+// -------------------------------------------------------------------------
+// Lower-level helpers
+// -------------------------------------------------------------------------
+
+// setIfAbsent is the skip-if-exists write path used by every handler
+// EXCEPT handleMaxOnCollision. When this function writes, the gateway
+// definitely did not have the key beforehand — no overwrite is possible
+// through this path. handleMaxOnCollision is the one deliberate
+// exception: it calls gateway.Set directly when the donor counter is
+// larger than the gateway's, because re-issuing already-consumed
+// execution indices would be worse than overwriting one uint64.
+//
+// If you add a new handler, route writes through setIfAbsent unless you
+// have a documented reason for collision-overwrite semantics like
+// handleMaxOnCollision does.
+func setIfAbsent(gateway storage.Storage, key, value []byte, stat *prefixStats, dryRun bool) error {
+	exists, err := gateway.Exist(key)
+	if err != nil {
+		return fmt.Errorf("Exist check for %q: %w", string(key), err)
+	}
+	if exists {
+		stat.skippedExists++
+		return nil
+	}
+	stat.copied++
+	if dryRun {
+		return nil
+	}
+	return gateway.Set(key, value)
+}
+
+// parseChainIDFromKey extracts the chain ID from a chain-scoped key like
+// `t:1:a:taskID` or `history:1:taskID:executionID`. Returns
+// taskengine.ErrLegacyKey if the second segment isn't a numeric chain ID.
+func parseChainIDFromKey(key []byte) (int64, error) {
+	s := string(key)
+	first := strings.IndexByte(s, ':')
+	if first < 0 {
+		return 0, taskengine.ErrLegacyKey
+	}
+	rest := s[first+1:]
+	second := strings.IndexByte(rest, ':')
+	if second < 0 {
+		return 0, taskengine.ErrLegacyKey
+	}
+	candidate := rest[:second]
+	id, err := strconv.ParseInt(candidate, 10, 64)
+	if err != nil {
+		return 0, taskengine.ErrLegacyKey
+	}
+	return id, nil
+}
+
+// alreadyStamped returns true when the donor key fragment (everything
+// after the matched prefix) appears to already be chain-stamped with the
+// given chain ID — i.e. it starts with `<chainID>:`. Used by
+// handleStampChainID to skip double-stamping if the donor ran a future
+// migration the tool doesn't know about.
+func alreadyStamped(rest string, donorChainID int64) bool {
+	prefix := strconv.FormatInt(donorChainID, 10) + ":"
+	return strings.HasPrefix(rest, prefix)
+}
+
+// isKeyNotFoundError lets us treat "key not present" as a non-error case
+// without importing badger directly. The storage package surfaces the
+// badger error verbatim from GetKey.
+func isKeyNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Key not found")
+}

--- a/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
@@ -68,38 +68,49 @@ func TestSetIfAbsent_DryRunDoesNotWrite(t *testing.T) {
 }
 
 // -------------------------------------------------------------------------
-// handleChainScopedPassThrough — validates embedded chain ID.
+// handleStampChainID — handles both legacy (chain-implicit) and
+// already-chain-scoped donor keys. Validates mis-stamp protection.
 // -------------------------------------------------------------------------
 
-func TestHandleChainScopedPassThrough_ValidatesMatchingChainID(t *testing.T) {
+func TestHandleStampChainID_PassesThroughMatchingChainScoped(t *testing.T) {
 	donor := newTestDB(t)
 	gw := newTestDB(t)
 	stat := &prefixStats{}
 
-	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:1:a:taskABC", "body"), stat, false, false)
+	// Donor key is already chain-scoped with the donor's chain ID — pass through.
+	err := handleStampChainID(donor, gw, 1, "t:", kvItem("t:1:a:taskABC", "body"), stat, false, false)
 	require.NoError(t, err)
 	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 0, stat.stampedChain, "key was already chain-scoped — must not count as a new stamp")
 }
 
-func TestHandleChainScopedPassThrough_RejectsMismatchedChainID(t *testing.T) {
+func TestHandleStampChainID_RejectsWrongChainScoped(t *testing.T) {
 	donor := newTestDB(t)
 	gw := newTestDB(t)
 	stat := &prefixStats{}
 
-	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:8453:a:taskABC", "body"), stat, false, false)
-	require.Error(t, err, "must refuse to import a key whose embedded chain ID doesn't match --donor-chain-id")
+	// Donor key embeds chain 8453 but we're merging as chain 1 — refuse
+	// to silently mis-stamp (would produce t:1:8453:a:taskABC, which
+	// would be wrong).
+	err := handleStampChainID(donor, gw, 1, "t:", kvItem("t:8453:a:taskABC", "body"), stat, false, false)
+	require.Error(t, err, "must refuse to mis-stamp a key whose embedded chain ID disagrees with --donor-chain-id")
 	assert.Contains(t, err.Error(), "embeds chain ID 8453")
 }
 
-func TestHandleChainScopedPassThrough_RejectsLegacyForm(t *testing.T) {
+func TestHandleStampChainID_StampsLegacyTaskStatusKey(t *testing.T) {
 	donor := newTestDB(t)
 	gw := newTestDB(t)
 	stat := &prefixStats{}
 
 	// Legacy form: `t:a:taskABC` (status code 'a', no numeric chain segment).
-	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:a:taskABC", "body"), stat, false, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "legacy (pre-chain-scoped) form")
+	err := handleStampChainID(donor, gw, 11155111, "t:", kvItem("t:a:taskABC", "body"), stat, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 1, stat.stampedChain)
+
+	got, err := gw.GetKey([]byte("t:11155111:a:taskABC"))
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(got))
 }
 
 // -------------------------------------------------------------------------
@@ -235,19 +246,40 @@ func TestDispatch_RoutesEachPrefixToItsHandler(t *testing.T) {
 		key    string
 		value  string
 	}{
-		{"t:", "t:1:a:taskA", "task-body"},
+		// t:, history: now decode the body as proto JSON, so the test
+		// values need to be valid proto JSON for their respective
+		// messages (avsproto.Task / avsproto.Execution). The body
+		// cleaner re-marshals, so the exact contents don't matter
+		// beyond being decodable.
+		{"t:", "t:1:a:taskA", `{"id":"taskA"}`},
 		{"u:", "u:1:0xowner:0xwallet:taskA", "taskA"},
-		{"history:", "history:1:taskA:exec1", "exec-blob"},
+		{"history:", "history:1:taskA:exec1", `{"id":"exec1"}`},
 		{"w:", "w:0xowner:0xwallet", "wallet"},
 		{"wsalt:", "wsalt:0xowner:0xfactory:0", "0xwallet"},
 		{"fl:", "fl:0xowner", "balance-blob"},
-		{"fr:", "fr:0xowner:exec1", "fee-blob"},
+		// fr: now decodes the body as a FeeRecord struct (stdlib json)
+		// — needs valid JSON. Body cleaner sets ChainID from --donor-chain-id.
+		{"fr:", "fr:0xowner:exec1", `{"execution_id":"exec1","owner":"0xowner"}`},
 		{"secret:", "secret:_:0xowner:_:apikey", "supersecret"},
 		{"execution_index_counter:", "execution_index_counter:taskA", "1"},
 		{"ct:cw:", "ct:cw:0xeoa", "5"},
 		{"pending:", "pending:taskA:exec1", ""},
 		{"trigger:", "trigger:taskA:exec1", "status"},
 		{"migration:", "migration:foo", "1"},
+		// Per-aggregator operational state added when tonight's
+		// rehearsal surfaced 10M+ q: keys on the base donor — both
+		// must route to drop, not stamp.
+		{"operator:", "operator:0xoperator1", "registered"},
+		{"q:", "q:t:c:1:taskA", "queue-entry"},
+		// t:seq is a sequence-counter key that LOOKS like a t: row.
+		// Dispatch order is load-bearing: t:seq must match the t:seq
+		// drop handler BEFORE t: tries to stamp it. Without the right
+		// ordering in prefixHandlers, this key would get rewritten to
+		// `t:1:seq` and corrupt the Badger sequence semantics.
+		{"t:seq", "t:seq", "42"},
+		// q:seq: is the queue's sequence counter. Same ordering
+		// concern as t:seq — must match q:seq: drop before q:.
+		{"q:seq:", "q:seq:taskA", "7"},
 	}
 	for _, c := range cases {
 		stat := st.forPrefix(c.prefix)
@@ -265,30 +297,16 @@ func TestDispatch_RoutesEachPrefixToItsHandler(t *testing.T) {
 	assert.Equal(t, 1, st.perPrefix["pending:"].dropped)
 	assert.Equal(t, 1, st.perPrefix["trigger:"].dropped)
 	assert.Equal(t, 1, st.perPrefix["migration:"].dropped)
-}
-
-// -------------------------------------------------------------------------
-// alreadyStamped — small helper.
-// -------------------------------------------------------------------------
-
-func TestAlreadyStamped(t *testing.T) {
-	for _, c := range []struct {
-		rest    string
-		chainID int64
-		want    bool
-		desc    string
-	}{
-		{"1:0xowner:0xwallet", 1, true, "matches chain prefix"},
-		{"0xowner:0xwallet", 1, false, "no chain prefix"},
-		{"8453:0xowner:0xwallet", 1, false, "wrong chain prefix"},
-		{"", 1, false, "empty"},
-		{"1", 1, false, "chain ID without trailing colon"},
-	} {
-		t.Run(c.desc, func(t *testing.T) {
-			got := alreadyStamped(c.rest, c.chainID)
-			assert.Equal(t, c.want, got, "alreadyStamped(%q, %d)", c.rest, c.chainID)
-		})
-	}
+	assert.Equal(t, 1, st.perPrefix["operator:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["q:"].dropped)
+	// t:seq must route to its own drop bucket, NOT t:'s stamp bucket.
+	// Confirms both that t:seq is in the dispatch table BEFORE t:
+	// AND that the t:seq handler is drop, not stamp.
+	assert.Equal(t, 1, st.perPrefix["t:seq"].dropped)
+	assert.Equal(t, 0, st.perPrefix["t:seq"].copied, "t:seq must never be copied — it's a Badger sequence counter")
+	assert.Equal(t, 0, st.perPrefix["t:seq"].stampedChain, "t:seq must never be stamped")
+	assert.Equal(t, 1, st.perPrefix["q:seq:"].dropped)
+	assert.Equal(t, 0, st.perPrefix["q:seq:"].copied)
 }
 
 // -------------------------------------------------------------------------

--- a/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
@@ -1,0 +1,323 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDB returns a fresh in-memory BadgerStorage backed by a t.TempDir.
+// Caller does not need to defer Close — t.Cleanup handles it.
+func newTestDB(t *testing.T) storage.Storage {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := storage.NewWithPath(dir)
+	require.NoError(t, err, "open BadgerDB at %s", dir)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func kvItem(key, value string) *storage.KeyValueItem {
+	return &storage.KeyValueItem{Key: []byte(key), Value: []byte(value)}
+}
+
+// -------------------------------------------------------------------------
+// setIfAbsent — the only write path. Single, focused tests.
+// -------------------------------------------------------------------------
+
+func TestSetIfAbsent_WritesWhenKeyAbsent(t *testing.T) {
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	require.NoError(t, setIfAbsent(gw, []byte("t:1:a:abc"), []byte("body"), stat, false))
+	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 0, stat.skippedExists)
+
+	got, err := gw.GetKey([]byte("t:1:a:abc"))
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(got))
+}
+
+func TestSetIfAbsent_SkipsWhenKeyPresent(t *testing.T) {
+	gw := newTestDB(t)
+	require.NoError(t, gw.Set([]byte("t:1:a:abc"), []byte("gateway-version")))
+
+	stat := &prefixStats{}
+	require.NoError(t, setIfAbsent(gw, []byte("t:1:a:abc"), []byte("donor-version"), stat, false))
+	assert.Equal(t, 0, stat.copied)
+	assert.Equal(t, 1, stat.skippedExists)
+
+	// CRITICAL: the donor's value MUST NOT have overwritten the gateway's.
+	got, err := gw.GetKey([]byte("t:1:a:abc"))
+	require.NoError(t, err)
+	assert.Equal(t, "gateway-version", string(got),
+		"setIfAbsent must never overwrite the gateway value (this is the core safety property of the merge tool)")
+}
+
+func TestSetIfAbsent_DryRunDoesNotWrite(t *testing.T) {
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	require.NoError(t, setIfAbsent(gw, []byte("t:1:a:abc"), []byte("body"), stat, true))
+	assert.Equal(t, 1, stat.copied)
+
+	_, err := gw.GetKey([]byte("t:1:a:abc"))
+	assert.True(t, isKeyNotFoundError(err), "dry-run must not actually write; got %v", err)
+}
+
+// -------------------------------------------------------------------------
+// handleChainScopedPassThrough — validates embedded chain ID.
+// -------------------------------------------------------------------------
+
+func TestHandleChainScopedPassThrough_ValidatesMatchingChainID(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:1:a:taskABC", "body"), stat, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stat.copied)
+}
+
+func TestHandleChainScopedPassThrough_RejectsMismatchedChainID(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:8453:a:taskABC", "body"), stat, false, false)
+	require.Error(t, err, "must refuse to import a key whose embedded chain ID doesn't match --donor-chain-id")
+	assert.Contains(t, err.Error(), "embeds chain ID 8453")
+}
+
+func TestHandleChainScopedPassThrough_RejectsLegacyForm(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := &prefixStats{}
+
+	// Legacy form: `t:a:taskABC` (status code 'a', no numeric chain segment).
+	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:a:taskABC", "body"), stat, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "legacy (pre-chain-scoped) form")
+}
+
+// -------------------------------------------------------------------------
+// handleStampChainID — rewrites chain-implicit keys.
+// -------------------------------------------------------------------------
+
+func TestHandleStampChainID_StampsLegacyKey(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := newStats().forPrefix("w:")
+
+	donorKV := kvItem("w:0xowner:0xwallet", "wallet-record")
+	require.NoError(t, handleStampChainID(donor, gw, 8453, "w:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.copied, "should have copied to gateway")
+	assert.Equal(t, 1, stat.stampedChain, "should have counted the chain stamp")
+
+	// Verify the new key was written and the legacy key was NOT (since the
+	// donor row is never moved — that's the donor's problem).
+	stampedKey := []byte("w:8453:0xowner:0xwallet")
+	got, err := gw.GetKey(stampedKey)
+	require.NoError(t, err)
+	assert.Equal(t, "wallet-record", string(got))
+
+	_, err = gw.GetKey([]byte("w:0xowner:0xwallet"))
+	assert.True(t, isKeyNotFoundError(err), "legacy unstamped key should NOT have been written to the gateway")
+}
+
+func TestHandleStampChainID_DetectsAlreadyStampedDonor(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	stat := newStats().forPrefix("w:")
+
+	// Donor key is already in chain-scoped form (e.g. a re-run of the tool,
+	// or the donor having run a future migration we don't know about).
+	donorKV := kvItem("w:1:0xowner:0xwallet", "wallet-record")
+	require.NoError(t, handleStampChainID(donor, gw, 1, "w:", donorKV, stat, false, false))
+
+	// Should pass through, NOT double-stamp into `w:1:1:0xowner...`.
+	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 0, stat.stampedChain, "donor was already stamped — must not double-stamp")
+
+	got, err := gw.GetKey([]byte("w:1:0xowner:0xwallet"))
+	require.NoError(t, err)
+	assert.Equal(t, "wallet-record", string(got))
+
+	_, err = gw.GetKey([]byte("w:1:1:0xowner:0xwallet"))
+	assert.True(t, isKeyNotFoundError(err), "must not have produced the double-stamped key")
+}
+
+// -------------------------------------------------------------------------
+// handleMaxOnCollision — execution_index_counter:.
+// -------------------------------------------------------------------------
+
+func TestHandleMaxOnCollision_DonorLarger(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	require.NoError(t, gw.Set([]byte("execution_index_counter:taskA"), []byte("5")))
+
+	stat := newStats().forPrefix("execution_index_counter:")
+	donorKV := kvItem("execution_index_counter:taskA", "12")
+	require.NoError(t, handleMaxOnCollision(donor, gw, 1, "execution_index_counter:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.collisionResolved, "donor was larger — collision resolved")
+	assert.Equal(t, 1, stat.copied, "collision-resolved overwrites count toward Copied so summary totals reconcile (CollRes is a subset of Copied)")
+
+	got, err := gw.GetKey([]byte("execution_index_counter:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, "12", string(got), "gateway should now hold donor's larger value")
+}
+
+func TestHandleMaxOnCollision_GatewayLarger(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	require.NoError(t, gw.Set([]byte("execution_index_counter:taskA"), []byte("100")))
+
+	stat := newStats().forPrefix("execution_index_counter:")
+	donorKV := kvItem("execution_index_counter:taskA", "12")
+	require.NoError(t, handleMaxOnCollision(donor, gw, 1, "execution_index_counter:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.skippedExists, "gateway was larger — donor's value ignored")
+	assert.Equal(t, 0, stat.collisionResolved)
+
+	got, err := gw.GetKey([]byte("execution_index_counter:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, "100", string(got), "gateway's larger value preserved")
+}
+
+func TestHandleMaxOnCollision_NoExisting(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+
+	stat := newStats().forPrefix("execution_index_counter:")
+	donorKV := kvItem("execution_index_counter:taskA", "7")
+	require.NoError(t, handleMaxOnCollision(donor, gw, 1, "execution_index_counter:", donorKV, stat, false, false))
+
+	assert.Equal(t, 1, stat.copied)
+
+	got, err := gw.GetKey([]byte("execution_index_counter:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, "7", string(got))
+}
+
+// -------------------------------------------------------------------------
+// handleDrop — the no-op path.
+// -------------------------------------------------------------------------
+
+func TestHandleDrop_NeverWrites(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+
+	for _, key := range []string{"ct:cw:0xeoa", "pending:taskA:exec1", "trigger:taskA:exec1", "migration:foo"} {
+		stat := &prefixStats{}
+		require.NoError(t, handleDrop(donor, gw, 1, "", kvItem(key, "value"), stat, false, false))
+		assert.Equal(t, 1, stat.dropped, "key %q should have been counted as dropped", key)
+
+		_, err := gw.GetKey([]byte(key))
+		assert.True(t, isKeyNotFoundError(err), "key %q must NOT have been written", key)
+	}
+}
+
+// -------------------------------------------------------------------------
+// dispatch — the routing layer.
+// -------------------------------------------------------------------------
+
+func TestDispatch_RoutesEachPrefixToItsHandler(t *testing.T) {
+	donor := newTestDB(t)
+	gw := newTestDB(t)
+	st := newStats()
+
+	cases := []struct {
+		prefix string
+		key    string
+		value  string
+	}{
+		{"t:", "t:1:a:taskA", "task-body"},
+		{"u:", "u:1:0xowner:0xwallet:taskA", "taskA"},
+		{"history:", "history:1:taskA:exec1", "exec-blob"},
+		{"w:", "w:0xowner:0xwallet", "wallet"},
+		{"wsalt:", "wsalt:0xowner:0xfactory:0", "0xwallet"},
+		{"fl:", "fl:0xowner", "balance-blob"},
+		{"fr:", "fr:0xowner:exec1", "fee-blob"},
+		{"secret:", "secret:_:0xowner:_:apikey", "supersecret"},
+		{"execution_index_counter:", "execution_index_counter:taskA", "1"},
+		{"ct:cw:", "ct:cw:0xeoa", "5"},
+		{"pending:", "pending:taskA:exec1", ""},
+		{"trigger:", "trigger:taskA:exec1", "status"},
+		{"migration:", "migration:foo", "1"},
+	}
+	for _, c := range cases {
+		stat := st.forPrefix(c.prefix)
+		stat.scanned++
+		require.NoError(t, dispatch(donor, gw, 1, kvItem(c.key, c.value), stat, false, false), "dispatch(%q)", c.key)
+	}
+
+	assert.Equal(t, 1, st.perPrefix["t:"].copied)
+	assert.Equal(t, 1, st.perPrefix["u:"].copied)
+	assert.Equal(t, 1, st.perPrefix["history:"].copied)
+	assert.Equal(t, 1, st.perPrefix["w:"].copied)
+	assert.Equal(t, 1, st.perPrefix["w:"].stampedChain)
+	assert.Equal(t, 1, st.perPrefix["secret:"].copied)
+	assert.Equal(t, 1, st.perPrefix["ct:cw:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["pending:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["trigger:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["migration:"].dropped)
+}
+
+// -------------------------------------------------------------------------
+// alreadyStamped — small helper.
+// -------------------------------------------------------------------------
+
+func TestAlreadyStamped(t *testing.T) {
+	for _, c := range []struct {
+		rest    string
+		chainID int64
+		want    bool
+		desc    string
+	}{
+		{"1:0xowner:0xwallet", 1, true, "matches chain prefix"},
+		{"0xowner:0xwallet", 1, false, "no chain prefix"},
+		{"8453:0xowner:0xwallet", 1, false, "wrong chain prefix"},
+		{"", 1, false, "empty"},
+		{"1", 1, false, "chain ID without trailing colon"},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := alreadyStamped(c.rest, c.chainID)
+			assert.Equal(t, c.want, got, "alreadyStamped(%q, %d)", c.rest, c.chainID)
+		})
+	}
+}
+
+// -------------------------------------------------------------------------
+// parseChainIDFromKey — round-trip.
+// -------------------------------------------------------------------------
+
+func TestParseChainIDFromKey(t *testing.T) {
+	id, err := parseChainIDFromKey([]byte("t:1:a:taskA"))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), id)
+
+	id, err = parseChainIDFromKey([]byte("history:8453:taskA:exec1"))
+	require.NoError(t, err)
+	assert.Equal(t, int64(8453), id)
+
+	_, err = parseChainIDFromKey([]byte("t:a:taskA"))
+	assert.Error(t, err, "non-numeric second segment is legacy form")
+
+	_, err = parseChainIDFromKey([]byte("t:seq"))
+	assert.Error(t, err, "single-segment form is legacy")
+}
+
+func TestSupportedChainList_IsDeterministic(t *testing.T) {
+	first := supportedChainList()
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, first, supportedChainList())
+	}
+	// Sanity: the chains we actually support appear.
+	for _, want := range []string{"ethereum", "base", "sepolia", "base-sepolia"} {
+		assert.Contains(t, first, want)
+	}
+}

--- a/scripts/migration/merge_hetzner_into_gateway/main.go
+++ b/scripts/migration/merge_hetzner_into_gateway/main.go
@@ -1,0 +1,234 @@
+// Standalone tool to merge a single Hetzner per-chain aggregator BadgerDB
+// (the "donor") into the unified Railway gateway BadgerDB. Used once
+// during the 2026-07-01 Hetzner decom to bring forward the ~3 weeks of
+// production data that Studio wrote to the Hetzner aggregators after the
+// May 2026 Railway migration but before this cutover.
+//
+// Run the tool ONCE PER DONOR — sequentially, not in parallel — passing
+// the donor's chain ID:
+//
+//	go run scripts/migration/merge_hetzner_into_gateway \
+//	    --donor-path   ./donors/ethereum-2026-06-04 \
+//	    --donor-chain-id 1 \
+//	    --gateway-path /data \
+//	    --dry-run [--verbose]
+//
+// Chain IDs:
+//
+//	1         Ethereum mainnet
+//	8453      Base mainnet
+//	11155111  Sepolia testnet
+//	84532     Base-Sepolia testnet
+//
+// Operational constraints
+// -----------------------
+//
+//   - Stop the Railway gateway service before running with --dry-run=false.
+//     BadgerDB is single-writer; the tool opens the same db_path the
+//     gateway uses.
+//   - ALWAYS run with --dry-run first against an rsync'd copy of the
+//     gateway DB. Inspect per-prefix counts and collisions before
+//     touching the real volume.
+//   - The tool uses skip-if-exists semantics: every Set is preceded by
+//     Exist; nothing the gateway has already written is ever overwritten,
+//     with ONE deliberate exception — `execution_index_counter:` uses a
+//     max-on-collision policy and will overwrite the gateway value when
+//     the donor counter is strictly larger (necessary so the gateway does
+//     not re-issue execution indices that the donor already consumed).
+//     Both kinds of writes are surfaced in the summary: brand-new keys
+//     show under "Copied", overwrites under "CollRes". Do NOT replace
+//     setIfAbsent with storage.Storage.Load — Load is bulk upsert and
+//     will silently clobber live data.
+//   - Take a fresh pre-merge backup of the gateway volume immediately
+//     before the merge runs. That backup is the only rollback target.
+//
+// Per-prefix policy
+// -----------------
+// Documented in docs/Operator.md and in the avs-infra change-log
+// `docs/changes/20260604-hetzner-data-restore-plan.md`. The dispatch
+// table in handlers.go is the source of truth for what each prefix
+// does — refer there before editing this comment.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// supportedChainIDs gates --donor-chain-id to avoid fat-finger merges
+// (e.g. accidentally importing the Sepolia donor with chain-id 1).
+var supportedChainIDs = map[int64]string{
+	1:        "ethereum",
+	8453:     "base",
+	11155111: "sepolia",
+	84532:    "base-sepolia",
+}
+
+func main() {
+	donorPath := flag.String("donor-path", "", "Path to the donor BadgerDB directory (the Hetzner aggregator's db_path)")
+	donorChainID := flag.Int64("donor-chain-id", 0, "Chain ID for the donor — must match the chain the donor aggregator was serving")
+	gatewayPath := flag.String("gateway-path", "", "Path to the Railway gateway BadgerDB directory (the merge destination)")
+	dryRun := flag.Bool("dry-run", true, "Print what would change without writing to the gateway. Defaults to TRUE; pass --dry-run=false to apply.")
+	verbose := flag.Bool("verbose", false, "Print one line per key processed")
+	failOnUnknownPrefix := flag.Bool("fail-on-unknown-prefix", true, "Hard-fail if the donor has keys with a prefix this tool does not recognize. Default true — disabling is for emergency-recovery investigation only.")
+	flag.Parse()
+
+	if *donorPath == "" {
+		dieUsage("--donor-path is required")
+	}
+	if *gatewayPath == "" {
+		dieUsage("--gateway-path is required")
+	}
+	if *donorChainID == 0 {
+		dieUsage("--donor-chain-id is required")
+	}
+	chainName, ok := supportedChainIDs[*donorChainID]
+	if !ok {
+		dieUsage(fmt.Sprintf("--donor-chain-id %d is not a supported chain (allowed: %s)", *donorChainID, supportedChainList()))
+	}
+	if *donorPath == *gatewayPath {
+		log.Fatalf("--donor-path and --gateway-path are the same (%s) — refusing to merge a DB into itself", *donorPath)
+	}
+
+	fmt.Println("Hetzner → gateway merge")
+	fmt.Println("=======================")
+	fmt.Printf("Donor path:     %s\n", *donorPath)
+	fmt.Printf("Donor chain:    %d (%s)\n", *donorChainID, chainName)
+	fmt.Printf("Gateway path:   %s\n", *gatewayPath)
+	fmt.Printf("Mode:           %s\n", modeLabel(*dryRun))
+	fmt.Printf("Started at:     %s\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Println()
+
+	donor, err := storage.NewWithPath(*donorPath)
+	if err != nil {
+		log.Fatalf("open donor BadgerDB at %s: %v\n\nWas the donor aggregator stopped before snapshotting?", *donorPath, err)
+	}
+	defer donor.Close()
+
+	gateway, err := storage.NewWithPath(*gatewayPath)
+	if err != nil {
+		log.Fatalf("open gateway BadgerDB at %s: %v\n\nThe tool opens Badger in read-write mode (it needs the write lock even for --dry-run, since dry-run still acquires the lock to guarantee no other writer is racing it). If the Railway gateway service is still running against this volume, stop it before re-running.", *gatewayPath, err)
+	}
+	defer gateway.Close()
+
+	mergeStats := newStats()
+
+	// Walk every prefix the dispatcher recognizes. Hard-fail when we see
+	// a key with an unknown prefix UNLESS --fail-on-unknown-prefix=false
+	// (which only emergency-recovery investigations should ever pass).
+	allPrefixes := knownPrefixes()
+	sort.Strings(allPrefixes) // deterministic output ordering
+
+	for _, prefix := range allPrefixes {
+		stat := mergeStats.forPrefix(prefix)
+		items, err := donor.GetByPrefix([]byte(prefix))
+		if err != nil {
+			log.Fatalf("scan donor prefix %q: %v", prefix, err)
+		}
+		for _, kv := range items {
+			stat.scanned++
+			if err := dispatch(donor, gateway, *donorChainID, kv, stat, *dryRun, *verbose); err != nil {
+				stat.errored++
+				log.Printf("ERROR on key %q: %v", string(kv.Key), err)
+			}
+		}
+	}
+
+	// Unknown-prefix scan: anything in the donor whose key doesn't start
+	// with one of the prefixes we know about is by definition unhandled.
+	// This catches future schema additions that drop in without the merge
+	// tool being updated.
+	unknown, err := scanForUnknownPrefixes(donor, allPrefixes)
+	if err != nil {
+		log.Fatalf("scan for unknown prefixes: %v", err)
+	}
+	if len(unknown) > 0 {
+		fmt.Println()
+		fmt.Printf("⚠️  Donor has keys with %d prefix(es) not recognized by this tool:\n", len(unknown))
+		for prefix, count := range unknown {
+			fmt.Printf("    %q  (%d keys)\n", prefix, count)
+		}
+		fmt.Println()
+		if *failOnUnknownPrefix {
+			log.Fatalf("Hard-failing per --fail-on-unknown-prefix=true. Either extend handlers.go with policy for these prefixes, or pass --fail-on-unknown-prefix=false (NOT recommended — silently drops data).")
+		}
+		fmt.Println("Continuing because --fail-on-unknown-prefix=false. The unknown-prefix keys have been DROPPED from this merge.")
+	}
+
+	fmt.Println()
+	mergeStats.print(*donorChainID, chainName)
+
+	if *dryRun {
+		fmt.Println()
+		fmt.Println("DRY RUN — no changes written. Re-run with --dry-run=false to apply.")
+	}
+}
+
+// scanForUnknownPrefixes walks every key in the donor via the storage
+// streaming iterator (KeysOnly — values are never fetched and no
+// per-key slice is built, so memory stays constant in the size of the
+// donor). Bucketizes any key whose prefix is not in `knownPrefixes`.
+//
+// Returned label is everything up to and including the first ':' in the
+// unknown key (e.g. "newprefix:") — matches the schema's naming
+// convention. Keys without a colon are bucketed under the full key.
+func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[string]int, error) {
+	unknown := map[string]int{}
+	err := donor.IterateKeysOnly([]byte(""), func(key []byte) error {
+		k := string(key)
+		for _, p := range knownPrefixes {
+			if len(k) >= len(p) && k[:len(p)] == p {
+				return nil
+			}
+		}
+		label := k
+		for i := 0; i < len(k); i++ {
+			if k[i] == ':' {
+				label = k[:i+1]
+				break
+			}
+		}
+		unknown[label]++
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return unknown, nil
+}
+
+func supportedChainList() string {
+	parts := make([]string, 0, len(supportedChainIDs))
+	for id, name := range supportedChainIDs {
+		parts = append(parts, fmt.Sprintf("%d=%s", id, name))
+	}
+	sort.Strings(parts)
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+func dieUsage(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	fmt.Fprintln(os.Stderr)
+	flag.Usage()
+	os.Exit(2)
+}
+
+func modeLabel(dryRun bool) string {
+	if dryRun {
+		return "DRY RUN (no writes)"
+	}
+	return "APPLY (writes to gateway)"
+}

--- a/scripts/migration/merge_hetzner_into_gateway/main.go
+++ b/scripts/migration/merge_hetzner_into_gateway/main.go
@@ -122,7 +122,16 @@ func main() {
 	// Walk every prefix the dispatcher recognizes. Hard-fail when we see
 	// a key with an unknown prefix UNLESS --fail-on-unknown-prefix=false
 	// (which only emergency-recovery investigations should ever pass).
-	allPrefixes := knownPrefixes()
+	//
+	// Important: dedupe outer-loop prefixes to skip strict extensions of
+	// another known prefix (e.g. `t:seq` is covered by `t:`, `q:seq:` by
+	// `q:`). Without this, every t:seq key gets iterated twice: once via
+	// GetByPrefix("t:") and once via GetByPrefix("t:seq") — bloating the
+	// scanned count and confusingly attributing the second pass to the
+	// shorter-prefix row of the summary. The dispatch table inside
+	// handlers.go still has the more specific entries first, so the
+	// correct (drop) handler still fires.
+	allPrefixes := outerLoopPrefixes(knownPrefixes())
 	sort.Strings(allPrefixes) // deterministic output ordering
 
 	for _, prefix := range allPrefixes {
@@ -201,6 +210,30 @@ func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[
 		return nil, err
 	}
 	return unknown, nil
+}
+
+// outerLoopPrefixes returns the subset of `all` that should drive the
+// outer GetByPrefix loop in main: for any two prefixes A and B in the
+// input where A is a strict prefix of B, only A is returned. This keeps
+// keys from being processed twice when the dispatch table contains
+// both a general and a more-specific entry for the same family (e.g.
+// `t:` and `t:seq`).
+func outerLoopPrefixes(all []string) []string {
+	out := make([]string, 0, len(all))
+nextCandidate:
+	for _, candidate := range all {
+		for _, other := range all {
+			if other == candidate {
+				continue
+			}
+			if len(other) < len(candidate) && candidate[:len(other)] == other {
+				// `other` is a strict prefix of `candidate` — skip `candidate`.
+				continue nextCandidate
+			}
+		}
+		out = append(out, candidate)
+	}
+	return out
 }
 
 func supportedChainList() string {

--- a/scripts/migration/merge_hetzner_into_gateway/stats.go
+++ b/scripts/migration/merge_hetzner_into_gateway/stats.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+// prefixStats tracks what happened to keys under a single prefix during
+// one merge run. All counters start at zero.
+type prefixStats struct {
+	prefix string
+	policy string
+
+	scanned           int // donor keys seen under this prefix
+	copied            int // written to gateway (or would be, in dry-run); includes collisionResolved
+	stampedChain      int // subset of copied where the key was rewritten with a chain prefix
+	skippedExists     int // gateway already had the key — preserved
+	collisionResolved int // subset of copied where an existing gateway value was overwritten (execution_index_counter: only, when donor counter > gateway counter)
+	dropped           int // explicit drop policy
+	errored           int // handler returned an error (logged separately)
+}
+
+type stats struct {
+	perPrefix map[string]*prefixStats
+}
+
+func newStats() *stats {
+	s := &stats{perPrefix: make(map[string]*prefixStats, len(prefixHandlers))}
+	for _, h := range prefixHandlers {
+		s.perPrefix[h.prefix] = &prefixStats{prefix: h.prefix, policy: h.policy}
+	}
+	return s
+}
+
+func (s *stats) forPrefix(prefix string) *prefixStats {
+	if v, ok := s.perPrefix[prefix]; ok {
+		return v
+	}
+	// Lazy-init for any future prefix added at runtime; should not happen
+	// in practice because the keys are seeded from prefixHandlers.
+	v := &prefixStats{prefix: prefix}
+	s.perPrefix[prefix] = v
+	return v
+}
+
+func (s *stats) print(donorChainID int64, chainName string) {
+	fmt.Println("Summary")
+	fmt.Println("-------")
+	fmt.Printf("Donor chain: %d (%s)\n", donorChainID, chainName)
+	fmt.Println()
+
+	// Sort prefixes by their order in prefixHandlers (the canonical layout)
+	// instead of alphabetical — keeps related rows together.
+	ordered := make([]string, 0, len(s.perPrefix))
+	for _, h := range prefixHandlers {
+		ordered = append(ordered, h.prefix)
+	}
+	// Include any lazy-added prefixes at the bottom in alphabetical order
+	// so they're visible if they ever appear.
+	extras := []string{}
+	for k := range s.perPrefix {
+		if _, ok := lookupPrefixIndex(k); !ok {
+			extras = append(extras, k)
+		}
+	}
+	sort.Strings(extras)
+	ordered = append(ordered, extras...)
+
+	// Column widths chosen by the longest values we know about.
+	// CollRes is the subset of Copied that overwrote an existing gateway
+	// value (execution_index_counter: max-on-collision); brand-new keys
+	// show under Copied only.
+	fmt.Printf("%-30s %-50s %8s %8s %8s %8s %8s %8s %8s\n",
+		"Prefix", "Policy", "Scanned", "Copied", "CollRes", "Stamped", "Existed", "Dropped", "Errors")
+	fmt.Println("----------------------------- " +
+		"-------------------------------------------------- " +
+		"-------- -------- -------- -------- -------- -------- --------")
+
+	totals := prefixStats{}
+	for _, p := range ordered {
+		ps := s.perPrefix[p]
+		if ps.scanned == 0 && ps.dropped == 0 && ps.errored == 0 {
+			continue // suppress zero rows for readability
+		}
+		fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
+			ps.prefix, ps.policy,
+			ps.scanned, ps.copied, ps.collisionResolved, ps.stampedChain, ps.skippedExists, ps.dropped, ps.errored)
+		totals.scanned += ps.scanned
+		totals.copied += ps.copied
+		totals.collisionResolved += ps.collisionResolved
+		totals.stampedChain += ps.stampedChain
+		totals.skippedExists += ps.skippedExists
+		totals.dropped += ps.dropped
+		totals.errored += ps.errored
+	}
+	fmt.Println("----------------------------- " +
+		"-------------------------------------------------- " +
+		"-------- -------- -------- -------- -------- -------- --------")
+	fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
+		"TOTAL", "",
+		totals.scanned, totals.copied, totals.collisionResolved, totals.stampedChain, totals.skippedExists, totals.dropped, totals.errored)
+
+	if totals.errored > 0 {
+		fmt.Println()
+		fmt.Printf("⚠️  %d errors occurred during merge — review the ERROR log lines above.\n", totals.errored)
+	}
+}
+
+// lookupPrefixIndex returns the position of prefix in prefixHandlers and
+// whether it was found. Used by print() to detect lazy-added prefixes.
+func lookupPrefixIndex(prefix string) (int, bool) {
+	for i, h := range prefixHandlers {
+		if h.prefix == prefix {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/storage/db.go
+++ b/storage/db.go
@@ -32,6 +32,19 @@ type Storage interface {
 	GetKeyHasPrefix(prefix []byte) ([][]byte, error)
 	FirstKVHasPrefix(prefix []byte) ([]byte, []byte, error)
 
+	// IterateKeysOnly walks every key whose name starts with `prefix`,
+	// invoking `visit` for each. Uses Badger's key-only iterator: values
+	// are NOT fetched. Constant-memory; safe for prefix=[]byte("") on
+	// large databases where GetByPrefix or ListKeys would OOM.
+	//
+	// The key bytes passed to `visit` are owned by Badger's iterator
+	// scratch space and MUST NOT be retained beyond the visitor's return.
+	// Use append([]byte{}, key...) if you need to keep them.
+	//
+	// A non-nil error from `visit` aborts the iteration and propagates
+	// out of IterateKeysOnly verbatim.
+	IterateKeysOnly(prefix []byte, visit func(key []byte) error) error
+
 	// A key only operation that returns key that has a prefix
 	ListKeys(prefix string) ([]string, error)
 	ListKeysMulti(prefixes []string) ([]string, error)
@@ -165,6 +178,29 @@ func (s *BadgerStorage) GetByPrefix(prefix []byte) ([]*KeyValueItem, error) {
 	}
 
 	return result, nil
+}
+
+// IterateKeysOnly walks every key whose name starts with `prefix`,
+// invoking `visit` for each. Uses Badger's KeysOnly iterator — values
+// are not fetched and no per-key slice is built, so memory stays
+// constant in the size of the database.
+//
+// The key bytes passed to `visit` are owned by the iterator and MUST
+// NOT be retained after the visitor returns. Copy with
+// append([]byte{}, key...) if you need to keep them.
+func (s *BadgerStorage) IterateKeysOnly(prefix []byte, visit func(key []byte) error) error {
+	return s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if err := visit(it.Item().Key()); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func (s *BadgerStorage) GetKeyHasPrefix(prefix []byte) ([][]byte, error) {

--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,12 @@
 package version
 
 var (
-	// Version can also be set through tag release at build time
-	semver   = "1.9.6"
+	// Bumped manually on each release to match the current main tag — see
+	// docs/Release.md. ldflags overrides this for properly-built Docker
+	// images (publish-prod-docker.yml), but Railway's source-build path
+	// does not pass -ldflags, so this default is what telemetry/health
+	// endpoints report for Railway-deployed services.
+	semver   = "3.0.0"
 	revision = "unknown"
 )
 


### PR DESCRIPTION
## Why

Promote staging → main so the full Hetzner→Railway migration pipeline ships to production in one coordinated cut: chain-scoped storage, the merge tool, the end-to-end rehearsal tooling that we ran live against production donors tonight, the Railway env-var hygiene, and the operator chain-registry resilience fix.

## What's in this batch (8 commits, ~2,000 lines net)

| Commit | Type | What |
|---|---|---|
| 3f24295 | `refactor:` | [#546](https://github.com/AvaProtocol/EigenLayer-AVS/pull/546) — derive `eth_ws_url` from `eth_rpc_url` in code, rename Railway env vars `${ETHEREUM_DWELLIR_RPC}` → `${ETHEREUM_RPC}` (etc.) so RPC provider names aren't baked into env vars. **10 Railway env vars → 5.** Operator + aggregator config parsers both derive WS so removing `eth_ws_url` from operator YAML doesn't leave it empty (caught by Copilot review). |
| ccb65a1 | `feat:` | [#545](https://github.com/AvaProtocol/EigenLayer-AVS/pull/545) — end-to-end Hetzner→gateway migration rehearsal tooling + merge-tool body cleaner + engine `DiscardUnknown` defense-in-depth. Tonight's rehearsal ran the full pipeline against real production data from all 4 chains; surfaced + fixed 4 real bugs that would have silently broken the production merge. |
| f3763ed | `feat:` | [#543](https://github.com/AvaProtocol/EigenLayer-AVS/pull/543) — chain-scope `w:` / `wsalt:` / `fl:` / `fr:` storage keys end-to-end (engine + executor + vm + validation + migration tools + tests) |
| c8e004e | `chore:` | [#542](https://github.com/AvaProtocol/EigenLayer-AVS/pull/542) — `scripts/migration/merge_hetzner_into_gateway` one-shot tool + `storage.IterateKeysOnly` streaming iterator |
| 184eb7b | `fix:` | chain_registry: non-blocking gRPC dial + retry-on-error RPC client cache (gateway no longer hangs when one chain's worker is briefly down) |
| da70c07 | `docs:` | drop explicit `eth_rpc_url` / `eth_ws_url` from operator config example |
| 2c0a82f | `docs:` | fix operator setup example to use current mainnet config |
| fcdebee | `chore:` | bump version.go semver default `1.9.6` → `3.0.0` to match released tag |

Highest-impact prefix: `feat:` (semantic-release will produce **v3.1.0**).

## What tonight's rehearsal (#545) validated end-to-end

Snapshotted all 4 Hetzner aggregator BadgerDBs live to local, ran the merge tool sequentially:

| Chain | Donor scanned | User-data preserved | Errors |
|---|---:|---:|---:|
| Sepolia (11155111) | 49,862 | 245 | 0 |
| Base-Sepolia (84532) | 11 | 4 | 0 |
| Base (8453) | 10,844,565 | 237,476 | 1 |
| Ethereum (1) | 7,726,017 | 29,718 | 7 |
| **Total** | **18.6M** | **267,443** | **8** |

The 8 errors are the `topics`-field schema-drift rows accepted as data loss (operator decision).

Read-path validated:
- Gateway boots cleanly with all 4 chains registered
- Paymaster `owner()` probe passes on each chain (incl. correct mainnet paymaster `0xf023eA…19D6f`)
- Tasks/executions/wallets deserialize as valid JSON, **100% have `task.ChainId` set correctly** after the merge tool's body cleaner
- `wsalt:` secondary-index integrity passes on all 4 chains
- HTTP routing works (401 on auth-gated paths)

## Bugs surfaced + fixed by the rehearsal (all included in #545)

1. **Every Hetzner donor predates `MigrateKeysToChainScoped`** — `t:`/`u:`/`history:` are all in legacy form. Without inline stamping the merge would have hard-failed on the first ethereum key.
2. **Two prefixes not in the dispatch table** — `operator:` (3-27 keys) + `q:` (7-10M keys per mainnet donor). Would have aborted the merge.
3. **~46% of mainnet tasks would have silently failed strict protojson decode** at engine load time (renamed proto fields `expression`, `epochs`, `totalExecution`, `interval`, `input`). Merge tool body cleaner re-serializes; engine loaders also got `DiscardUnknown: true` as defense-in-depth.
4. **100% of merged task bodies had `task.ChainId == 0`** — engine's default-fallback would have silently re-keyed base tasks onto the gateway's default chain on next update. Merge tool now populates the body's chain_id during stamping.

## Why not `feat!:`

The chain-scoped key change is breaking for any persisted gateway data, but:
- Public gRPC/REST API signatures are unchanged — SDKs see no breakage
- The Railway gateway had no meaningful user data yet (confirmed before #543 landed)
- Hetzner data is migrated via the merge tool, which now writes the new format directly + cleans up old proto fields

So from the SDK consumer's perspective this is backward-compatible; from the operator's perspective it's a storage migration handled by the bundled tools.

## Railway env-var prep (already done)

All 5 shared variables (`ETHEREUM_RPC`, `BASE_RPC`, `SEPOLIA_RPC`, `BASE_SEPOLIA_RPC`, `BNB_RPC`) are set in the `eigenlayer-avs` / `production` Shared Variables panel and shared with all 7 consuming services. Verified via `railway variables --service <svc>` — 11/11 expected assignments resolve to URLs. The new YAML in this batch reads from these via `${ETHEREUM_RPC}` etc.

Legacy `*_DWELLIR_RPC` / `*_DWELLIR_WS` per-service vars stay set for now; they become unused once the redeploys complete and can be swept in a follow-up.

## Post-merge checklist

1. **Manually dispatch `publish-dev-docker`** workflow — the workflow only auto-runs on staging pushes that touch `protobuf/avs.proto`, which none of these commits did. Manual dispatch builds + tags the `:latest` image for Railway.
2. **Verify each Railway service** picks up the new image cleanly. Watch for startup logs confirming chain-config parse + paymaster probe pass on all 4 chains.
3. **Sweep the legacy `*_DWELLIR_RPC` / `*_DWELLIR_WS` Railway vars** once services are stable on the new YAML.
4. **Schedule the actual production merge maintenance window** — the rehearsal already proved the data migration works on real data; the production run is just the same flow against fresh donor snapshots.

## Out of scope for this promotion

- `chain_id` field on `ListWalletReq` / `GetWalletReq` / `SetWalletReq` proto messages, threaded via REST JWT audience. Wallet APIs currently serve only the default chain. Follow-up PR.
- Phase 1 (stop testnet Hetzner containers) and Phase 3 (2026-07-01: stop mainnet Hetzner containers) — both gated on successful prod merge.
- Cleanup of inlined dev secrets in `config/gateway-dev.yaml` (pre-existing leak; `gateway-dev-rehearsal.yaml` introduced in #545 uses `${REHEARSAL_*}` env vars from day one).

## Test plan

- [x] `go build ./...` clean across the entire diff
- [x] Full `core/taskengine/` test suite passes at #545 head (236.7s, all subtests green)
- [x] Copilot reviews on #543 / #545 / #546 all addressed
- [x] End-to-end rehearsal against all 4 production donors — 267,443 user-data keys merged with 8 expected errors
- [x] Railway env-var setup verified (11/11 shared-var references resolve correctly across 7 services)
- [ ] CI passes on this promotion PR
- [ ] After merge: dispatch `publish-dev-docker`, verify services come up healthy
