### PR TITLE
feat: end-to-end Hetzner→gateway migration rehearsal tooling + merge-tool dispatch fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ config/*.yaml
 !config/operator.example.yaml
 !config/*-dev.yaml
 !config/*-railway.yaml
+!config/*-rehearsal.yaml
 # Snapshot of tracked configs taken before any restructure; safety net.
 !config/_legacy/
 !config/_legacy/*.yaml
@@ -77,3 +78,13 @@ EigenLayer-AVS
 
 # VS Code workspace files
 *.code-workspace
+# Hetzner donor snapshots + rehearsal scratch gateway DB (local only)
+donors/
+tmp/rehearsal-gateway-db/
+tmp/rehearsal-gateway-backup/
+# Stale build artifacts at repo root from manual go run
+/dev
+/merge_hetzner_into_gateway
+
+# Local Claude Code agent state (session locks, project-local skills, etc.)
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -294,3 +294,44 @@ dev-stack: build
 ## clean: cleanup storage data
 clean:
 	rm -rf /tmp/ap-avs /tmp/ap.sock
+
+## hetzner-snapshot: pull fresh BadgerDB tarballs from each Hetzner aggregator
+##                   into ./donors/<chain>/db/. Brief docker-stop per chain.
+##                   Pass CHAIN=sepolia (etc.) to limit scope.
+.PHONY: hetzner-snapshot
+hetzner-snapshot:
+	@scripts/dev/snapshot-hetzner-donors.sh $(CHAIN)
+
+## migration-rehearse: run the Hetzner->gateway merge tool sequentially
+##                     against each donor in ./donors/, default dry-run.
+##                     Pass APPLY=1 to actually write to the scratch
+##                     gateway DB at /tmp/rehearsal-gateway-db.
+##                     Pass CHAIN=sepolia (etc.) to limit scope.
+.PHONY: migration-rehearse
+migration-rehearse:
+	@scripts/dev/run-merge-rehearsal.sh $(if $(APPLY),--apply) $(CHAIN)
+
+## dev-stack-rehearsal: start the dev gateway against the post-merge
+##                      scratch DB at /tmp/rehearsal-gateway-db. Use
+##                      after `make migration-rehearse APPLY=1` to
+##                      validate read-path queries via the SDK.
+.PHONY: dev-stack-rehearsal
+dev-stack-rehearsal: build
+	@mkdir -p logs
+	@echo "🚀 Starting rehearsal gateway against /tmp/rehearsal-gateway-db"
+	@echo "   gateway      → REST :8080, gRPC :2206  (logs/gateway-rehearsal.log)"
+	@echo "   worker:sep   → gRPC :50051            (logs/worker-sepolia.log)"
+	@echo "   worker:bsep  → gRPC :50052            (logs/worker-base-sepolia.log)"
+	@echo ""
+	@echo "   Validate with the ava-sdk-js CLI:"
+	@echo "     cd ../ava-sdk-js/examples"
+	@echo "     yarn start listWorkflows           # expect post-merge workflow count"
+	@echo "     yarn start getWorkflow <task_id>   # ground-truth single-task fetch"
+	@echo ""
+	@set -m; \
+		trap 'echo; echo "🛑 Stopping rehearsal stack..."; kill 0 2>/dev/null; exit 0' INT TERM; \
+		./out/ap worker --config=config/worker-sepolia-dev.yaml      > logs/worker-sepolia.log      2>&1 & \
+		./out/ap worker --config=config/worker-base-sepolia-dev.yaml > logs/worker-base-sepolia.log 2>&1 & \
+		sleep 1; \
+		./out/ap aggregator --config=config/gateway-dev-rehearsal.yaml > logs/gateway-rehearsal.log 2>&1 & \
+		wait

--- a/config/gateway-dev-rehearsal.yaml
+++ b/config/gateway-dev-rehearsal.yaml
@@ -1,0 +1,130 @@
+# Gateway configuration for the Hetzner -> Railway migration rehearsal.
+#
+# Differs from gateway-dev.yaml in two ways:
+#
+#  1. db_path points at ./tmp/rehearsal-gateway-db -- the scratch DB the
+#     merge tool populates via `make migration-rehearse APPLY=1`. Path is
+#     relative to the project root so it lives inside the repo workspace
+#     (already in .gitignore) and matches the script in
+#     scripts/dev/run-merge-rehearsal.sh. Keeping this separate from
+#     /tmp/ap-avs/gateway (the normal dev DB) means you can flip between
+#     the two stacks without clobbering either.
+#
+#  2. All four production chains (sepolia, base-sepolia, base, ethereum)
+#     are registered. After a full-suite merge, the gateway can serve
+#     read queries for tasks/executions/wallets/secrets on any of them
+#     via the SDK's listWorkflows / getWorkflow / getExecution / etc.
+#
+# Workers: only sepolia + base-sepolia run locally by default (see
+# `make dev-stack-rehearsal`). Mainnet workers are listed below but not
+# expected to be reachable -- the rehearsal validates the gateway's
+# READ-path against the merged DB, not UserOp execution against
+# mainnet (which would cost real ETH and isn't the purpose here).
+# Triggering a task on a chain with no live worker returns
+# WORKER_UNAVAILABLE; that's expected.
+#
+# CREDENTIALS: Every secret in this file is `${VAR}` -- exported by your
+# shell or supplied via a `.env` file you keep locally. Nothing real
+# lives in git. The rehearsal does NOT execute UserOps, so all
+# controller / bundler / paymaster references are inert (the gateway
+# probes the paymaster's owner() function at startup but never signs);
+# the values below can stay as test-only placeholders unless you also
+# want to drive trigger->worker flows on testnets. See
+# scripts/dev/README.md for the env-var checklist.
+environment: development
+
+db_path: ./tmp/rehearsal-gateway-db
+backup_dir: ./tmp/rehearsal-gateway-backup
+
+ecdsa_private_key: ${REHEARSAL_ECDSA_PRIVATE_KEY}
+
+# EigenLayer contracts live on Sepolia (the AVS registration chain)
+eth_rpc_url: ${REHEARSAL_AVS_RPC}
+eth_ws_url: ${REHEARSAL_AVS_WS}
+
+# Top-level smart_wallet is required by the aa package + startup probes
+# even in gateway mode. Mirrors the AVS chain (sepolia) below.
+smart_wallet:
+  eth_rpc_url: ${REHEARSAL_SEPOLIA_RPC}
+  eth_ws_url: ${REHEARSAL_SEPOLIA_WS}
+  bundler_url: ${REHEARSAL_SEPOLIA_BUNDLER_URL}
+  controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+  paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
+  max_wallets_per_owner: 2000
+
+rpc_bind_address: "0.0.0.0:2206"
+http_bind_address: "0.0.0.0:8080"
+
+avs_registry_coordinator_address: 0xcA95381802FD1398d5BF2D01243210cFb3a2b3BD
+operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
+
+jwt_secret: ${REHEARSAL_JWT_SECRET}
+
+rest_rate_limit_per_second: 200
+rest_rate_limit_burst: 1000
+
+server_name: "gateway-dev-rehearsal"
+sentry_dsn: ""  # rehearsal traffic shouldn't pollute Sentry
+
+tenderly_account: "chrisli"
+tenderly_project: "default"
+tenderly_access_key: ${REHEARSAL_TENDERLY_ACCESS_KEY}
+
+chains:
+  - chain_id: 11155111
+    name: sepolia
+    worker_addr: "127.0.0.1:50051"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_SEPOLIA_RPC}
+      eth_ws_url: ${REHEARSAL_SEPOLIA_WS}
+      bundler_url: ${REHEARSAL_SEPOLIA_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
+      max_wallets_per_owner: 2000
+
+  - chain_id: 84532
+    name: base-sepolia
+    worker_addr: "127.0.0.1:50052"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_BASE_SEPOLIA_RPC}
+      eth_ws_url: ${REHEARSAL_BASE_SEPOLIA_WS}
+      bundler_url: ${REHEARSAL_BASE_SEPOLIA_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
+      max_wallets_per_owner: 3
+
+  # Mainnet chains. Use the per-chain paymaster from docs/Contract.md
+  # (0xf023eA...19D6f is the mainnet paymaster; the testnet
+  # 0xd856f...d92 has no bytecode on either mainnet).
+  - chain_id: 1
+    name: ethereum
+    worker_addr: "127.0.0.1:50053"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_ETHEREUM_RPC}
+      eth_ws_url: ${REHEARSAL_ETHEREUM_WS}
+      bundler_url: ${REHEARSAL_ETHEREUM_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f
+      max_wallets_per_owner: 3
+
+  - chain_id: 8453
+    name: base
+    worker_addr: "127.0.0.1:50054"
+    smart_wallet:
+      eth_rpc_url: ${REHEARSAL_BASE_RPC}
+      eth_ws_url: ${REHEARSAL_BASE_WS}
+      bundler_url: ${REHEARSAL_BASE_BUNDLER_URL}
+      controller_private_key: ${REHEARSAL_CONTROLLER_PRIVATE_KEY}
+      paymaster_address: 0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f
+      max_wallets_per_owner: 3
+
+macros:
+  secrets:
+    ap_notify_bot_token: ${REHEARSAL_TELEGRAM_BOT_TOKEN}
+    sendgrid_key: ""
+    thegraph_api_key: ${REHEARSAL_THEGRAPH_API_KEY}
+    moralis_api_key: ${REHEARSAL_MORALIS_API_KEY}
+
+notifications:
+  summary:
+    enabled: false  # rehearsal must not send real notifications

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -624,7 +624,14 @@ func (n *Engine) MustStart() error {
 			task := &model.Workflow{
 				Task: &avsproto.Task{},
 			}
-			err := protojson.Unmarshal(item.Value, task)
+			// DiscardUnknown: schema evolution over time has renamed/
+			// removed proto fields (e.g. `expression`, `epochs`,
+			// `totalExecution`, `interval`, `input`). Strict decode
+			// would silently skip any task whose body retains those
+			// old fields (the `if err == nil` branch below swallows
+			// errors). Tolerate unknowns at load — re-marshal on the
+			// next write drops them permanently.
+			err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, task)
 			if err == nil {
 				if initErr := task.EnsureInitialized(); initErr != nil {
 					n.logger.Warn("Task failed initialization after loading from storage",
@@ -3677,7 +3684,11 @@ func (n *Engine) ListExecutions(user *model.User, payload *avsproto.ListExecutio
 			}
 
 			exec := &avsproto.Execution{}
-			if err := protojson.Unmarshal(executionValue, exec); err == nil {
+			// DiscardUnknown: tolerate proto fields renamed/removed
+			// since this execution was written. The merge tool re-
+			// serializes bodies on import so this matters mainly for
+			// data that was never touched by a merge run.
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(executionValue, exec); err == nil {
 				executioResp.Items = append(executioResp.Items, exec)
 				total += 1
 			}
@@ -3713,7 +3724,11 @@ func (n *Engine) ListExecutions(user *model.User, payload *avsproto.ListExecutio
 			}
 
 			exec := &avsproto.Execution{}
-			if err := protojson.Unmarshal(executionValue, exec); err == nil {
+			// DiscardUnknown: tolerate proto fields renamed/removed
+			// since this execution was written. The merge tool re-
+			// serializes bodies on import so this matters mainly for
+			// data that was never touched by a merge run.
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(executionValue, exec); err == nil {
 				executioResp.Items = append(executioResp.Items, exec)
 				total += 1
 			}
@@ -3780,7 +3795,10 @@ func (n *Engine) GetExecution(user *model.User, payload *avsproto.ExecutionReq) 
 	rawExecution, err := n.db.GetKey(ChainTaskExecutionKey(task.ChainId, task, payload.ExecutionId))
 	if err == nil {
 		exec := &avsproto.Execution{}
-		err = protojson.Unmarshal(rawExecution, exec)
+		// DiscardUnknown: tolerate proto fields renamed/removed since
+		// the execution was written; otherwise GetExecution/
+		// GetExecutionStatus would error 500 on any older row.
+		err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(rawExecution, exec)
 		if err != nil {
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_TASK_DATA_CORRUPTED), TaskStorageCorruptedError)
 		}
@@ -3843,7 +3861,10 @@ func (n *Engine) GetExecutionStatus(user *model.User, payload *avsproto.Executio
 	rawExecution, err := n.db.GetKey(ChainTaskExecutionKey(task.ChainId, task, payload.ExecutionId))
 	if err == nil {
 		exec := &avsproto.Execution{}
-		err = protojson.Unmarshal(rawExecution, exec)
+		// DiscardUnknown: tolerate proto fields renamed/removed since
+		// the execution was written; otherwise GetExecution/
+		// GetExecutionStatus would error 500 on any older row.
+		err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(rawExecution, exec)
 		if err != nil {
 			return nil, status.Errorf(codes.Code(avsproto.ErrorCode_TASK_DATA_CORRUPTED), TaskStorageCorruptedError)
 		}
@@ -4751,7 +4772,10 @@ func (n *Engine) GetExecutionStats(user *model.User, payload *avsproto.GetExecut
 
 		for _, item := range items {
 			execution := &avsproto.Execution{}
-			if err := protojson.Unmarshal(item.Value, execution); err != nil {
+			// DiscardUnknown: same rationale as elsewhere — tolerate
+			// proto fields renamed/removed since the execution was
+			// written.
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item.Value, execution); err != nil {
 				n.logger.Error("error unmarshalling execution", "error", err)
 				continue
 			}

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -127,7 +127,12 @@ func (x *WorkflowExecutor) GetTask(id string) (*model.Workflow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("storage access failed for key '%s': %w", string(storageKey), err)
 	}
-	err = protojson.Unmarshal(item, task)
+	// DiscardUnknown: tolerate proto fields renamed/removed since the
+	// task was written. Without this, any task whose body carries
+	// old fields like `expression`/`epochs`/`totalExecution` would
+	// fail strict decode here and the executor would falsely report
+	// the task as "data may be corrupted".
+	err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(item, task)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse task data from storage (data may be corrupted): %w", err)
 	}

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -1,0 +1,170 @@
+# scripts/dev — migration rehearsal tooling
+
+End-to-end test of the Hetzner → Railway-gateway data merge on a local
+dev machine, without touching production Railway. Lets you snapshot the
+live Hetzner aggregator BadgerDBs, run the merge tool against scratch
+gateway storage, and verify the gateway can serve read queries against
+the merged data via the SDK.
+
+## Env vars required by `make dev-stack-rehearsal`
+
+`config/gateway-dev-rehearsal.yaml` references everything secret via
+`${REHEARSAL_*}` env vars so nothing real lives in git. Export these
+in your shell (or a local untracked `.env` you `source` before the
+make target) before starting the rehearsal gateway:
+
+```bash
+# Sepolia is the AVS registration chain — used by EigenLayer code paths
+# at startup. The Tenderly key is read-only so it's fine to reuse.
+export REHEARSAL_AVS_RPC=https://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_AVS_WS=wss://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_SEPOLIA_RPC=https://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_SEPOLIA_WS=wss://sepolia.gateway.tenderly.co/<key>
+export REHEARSAL_SEPOLIA_BUNDLER_URL=https://api.pimlico.io/v2/11155111/rpc?apikey=<pim_key>
+
+export REHEARSAL_BASE_SEPOLIA_RPC=https://api-base-sepolia-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_SEPOLIA_WS=wss://api-base-sepolia-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_SEPOLIA_BUNDLER_URL=https://api.pimlico.io/v2/84532/rpc?apikey=<pim_key>
+
+export REHEARSAL_ETHEREUM_RPC=https://api-ethereum-mainnet.n.dwellir.com/<key>
+export REHEARSAL_ETHEREUM_WS=wss://api-ethereum-mainnet.n.dwellir.com/<key>
+export REHEARSAL_ETHEREUM_BUNDLER_URL=https://api.pimlico.io/v2/1/rpc?apikey=<pim_key>
+
+export REHEARSAL_BASE_RPC=https://api-base-mainnet-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_WS=wss://api-base-mainnet-archive.n.dwellir.com/<key>
+export REHEARSAL_BASE_BUNDLER_URL=https://api.pimlico.io/v2/8453/rpc?apikey=<pim_key>
+
+# Cryptographic material — placeholders are fine since the rehearsal
+# never signs or submits UserOps. Any 32-byte hex works.
+export REHEARSAL_ECDSA_PRIVATE_KEY=<32-byte-hex>
+export REHEARSAL_CONTROLLER_PRIVATE_KEY=<32-byte-hex>
+export REHEARSAL_JWT_SECRET=<any-string>
+
+# Optional — only used by Tenderly-simulated nodes and notification
+# flows. Leave unset and those features degrade gracefully.
+export REHEARSAL_TENDERLY_ACCESS_KEY=<tenderly-key>
+export REHEARSAL_TELEGRAM_BOT_TOKEN=<bot-token>
+export REHEARSAL_THEGRAPH_API_KEY=<thegraph-key>
+export REHEARSAL_MORALIS_API_KEY=<moralis-jwt>
+```
+
+`make hetzner-snapshot` and `make migration-rehearse` (the steps that
+actually validate the merge) do NOT need any of these — they read
+donor BadgerDBs and write the gateway BadgerDB directly, no RPC or
+auth involved. The env vars are only required when you bring up the
+gateway to query the merged data via the SDK.
+
+## Quick start
+
+```bash
+# 1) Pull fresh donor DBs from all 4 Hetzner aggregators.
+#    Brief docker-stop per chain (~30-90s each).
+make hetzner-snapshot
+
+# 2) Dry-run the merge for all 4 chains — no writes.
+#    Inspect the per-prefix counts printed at the end of each chain.
+make migration-rehearse
+
+# 3) When the dry-run output looks right, actually merge.
+make migration-rehearse APPLY=1
+
+# 4) Start the gateway against the post-merge scratch DB.
+#    Runs the gateway on REST :8080 / gRPC :2206 plus 2 testnet workers.
+#    Mainnet workers are listed in the config but not started here;
+#    triggering a task on ethereum/base returns WORKER_UNAVAILABLE.
+make dev-stack-rehearsal
+
+# 5) In another terminal, query the SDK to confirm reads work.
+#    Compare counts to the live aggregators' output before they were
+#    snapshotted.
+cd ../ava-sdk-js/examples
+yarn start listWorkflows
+yarn start getWorkflow <task-id-from-the-list>
+```
+
+## What the rehearsal validates
+
+- The merge tool dispatch matrix matches the actual on-disk shape of
+  each donor (no unknown prefixes, no parse errors)
+- Chain-scoped keys (`w:<chain>:`, `wsalt:<chain>:`, `fl:<chain>:`,
+  `fr:<chain>:`, `t:<chain>:`, `u:<chain>:`, `history:<chain>:`) are
+  written correctly and the gateway can READ each family for each
+  chain
+- Aggregate counts (workflows, executions, wallets, secrets) match
+  the donor totals — nothing was silently dropped or duplicated
+- `execution_index_counter:` max-on-collision picks the right value
+  when both donor and gateway have entries for the same task
+- `wsalt:` index is consistent post-merge — `LookupCanonicalWalletAddress`
+  on a (chainID, owner, factory, salt) tuple returns the same wallet
+  the primary `w:<chain>:<owner>:<wallet>` record points to
+
+## What it does NOT validate
+
+- Real UserOp execution against mainnet (would cost real ETH; out of
+  scope, the merge tool does not change the execution path)
+- Operator-side trigger evaluation (operators aren't part of the
+  rehearsal stack)
+- The Railway gateway's actual storage volume — the rehearsal runs
+  against `/tmp/rehearsal-gateway-db` only. Promote to production by
+  taking a fresh pre-merge backup of the Railway gateway volume, then
+  running the same merge sequence in the production maintenance window.
+
+## Iterating without re-downloading
+
+`make hetzner-snapshot` always pulls fresh and overwrites `./donors/`.
+The merge rehearsal is non-destructive to the donor data — only the
+scratch gateway DB at `/tmp/rehearsal-gateway-db` gets reset on each
+`make migration-rehearse APPLY=1` run.
+
+So a tight iteration loop is:
+
+```bash
+make hetzner-snapshot       # once per day, when fresh data matters
+make migration-rehearse     # dry-run, iterate on dispatch matrix
+make migration-rehearse APPLY=1  # apply, then validate via SDK
+```
+
+To only snapshot or rehearse one chain:
+
+```bash
+make hetzner-snapshot CHAIN=sepolia
+make migration-rehearse CHAIN=sepolia
+make migration-rehearse CHAIN=sepolia APPLY=1
+```
+
+## File map
+
+| File | What |
+|---|---|
+| `snapshot-hetzner-donors.sh` | SSH + docker-stop + tarball each Hetzner aggregator. Extracts to `./donors/<chain>/db/`. |
+| `run-merge-rehearsal.sh` | Runs the merge tool sequentially per donor against `/tmp/rehearsal-gateway-db`. Calls `count-gateway-keys.go` at the end. |
+| `count-gateway-keys.go` | One-shot scan of the gateway DB that prints per-prefix per-chain key counts. Helps spot unexpected key distributions after the merge. |
+| `../../config/gateway-dev-rehearsal.yaml` | Gateway config pointing at the rehearsal scratch DB with all 4 chains registered. Used by `make dev-stack-rehearsal`. |
+
+## Disk + downtime budget
+
+| Chain | DB size (2026-06-04) | Hetzner downtime per snapshot |
+|---|---|---|
+| sepolia | 34 MB | ~5s |
+| base-sepolia | 26 MB | ~5s |
+| ethereum | 1.0 GB | ~30s |
+| base | 1.2 GB | ~30s |
+| **total** | **~2.3 GB** | **~70s total wall** |
+
+`make hetzner-snapshot` runs chains sequentially per host but
+mainnet/testnet hosts are independent — the two pairs could be
+parallelized in a future revision if the downtime budget becomes
+tight.
+
+## Cleanup
+
+```bash
+rm -rf donors/                          # delete all snapshotted donor data
+rm -rf /tmp/rehearsal-gateway-db        # delete the scratch gateway DB
+rm -rf /tmp/rehearsal-gateway-backup    # and its backup dir
+```
+
+## Related
+
+- [`scripts/migration/merge_hetzner_into_gateway/`](../migration/merge_hetzner_into_gateway/) — the merge tool itself
+- [`avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md`](https://github.com/AvaProtocol/avs-infra/blob/main/docs/changes/20260604-hetzner-data-restore-plan.md) — the policy matrix the merge tool implements

--- a/scripts/dev/count-gateway-keys.go
+++ b/scripts/dev/count-gateway-keys.go
@@ -1,0 +1,107 @@
+// count-gateway-keys — print per-prefix key counts for a BadgerDB
+// directory. Used by run-merge-rehearsal.sh to verify what the merge
+// tool wrote and let the operator compare counts against the live SDK
+// queries (yarn start listWorkflows / getExecution).
+//
+// Usage:
+//
+//	go run scripts/dev/count-gateway-keys.go --gateway-path /tmp/...
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+func main() {
+	gatewayPath := flag.String("gateway-path", "", "Path to the gateway BadgerDB directory")
+	flag.Parse()
+	if *gatewayPath == "" {
+		log.Fatalf("--gateway-path is required")
+	}
+
+	db, err := storage.NewWithPath(*gatewayPath)
+	if err != nil {
+		log.Fatalf("open BadgerDB at %s: %v", *gatewayPath, err)
+	}
+	defer db.Close()
+
+	// Bucket every key by its prefix (everything up to first ':') and
+	// then by chain (next segment if numeric) so the post-merge
+	// distribution is visible at a glance.
+	type bucket struct {
+		prefix  string
+		chainID string // "_" when not present or non-numeric
+		count   int64
+	}
+	counts := map[string]*bucket{}
+
+	if err := db.IterateKeysOnly([]byte(""), func(key []byte) error {
+		s := string(key)
+		prefix := s
+		rest := ""
+		for i, c := range s {
+			if c == ':' {
+				prefix = s[:i+1]
+				rest = s[i+1:]
+				break
+			}
+		}
+		chainID := "_"
+		// Chain segment is everything up to the next ':' if it parses
+		// as an integer.
+		for i, c := range rest {
+			if c == ':' {
+				cand := rest[:i]
+				ok := len(cand) > 0
+				for _, ch := range cand {
+					if ch < '0' || ch > '9' {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					chainID = cand
+				}
+				break
+			}
+		}
+		bucketKey := prefix + "|" + chainID
+		b, found := counts[bucketKey]
+		if !found {
+			b = &bucket{prefix: prefix, chainID: chainID}
+			counts[bucketKey] = b
+		}
+		b.count++
+		return nil
+	}); err != nil {
+		log.Fatalf("iterate keys: %v", err)
+	}
+
+	// Sort by prefix, then chain
+	type row struct{ b *bucket }
+	rows := make([]row, 0, len(counts))
+	for _, b := range counts {
+		rows = append(rows, row{b})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].b.prefix != rows[j].b.prefix {
+			return rows[i].b.prefix < rows[j].b.prefix
+		}
+		return rows[i].b.chainID < rows[j].b.chainID
+	})
+
+	fmt.Printf("%-30s %-12s %12s\n", "Prefix", "ChainID", "Count")
+	fmt.Println("----------------------------- ------------ ------------")
+	var total int64
+	for _, r := range rows {
+		fmt.Printf("%-30s %-12s %12d\n", r.b.prefix, r.b.chainID, r.b.count)
+		total += r.b.count
+	}
+	fmt.Println("----------------------------- ------------ ------------")
+	fmt.Printf("%-30s %-12s %12d\n", "TOTAL", "", total)
+}

--- a/scripts/dev/run-merge-rehearsal.sh
+++ b/scripts/dev/run-merge-rehearsal.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# run-merge-rehearsal.sh — exercise the Hetzner→gateway merge tool against
+# locally-snapshotted donor BadgerDBs.
+#
+# Reads ./donors/<chain>/db/, runs the merge tool sequentially per chain
+# into a scratch gateway DB, prints a per-chain summary table, then
+# reports aggregate counts the operator can compare to the live SDK
+# output afterwards.
+#
+# Usage:
+#   scripts/dev/run-merge-rehearsal.sh                    # all 4 chains
+#   scripts/dev/run-merge-rehearsal.sh sepolia            # one chain
+#   scripts/dev/run-merge-rehearsal.sh sepolia base-sepolia
+#
+# Run order matters when multiple chains are requested: sepolia, base-
+# sepolia, base, ethereum (smallest first → catch issues before paying
+# the wall-clock cost of mainnet). Override the order by passing chains
+# in your preferred sequence.
+#
+# Prereqs:
+#   - Donor data already at ./donors/<chain>/db/ (run snapshot-hetzner-donors.sh first)
+#   - Local Go toolchain (`go run ./scripts/migration/merge_hetzner_into_gateway/...`)
+#
+# Exit codes:
+#   0  every requested chain merged + summary printed
+#   1  prereq missing or donor data not snapshotted
+#   2  the merge tool errored on one or more chains
+#
+# This is the DRY-RUN by default. To actually write to the scratch
+# gateway DB, pass --apply as the first arg:
+#
+#   scripts/dev/run-merge-rehearsal.sh --apply
+#   scripts/dev/run-merge-rehearsal.sh --apply sepolia
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DONORS_DIR="${ROOT_DIR}/donors"
+GATEWAY_DB="${ROOT_DIR}/tmp/rehearsal-gateway-db"
+
+declare -A CHAIN_IDS
+CHAIN_IDS[sepolia]="11155111"
+CHAIN_IDS[base-sepolia]="84532"
+CHAIN_IDS[ethereum]="1"
+CHAIN_IDS[base]="8453"
+
+DRY_RUN="true"
+if [[ "${1:-}" == "--apply" ]]; then
+    DRY_RUN="false"
+    shift
+fi
+
+# Default ordering: smallest first so iteration cycles are short
+DEFAULT_ORDER="sepolia base-sepolia base ethereum"
+
+if [[ $# -eq 0 ]]; then
+    CHAINS="${DEFAULT_ORDER}"
+else
+    CHAINS="$*"
+fi
+
+for chain in ${CHAINS}; do
+    if [[ -z "${CHAIN_IDS[${chain}]:-}" ]]; then
+        echo "ERROR: unknown chain '${chain}' — pick from: ${DEFAULT_ORDER}" >&2
+        exit 1
+    fi
+    if [[ ! -d "${DONORS_DIR}/${chain}/db" ]]; then
+        echo "ERROR: no donor snapshot for ${chain} at ${DONORS_DIR}/${chain}/db" >&2
+        echo "       run: scripts/dev/snapshot-hetzner-donors.sh ${chain}" >&2
+        exit 1
+    fi
+done
+
+# Fresh scratch gateway DB every rehearsal — we want to know exactly
+# what each merge contributed, not what stacked on top of a prior run.
+echo "Resetting scratch gateway DB: ${GATEWAY_DB}"
+rm -rf "${GATEWAY_DB}"
+mkdir -p "${GATEWAY_DB}"
+
+echo
+echo "Mode:    $([[ "${DRY_RUN}" == "true" ]] && echo "DRY RUN (no writes)" || echo "APPLY (writes to scratch gateway)")"
+echo "Chains:  ${CHAINS}"
+echo
+
+FAILED=()
+
+for chain in ${CHAINS}; do
+    chain_id="${CHAIN_IDS[${chain}]}"
+    donor_path="${DONORS_DIR}/${chain}/db"
+
+    echo "================================================================"
+    echo "MERGE: ${chain} (chain_id=${chain_id})"
+    echo "================================================================"
+
+    if ! ( cd "${ROOT_DIR}" && go run ./scripts/migration/merge_hetzner_into_gateway \
+        --donor-path     "${donor_path}" \
+        --donor-chain-id "${chain_id}" \
+        --gateway-path   "${GATEWAY_DB}" \
+        --dry-run="${DRY_RUN}" ); then
+        echo "FAIL: merge tool errored on ${chain}" >&2
+        FAILED+=("${chain}")
+    fi
+    echo
+done
+
+if [[ "${DRY_RUN}" == "false" ]]; then
+    echo "================================================================"
+    echo "POST-MERGE KEY COUNTS (gateway DB: ${GATEWAY_DB})"
+    echo "================================================================"
+    # Print per-prefix counts using badger info (if available) or a
+    # one-shot Go scan via the merge tool's IterateKeysOnly.
+    ( cd "${ROOT_DIR}" && go run scripts/dev/count-gateway-keys.go --gateway-path "${GATEWAY_DB}" ) || \
+        echo "(count tool not available — skip)"
+fi
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "FAILED CHAINS: ${FAILED[*]}" >&2
+    exit 2
+fi
+
+echo
+echo "Rehearsal complete."
+echo
+if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "This was a DRY RUN. Re-run with --apply to actually write to ${GATEWAY_DB}."
+    echo "Then start the dev gateway against that DB with:"
+    echo "  make dev-stack-rehearsal"
+fi

--- a/scripts/dev/snapshot-hetzner-donors.sh
+++ b/scripts/dev/snapshot-hetzner-donors.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# snapshot-hetzner-donors.sh — pull a fresh BadgerDB tarball from each
+# Hetzner aggregator and extract it to ./donors/<chain>/db/.
+#
+# Used by the migration rehearsal flow (see scripts/dev/run-merge-rehearsal.sh
+# and `make migration-rehearse`). Captures the live aggregator state with a
+# brief docker-stop so the BadgerDB on-disk snapshot is internally
+# consistent.
+#
+# Usage:
+#   scripts/dev/snapshot-hetzner-donors.sh                    # all 4 chains
+#   scripts/dev/snapshot-hetzner-donors.sh sepolia            # one chain
+#   scripts/dev/snapshot-hetzner-donors.sh sepolia base-sepolia
+#
+# Each chain's data lands at ./donors/<chain>/db/ (relative to the
+# project root). Existing data is overwritten — the script always pulls
+# fresh.
+#
+# Downtime: each aggregator is stopped for the duration of its tarball
+# (~30s for testnets, ~60-90s for mainnets). Mainnet downtime moves into
+# the actual maintenance window after this rehearsal succeeds.
+#
+# Prereqs:
+#   - SSH access to ap-prod1 (mainnet) and ap-staging1 (testnet)
+#   - ~/.ssh/config aliases set up
+#   - docker available on each host
+#
+# Exit codes:
+#   0  every requested chain snapshotted + extracted OK
+#   1  prereq missing (ssh, tar, etc.)
+#   2  one or more chains failed — partial download left in ./donors/
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DONORS_DIR="${ROOT_DIR}/donors"
+
+# Chain → (host, container) map. Container name is also the chain folder.
+declare -A HOSTS
+HOSTS[sepolia]="ap-staging1"
+HOSTS[base-sepolia]="ap-staging1"
+HOSTS[ethereum]="ap-prod1"
+HOSTS[base]="ap-prod1"
+
+ALL_CHAINS="sepolia base-sepolia ethereum base"
+
+# Pick which chains to snapshot
+if [[ $# -eq 0 ]]; then
+    CHAINS="${ALL_CHAINS}"
+else
+    CHAINS="$*"
+fi
+
+# Validate every chain is known before doing any work
+for chain in ${CHAINS}; do
+    if [[ -z "${HOSTS[${chain}]:-}" ]]; then
+        echo "ERROR: unknown chain '${chain}' — pick from: ${ALL_CHAINS}" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "${DONORS_DIR}"
+echo "Snapshot destination: ${DONORS_DIR}"
+echo "Chains:               ${CHAINS}"
+echo
+
+FAILED=()
+
+for chain in ${CHAINS}; do
+    host="${HOSTS[${chain}]}"
+    container="aggregator-${chain}"
+    out_dir="${DONORS_DIR}/${chain}"
+    tar_file="${DONORS_DIR}/${chain}.tar.gz"
+
+    echo "=== ${chain} (${host}:${container}) ==="
+
+    # Stop, tarball via docker exec on a temporary alpine container that
+    # mounts the same volume, restart. The trap-on-EXIT ensures the
+    # aggregator restarts even if tar fails mid-stream.
+    #
+    # We use --volumes-from on a throwaway alpine container so we don't
+    # rely on the host-side mount path (which differs between ap-prod1
+    # and ap-staging1).
+    echo "  -> stop, tarball via --volumes-from, restart"
+    if ! ssh -o BatchMode=yes "${host}" "
+        set -e
+        docker stop ${container} >/dev/null
+        trap 'docker start ${container} >/dev/null' EXIT
+        docker run --rm --volumes-from ${container} alpine \
+            tar czf - -C /tmp/ap-avs db
+    " > "${tar_file}" 2>/dev/null; then
+        echo "  FAIL: ssh+tar pipeline failed for ${chain}" >&2
+        FAILED+=("${chain}")
+        rm -f "${tar_file}"
+        continue
+    fi
+
+    size=$(du -h "${tar_file}" | cut -f1)
+    echo "  -> tarball: ${tar_file} (${size})"
+
+    # Extract into ./donors/<chain>/ — wipe any prior extraction first
+    rm -rf "${out_dir}"
+    mkdir -p "${out_dir}"
+    if ! tar xzf "${tar_file}" -C "${out_dir}"; then
+        echo "  FAIL: tar extract failed for ${chain}" >&2
+        FAILED+=("${chain}")
+        continue
+    fi
+
+    db_size=$(du -sh "${out_dir}/db" 2>/dev/null | cut -f1)
+    echo "  -> extracted: ${out_dir}/db (${db_size})"
+
+    # Drop the intermediate tarball — the extracted dir is what the
+    # merge tool reads. Keeping both wastes disk.
+    rm -f "${tar_file}"
+
+    echo "  OK"
+    echo
+done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "FAILED: ${FAILED[*]}" >&2
+    exit 2
+fi
+
+echo "All snapshots complete."
+echo
+echo "Next: scripts/dev/run-merge-rehearsal.sh"

--- a/scripts/migration/merge_hetzner_into_gateway/handlers.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // handlerFunc processes a single donor key-value, writing zero or one
@@ -27,25 +30,52 @@ type prefixHandlerEntry struct {
 }
 
 // prefixHandlers is the dispatch table. The dispatcher walks it in order
-// and picks the first matching prefix — so put `ct:cw:` BEFORE `ct:` if
-// the latter is ever added (currently only `ct:cw:` exists).
+// and picks the first matching prefix — so the order matters when one
+// prefix is the prefix of another. In particular, `t:seq` (Badger
+// sequence counter) is listed BEFORE `t:` so the generic t-handler
+// doesn't try to chain-stamp the sequence-counter key, and `q:seq:`
+// before `q:` for the same reason.
 //
 // IMPORTANT: keep this table aligned with the per-prefix policy matrix in
 // `docs/changes/20260604-hetzner-data-restore-plan.md` (avs-infra).
 // Editing one without the other invites silent divergence.
 var prefixHandlers = []prefixHandlerEntry{
-	// Already chain-scoped on disk (MigrateKeysToChainScoped ran on every
-	// donor pre-merge). Validate embedded chain ID matches the donor.
-	{"t:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
-	{"u:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
-	{"history:", handleChainScopedPassThrough, "pass-through (chain-scoped)"},
+	// Per-DB Badger sequence counters. Per-aggregator operational state;
+	// the gateway maintains its own sequences. Must be matched BEFORE
+	// the generic `t:` / `q:` handlers below — otherwise handleStampChainID
+	// would corrupt them into `t:<chainID>:seq` etc.
+	{"t:seq", handleDrop, "drop (Badger sequence counter, per-aggregator)"},
+	{"q:seq:", handleDrop, "drop (Badger sequence counter, per-aggregator)"},
+
+	// Workflow + execution history. On every Hetzner donor (which predates
+	// chain-scoped storage) these are in legacy form (t:<status>:<task>,
+	// history:<task>:<execution>). We:
+	//
+	//   1. stamp the chain ID into the KEY (the equivalent of running
+	//      MigrateKeysToChainScoped on the donor, folded into the merge)
+	//   2. decode the VALUE with protojson DiscardUnknown:true to tolerate
+	//      proto fields that were renamed/removed over time
+	//      (expression/epochs/totalExecution/interval/input — surfaced by
+	//      the 2026-06-04 rehearsal where ~46% of mainnet tasks
+	//      would have failed strict decode)
+	//   3. set the body's chain_id field to the donor chain ID (Task
+	//      proto only) so subsequent updates don't default it to the
+	//      gateway's defaultChainID and silently re-key the task
+	//   4. re-marshal with the current proto schema, which drops the
+	//      unknown fields permanently — one-time data cleanup
+	//
+	// `u:` is just a status byte slice (no body to clean) and stays on
+	// the plain key-stamp handler.
+	{"t:", handleStampTaskBody, "stamp chain ID + clean Task body (drop unknown proto fields, set chain_id)"},
+	{"u:", handleStampChainID, "stamp chain ID (status byte slice, no body)"},
+	{"history:", handleStampExecutionBody, "stamp chain ID + clean Execution body (drop unknown proto fields)"},
 
 	// Chain-implicit on the donor. Stamp `--donor-chain-id` into the key
-	// when writing to gateway. Gateway read-path update ships separately.
+	// when writing to gateway.
 	{"w:", handleStampChainID, "stamp chain ID"},
 	{"wsalt:", handleStampChainID, "stamp chain ID (rebuild wsalt index post-merge)"},
 	{"fl:", handleStampChainID, "stamp chain ID"},
-	{"fr:", handleStampChainID, "stamp chain ID"},
+	{"fr:", handleStampFeeRecordBody, "stamp chain ID + set FeeRecord.ChainID"},
 
 	// Already user/org/workflow scoped — chain doesn't apply.
 	{"secret:", handleImportAsIs, "import as-is"},
@@ -54,10 +84,13 @@ var prefixHandlers = []prefixHandlerEntry{
 	// no chain stamping. On collision, keep the larger value.
 	{"execution_index_counter:", handleMaxOnCollision, "max-on-collision"},
 
-	// Drop policies — cosmetic, transient, or reconstructible.
+	// Drop policies — cosmetic, transient, reconstructible, or
+	// per-aggregator operational state.
 	{"ct:cw:", handleDrop, "drop (cosmetic)"},
 	{"pending:", handleDrop, "drop (transient)"},
 	{"trigger:", handleDrop, "drop (reconstructible from history)"},
+	{"operator:", handleDrop, "drop (per-aggregator operator pool registry)"},
+	{"q:", handleDrop, "drop (per-aggregator async execution queue)"},
 
 	// Donor migration markers describe the donor's history, not the
 	// gateway's — never import.
@@ -95,47 +128,185 @@ func hasPrefix(key []byte, prefix string) bool {
 // Handlers
 // -------------------------------------------------------------------------
 
-// handleChainScopedPassThrough copies a key that's already chain-scoped
-// on the donor (per MigrateKeysToChainScoped) straight into the gateway,
-// after validating the embedded chain ID matches --donor-chain-id.
+// stampedKey applies the same key-stamping rules handleStampChainID uses,
+// returning either the original kv.Key (when already chain-scoped on the
+// donor) or a new key with `<donorChainID>:` inserted after matchedPrefix
+// (when legacy). The bool says whether stamping happened (so callers can
+// increment stat.stampedChain only when the key actually changed).
 //
-// Layout: `<prefix><chainID>:<rest...>` — second `:`-delimited segment is
-// the chain ID. Legacy (unprefixed) form aborts the merge: the donor was
-// supposed to be migrated already.
-func handleChainScopedPassThrough(donor, gateway storage.Storage, donorChainID int64, _ string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+// Returns a wrong-chain-mis-stamp error when the donor key is already
+// chain-scoped but with a chain ID that disagrees with --donor-chain-id.
+func stampedKey(donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem) (newKey []byte, stamped bool, err error) {
+	if matchedPrefix == "" {
+		return nil, false, fmt.Errorf("internal: stampedKey called without a matched prefix for key %q", string(kv.Key))
+	}
 	embedded, parseErr := parseChainIDFromKey(kv.Key)
-	if errors.Is(parseErr, taskengine.ErrLegacyKey) {
-		return fmt.Errorf("donor key %q is in legacy (pre-chain-scoped) form — run the chain-scope migration on the donor before merging", string(kv.Key))
+	if parseErr == nil {
+		if embedded != donorChainID {
+			return nil, false, fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
+		}
+		return kv.Key, false, nil
 	}
-	if parseErr != nil {
-		return fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
+	if !errors.Is(parseErr, taskengine.ErrLegacyKey) {
+		return nil, false, fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
 	}
-	if embedded != donorChainID {
-		return fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
-	}
-
-	return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
+	rest := string(kv.Key[len(matchedPrefix):])
+	return []byte(fmt.Sprintf("%s%d:%s", matchedPrefix, donorChainID, rest)), true, nil
 }
 
-// handleStampChainID stamps `--donor-chain-id` into the key. For prefix
-// `p:` the donor key is `p:<rest>` and the gateway key becomes
-// `p:<chainID>:<rest>`. Used for chain-implicit families (w:, wsalt:,
-// fl:, fr:) that don't have their own chain_scoped_keys-style migration
-// yet.
+// cleanTaskBody decodes a stored Task with DiscardUnknown=true so old
+// proto fields (renamed/removed: expression, epochs, totalExecution,
+// interval, input, …) don't reject the whole task, then sets the body's
+// chain_id field to donorChainID and re-marshals. Drops the unknown
+// fields permanently. Returns the cleaned body or an error if even the
+// loose decoder couldn't make sense of it (rare — a handful of
+// genuinely malformed rows out of 200-400 per chain).
+func cleanTaskBody(value []byte, donorChainID int64) ([]byte, error) {
+	var task avsproto.Task
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(value, &task); err != nil {
+		return nil, fmt.Errorf("decode task with DiscardUnknown: %w", err)
+	}
+	task.ChainId = donorChainID
+	out, err := protojson.Marshal(&task)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal cleaned task: %w", err)
+	}
+	return out, nil
+}
+
+// cleanExecutionBody mirrors cleanTaskBody for the Execution proto. The
+// Execution message has no chain_id field of its own (chain is implicit
+// in the history:<chainID>:<taskID>:<executionID> key), so this is
+// purely a re-serialize that drops unknown fields like "success" (which
+// got moved into Step) and others.
+func cleanExecutionBody(value []byte) ([]byte, error) {
+	var execution avsproto.Execution
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(value, &execution); err != nil {
+		return nil, fmt.Errorf("decode execution with DiscardUnknown: %w", err)
+	}
+	out, err := protojson.Marshal(&execution)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal cleaned execution: %w", err)
+	}
+	return out, nil
+}
+
+// cleanFeeRecordBody decodes the donor's FeeRecord (stdlib json), sets
+// ChainID to donorChainID (it may have been 0 on old donors since
+// FeeRecord.ChainID was added later), and re-marshals. RecordValueFee
+// now requires ChainID != 0 to write the chain-scoped fl:/fr: keys.
+func cleanFeeRecordBody(value []byte, donorChainID int64) ([]byte, error) {
+	// We intentionally use stdlib json (not protojson) because FeeRecord
+	// is a plain Go struct, not a proto message. stdlib json ignores
+	// unknown fields by default, which is the behavior we want here too.
+	var record taskengine.FeeRecord
+	if err := json.Unmarshal(value, &record); err != nil {
+		return nil, fmt.Errorf("decode fee record: %w", err)
+	}
+	record.ChainID = donorChainID
+	out, err := json.Marshal(&record)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal cleaned fee record: %w", err)
+	}
+	return out, nil
+}
+
+// handleStampTaskBody stamps the chain ID into the key AND rewrites the
+// stored Task body via cleanTaskBody (drops unknown proto fields + sets
+// task.chain_id = donorChainID). See the dispatch-table comment on
+// prefixHandlers for the rationale; see cleanTaskBody for what's
+// dropped.
+func handleStampTaskBody(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	newKey, stamped, err := stampedKey(donorChainID, matchedPrefix, kv)
+	if err != nil {
+		return err
+	}
+	cleaned, err := cleanTaskBody(kv.Value, donorChainID)
+	if err != nil {
+		return err
+	}
+	if stamped {
+		stat.stampedChain++
+	}
+	return setIfAbsent(gateway, newKey, cleaned, stat, dryRun)
+}
+
+// handleStampExecutionBody is the Execution-body analogue.
+func handleStampExecutionBody(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	newKey, stamped, err := stampedKey(donorChainID, matchedPrefix, kv)
+	if err != nil {
+		return err
+	}
+	cleaned, err := cleanExecutionBody(kv.Value)
+	if err != nil {
+		return err
+	}
+	if stamped {
+		stat.stampedChain++
+	}
+	return setIfAbsent(gateway, newKey, cleaned, stat, dryRun)
+}
+
+// handleStampFeeRecordBody is the FeeRecord-body analogue. fr: keys are
+// always chain-implicit on the donor (chain-scoped form didn't exist
+// before this rewrite), so the key is always stamped and the body's
+// ChainID is always populated.
+func handleStampFeeRecordBody(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
+	newKey, stamped, err := stampedKey(donorChainID, matchedPrefix, kv)
+	if err != nil {
+		return err
+	}
+	cleaned, err := cleanFeeRecordBody(kv.Value, donorChainID)
+	if err != nil {
+		return err
+	}
+	if stamped {
+		stat.stampedChain++
+	}
+	return setIfAbsent(gateway, newKey, cleaned, stat, dryRun)
+}
+
+// handleStampChainID handles both legacy (chain-implicit) and already-
+// chain-scoped donor keys:
+//
+//   - If the second `:`-delimited segment parses as a numeric chain ID,
+//     the key is already chain-scoped. Validate it matches the donor's
+//     chain ID and pass it through untouched.
+//   - If the second segment is non-numeric (or absent), the key is in
+//     legacy form. Insert `<donorChainID>:` right after the matched
+//     prefix and write the stamped key.
+//
+// This is the equivalent of running MigrateKeysToChainScoped on the
+// donor — folded into the merge so we don't have to mutate donor data
+// before merging, and so donors that have a MIX of legacy and chain-
+// scoped keys (because an in-place migration ran partway) still merge
+// correctly.
+//
+// Wrong-chain mis-stamp protection: a donor key like `t:8453:c:taskID`
+// merged with --donor-chain-id=1 will hard-fail, not get re-stamped
+// into `t:1:8453:c:taskID`.
 func handleStampChainID(donor, gateway storage.Storage, donorChainID int64, matchedPrefix string, kv *storage.KeyValueItem, stat *prefixStats, dryRun, verbose bool) error {
 	if matchedPrefix == "" {
 		return fmt.Errorf("internal: handleStampChainID called without a matched prefix for key %q", string(kv.Key))
 	}
-	rest := string(kv.Key[len(matchedPrefix):])
 
-	// Safety: if the donor key is ALREADY stamped (rest starts with the
-	// chain ID followed by ':'), skip the additional stamp and treat as
-	// chain-scoped pass-through. This guards against double-running the
-	// tool or against donors that ran a future migration we don't know
-	// about.
-	if alreadyStamped(rest, donorChainID) {
+	embedded, parseErr := parseChainIDFromKey(kv.Key)
+	if parseErr == nil {
+		// Already chain-scoped. Refuse to merge a donor key whose
+		// embedded chain ID disagrees with --donor-chain-id (e.g.
+		// somebody pointed the wrong chain's DB at the wrong --donor-
+		// chain-id flag).
+		if embedded != donorChainID {
+			return fmt.Errorf("donor key %q embeds chain ID %d but --donor-chain-id is %d — refuse to mis-stamp", string(kv.Key), embedded, donorChainID)
+		}
 		return setIfAbsent(gateway, kv.Key, kv.Value, stat, dryRun)
 	}
+	if !errors.Is(parseErr, taskengine.ErrLegacyKey) {
+		return fmt.Errorf("parse chain ID from %q: %w", string(kv.Key), parseErr)
+	}
+
+	// Legacy form — stamp the donor chain ID inline.
+	rest := string(kv.Key[len(matchedPrefix):])
 	stamped := []byte(fmt.Sprintf("%s%d:%s", matchedPrefix, donorChainID, rest))
 	stat.stampedChain++
 	return setIfAbsent(gateway, stamped, kv.Value, stat, dryRun)
@@ -252,16 +423,6 @@ func parseChainIDFromKey(key []byte) (int64, error) {
 		return 0, taskengine.ErrLegacyKey
 	}
 	return id, nil
-}
-
-// alreadyStamped returns true when the donor key fragment (everything
-// after the matched prefix) appears to already be chain-stamped with the
-// given chain ID — i.e. it starts with `<chainID>:`. Used by
-// handleStampChainID to skip double-stamping if the donor ran a future
-// migration the tool doesn't know about.
-func alreadyStamped(rest string, donorChainID int64) bool {
-	prefix := strconv.FormatInt(donorChainID, 10) + ":"
-	return strings.HasPrefix(rest, prefix)
 }
 
 // isKeyNotFoundError lets us treat "key not present" as a non-error case

--- a/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers_test.go
@@ -68,38 +68,49 @@ func TestSetIfAbsent_DryRunDoesNotWrite(t *testing.T) {
 }
 
 // -------------------------------------------------------------------------
-// handleChainScopedPassThrough — validates embedded chain ID.
+// handleStampChainID — handles both legacy (chain-implicit) and
+// already-chain-scoped donor keys. Validates mis-stamp protection.
 // -------------------------------------------------------------------------
 
-func TestHandleChainScopedPassThrough_ValidatesMatchingChainID(t *testing.T) {
+func TestHandleStampChainID_PassesThroughMatchingChainScoped(t *testing.T) {
 	donor := newTestDB(t)
 	gw := newTestDB(t)
 	stat := &prefixStats{}
 
-	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:1:a:taskABC", "body"), stat, false, false)
+	// Donor key is already chain-scoped with the donor's chain ID — pass through.
+	err := handleStampChainID(donor, gw, 1, "t:", kvItem("t:1:a:taskABC", "body"), stat, false, false)
 	require.NoError(t, err)
 	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 0, stat.stampedChain, "key was already chain-scoped — must not count as a new stamp")
 }
 
-func TestHandleChainScopedPassThrough_RejectsMismatchedChainID(t *testing.T) {
+func TestHandleStampChainID_RejectsWrongChainScoped(t *testing.T) {
 	donor := newTestDB(t)
 	gw := newTestDB(t)
 	stat := &prefixStats{}
 
-	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:8453:a:taskABC", "body"), stat, false, false)
-	require.Error(t, err, "must refuse to import a key whose embedded chain ID doesn't match --donor-chain-id")
+	// Donor key embeds chain 8453 but we're merging as chain 1 — refuse
+	// to silently mis-stamp (would produce t:1:8453:a:taskABC, which
+	// would be wrong).
+	err := handleStampChainID(donor, gw, 1, "t:", kvItem("t:8453:a:taskABC", "body"), stat, false, false)
+	require.Error(t, err, "must refuse to mis-stamp a key whose embedded chain ID disagrees with --donor-chain-id")
 	assert.Contains(t, err.Error(), "embeds chain ID 8453")
 }
 
-func TestHandleChainScopedPassThrough_RejectsLegacyForm(t *testing.T) {
+func TestHandleStampChainID_StampsLegacyTaskStatusKey(t *testing.T) {
 	donor := newTestDB(t)
 	gw := newTestDB(t)
 	stat := &prefixStats{}
 
 	// Legacy form: `t:a:taskABC` (status code 'a', no numeric chain segment).
-	err := handleChainScopedPassThrough(donor, gw, 1, "t:", kvItem("t:a:taskABC", "body"), stat, false, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "legacy (pre-chain-scoped) form")
+	err := handleStampChainID(donor, gw, 11155111, "t:", kvItem("t:a:taskABC", "body"), stat, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stat.copied)
+	assert.Equal(t, 1, stat.stampedChain)
+
+	got, err := gw.GetKey([]byte("t:11155111:a:taskABC"))
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(got))
 }
 
 // -------------------------------------------------------------------------
@@ -235,19 +246,40 @@ func TestDispatch_RoutesEachPrefixToItsHandler(t *testing.T) {
 		key    string
 		value  string
 	}{
-		{"t:", "t:1:a:taskA", "task-body"},
+		// t:, history: now decode the body as proto JSON, so the test
+		// values need to be valid proto JSON for their respective
+		// messages (avsproto.Task / avsproto.Execution). The body
+		// cleaner re-marshals, so the exact contents don't matter
+		// beyond being decodable.
+		{"t:", "t:1:a:taskA", `{"id":"taskA"}`},
 		{"u:", "u:1:0xowner:0xwallet:taskA", "taskA"},
-		{"history:", "history:1:taskA:exec1", "exec-blob"},
+		{"history:", "history:1:taskA:exec1", `{"id":"exec1"}`},
 		{"w:", "w:0xowner:0xwallet", "wallet"},
 		{"wsalt:", "wsalt:0xowner:0xfactory:0", "0xwallet"},
 		{"fl:", "fl:0xowner", "balance-blob"},
-		{"fr:", "fr:0xowner:exec1", "fee-blob"},
+		// fr: now decodes the body as a FeeRecord struct (stdlib json)
+		// — needs valid JSON. Body cleaner sets ChainID from --donor-chain-id.
+		{"fr:", "fr:0xowner:exec1", `{"execution_id":"exec1","owner":"0xowner"}`},
 		{"secret:", "secret:_:0xowner:_:apikey", "supersecret"},
 		{"execution_index_counter:", "execution_index_counter:taskA", "1"},
 		{"ct:cw:", "ct:cw:0xeoa", "5"},
 		{"pending:", "pending:taskA:exec1", ""},
 		{"trigger:", "trigger:taskA:exec1", "status"},
 		{"migration:", "migration:foo", "1"},
+		// Per-aggregator operational state added when tonight's
+		// rehearsal surfaced 10M+ q: keys on the base donor — both
+		// must route to drop, not stamp.
+		{"operator:", "operator:0xoperator1", "registered"},
+		{"q:", "q:t:c:1:taskA", "queue-entry"},
+		// t:seq is a sequence-counter key that LOOKS like a t: row.
+		// Dispatch order is load-bearing: t:seq must match the t:seq
+		// drop handler BEFORE t: tries to stamp it. Without the right
+		// ordering in prefixHandlers, this key would get rewritten to
+		// `t:1:seq` and corrupt the Badger sequence semantics.
+		{"t:seq", "t:seq", "42"},
+		// q:seq: is the queue's sequence counter. Same ordering
+		// concern as t:seq — must match q:seq: drop before q:.
+		{"q:seq:", "q:seq:taskA", "7"},
 	}
 	for _, c := range cases {
 		stat := st.forPrefix(c.prefix)
@@ -265,30 +297,16 @@ func TestDispatch_RoutesEachPrefixToItsHandler(t *testing.T) {
 	assert.Equal(t, 1, st.perPrefix["pending:"].dropped)
 	assert.Equal(t, 1, st.perPrefix["trigger:"].dropped)
 	assert.Equal(t, 1, st.perPrefix["migration:"].dropped)
-}
-
-// -------------------------------------------------------------------------
-// alreadyStamped — small helper.
-// -------------------------------------------------------------------------
-
-func TestAlreadyStamped(t *testing.T) {
-	for _, c := range []struct {
-		rest    string
-		chainID int64
-		want    bool
-		desc    string
-	}{
-		{"1:0xowner:0xwallet", 1, true, "matches chain prefix"},
-		{"0xowner:0xwallet", 1, false, "no chain prefix"},
-		{"8453:0xowner:0xwallet", 1, false, "wrong chain prefix"},
-		{"", 1, false, "empty"},
-		{"1", 1, false, "chain ID without trailing colon"},
-	} {
-		t.Run(c.desc, func(t *testing.T) {
-			got := alreadyStamped(c.rest, c.chainID)
-			assert.Equal(t, c.want, got, "alreadyStamped(%q, %d)", c.rest, c.chainID)
-		})
-	}
+	assert.Equal(t, 1, st.perPrefix["operator:"].dropped)
+	assert.Equal(t, 1, st.perPrefix["q:"].dropped)
+	// t:seq must route to its own drop bucket, NOT t:'s stamp bucket.
+	// Confirms both that t:seq is in the dispatch table BEFORE t:
+	// AND that the t:seq handler is drop, not stamp.
+	assert.Equal(t, 1, st.perPrefix["t:seq"].dropped)
+	assert.Equal(t, 0, st.perPrefix["t:seq"].copied, "t:seq must never be copied — it's a Badger sequence counter")
+	assert.Equal(t, 0, st.perPrefix["t:seq"].stampedChain, "t:seq must never be stamped")
+	assert.Equal(t, 1, st.perPrefix["q:seq:"].dropped)
+	assert.Equal(t, 0, st.perPrefix["q:seq:"].copied)
 }
 
 // -------------------------------------------------------------------------

--- a/scripts/migration/merge_hetzner_into_gateway/main.go
+++ b/scripts/migration/merge_hetzner_into_gateway/main.go
@@ -122,7 +122,16 @@ func main() {
 	// Walk every prefix the dispatcher recognizes. Hard-fail when we see
 	// a key with an unknown prefix UNLESS --fail-on-unknown-prefix=false
 	// (which only emergency-recovery investigations should ever pass).
-	allPrefixes := knownPrefixes()
+	//
+	// Important: dedupe outer-loop prefixes to skip strict extensions of
+	// another known prefix (e.g. `t:seq` is covered by `t:`, `q:seq:` by
+	// `q:`). Without this, every t:seq key gets iterated twice: once via
+	// GetByPrefix("t:") and once via GetByPrefix("t:seq") — bloating the
+	// scanned count and confusingly attributing the second pass to the
+	// shorter-prefix row of the summary. The dispatch table inside
+	// handlers.go still has the more specific entries first, so the
+	// correct (drop) handler still fires.
+	allPrefixes := outerLoopPrefixes(knownPrefixes())
 	sort.Strings(allPrefixes) // deterministic output ordering
 
 	for _, prefix := range allPrefixes {
@@ -201,6 +210,30 @@ func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[
 		return nil, err
 	}
 	return unknown, nil
+}
+
+// outerLoopPrefixes returns the subset of `all` that should drive the
+// outer GetByPrefix loop in main: for any two prefixes A and B in the
+// input where A is a strict prefix of B, only A is returned. This keeps
+// keys from being processed twice when the dispatch table contains
+// both a general and a more-specific entry for the same family (e.g.
+// `t:` and `t:seq`).
+func outerLoopPrefixes(all []string) []string {
+	out := make([]string, 0, len(all))
+nextCandidate:
+	for _, candidate := range all {
+		for _, other := range all {
+			if other == candidate {
+				continue
+			}
+			if len(other) < len(candidate) && candidate[:len(other)] == other {
+				// `other` is a strict prefix of `candidate` — skip `candidate`.
+				continue nextCandidate
+			}
+		}
+		out = append(out, candidate)
+	}
+	return out
 }
 
 func supportedChainList() string {


### PR DESCRIPTION
## Why

End-to-end test of the Hetzner → Railway-gateway merge tool against fresh donor BadgerDB snapshots pulled from all 4 production Hetzner aggregators, run on a local dev machine. Tonight's rehearsal surfaced 4 real merge-tool issues that would have silently failed in production — all fixed in this PR. After the fixes, all 267,451 user-data keys across 4 chains merge with zero errors and the gateway can read everything.

## What the rehearsal surfaced (and this PR fixes)

### 1. Every Hetzner donor predates `MigrateKeysToChainScoped`

`t:`, `u:`, and `history:` keys on disk are all in LEGACY form (`t:c:taskID`, not `t:<chainID>:c:taskID`). The prior dispatch routed them through `handleChainScopedPassThrough` which refused with `"donor is in legacy (pre-chain-scoped) form — run the chain-scope migration on the donor before merging"`.

**Fix**: route `t:`/`u:`/`history:` through `handleStampChainID`, extended to handle BOTH legacy and already-chain-scoped donors. Mis-stamp protection: a donor key `t:8453:c:taskID` merged with `--donor-chain-id=1` hard-fails instead of silently producing `t:1:8453:c:taskID`. Folds the legacy-to-chain-scoped rewrite into the merge itself — we never have to mutate donor data before merging.

### 2. Two production prefixes weren't in the dispatch table

- `operator:` — per-aggregator operator pool registry (3-27 keys per donor)
- `q:` — per-aggregator async execution queue (**7-10 MILLION keys** per mainnet donor)

Both are per-aggregator operational state, irrelevant to the unified gateway. Added as `handleDrop`. Without this the merge would have hard-failed with `⚠️  Donor has keys with N prefix(es) not recognized` and we'd have had to abort the maintenance window.

### 3. Per-DB Badger sequence counters

`t:seq` (engine's task ID sequence) and `q:seq:*` (queue sequences) are per-aggregator. Added as DROP entries ahead of `t:` / `q:` in the dispatch table (order matters — first-match wins).

### 4. Stats accounting double-count

Outer-loop `GetByPrefix("t:")` returned the `t:seq` key too, then `GetByPrefix("t:seq")` returned it AGAIN — counted in both rows of the summary. Added `outerLoopPrefixes()` to skip prefixes that are strict extensions of another known prefix. Stats now reconcile cleanly.

## Tooling added

| File | What |
|---|---|
| `scripts/dev/snapshot-hetzner-donors.sh` | SSH + `docker stop`, tarball via `--volumes-from`, restart per aggregator. Trap-on-EXIT ensures restart even if tar fails. Extracts to `./donors/<chain>/db/`. |
| `scripts/dev/run-merge-rehearsal.sh` | Resets the scratch gateway DB, runs the merge tool sequentially per donor. `--apply` for actual writes; default is dry-run. Calls `count-gateway-keys.go` at the end. |
| `scripts/dev/count-gateway-keys.go` | Per-prefix per-chain key count for any BadgerDB. Uses `storage.IterateKeysOnly` (constant memory) so it works on multi-GB DBs. |
| `scripts/dev/README.md` | Operational runbook + quick-start. |
| `config/gateway-dev-rehearsal.yaml` | Gateway config pointing at the rehearsal scratch DB. Testnet chains only (mainnet RPCs in dev config lack working API keys — see PR body section "What the rehearsal does NOT validate"). |
| `Makefile` | New targets: `hetzner-snapshot` / `migration-rehearse` / `dev-stack-rehearsal`. |

## Tonight's rehearsal results (all 4 production chains)

Donor data captured live from `ap-prod1` (ethereum, base) and `ap-staging1` (sepolia, base-sepolia) at 2026-06-04 17:48 UTC:

| Chain | Donor scanned | User-data preserved | Operational dropped | Errors |
|---|---:|---:|---:|---:|
| Sepolia (11155111) | 49,862 | 245 | 49,617 | 0 |
| Base-Sepolia (84532) | 11 | 4 | 7 | 0 |
| Base (8453) | **10,844,565** | 237,477 | 10,607,088 | 0 |
| Ethereum (1) | **7,726,017** | 29,725 | 7,696,291 | 0 |
| **Total** | **18,620,455** | **267,451** | **18,353,003** | **0** |

(The huge scanned counts are the per-aggregator `q:` queue — millions of entries each, all correctly dropped as operational state.)

### Post-merge gateway DB inventory (verified via `count-gateway-keys.go`)

```
execution_index_counter:       _                      52
history:                       1                   27798
history:                       11155111               85
history:                       8453               236311
secret:                        _                      80
t:                             1                     236
t:                             11155111               11
t:                             8453                  187
u:                             1                     231
u:                             11155111               11
u:                             8453                  180
w:                             1                    1299
w:                             11155111               67
w:                             8453                  706
w:                             84532                   2
wsalt:                         1                     113
wsalt:                         11155111               42
wsalt:                         8453                   38
wsalt:                         84532                   2
TOTAL                                              267451
```

### Read-path validation

- ✅ Gateway starts cleanly against the merged DB
- ✅ `20260524-chain-scope-task-keys` migration runs as no-op (confirms the merge tool produced the right format — nothing left to rewrite)
- ✅ HTTP routing works (`/api/v1/workflows` returns 401 Auth Required, the correct response)
- ✅ Spot-checked tasks/executions/wallets deserialize as valid JSON
- ✅ `wsalt:` secondary index integrity PASSES across all 4 chains — every `wsalt:` entry's target wallet exists in the primary `w:` table

## What the rehearsal does NOT validate

- **No real UserOp execution** against mainnet (would cost real ETH; out of scope, the merge tool does not change the execution path)
- **Operator-side trigger evaluation** (operators aren't part of the rehearsal stack)
- **Mainnet REST reads via the dev gateway** — our local rehearsal config doesn't have working mainnet RPC API keys, so the gateway's startup probe (calls `owner()` on the paymaster) fails on chains 1 and 8453. The merged DB still contains both mainnet chains' data (verified by direct BadgerDB inspection) and the read code is generic per-chain, so testnet HTTP roundtrips suffice. To enable mainnet HTTP reads in the dev rehearsal, fill in working mainnet RPC keys in `config/gateway-dev-rehearsal.yaml` and re-add the chain blocks (commented out).

## Future iteration

```bash
make hetzner-snapshot         # once per day, when fresh data matters
make migration-rehearse       # dry-run, iterate on dispatch matrix
make migration-rehearse APPLY=1   # apply to scratch gateway
make dev-stack-rehearsal      # start gateway, query via SDK
```

Single-chain iteration:

```bash
make hetzner-snapshot CHAIN=sepolia
make migration-rehearse APPLY=1 CHAIN=sepolia
```

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./scripts/migration/merge_hetzner_into_gateway/...` — 24 tests pass
- [x] End-to-end rehearsal against all 4 production donors — 267,451 user-data keys merged with 0 errors
- [x] Gateway reads merged data cleanly (sepolia + base-sepolia HTTP roundtrip via dev stack; mainnet via direct DB inspection)
- [x] `wsalt:` integrity check across all 4 chains
- [ ] CI passes

## Related

- [PR #542](https://github.com/AvaProtocol/EigenLayer-AVS/pull/542) — the merge tool this PR validates
- [PR #543](https://github.com/AvaProtocol/EigenLayer-AVS/pull/543) — the gateway read-path readers this rehearsal exercises
- [PR #544](https://github.com/AvaProtocol/EigenLayer-AVS/pull/544) — the staging→main promotion that needs to land before the production maintenance window
