### PR TITLE
fix: address Copilot review on PR #544 (docs + test + perf)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,20 +305,20 @@ hetzner-snapshot:
 ## migration-rehearse: run the Hetzner->gateway merge tool sequentially
 ##                     against each donor in ./donors/, default dry-run.
 ##                     Pass APPLY=1 to actually write to the scratch
-##                     gateway DB at /tmp/rehearsal-gateway-db.
+##                     gateway DB at ./tmp/rehearsal-gateway-db.
 ##                     Pass CHAIN=sepolia (etc.) to limit scope.
 .PHONY: migration-rehearse
 migration-rehearse:
 	@scripts/dev/run-merge-rehearsal.sh $(if $(APPLY),--apply) $(CHAIN)
 
 ## dev-stack-rehearsal: start the dev gateway against the post-merge
-##                      scratch DB at /tmp/rehearsal-gateway-db. Use
+##                      scratch DB at ./tmp/rehearsal-gateway-db. Use
 ##                      after `make migration-rehearse APPLY=1` to
 ##                      validate read-path queries via the SDK.
 .PHONY: dev-stack-rehearsal
 dev-stack-rehearsal: build
 	@mkdir -p logs
-	@echo "🚀 Starting rehearsal gateway against /tmp/rehearsal-gateway-db"
+	@echo "🚀 Starting rehearsal gateway against ./tmp/rehearsal-gateway-db"
 	@echo "   gateway      → REST :8080, gRPC :2206  (logs/gateway-rehearsal.log)"
 	@echo "   worker:sep   → gRPC :50051            (logs/worker-sepolia.log)"
 	@echo "   worker:bsep  → gRPC :50052            (logs/worker-base-sepolia.log)"

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -21,6 +21,14 @@ operator_address: <operator_address>
 avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
 operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
+# Ethereum mainnet RPC. eth_ws_url is OPTIONAL — when omitted, the
+# operator derives it from eth_rpc_url by swapping the scheme
+# (https→wss, http→ws). Every supported RPC provider (Dwellir, Tenderly,
+# Alchemy, Infura) serves both transports at the same host+path with
+# only the scheme differing, so one URL is enough. Set eth_ws_url
+# explicitly only if your provider exposes WS at a different URL.
+eth_rpc_url: <your_ethereum_mainnet_rpc_url>
+
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 

--- a/operator/derive_ws_url_test.go
+++ b/operator/derive_ws_url_test.go
@@ -1,21 +1,18 @@
 package operator
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
-)
-
-// Operator-side mirror of the test that lives in core/config: when the
-// operator YAML omits eth_ws_url at any of its three layers (top-level,
-// target_chain, per-chain entry in Chains), NewOperatorFromConfig
-// derives it from the matching eth_rpc_url via config.DeriveWsURL.
+// Exercises applyWsURLDerivation — the same helper NewOperatorFromConfig
+// calls at startup. Tests the production code path directly so removing
+// or changing the derivation block in operator.go would break these
+// tests immediately (no in-test re-implementation that could mask the
+// removal).
 //
-// Regression guard for the Railway env-var rename in #546 — without
+// Regression guard for the Railway env-var rename in #546: without
 // derivation, removing eth_ws_url from operator-railway.yaml would
 // leave c.EthWsUrl empty and operator/operator.go:NewOperator would
