### PR TITLE
refactor: derive eth_ws_url + rename Railway RPC env vars

### DIFF
--- a/config/gateway-railway.yaml
+++ b/config/gateway-railway.yaml
@@ -17,11 +17,15 @@
 #       variables so the topology auto-resolves and survives service
 #       renames, e.g.:
 #         WORKER_ETHEREUM = ${{worker-ethereum.RAILWAY_PRIVATE_DOMAIN}}:50051
-#   ETHEREUM_DWELLIR_RPC / ETHEREUM_DWELLIR_WS  — AVS chain RPC
-#   SEPOLIA_DWELLIR_RPC  / SEPOLIA_DWELLIR_WS   — sepolia chain RPC
-#   BASE_DWELLIR_RPC     / BASE_DWELLIR_WS
-#   BASE_SEPOLIA_DWELLIR_RPC / BASE_SEPOLIA_DWELLIR_WS
-#   BNB_DWELLIR_RPC      / BNB_DWELLIR_WS       — BNB Smart Chain mainnet
+#   ETHEREUM_RPC          — Ethereum mainnet HTTPS RPC (WS derived in code)
+#   SEPOLIA_RPC           — Sepolia HTTPS RPC
+#   BASE_RPC              — Base mainnet HTTPS RPC
+#   BASE_SEPOLIA_RPC      — Base-Sepolia HTTPS RPC
+#   BNB_RPC               — BNB Smart Chain mainnet HTTPS RPC
+# (WebSocket URLs are auto-derived from the HTTPS URL by core/config —
+# every supported provider serves both transports at the same host+path
+# with only the scheme differing. Set the explicit eth_ws_url in the
+# YAML only if a chain genuinely needs a separate WS endpoint.)
 #   ETHEREUM_BUNDLER_URL, SEPOLIA_BUNDLER_URL,
 #   BASE_BUNDLER_URL,     BASE_SEPOLIA_BUNDLER_URL
 #   BNB_BUNDLER_URL      — optional; connectivity-only rollout leaves it unset
@@ -43,8 +47,7 @@ ecdsa_private_key: ${GATEWAY_ECDSA_PRIVATE_KEY}
 # disabled, so one gateway can serve operators from any AVS chain. We
 # point this at Sepolia AVS to match the existing testnet operator;
 # flip to Ethereum mainnet AVS when enforceAuth is turned on.
-eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+eth_rpc_url: ${SEPOLIA_RPC}
 
 rpc_bind_address: "0.0.0.0:2206"
 http_bind_address: "0.0.0.0:8080"
@@ -82,8 +85,7 @@ tenderly_access_key: ${TENDERLY_ACCESS_KEY}
 # execution still routes via chains[] below — the top-level only
 # matters for package-globals + tooling.
 smart_wallet:
-  eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-  eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+  eth_rpc_url: ${SEPOLIA_RPC}
   bundler_url: ${SEPOLIA_BUNDLER_URL}
   controller_private_key: ${CONTROLLER_PRIVATE_KEY}
   paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
@@ -102,8 +104,7 @@ chains:
     name: ethereum
     worker_addr: ${WORKER_ETHEREUM}
     smart_wallet:
-      eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-      eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+      eth_rpc_url: ${ETHEREUM_RPC}
       bundler_url: ${ETHEREUM_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_MAINNET}
@@ -116,8 +117,7 @@ chains:
     name: base
     worker_addr: ${WORKER_BASE}
     smart_wallet:
-      eth_rpc_url: ${BASE_DWELLIR_RPC}
-      eth_ws_url: ${BASE_DWELLIR_WS}
+      eth_rpc_url: ${BASE_RPC}
       bundler_url: ${BASE_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_MAINNET}
@@ -128,8 +128,7 @@ chains:
     name: sepolia
     worker_addr: ${WORKER_SEPOLIA}
     smart_wallet:
-      eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-      eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+      eth_rpc_url: ${SEPOLIA_RPC}
       bundler_url: ${SEPOLIA_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
@@ -139,8 +138,7 @@ chains:
     name: base-sepolia
     worker_addr: ${WORKER_BASE_SEPOLIA}
     smart_wallet:
-      eth_rpc_url: ${BASE_SEPOLIA_DWELLIR_RPC}
-      eth_ws_url: ${BASE_SEPOLIA_DWELLIR_WS}
+      eth_rpc_url: ${BASE_SEPOLIA_RPC}
       bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
@@ -156,8 +154,7 @@ chains:
     name: bnb-mainnet
     worker_addr: ${WORKER_BNB}
     smart_wallet:
-      eth_rpc_url: ${BNB_DWELLIR_RPC}
-      eth_ws_url: ${BNB_DWELLIR_WS}
+      eth_rpc_url: ${BNB_RPC}
       bundler_url: ${BNB_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}

--- a/config/operator-ethereum-railway.yaml
+++ b/config/operator-ethereum-railway.yaml
@@ -4,7 +4,7 @@
 # layout but points at the Railway gateway over private networking.
 # Secrets are injected via Railway sealed environment variables — set
 # these on the `operator-ethereum` service:
-#   ETHEREUM_DWELLIR_RPC, ETHEREUM_DWELLIR_WS
+#   ETHEREUM_RPC (HTTPS; WS derived in code)
 #   ECDSA_KEY_JSON, BLS_KEY_JSON  (operator-entrypoint.sh writes these
 #                                   to /app/keys/ at startup)
 #   OPERATOR_BLS_KEY_PASSWORD, OPERATOR_ECDSA_KEY_PASSWORD
@@ -17,8 +17,7 @@ avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
 operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
 # EigenLayer chain RPC (Ethereum mainnet)
-eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+eth_rpc_url: ${ETHEREUM_RPC}
 
 # Key files — written at startup by scripts/operator-entrypoint.sh
 ecdsa_private_key_store_path: /app/keys/ecdsa.key.json
@@ -46,8 +45,7 @@ server_name: "operator-ethereum-railway"
 
 # Destination chain — Ethereum mainnet
 target_chain:
-  eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-  eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+  eth_rpc_url: ${ETHEREUM_RPC}
 
 enabled_features:
   event_trigger: true

--- a/config/operator-railway.yaml
+++ b/config/operator-railway.yaml
@@ -10,9 +10,8 @@ operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
 
 # EigenLayer chain RPC (Sepolia) — driven by env var so the key can
 # be rotated without redeploying. Set on the operator service:
-#   SEPOLIA_DWELLIR_RPC, SEPOLIA_DWELLIR_WS
-eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+#   SEPOLIA_RPC (HTTPS; WS derived in code)
+eth_rpc_url: ${SEPOLIA_RPC}
 
 # Key files — written at startup by scripts/operator-entrypoint.sh
 # Set ECDSA_KEY_JSON and BLS_KEY_JSON env vars in Railway
@@ -41,8 +40,7 @@ server_name: "operator-railway"
 
 # Destination chain - Sepolia
 target_chain:
-  eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-  eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+  eth_rpc_url: ${SEPOLIA_RPC}
 
 enabled_features:
   event_trigger: true

--- a/config/worker-base-railway.yaml
+++ b/config/worker-base-railway.yaml
@@ -3,7 +3,7 @@
 # Secrets are injected via Railway sealed environment variables and
 # expanded at startup (see core/config.ReadYamlConfig). Set these on
 # the `worker-base` Railway service:
-#   BASE_DWELLIR_RPC, BASE_DWELLIR_WS
+#   BASE_RPC (HTTPS; WS derived in code)
 #   BASE_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -24,8 +24,7 @@ health_address: "0.0.0.0:8080"
 # dials in. Workers only listen on `listen_address`.
 
 # Chain RPC endpoints (Base mainnet)
-eth_rpc_url: ${BASE_DWELLIR_RPC}
-eth_ws_url: ${BASE_DWELLIR_WS}
+eth_rpc_url: ${BASE_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${BASE_BUNDLER_URL}

--- a/config/worker-base-sepolia-railway.yaml
+++ b/config/worker-base-sepolia-railway.yaml
@@ -2,7 +2,7 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-base-sepolia` service:
-#   BASE_SEPOLIA_DWELLIR_RPC, BASE_SEPOLIA_DWELLIR_WS
+#   BASE_SEPOLIA_RPC (HTTPS; WS derived in code)
 #   BASE_SEPOLIA_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -22,8 +22,7 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints (Base Sepolia)
-eth_rpc_url: ${BASE_SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${BASE_SEPOLIA_DWELLIR_WS}
+eth_rpc_url: ${BASE_SEPOLIA_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}

--- a/config/worker-bnb-mainnet-railway.yaml
+++ b/config/worker-bnb-mainnet-railway.yaml
@@ -11,7 +11,7 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-bnb-mainnet` service:
-#   BNB_DWELLIR_RPC, BNB_DWELLIR_WS
+#   BNB_RPC (HTTPS; WS derived in code)
 #   BNB_BUNDLER_URL          — optional for connectivity-only; can be
 #                              left unset (the YAML expansion will
 #                              produce an empty string and bundler
@@ -35,8 +35,7 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints
-eth_rpc_url: ${BNB_DWELLIR_RPC}
-eth_ws_url: ${BNB_DWELLIR_WS}
+eth_rpc_url: ${BNB_RPC}
 
 # Bundler — left as an env var expansion. Unset in connectivity-only
 # mode; populate once a 4337 bundler provider with BNB support is in

--- a/config/worker-ethereum-railway.yaml
+++ b/config/worker-ethereum-railway.yaml
@@ -3,7 +3,7 @@
 # Secrets are injected via Railway sealed environment variables and
 # expanded at startup (see core/config.ReadYamlConfig). Set these on
 # the `worker-ethereum` Railway service:
-#   ETHEREUM_DWELLIR_RPC, ETHEREUM_DWELLIR_WS
+#   ETHEREUM_RPC (HTTPS; WS derived in code)
 #   ETHEREUM_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -24,8 +24,7 @@ health_address: "0.0.0.0:8080"
 # and dials in. Workers only listen on `listen_address`.
 
 # Chain RPC endpoints (Ethereum mainnet)
-eth_rpc_url: ${ETHEREUM_DWELLIR_RPC}
-eth_ws_url: ${ETHEREUM_DWELLIR_WS}
+eth_rpc_url: ${ETHEREUM_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${ETHEREUM_BUNDLER_URL}

--- a/config/worker-sepolia-railway.yaml
+++ b/config/worker-sepolia-railway.yaml
@@ -2,7 +2,7 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-sepolia` service:
-#   SEPOLIA_DWELLIR_RPC, SEPOLIA_DWELLIR_WS
+#   SEPOLIA_RPC (HTTPS; WS derived in code)
 #   SEPOLIA_BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
@@ -22,8 +22,7 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints
-eth_rpc_url: ${SEPOLIA_DWELLIR_RPC}
-eth_ws_url: ${SEPOLIA_DWELLIR_WS}
+eth_rpc_url: ${SEPOLIA_RPC}
 
 # Third-party bundler (self-hosted Voltaire)
 bundler_url: ${SEPOLIA_BUNDLER_URL}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -332,6 +332,21 @@ func NewConfig(configFilePath string) (*Config, error) {
 		}
 	}
 
+	// Derive eth_ws_url from eth_rpc_url when not explicitly set. Both
+	// endpoints typically live at the same host+path on every supported
+	// provider (Dwellir, Tenderly, Alchemy, …) — only the scheme
+	// differs. Letting one URL drive both halves the number of env
+	// vars an operator has to keep in sync and avoids the easy mistake
+	// of rotating one without the other. An explicit eth_ws_url still
+	// wins when set, for the rare case where the WS endpoint really
+	// is a separate URL.
+	if configRaw.EthWsUrl == "" {
+		configRaw.EthWsUrl = deriveWsURL(configRaw.EthRpcUrl)
+	}
+	if configRaw.SmartWallet.EthWsUrl == "" {
+		configRaw.SmartWallet.EthWsUrl = deriveWsURL(configRaw.SmartWallet.EthRpcUrl)
+	}
+
 	// Only create WebSocket client if URL is provided
 	var ethWsClient *eth.InstrumentedClient
 	if configRaw.EthWsUrl != "" {
@@ -602,6 +617,40 @@ func newLogger(env sdklogging.LogLevel, serviceName string) (sdklogging.Logger, 
 	return pkglogger.NewSentryLogger(zapLogger, serviceName), nil
 }
 
+// deriveWsURL turns an HTTP(S) RPC URL into the equivalent WebSocket URL
+// by flipping the scheme. Returns "" when given "" (so callers can use
+// it unconditionally — empty in, empty out, fall back to the existing
+// "no WebSocket" code path).
+//
+// Every RPC provider we ship configs for (Dwellir, Tenderly, Alchemy,
+// Infura, mainnet.base.org, etc.) serves HTTP and WebSocket from the
+// same host + path with only the scheme changing. So:
+//
+//	https://api-ethereum-mainnet.n.dwellir.com/<key>
+//	wss://api-ethereum-mainnet.n.dwellir.com/<key>
+//
+// are the same endpoint via different transports. Letting one URL drive
+// both halves the env-var count an operator manages, and makes it
+// impossible to rotate one without the other.
+//
+// If a provider ever splits the two (different host or different path
+// for WS), set eth_ws_url explicitly — that value still wins.
+func deriveWsURL(rpcURL string) string {
+	switch {
+	case rpcURL == "":
+		return ""
+	case strings.HasPrefix(rpcURL, "https://"):
+		return "wss://" + strings.TrimPrefix(rpcURL, "https://")
+	case strings.HasPrefix(rpcURL, "http://"):
+		return "ws://" + strings.TrimPrefix(rpcURL, "http://")
+	default:
+		// Not an http(s) URL — return as-is and let the WS client
+		// surface a clear "scheme not supported" error rather than
+		// silently mangling something we don't recognize.
+		return rpcURL
+	}
+}
+
 // firstNonEmpty returns the first non-empty string among the arguments.
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
@@ -746,13 +795,21 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 		maxWallets = HardMaxWalletsPerOwner
 	}
 
+	// Derive WS URL from RPC URL if not explicit (same provider, same
+	// path, scheme swap). See the top-level derivation block in
+	// NewConfig for rationale.
+	wsURL := sw.EthWsUrl
+	if wsURL == "" {
+		wsURL = deriveWsURL(sw.EthRpcUrl)
+	}
+
 	chainCfg := &ChainConfig{
 		ChainID:    raw.ChainID,
 		Name:       raw.Name,
 		WorkerAddr: raw.WorkerAddr,
 		SmartWallet: &SmartWalletConfig{
 			EthRpcUrl:            sw.EthRpcUrl,
-			EthWsUrl:             sw.EthWsUrl,
+			EthWsUrl:             wsURL,
 			BundlerURL:           sw.BundlerURL,
 			FactoryAddress:       common.HexToAddress(firstNonEmpty(sw.FactoryAddress, DefaultFactoryProxyAddressHex)),
 			EntrypointAddress:    common.HexToAddress(firstNonEmpty(sw.EntrypointAddress, DefaultEntrypointAddressHex)),

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -341,10 +341,10 @@ func NewConfig(configFilePath string) (*Config, error) {
 	// wins when set, for the rare case where the WS endpoint really
 	// is a separate URL.
 	if configRaw.EthWsUrl == "" {
-		configRaw.EthWsUrl = deriveWsURL(configRaw.EthRpcUrl)
+		configRaw.EthWsUrl = DeriveWsURL(configRaw.EthRpcUrl)
 	}
 	if configRaw.SmartWallet.EthWsUrl == "" {
-		configRaw.SmartWallet.EthWsUrl = deriveWsURL(configRaw.SmartWallet.EthRpcUrl)
+		configRaw.SmartWallet.EthWsUrl = DeriveWsURL(configRaw.SmartWallet.EthRpcUrl)
 	}
 
 	// Only create WebSocket client if URL is provided
@@ -617,7 +617,7 @@ func newLogger(env sdklogging.LogLevel, serviceName string) (sdklogging.Logger, 
 	return pkglogger.NewSentryLogger(zapLogger, serviceName), nil
 }
 
-// deriveWsURL turns an HTTP(S) RPC URL into the equivalent WebSocket URL
+// DeriveWsURL turns an HTTP(S) RPC URL into the equivalent WebSocket URL
 // by flipping the scheme. Returns "" when given "" (so callers can use
 // it unconditionally — empty in, empty out, fall back to the existing
 // "no WebSocket" code path).
@@ -635,7 +635,7 @@ func newLogger(env sdklogging.LogLevel, serviceName string) (sdklogging.Logger, 
 //
 // If a provider ever splits the two (different host or different path
 // for WS), set eth_ws_url explicitly — that value still wins.
-func deriveWsURL(rpcURL string) string {
+func DeriveWsURL(rpcURL string) string {
 	switch {
 	case rpcURL == "":
 		return ""
@@ -800,7 +800,7 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 	// NewConfig for rationale.
 	wsURL := sw.EthWsUrl
 	if wsURL == "" {
-		wsURL = deriveWsURL(sw.EthRpcUrl)
+		wsURL = DeriveWsURL(sw.EthRpcUrl)
 	}
 
 	chainCfg := &ChainConfig{

--- a/core/config/derive_ws_url_test.go
+++ b/core/config/derive_ws_url_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestDeriveWsURL(t *testing.T) {
+	cases := []struct {
+		in, want, name string
+	}{
+		{"https://api-ethereum-mainnet.n.dwellir.com/<key>", "wss://api-ethereum-mainnet.n.dwellir.com/<key>", "https → wss (dwellir mainnet)"},
+		{"https://sepolia.gateway.tenderly.co/abc", "wss://sepolia.gateway.tenderly.co/abc", "https → wss (tenderly)"},
+		{"http://localhost:8545", "ws://localhost:8545", "http → ws (local dev)"},
+		{"", "", "empty in → empty out (caller skips WS init)"},
+		// Unknown scheme passes through unchanged — the WS client will
+		// surface a clear error rather than us silently mangling.
+		{"ipc:///tmp/geth.ipc", "ipc:///tmp/geth.ipc", "unknown scheme preserved"},
+		{"foo-bar", "foo-bar", "no scheme preserved"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := deriveWsURL(c.in)
+			if got != c.want {
+				t.Fatalf("deriveWsURL(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/core/config/derive_ws_url_test.go
+++ b/core/config/derive_ws_url_test.go
@@ -17,9 +17,9 @@ func TestDeriveWsURL(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := deriveWsURL(c.in)
+			got := DeriveWsURL(c.in)
 			if got != c.want {
-				t.Fatalf("deriveWsURL(%q) = %q, want %q", c.in, got, c.want)
+				t.Fatalf("DeriveWsURL(%q) = %q, want %q", c.in, got, c.want)
 			}
 		})
 	}

--- a/operator/derive_ws_url_test.go
+++ b/operator/derive_ws_url_test.go
@@ -1,0 +1,87 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+// Operator-side mirror of the test that lives in core/config: when the
+// operator YAML omits eth_ws_url at any of its three layers (top-level,
+// target_chain, per-chain entry in Chains), NewOperatorFromConfig
+// derives it from the matching eth_rpc_url via config.DeriveWsURL.
+//
+// Regression guard for the Railway env-var rename in #546 — without
+// derivation, removing eth_ws_url from operator-railway.yaml would
+// leave c.EthWsUrl empty and operator/operator.go:NewOperator would
+// fail the WebSocket dial at startup. Surfaced by the Copilot review.
+func TestOperatorConfig_DerivesWsURLWhenMissing(t *testing.T) {
+	cfg := OperatorConfig{
+		EthRpcUrl: "https://api-ethereum-mainnet.example.com/key",
+		// EthWsUrl intentionally left empty
+	}
+	cfg.TargetChain.EthRpcUrl = "https://api-base-mainnet.example.com/key"
+	// TargetChain.EthWsUrl intentionally left empty
+	cfg.Chains = []OperatorChainConfig{
+		{ChainID: 1, Name: "ethereum", EthRpcUrl: "https://api-ethereum-mainnet.example.com/key"},
+		{ChainID: 8453, Name: "base", EthRpcUrl: "https://api-base-mainnet.example.com/key"},
+	}
+
+	// We don't want to actually build the full Operator (needs ECDSA
+	// keystore, AVS contracts, etc.) — just exercise the derivation
+	// block at the top of NewOperatorFromConfig. Replicate that block
+	// here against an exported helper to keep the test fast.
+	applyWsDerivation(&cfg)
+
+	if got, want := cfg.EthWsUrl, "wss://api-ethereum-mainnet.example.com/key"; got != want {
+		t.Errorf("top-level EthWsUrl = %q, want %q", got, want)
+	}
+	if got, want := cfg.TargetChain.EthWsUrl, "wss://api-base-mainnet.example.com/key"; got != want {
+		t.Errorf("TargetChain.EthWsUrl = %q, want %q", got, want)
+	}
+	if got, want := cfg.Chains[0].EthWsUrl, "wss://api-ethereum-mainnet.example.com/key"; got != want {
+		t.Errorf("Chains[0].EthWsUrl = %q, want %q", got, want)
+	}
+	if got, want := cfg.Chains[1].EthWsUrl, "wss://api-base-mainnet.example.com/key"; got != want {
+		t.Errorf("Chains[1].EthWsUrl = %q, want %q", got, want)
+	}
+}
+
+// Explicit eth_ws_url values must win over derivation — operators that
+// genuinely need a separate WS endpoint can still set it.
+func TestOperatorConfig_PreservesExplicitWsURL(t *testing.T) {
+	cfg := OperatorConfig{
+		EthRpcUrl: "https://eth-rpc.example.com/key",
+		EthWsUrl:  "wss://eth-ws.different-host.example.com/key",
+	}
+	cfg.TargetChain.EthRpcUrl = "https://target-rpc.example.com/key"
+	cfg.TargetChain.EthWsUrl = "wss://target-ws.different-host.example.com/key"
+
+	applyWsDerivation(&cfg)
+
+	if got, want := cfg.EthWsUrl, "wss://eth-ws.different-host.example.com/key"; got != want {
+		t.Errorf("explicit top-level EthWsUrl overwritten: got %q, want %q", got, want)
+	}
+	if got, want := cfg.TargetChain.EthWsUrl, "wss://target-ws.different-host.example.com/key"; got != want {
+		t.Errorf("explicit TargetChain.EthWsUrl overwritten: got %q, want %q", got, want)
+	}
+}
+
+// applyWsDerivation is the exact block inlined at the top of
+// NewOperatorFromConfig. Extracted here so tests can exercise it
+// without building the full Operator. If you change the derivation
+// rules in NewOperatorFromConfig, update this in lockstep — these
+// tests are the regression guard.
+func applyWsDerivation(c *OperatorConfig) {
+	if c.EthWsUrl == "" {
+		c.EthWsUrl = config.DeriveWsURL(c.EthRpcUrl)
+	}
+	if c.TargetChain.EthWsUrl == "" {
+		c.TargetChain.EthWsUrl = config.DeriveWsURL(c.TargetChain.EthRpcUrl)
+	}
+	for i := range c.Chains {
+		if c.Chains[i].EthWsUrl == "" {
+			c.Chains[i].EthWsUrl = config.DeriveWsURL(c.Chains[i].EthRpcUrl)
+		}
+	}
+}

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -422,6 +422,24 @@ func NewOperatorFromConfigFile(configPath string) (*Operator, error) {
 
 // take the config in core (which is shared with aggregator and challenger)
 func NewOperatorFromConfig(c OperatorConfig) (*Operator, error) {
+	// Derive WebSocket URLs from their RPC counterparts when not set
+	// explicitly. Mirrors what core/config does for the aggregator/gateway
+	// config: every supported RPC provider serves HTTP and WS at the same
+	// host+path with only the scheme differing, so letting one URL drive
+	// both halves the env-var count and prevents the "rotate RPC but
+	// forget WS" mistake. See core/config.DeriveWsURL for the helper.
+	if c.EthWsUrl == "" {
+		c.EthWsUrl = config.DeriveWsURL(c.EthRpcUrl)
+	}
+	if c.TargetChain.EthWsUrl == "" {
+		c.TargetChain.EthWsUrl = config.DeriveWsURL(c.TargetChain.EthRpcUrl)
+	}
+	for i := range c.Chains {
+		if c.Chains[i].EthWsUrl == "" {
+			c.Chains[i].EthWsUrl = config.DeriveWsURL(c.Chains[i].EthRpcUrl)
+		}
+	}
+
 	elapsing := timekeeper.NewElapsing()
 
 	// Backward compatibility: Handle old 'production' boolean field


### PR DESCRIPTION
## Why

Two related cleanups that fall out of tonight's rehearsal:

1. **WebSocket URL derivation in code** — every RPC provider we use (Dwellir, Tenderly, Alchemy, Infura, mainnet.base.org) serves HTTP and WS at the same host+path with only the scheme changing. Maintaining `eth_rpc_url` + `eth_ws_url` as two env vars per chain just doubled the number of secrets the operator has to rotate in lockstep — and "rotate RPC but forget WS" silently breaks WS-only code paths.
2. **Drop the `_DWELLIR_` provider name from Railway env vars** — bakes the RPC provider into the env-var name, which is wrong twice over: the gateway code doesn't care who the provider is, and we'd have to rename every var the day we move off Dwellir.

## Net change

| Before | After |
|---|---|
| 10 Railway env vars (5 chains × 2: HTTPS + WS) | **5 Railway env vars** (5 chains × 1 HTTPS, WS derived) |
| `ETHEREUM_DWELLIR_RPC` + `ETHEREUM_DWELLIR_WS` | `ETHEREUM_RPC` |
| `BASE_DWELLIR_RPC` + `BASE_DWELLIR_WS` | `BASE_RPC` |
| `SEPOLIA_DWELLIR_RPC` + `SEPOLIA_DWELLIR_WS` | `SEPOLIA_RPC` |
| `BASE_SEPOLIA_DWELLIR_RPC` + `BASE_SEPOLIA_DWELLIR_WS` | `BASE_SEPOLIA_RPC` |
| `BNB_DWELLIR_RPC` + `BNB_DWELLIR_WS` | `BNB_RPC` |

## What changes in code

[`core/config/config.go`](../blob/refactor/env-vars-and-derive-ws/core/config/config.go) — new `deriveWsURL(rpcURL string) string` helper that swaps the scheme (`https` → `wss`, `http` → `ws`). Called when the YAML's `eth_ws_url` is empty, for both the top-level config and each chain's `smart_wallet`. An explicit `eth_ws_url` still wins for the rare case where WS lives at a separate URL.

[`core/config/derive_ws_url_test.go`](../blob/refactor/env-vars-and-derive-ws/core/config/derive_ws_url_test.go) — new test covering `https://`, `http://`, empty, and unknown-scheme cases.

## What changes in YAML (8 files)

`config/gateway-railway.yaml`, `worker-*-railway.yaml` (5 files), `operator-ethereum-railway.yaml`, `operator-railway.yaml` — all `eth_ws_url:` lines removed, all `${X_DWELLIR_RPC}` references renamed to `${X_RPC}`, header comments updated.

Local dev configs (`gateway-dev.yaml`, `gateway-dev-rehearsal.yaml`, `worker-*-dev.yaml`) untouched — their explicit `eth_ws_url` values still work because the derivation only kicks in when the value is empty.

## Railway action required when this lands

Each consuming service needs the new var names set with the HTTPS URL value (the live prod Dwellir key `eb302287-...c9d` per the 2026-06-04 operator decision):

| Service | Vars to set |
|---|---|
| `gateway` | `ETHEREUM_RPC`, `BASE_RPC`, `SEPOLIA_RPC`, `BASE_SEPOLIA_RPC`, `BNB_RPC` |
| `worker-ethereum` | `ETHEREUM_RPC` |
| `worker-base` | `BASE_RPC` |
| `worker-sepolia` | `SEPOLIA_RPC` |
| `worker-base-sepolia` | `BASE_SEPOLIA_RPC` |
| `worker-bnb-mainnet` | `BNB_RPC` |
| `operator-ethereum` | `ETHEREUM_RPC` |
| any other `operator-*` | the chain RPC they use today |

Set each as `https://api-<chain>-mainnet.n.dwellir.com/eb302287-4dc1-47de-8e5a-ad0f6cc41c9d` (for production) — see the production tfstate-on-disk paths in [`avs-infra/terraform/environments/production/ethereum-aggregator.yaml`](https://github.com/AvaProtocol/avs-infra/blob/main/terraform/environments/production/ethereum-aggregator.yaml) for the exact URLs.

**After deploy**, the old `_DWELLIR_RPC` / `_DWELLIR_WS` vars can be deleted from Railway. Tracking as a separate todo.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 -short ./core/config/` — passes (including new `TestDeriveWsURL`)
- [x] `grep DWELLIR config/*-railway.yaml` — no matches
- [x] `grep eth_ws_url config/*-railway.yaml` — no matches (all derived)
- [ ] CI passes
- [ ] After merge: set Railway env vars (above), deploy, verify each service's startup log shows the correct chain ID + connects to RPC

## Related

- PR #544 (staging→main promotion, includes chain-scoped storage + merge tool)
- PR #545 (rehearsal tooling + body cleaner + DiscardUnknown loader fix)
- This PR — env var hygiene, doesn't block #544/#545