-// fail the WebSocket dial at startup. Surfaced by the Copilot review.
-func TestOperatorConfig_DerivesWsURLWhenMissing(t *testing.T) {
+// fail the WebSocket dial at startup. Surfaced by Copilot review.
+func TestApplyWsURLDerivation_FillsMissingAtAllLayers(t *testing.T) {
 	cfg := OperatorConfig{
 		EthRpcUrl: "https://api-ethereum-mainnet.example.com/key",
 		// EthWsUrl intentionally left empty
@@ -27,11 +24,7 @@ func TestOperatorConfig_DerivesWsURLWhenMissing(t *testing.T) {
 		{ChainID: 8453, Name: "base", EthRpcUrl: "https://api-base-mainnet.example.com/key"},
 	}
 
-	// We don't want to actually build the full Operator (needs ECDSA
-	// keystore, AVS contracts, etc.) — just exercise the derivation
-	// block at the top of NewOperatorFromConfig. Replicate that block
-	// here against an exported helper to keep the test fast.
-	applyWsDerivation(&cfg)
+	applyWsURLDerivation(&cfg)
 
 	if got, want := cfg.EthWsUrl, "wss://api-ethereum-mainnet.example.com/key"; got != want {
 		t.Errorf("top-level EthWsUrl = %q, want %q", got, want)
@@ -49,7 +42,7 @@ func TestOperatorConfig_DerivesWsURLWhenMissing(t *testing.T) {
 
 // Explicit eth_ws_url values must win over derivation — operators that
 // genuinely need a separate WS endpoint can still set it.
-func TestOperatorConfig_PreservesExplicitWsURL(t *testing.T) {
+func TestApplyWsURLDerivation_PreservesExplicitValues(t *testing.T) {
 	cfg := OperatorConfig{
 		EthRpcUrl: "https://eth-rpc.example.com/key",
 		EthWsUrl:  "wss://eth-ws.different-host.example.com/key",
@@ -57,31 +50,12 @@ func TestOperatorConfig_PreservesExplicitWsURL(t *testing.T) {
 	cfg.TargetChain.EthRpcUrl = "https://target-rpc.example.com/key"
 	cfg.TargetChain.EthWsUrl = "wss://target-ws.different-host.example.com/key"
 
-	applyWsDerivation(&cfg)
+	applyWsURLDerivation(&cfg)
 
 	if got, want := cfg.EthWsUrl, "wss://eth-ws.different-host.example.com/key"; got != want {
 		t.Errorf("explicit top-level EthWsUrl overwritten: got %q, want %q", got, want)
 	}
 	if got, want := cfg.TargetChain.EthWsUrl, "wss://target-ws.different-host.example.com/key"; got != want {
 		t.Errorf("explicit TargetChain.EthWsUrl overwritten: got %q, want %q", got, want)
-	}
-}
-
-// applyWsDerivation is the exact block inlined at the top of
-// NewOperatorFromConfig. Extracted here so tests can exercise it
-// without building the full Operator. If you change the derivation
-// rules in NewOperatorFromConfig, update this in lockstep — these
-// tests are the regression guard.
-func applyWsDerivation(c *OperatorConfig) {
-	if c.EthWsUrl == "" {
-		c.EthWsUrl = config.DeriveWsURL(c.EthRpcUrl)
-	}
-	if c.TargetChain.EthWsUrl == "" {
-		c.TargetChain.EthWsUrl = config.DeriveWsURL(c.TargetChain.EthRpcUrl)
-	}
-	for i := range c.Chains {
-		if c.Chains[i].EthWsUrl == "" {
-			c.Chains[i].EthWsUrl = config.DeriveWsURL(c.Chains[i].EthRpcUrl)
-		}
 	}
 }

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -235,6 +235,36 @@ func (o *Operator) primaryEventProgress() int64 {
 // When Chains is empty, falls back to a single-entry list derived from the
 // legacy TargetChain (or the EigenLayer RPC as a last resort), so pre-multi-
 // chain operator configs keep working without modification.
+// applyWsURLDerivation fills in c.EthWsUrl / c.TargetChain.EthWsUrl /
+// each c.Chains[i].EthWsUrl when they're left empty in the YAML, by
+// flipping the scheme of the matching eth_rpc_url via
+// core/config.DeriveWsURL.
+//
+// Mirrors the equivalent block in core/config for the aggregator/gateway
+// config: every supported RPC provider (Dwellir, Tenderly, Alchemy,
+// Infura, mainnet.base.org) serves HTTP and WS at the same host+path
+// with only the scheme differing, so letting one URL drive both halves
+// the env-var count operators maintain and prevents the
+// "rotate RPC but forget WS" failure mode.
+//
+// Extracted from NewOperatorFromConfig so derive_ws_url_test.go can
+// exercise the exact production code path rather than re-implementing
+// the rules in the test file (which would let the test pass even if
+// the production call site were accidentally removed).
+func applyWsURLDerivation(c *OperatorConfig) {
+	if c.EthWsUrl == "" {
+		c.EthWsUrl = config.DeriveWsURL(c.EthRpcUrl)
+	}
+	if c.TargetChain.EthWsUrl == "" {
+		c.TargetChain.EthWsUrl = config.DeriveWsURL(c.TargetChain.EthRpcUrl)
+	}
+	for i := range c.Chains {
+		if c.Chains[i].EthWsUrl == "" {
+			c.Chains[i].EthWsUrl = config.DeriveWsURL(c.Chains[i].EthRpcUrl)
+		}
+	}
+}
+
 func (c *OperatorConfig) EffectiveChains() []OperatorChainConfig {
 	if len(c.Chains) > 0 {
 		return c.Chains
@@ -422,23 +452,7 @@ func NewOperatorFromConfigFile(configPath string) (*Operator, error) {
 
 // take the config in core (which is shared with aggregator and challenger)
 func NewOperatorFromConfig(c OperatorConfig) (*Operator, error) {
-	// Derive WebSocket URLs from their RPC counterparts when not set
-	// explicitly. Mirrors what core/config does for the aggregator/gateway
-	// config: every supported RPC provider serves HTTP and WS at the same
-	// host+path with only the scheme differing, so letting one URL drive
-	// both halves the env-var count and prevents the "rotate RPC but
-	// forget WS" mistake. See core/config.DeriveWsURL for the helper.
-	if c.EthWsUrl == "" {
-		c.EthWsUrl = config.DeriveWsURL(c.EthRpcUrl)
-	}
-	if c.TargetChain.EthWsUrl == "" {
-		c.TargetChain.EthWsUrl = config.DeriveWsURL(c.TargetChain.EthRpcUrl)
-	}
-	for i := range c.Chains {
-		if c.Chains[i].EthWsUrl == "" {
-			c.Chains[i].EthWsUrl = config.DeriveWsURL(c.Chains[i].EthRpcUrl)
-		}
-	}
+	applyWsURLDerivation(&c)
 
 	elapsing := timekeeper.NewElapsing()
 

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -105,7 +105,7 @@ yarn start getWorkflow <task-id-from-the-list>
 - Operator-side trigger evaluation (operators aren't part of the
   rehearsal stack)
 - The Railway gateway's actual storage volume — the rehearsal runs
-  against `/tmp/rehearsal-gateway-db` only. Promote to production by
+  against `./tmp/rehearsal-gateway-db` only. Promote to production by
   taking a fresh pre-merge backup of the Railway gateway volume, then
   running the same merge sequence in the production maintenance window.
 
@@ -113,7 +113,7 @@ yarn start getWorkflow <task-id-from-the-list>
 
 `make hetzner-snapshot` always pulls fresh and overwrites `./donors/`.
 The merge rehearsal is non-destructive to the donor data — only the
-scratch gateway DB at `/tmp/rehearsal-gateway-db` gets reset on each
+scratch gateway DB at `./tmp/rehearsal-gateway-db` gets reset on each
 `make migration-rehearse APPLY=1` run.
 
 So a tight iteration loop is:
@@ -137,7 +137,7 @@ make migration-rehearse CHAIN=sepolia APPLY=1
 | File | What |
 |---|---|
 | `snapshot-hetzner-donors.sh` | SSH + docker-stop + tarball each Hetzner aggregator. Extracts to `./donors/<chain>/db/`. |
-| `run-merge-rehearsal.sh` | Runs the merge tool sequentially per donor against `/tmp/rehearsal-gateway-db`. Calls `count-gateway-keys.go` at the end. |
+| `run-merge-rehearsal.sh` | Runs the merge tool sequentially per donor against `./tmp/rehearsal-gateway-db`. Calls `count-gateway-keys.go` at the end. |
 | `count-gateway-keys.go` | One-shot scan of the gateway DB that prints per-prefix per-chain key counts. Helps spot unexpected key distributions after the merge. |
 | `../../config/gateway-dev-rehearsal.yaml` | Gateway config pointing at the rehearsal scratch DB with all 4 chains registered. Used by `make dev-stack-rehearsal`. |
 
@@ -160,8 +160,8 @@ tight.
 
 ```bash
 rm -rf donors/                          # delete all snapshotted donor data
-rm -rf /tmp/rehearsal-gateway-db        # delete the scratch gateway DB
-rm -rf /tmp/rehearsal-gateway-backup    # and its backup dir
+rm -rf ./tmp/rehearsal-gateway-db        # delete the scratch gateway DB
+rm -rf ./tmp/rehearsal-gateway-backup    # and its backup dir
 ```
 
 ## Related

--- a/scripts/migration/merge_hetzner_into_gateway/README.md
+++ b/scripts/migration/merge_hetzner_into_gateway/README.md
@@ -64,8 +64,12 @@ go run ./scripts/migration/merge_hetzner_into_gateway \
 
 # 6. After all four merges, run BackfillWalletSaltIndex against the gateway
 #    to rebuild the wsalt: secondary index (the merge stamps the keys but
-#    doesn't re-derive the canonical pointers):
-go run ./scripts/migration/backfill_wallet_salt_index --config config/gateway-railway.yaml
+#    doesn't re-derive the canonical pointers). --chain-id is REQUIRED
+#    because wsalt: keys are chain-scoped; run once per chain.
+for chain in 1 8453 11155111 84532; do
+  go run ./scripts/migration/backfill_wallet_salt_index \
+    --config config/gateway-railway.yaml --chain-id "$chain"
+done
 
 # 7. Start the Railway gateway service. Smoke-test workflows + execution
 #    queries across all four chains.

--- a/scripts/migration/merge_hetzner_into_gateway/handlers.go
+++ b/scripts/migration/merge_hetzner_into_gateway/handlers.go
@@ -27,6 +27,12 @@ type prefixHandlerEntry struct {
 	prefix string
 	handle handlerFunc
 	policy string // short label that prints in summary
+	// dropOnly marks entries whose handler discards the value and
+	// returns immediately. Lets the outer scan loop use
+	// IterateKeysOnly (constant memory, no value fetch) instead of
+	// GetByPrefix (materializes every K/V into a slice). Critical for
+	// the q: family which has 7–10M entries on mainnet donors.
+	dropOnly bool
 }
 
 // prefixHandlers is the dispatch table. The dispatcher walks it in order
@@ -44,8 +50,8 @@ var prefixHandlers = []prefixHandlerEntry{
 	// the gateway maintains its own sequences. Must be matched BEFORE
 	// the generic `t:` / `q:` handlers below — otherwise handleStampChainID
 	// would corrupt them into `t:<chainID>:seq` etc.
-	{"t:seq", handleDrop, "drop (Badger sequence counter, per-aggregator)"},
-	{"q:seq:", handleDrop, "drop (Badger sequence counter, per-aggregator)"},
+	{"t:seq", handleDrop, "drop (Badger sequence counter, per-aggregator)", true},
+	{"q:seq:", handleDrop, "drop (Badger sequence counter, per-aggregator)", true},
 
 	// Workflow + execution history. On every Hetzner donor (which predates
 	// chain-scoped storage) these are in legacy form (t:<status>:<task>,
@@ -66,35 +72,51 @@ var prefixHandlers = []prefixHandlerEntry{
 	//
 	// `u:` is just a status byte slice (no body to clean) and stays on
 	// the plain key-stamp handler.
-	{"t:", handleStampTaskBody, "stamp chain ID + clean Task body (drop unknown proto fields, set chain_id)"},
-	{"u:", handleStampChainID, "stamp chain ID (status byte slice, no body)"},
-	{"history:", handleStampExecutionBody, "stamp chain ID + clean Execution body (drop unknown proto fields)"},
+	{"t:", handleStampTaskBody, "stamp chain ID + clean Task body (drop unknown proto fields, set chain_id)", false},
+	{"u:", handleStampChainID, "stamp chain ID (status byte slice, no body)", false},
+	{"history:", handleStampExecutionBody, "stamp chain ID + clean Execution body (drop unknown proto fields)", false},
 
 	// Chain-implicit on the donor. Stamp `--donor-chain-id` into the key
 	// when writing to gateway.
-	{"w:", handleStampChainID, "stamp chain ID"},
-	{"wsalt:", handleStampChainID, "stamp chain ID (rebuild wsalt index post-merge)"},
-	{"fl:", handleStampChainID, "stamp chain ID"},
-	{"fr:", handleStampFeeRecordBody, "stamp chain ID + set FeeRecord.ChainID"},
+	{"w:", handleStampChainID, "stamp chain ID", false},
+	{"wsalt:", handleStampChainID, "stamp chain ID (rebuild wsalt index post-merge)", false},
+	{"fl:", handleStampChainID, "stamp chain ID", false},
+	{"fr:", handleStampFeeRecordBody, "stamp chain ID + set FeeRecord.ChainID", false},
 
 	// Already user/org/workflow scoped — chain doesn't apply.
-	{"secret:", handleImportAsIs, "import as-is"},
+	{"secret:", handleImportAsIs, "import as-is", false},
 
 	// Monotonic counters keyed by taskID — taskID is globally unique, so
 	// no chain stamping. On collision, keep the larger value.
-	{"execution_index_counter:", handleMaxOnCollision, "max-on-collision"},
+	{"execution_index_counter:", handleMaxOnCollision, "max-on-collision", false},
 
 	// Drop policies — cosmetic, transient, reconstructible, or
-	// per-aggregator operational state.
-	{"ct:cw:", handleDrop, "drop (cosmetic)"},
-	{"pending:", handleDrop, "drop (transient)"},
-	{"trigger:", handleDrop, "drop (reconstructible from history)"},
-	{"operator:", handleDrop, "drop (per-aggregator operator pool registry)"},
-	{"q:", handleDrop, "drop (per-aggregator async execution queue)"},
+	// per-aggregator operational state. dropOnly=true lets the outer
+	// scan loop stream keys via IterateKeysOnly (constant memory)
+	// instead of materializing every K/V slice — critical for the
+	// q: family which has 7–10M entries on mainnet donors.
+	{"ct:cw:", handleDrop, "drop (cosmetic)", true},
+	{"pending:", handleDrop, "drop (transient)", true},
+	{"trigger:", handleDrop, "drop (reconstructible from history)", true},
+	{"operator:", handleDrop, "drop (per-aggregator operator pool registry)", true},
+	{"q:", handleDrop, "drop (per-aggregator async execution queue)", true},
 
 	// Donor migration markers describe the donor's history, not the
 	// gateway's — never import.
-	{"migration:", handleDrop, "drop (donor history not gateway's)"},
+	{"migration:", handleDrop, "drop (donor history not gateway's)", true},
+}
+
+// isDropOnly returns whether the dispatch entry for `prefix` is a
+// drop-only handler (no value needed, no write). Used by the outer
+// scan loop to switch from GetByPrefix (materializes K/V slice) to
+// IterateKeysOnly (constant memory).
+func isDropOnly(prefix string) bool {
+	for _, h := range prefixHandlers {
+		if h.prefix == prefix {
+			return h.dropOnly
+		}
+	}
+	return false
 }
 
 func knownPrefixes() []string {

--- a/scripts/migration/merge_hetzner_into_gateway/main.go
+++ b/scripts/migration/merge_hetzner_into_gateway/main.go
@@ -51,6 +51,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -136,6 +137,27 @@ func main() {
 
 	for _, prefix := range allPrefixes {
 		stat := mergeStats.forPrefix(prefix)
+
+		// Drop-only prefixes don't need values — stream keys via the
+		// constant-memory IterateKeysOnly to avoid materializing every
+		// K/V into a slice. The q: family alone has 7–10M entries per
+		// mainnet donor; loading all of them at once is ~GBs of value
+		// payload that gets thrown away by handleDrop anyway.
+		if isDropOnly(prefix) {
+			err := donor.IterateKeysOnly([]byte(prefix), func(key []byte) error {
+				stat.scanned++
+				stat.dropped++
+				if *verbose {
+					fmt.Printf("  [drop] %q\n", string(key))
+				}
+				return nil
+			})
+			if err != nil {
+				log.Fatalf("stream-scan donor prefix %q: %v", prefix, err)
+			}
+			continue
+		}
+
 		items, err := donor.GetByPrefix([]byte(prefix))
 		if err != nil {
 			log.Fatalf("scan donor prefix %q: %v", prefix, err)
@@ -187,15 +209,27 @@ func main() {
 // Returned label is everything up to and including the first ':' in the
 // unknown key (e.g. "newprefix:") — matches the schema's naming
 // convention. Keys without a colon are bucketed under the full key.
+//
+// Avoids `string(key)` on every key — that would allocate millions of
+// short strings just to immediately discard them when the key matches
+// a known prefix (which is the overwhelmingly common case). Compares
+// against pre-encoded []byte prefixes and only converts to string when
+// bucketing an actual unknown key.
 func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[string]int, error) {
+	knownPrefixesBytes := make([][]byte, len(knownPrefixes))
+	for i, p := range knownPrefixes {
+		knownPrefixesBytes[i] = []byte(p)
+	}
+
 	unknown := map[string]int{}
 	err := donor.IterateKeysOnly([]byte(""), func(key []byte) error {
-		k := string(key)
-		for _, p := range knownPrefixes {
-			if len(k) >= len(p) && k[:len(p)] == p {
+		for _, pb := range knownPrefixesBytes {
+			if bytes.HasPrefix(key, pb) {
 				return nil
 			}
 		}
+		// Unknown — pay the string-alloc cost only for the bucketing label.
+		k := string(key)
 		label := k
 		for i := 0; i < len(k); i++ {
 			if k[i] == ':' {


### PR DESCRIPTION
## Why

All 10 Copilot findings on PR #544 (the staging→main promotion). Triaged the in-code concerns; deferred nothing.

## What changes

### Docs (the biggest user-facing one)
- **`docs/Operator.md`** — the operator setup example was missing `eth_rpc_url` after the WS-from-RPC derivation refactor. Only WS is now derivable; `eth_rpc_url` is still required. Re-added with a comment explaining that `eth_ws_url` is OPTIONAL (auto-derived). An operator following the doc as written would have hit a startup config error.
- **`scripts/migration/merge_hetzner_into_gateway/README.md`** — `BackfillWalletSaltIndex` example was missing the now-required `--chain-id` flag. Switched to a for-loop over the 4 supported chains.
- **`scripts/dev/README.md` + `Makefile`** — 5 places still referenced `/tmp/rehearsal-gateway-db` while the script, `.gitignore`, and config all use `./tmp/rehearsal-gateway-db`. Aligned everything on the repo-relative path so cleanup commands target the right directory.

### Test refactor (#9 from Copilot)
- **`operator/operator.go` + `operator/derive_ws_url_test.go`** — extracted the WS-derivation block from `NewOperatorFromConfig` into a named helper `applyWsURLDerivation`. The tests now exercise the production code path directly instead of re-implementing the rules in the test file (which would have let the test pass even if the production block were removed).

### Performance (#1, #2 from Copilot)
- **Drop-only prefixes stream keys via `IterateKeysOnly` instead of `GetByPrefix`** — added a `dropOnly` field to dispatch table entries. `q:` alone has 7-10M entries per mainnet donor; `GetByPrefix` was materializing the full value payload (~GB) into a slice just for `handleDrop` to throw it away. Affected prefixes: `ct:cw:`, `pending:`, `trigger:`, `operator:`, `q:`, `t:seq`, `q:seq:`, `migration:`.
- **`scanForUnknownPrefixes` no longer allocates a Go string for every key** — pre-encodes `knownPrefixes` to `[][]byte` and uses `bytes.HasPrefix` on raw key bytes. Only converts to string when bucketing an actually-unknown key (rare).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./scripts/migration/merge_hetzner_into_gateway/...` — passes
- [x] `go test ./operator/...` — passes (incl. extracted-helper test)
- [x] `go test ./core/config/...` — passes
- [x] `make migration-rehearse APPLY=1` — same 267,443-key result with 8 expected errors across all 4 production chains, **no regression** from the perf changes
- [ ] CI passes

## After this lands

The fixes will be picked up by PR #544 automatically since `staging` is the head of #544. Re-review/merge of #544 ships the full bundle to production.

## Per-finding mapping

| Copilot # | Severity | Fix |
|---|---|---|
| 1 (`main.go:141` OOM on GetByPrefix) | 🟡 Medium | `IterateKeysOnly` for drop-only prefixes |
| 2 (`main.go:197` string-alloc) | 🔵 Low | `bytes.HasPrefix` on raw key bytes |
| 3 (`scripts/migration/.../README.md:68` missing `--chain-id`) | 🟡 Medium | Updated example to a for-loop over chains |
| 4-7 (`scripts/dev/README.md` path mismatches) | 🔵 Low | Bulk renamed `/tmp/` → `./tmp/` |
| 8 (`docs/Operator.md` missing `eth_rpc_url`) | 🟠 High | Re-added with doc note that WS is now optional |
| 9 (`operator/derive_ws_url_test.go` re-implements logic) | 🟡 Medium | Extracted `applyWsURLDerivation` helper |
| 10 (`Makefile:321` path mismatch) | 🔵 Low | Same bulk path fix |
