### PR TITLE
feat: add ap-avs migrate-hetzner subcommand

### DIFF
--- a/cmd/migrateHetzner.go
+++ b/cmd/migrateHetzner.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/migration/hetznermerge"
+	"github.com/spf13/cobra"
+)
+
+var (
+	migrateHetznerDonorPath           string
+	migrateHetznerDonorChainID        int64
+	migrateHetznerGatewayPath         string
+	migrateHetznerDryRun              bool
+	migrateHetznerVerbose             bool
+	migrateHetznerFailOnUnknownPrefix bool
+
+	migrateHetznerCmd = &cobra.Command{
+		Use:   "migrate-hetzner",
+		Short: "Merge a Hetzner per-chain aggregator BadgerDB into the unified Railway gateway BadgerDB",
+		Long: `One-shot tool to bring a Hetzner per-chain aggregator's data forward into
+the unified Railway gateway. Used during the Hetzner -> Railway cutover
+to preserve the ~3 weeks of production workflows, executions, secrets,
+and fee records that accumulated on the Hetzner aggregators between the
+May 2026 Railway migration and the actual data merge.
+
+Run this once per donor (one Hetzner aggregator's BadgerDB), sequentially,
+passing the donor's chain ID:
+
+  1         Ethereum mainnet
+  8453      Base mainnet
+  11155111  Sepolia testnet
+  84532     Base-Sepolia testnet
+
+Per-prefix policy is in core/migration/hetznermerge/handlers.go. Full
+context + safety rules + production runbook in the avs-infra change-log:
+  - 20260604-hetzner-data-restore-plan.md
+  - 20260605-hetzner-merge-production-runbook.md
+
+OPERATIONAL CONSTRAINTS:
+
+  * Stop the Railway gateway service before running with --dry-run=false.
+    BadgerDB is single-writer; the tool opens the same db_path the
+    gateway uses.
+  * ALWAYS run with --dry-run=true first against an rsync'd copy of the
+    gateway DB. Inspect per-prefix counts and collisions before touching
+    the real volume.
+  * Take a fresh pre-merge backup of the gateway volume immediately
+    before the merge runs. That backup is the only rollback target.
+  * After all four donors are merged, run "ap-avs backfill-wallet-salt-index
+    --chain-id <N>" once per chain to rebuild the wsalt: secondary index.
+
+Production usage (Railway, via CMD override on the gateway service):
+
+  # 1. Stop the gateway, take a snapshot of the gateway-volume.
+  # 2. Upload donor tarballs to /data/donors/<chain>/db/ on the volume.
+  # 3. Override the gateway service's start CMD to run this subcommand:
+  ap-avs migrate-hetzner \
+      --donor-path     /data/donors/ethereum/db \
+      --donor-chain-id 1 \
+      --gateway-path   /data/gateway \
+      --dry-run=false
+  # 4. Repeat for each chain, then restore the default CMD + restart.
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			opts := hetznermerge.Options{
+				DonorPath:           migrateHetznerDonorPath,
+				DonorChainID:        migrateHetznerDonorChainID,
+				GatewayPath:         migrateHetznerGatewayPath,
+				DryRun:              migrateHetznerDryRun,
+				Verbose:             migrateHetznerVerbose,
+				FailOnUnknownPrefix: migrateHetznerFailOnUnknownPrefix,
+			}
+			if err := opts.Validate(); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
+			if _, err := hetznermerge.Run(opts, stdoutWriter{}); err != nil {
+				fmt.Fprintf(os.Stderr, "migrate-hetzner failed: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+// stdoutWriter satisfies hetznermerge.Writer for the Cobra subcommand.
+// Mirrors the same type in scripts/migration/merge_hetzner_into_gateway/
+// — kept local to avoid a cross-package dependency for a 4-line shim.
+type stdoutWriter struct{}
+
+func (stdoutWriter) Println(args ...any)               { fmt.Println(args...) }
+func (stdoutWriter) Printf(format string, args ...any) { fmt.Printf(format, args...) }
+
+func init() {
+	migrateHetznerCmd.Flags().StringVar(&migrateHetznerDonorPath, "donor-path", "",
+		"Path to the donor BadgerDB directory (the Hetzner aggregator's db_path)")
+	migrateHetznerCmd.Flags().Int64Var(&migrateHetznerDonorChainID, "donor-chain-id", 0,
+		"Chain ID for the donor — must match the chain the donor aggregator was serving (1 / 8453 / 11155111 / 84532)")
+	migrateHetznerCmd.Flags().StringVar(&migrateHetznerGatewayPath, "gateway-path", "",
+		"Path to the Railway gateway BadgerDB directory (the merge destination)")
+	migrateHetznerCmd.Flags().BoolVar(&migrateHetznerDryRun, "dry-run", true,
+		"Print what would change without writing to the gateway. Defaults to TRUE; pass --dry-run=false to apply.")
+	migrateHetznerCmd.Flags().BoolVar(&migrateHetznerVerbose, "verbose", false,
+		"Print one line per key processed")
+	migrateHetznerCmd.Flags().BoolVar(&migrateHetznerFailOnUnknownPrefix, "fail-on-unknown-prefix", true,
+		"Hard-fail if the donor has keys with a prefix this tool does not recognize. Default true.")
+	rootCmd.AddCommand(migrateHetznerCmd)
+}

--- a/core/migration/hetznermerge/handlers.go
+++ b/core/migration/hetznermerge/handlers.go
@@ -1,4 +1,4 @@
-package main
+package hetznermerge
 
 import (
 	"encoding/json"

--- a/core/migration/hetznermerge/handlers_test.go
+++ b/core/migration/hetznermerge/handlers_test.go
@@ -1,4 +1,4 @@
-package main
+package hetznermerge
 
 import (
 	"testing"

--- a/core/migration/hetznermerge/hetznermerge.go
+++ b/core/migration/hetznermerge/hetznermerge.go
@@ -1,0 +1,317 @@
+// Package hetznermerge is the library implementation of the
+// Hetzner -> Railway-gateway data merge tool. It exists in core/ so both
+// the standalone script at scripts/migration/merge_hetzner_into_gateway/
+// AND the `ap-avs migrate-hetzner` Cobra subcommand can call into it
+// without duplicating the dispatch/handler/stats logic.
+//
+// The actual per-prefix policy lives in handlers.go; per-prefix counters
+// + summary printing in stats.go. This file defines the public entry
+// point Run() that both callers share.
+//
+// For an end-to-end overview of WHY this tool exists, what each prefix
+// does, and the operational safety rules, see:
+//
+//   - scripts/migration/merge_hetzner_into_gateway/README.md
+//   - avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md
+//   - avs-infra/docs/changes/20260605-hetzner-merge-production-runbook.md
+package hetznermerge
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// SupportedChainIDs gates Options.DonorChainID to avoid fat-finger
+// merges (e.g. accidentally importing the Sepolia donor with chain-id 1).
+// Exposed so callers can build their own validation messages without
+// re-defining the map.
+var SupportedChainIDs = map[int64]string{
+	1:        "ethereum",
+	8453:     "base",
+	11155111: "sepolia",
+	84532:    "base-sepolia",
+}
+
+// Options is the set of inputs the merge run needs. Mirrors the flags
+// of the standalone CLI 1:1 so the standalone wrapper and the Cobra
+// subcommand can both populate this struct and call Run.
+type Options struct {
+	DonorPath           string // BadgerDB dir for the donor (Hetzner aggregator snapshot)
+	DonorChainID        int64  // chain ID for the donor; must be in SupportedChainIDs
+	GatewayPath         string // BadgerDB dir for the gateway (merge destination)
+	DryRun              bool   // print what would change without writing
+	Verbose             bool   // print one line per key processed
+	FailOnUnknownPrefix bool   // hard-fail when donor has prefixes the dispatch doesn't know
+}
+
+// Validate returns an error explaining the first invalid Options field,
+// or nil when the inputs are usable. Callers should surface the error
+// directly to the user (it's already formatted to match the CLI flag
+// names operators see).
+func (o Options) Validate() error {
+	if o.DonorPath == "" {
+		return fmt.Errorf("--donor-path is required")
+	}
+	if o.GatewayPath == "" {
+		return fmt.Errorf("--gateway-path is required")
+	}
+	if o.DonorChainID == 0 {
+		return fmt.Errorf("--donor-chain-id is required")
+	}
+	if _, ok := SupportedChainIDs[o.DonorChainID]; !ok {
+		return fmt.Errorf("--donor-chain-id %d is not a supported chain (allowed: %s)",
+			o.DonorChainID, supportedChainList())
+	}
+	if o.DonorPath == o.GatewayPath {
+		return fmt.Errorf("--donor-path and --gateway-path are the same (%s) — refusing to merge a DB into itself",
+			o.DonorPath)
+	}
+	return nil
+}
+
+// Result reports what happened. The caller decides whether to surface
+// errored == 0 as success or to fail the process; the merge tool's
+// historical behavior is to keep going on per-key errors and let the
+// summary table reflect the count.
+type Result struct {
+	Stats               *stats
+	UnknownPrefix       map[string]int // label -> count of donor keys under an unrecognized prefix
+	HardFailedOnUnknown bool           // true when Run aborted because of unknown prefixes + FailOnUnknownPrefix
+}
+
+// Run is the merge tool's library entry point. Both
+// scripts/migration/merge_hetzner_into_gateway/main.go (the standalone
+// CLI) and cmd/migrateHetzner.go (the `ap-avs migrate-hetzner`
+// subcommand) call this.
+//
+// It opens the donor + gateway BadgerDBs in read-write mode (Badger
+// requires the write lock even for the dry-run path), walks every
+// known prefix on the donor, dispatches each key through the per-prefix
+// handler in handlers.go, accumulates per-prefix counters in stats.go,
+// and writes results to the gateway via setIfAbsent (skip-if-exists).
+//
+// Errors from individual donor keys are logged via the writer interface
+// (see writer below) and counted in stats.errored — the merge continues.
+// The function returns a non-nil error only for setup failures (bad
+// options, can't open a DB, can't iterate) or when FailOnUnknownPrefix
+// hits.
+//
+// The writer parameter receives every progress / summary line. Pass
+// os.Stdout for CLI usage; tests pass a *bytes.Buffer.
+func Run(opts Options, writer Writer) (*Result, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	chainName := SupportedChainIDs[opts.DonorChainID]
+
+	writer.Println("Hetzner → gateway merge")
+	writer.Println("=======================")
+	writer.Printf("Donor path:     %s\n", opts.DonorPath)
+	writer.Printf("Donor chain:    %d (%s)\n", opts.DonorChainID, chainName)
+	writer.Printf("Gateway path:   %s\n", opts.GatewayPath)
+	writer.Printf("Mode:           %s\n", modeLabel(opts.DryRun))
+	writer.Printf("Started at:     %s\n", time.Now().UTC().Format(time.RFC3339))
+	writer.Println()
+
+	donor, err := storage.NewWithPath(opts.DonorPath)
+	if err != nil {
+		return nil, fmt.Errorf("open donor BadgerDB at %s: %w\n\nWas the donor aggregator stopped before snapshotting?", opts.DonorPath, err)
+	}
+	defer donor.Close()
+
+	gateway, err := storage.NewWithPath(opts.GatewayPath)
+	if err != nil {
+		return nil, fmt.Errorf("open gateway BadgerDB at %s: %w\n\nThe tool opens Badger in read-write mode (it needs the write lock even for --dry-run, since dry-run still acquires the lock to guarantee no other writer is racing it). If the Railway gateway service is still running against this volume, stop it before re-running.", opts.GatewayPath, err)
+	}
+	defer gateway.Close()
+
+	mergeStats := newStats()
+	result := &Result{Stats: mergeStats}
+
+	// Walk every prefix the dispatcher recognizes. Hard-fail when we see
+	// a key with an unknown prefix UNLESS FailOnUnknownPrefix is false
+	// (which only emergency-recovery investigations should ever pass).
+	//
+	// Important: dedupe outer-loop prefixes to skip strict extensions of
+	// another known prefix (e.g. `t:seq` is covered by `t:`, `q:seq:` by
+	// `q:`). Without this, every t:seq key gets iterated twice: once via
+	// GetByPrefix("t:") and once via GetByPrefix("t:seq") — bloating the
+	// scanned count and confusingly attributing the second pass to the
+	// shorter-prefix row of the summary. The dispatch table inside
+	// handlers.go still has the more specific entries first, so the
+	// correct (drop) handler still fires.
+	allPrefixes := outerLoopPrefixes(knownPrefixes())
+	sort.Strings(allPrefixes) // deterministic output ordering
+
+	for _, prefix := range allPrefixes {
+		stat := mergeStats.forPrefix(prefix)
+
+		// Drop-only prefixes don't need values — stream keys via the
+		// constant-memory IterateKeysOnly to avoid materializing every
+		// K/V into a slice. The q: family alone has 7–10M entries per
+		// mainnet donor; loading all of them at once is ~GBs of value
+		// payload that gets thrown away by handleDrop anyway.
+		if isDropOnly(prefix) {
+			err := donor.IterateKeysOnly([]byte(prefix), func(key []byte) error {
+				stat.scanned++
+				stat.dropped++
+				if opts.Verbose {
+					writer.Printf("  [drop] %q\n", string(key))
+				}
+				return nil
+			})
+			if err != nil {
+				return result, fmt.Errorf("stream-scan donor prefix %q: %w", prefix, err)
+			}
+			continue
+		}
+
+		items, err := donor.GetByPrefix([]byte(prefix))
+		if err != nil {
+			return result, fmt.Errorf("scan donor prefix %q: %w", prefix, err)
+		}
+		for _, kv := range items {
+			stat.scanned++
+			if err := dispatch(donor, gateway, opts.DonorChainID, kv, stat, opts.DryRun, opts.Verbose); err != nil {
+				stat.errored++
+				writer.Printf("ERROR on key %q: %v\n", string(kv.Key), err)
+			}
+		}
+	}
+
+	// Unknown-prefix scan: anything in the donor whose key doesn't start
+	// with one of the prefixes we know about is by definition unhandled.
+	// This catches future schema additions that drop in without the merge
+	// tool being updated.
+	unknown, err := scanForUnknownPrefixes(donor, allPrefixes)
+	if err != nil {
+		return result, fmt.Errorf("scan for unknown prefixes: %w", err)
+	}
+	result.UnknownPrefix = unknown
+	if len(unknown) > 0 {
+		writer.Println()
+		writer.Printf("⚠️  Donor has keys with %d prefix(es) not recognized by this tool:\n", len(unknown))
+		for prefix, count := range unknown {
+			writer.Printf("    %q  (%d keys)\n", prefix, count)
+		}
+		writer.Println()
+		if opts.FailOnUnknownPrefix {
+			result.HardFailedOnUnknown = true
+			return result, fmt.Errorf("hard-failing per --fail-on-unknown-prefix=true. Either extend handlers.go with policy for these prefixes, or pass --fail-on-unknown-prefix=false (NOT recommended — silently drops data)")
+		}
+		writer.Println("Continuing because --fail-on-unknown-prefix=false. The unknown-prefix keys have been DROPPED from this merge.")
+	}
+
+	writer.Println()
+	mergeStats.print(writer, opts.DonorChainID, chainName)
+
+	if opts.DryRun {
+		writer.Println()
+		writer.Println("DRY RUN — no changes written. Re-run with --dry-run=false to apply.")
+	}
+
+	return result, nil
+}
+
+// Writer is the minimal output sink the package emits to. Both the CLI
+// (os.Stdout) and tests (*bytes.Buffer) satisfy it.
+type Writer interface {
+	Println(args ...any)
+	Printf(format string, args ...any)
+}
+
+// scanForUnknownPrefixes walks every key in the donor via the storage
+// streaming iterator (KeysOnly — values are never fetched and no
+// per-key slice is built, so memory stays constant in the size of the
+// donor). Bucketizes any key whose prefix is not in `knownPrefixes`.
+//
+// Returned label is everything up to and including the first ':' in the
+// unknown key (e.g. "newprefix:") — matches the schema's naming
+// convention. Keys without a colon are bucketed under the full key.
+//
+// Avoids `string(key)` on every key — that would allocate millions of
+// short strings just to immediately discard them when the key matches
+// a known prefix (which is the overwhelmingly common case). Compares
+// against pre-encoded []byte prefixes and only converts to string when
+// bucketing an actual unknown key.
+func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[string]int, error) {
+	knownPrefixesBytes := make([][]byte, len(knownPrefixes))
+	for i, p := range knownPrefixes {
+		knownPrefixesBytes[i] = []byte(p)
+	}
+
+	unknown := map[string]int{}
+	err := donor.IterateKeysOnly([]byte(""), func(key []byte) error {
+		for _, pb := range knownPrefixesBytes {
+			if bytes.HasPrefix(key, pb) {
+				return nil
+			}
+		}
+		// Unknown — pay the string-alloc cost only for the bucketing label.
+		k := string(key)
+		label := k
+		for i := 0; i < len(k); i++ {
+			if k[i] == ':' {
+				label = k[:i+1]
+				break
+			}
+		}
+		unknown[label]++
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return unknown, nil
+}
+
+// outerLoopPrefixes returns the subset of `all` that should drive the
+// outer GetByPrefix loop in Run: for any two prefixes A and B in the
+// input where A is a strict prefix of B, only A is returned. This keeps
+// keys from being processed twice when the dispatch table contains
+// both a general and a more-specific entry for the same family (e.g.
+// `t:` and `t:seq`).
+func outerLoopPrefixes(all []string) []string {
+	out := make([]string, 0, len(all))
+nextCandidate:
+	for _, candidate := range all {
+		for _, other := range all {
+			if other == candidate {
+				continue
+			}
+			if len(other) < len(candidate) && candidate[:len(other)] == other {
+				// `other` is a strict prefix of `candidate` — skip `candidate`.
+				continue nextCandidate
+			}
+		}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func supportedChainList() string {
+	parts := make([]string, 0, len(SupportedChainIDs))
+	for id, name := range SupportedChainIDs {
+		parts = append(parts, fmt.Sprintf("%d=%s", id, name))
+	}
+	sort.Strings(parts)
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+func modeLabel(dryRun bool) string {
+	if dryRun {
+		return "DRY RUN (no writes)"
+	}
+	return "APPLY (writes to gateway)"
+}

--- a/core/migration/hetznermerge/stats.go
+++ b/core/migration/hetznermerge/stats.go
@@ -1,7 +1,6 @@
-package main
+package hetznermerge
 
 import (
-	"fmt"
 	"sort"
 )
 
@@ -43,11 +42,11 @@ func (s *stats) forPrefix(prefix string) *prefixStats {
 	return v
 }
 
-func (s *stats) print(donorChainID int64, chainName string) {
-	fmt.Println("Summary")
-	fmt.Println("-------")
-	fmt.Printf("Donor chain: %d (%s)\n", donorChainID, chainName)
-	fmt.Println()
+func (s *stats) print(w Writer, donorChainID int64, chainName string) {
+	w.Println("Summary")
+	w.Println("-------")
+	w.Printf("Donor chain: %d (%s)\n", donorChainID, chainName)
+	w.Println()
 
 	// Sort prefixes by their order in prefixHandlers (the canonical layout)
 	// instead of alphabetical — keeps related rows together.
@@ -70,9 +69,9 @@ func (s *stats) print(donorChainID int64, chainName string) {
 	// CollRes is the subset of Copied that overwrote an existing gateway
 	// value (execution_index_counter: max-on-collision); brand-new keys
 	// show under Copied only.
-	fmt.Printf("%-30s %-50s %8s %8s %8s %8s %8s %8s %8s\n",
+	w.Printf("%-30s %-50s %8s %8s %8s %8s %8s %8s %8s\n",
 		"Prefix", "Policy", "Scanned", "Copied", "CollRes", "Stamped", "Existed", "Dropped", "Errors")
-	fmt.Println("----------------------------- " +
+	w.Println("----------------------------- " +
 		"-------------------------------------------------- " +
 		"-------- -------- -------- -------- -------- -------- --------")
 
@@ -82,7 +81,7 @@ func (s *stats) print(donorChainID int64, chainName string) {
 		if ps.scanned == 0 && ps.dropped == 0 && ps.errored == 0 {
 			continue // suppress zero rows for readability
 		}
-		fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
+		w.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
 			ps.prefix, ps.policy,
 			ps.scanned, ps.copied, ps.collisionResolved, ps.stampedChain, ps.skippedExists, ps.dropped, ps.errored)
 		totals.scanned += ps.scanned
@@ -93,16 +92,16 @@ func (s *stats) print(donorChainID int64, chainName string) {
 		totals.dropped += ps.dropped
 		totals.errored += ps.errored
 	}
-	fmt.Println("----------------------------- " +
+	w.Println("----------------------------- " +
 		"-------------------------------------------------- " +
 		"-------- -------- -------- -------- -------- -------- --------")
-	fmt.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
+	w.Printf("%-30s %-50s %8d %8d %8d %8d %8d %8d %8d\n",
 		"TOTAL", "",
 		totals.scanned, totals.copied, totals.collisionResolved, totals.stampedChain, totals.skippedExists, totals.dropped, totals.errored)
 
 	if totals.errored > 0 {
-		fmt.Println()
-		fmt.Printf("⚠️  %d errors occurred during merge — review the ERROR log lines above.\n", totals.errored)
+		w.Println()
+		w.Printf("⚠️  %d errors occurred during merge — review the ERROR log lines above.\n", totals.errored)
 	}
 }
 

--- a/scripts/migration/merge_hetzner_into_gateway/main.go
+++ b/scripts/migration/merge_hetzner_into_gateway/main.go
@@ -1,11 +1,6 @@
-// Standalone tool to merge a single Hetzner per-chain aggregator BadgerDB
-// (the "donor") into the unified Railway gateway BadgerDB. Used once
-// during the 2026-07-01 Hetzner decom to bring forward the ~3 weeks of
-// production data that Studio wrote to the Hetzner aggregators after the
-// May 2026 Railway migration but before this cutover.
-//
-// Run the tool ONCE PER DONOR — sequentially, not in parallel — passing
-// the donor's chain ID:
+// Standalone CLI wrapper around core/migration/hetznermerge. Operators
+// who want to run the merge without installing the full ap-avs binary
+// can do:
 //
 //	go run scripts/migration/merge_hetzner_into_gateway \
 //	    --donor-path   ./donors/ethereum-2026-06-04 \
@@ -13,289 +8,61 @@
 //	    --gateway-path /data \
 //	    --dry-run [--verbose]
 //
-// Chain IDs:
+// All the actual merge logic, per-prefix policy, and stats lives in
+// core/migration/hetznermerge — this file is intentionally a thin
+// flag-parsing wrapper. The Cobra subcommand `ap-avs migrate-hetzner`
+// at cmd/migrateHetzner.go shares the same library entry point and is
+// the recommended way to run this in production.
 //
-//	1         Ethereum mainnet
-//	8453      Base mainnet
-//	11155111  Sepolia testnet
-//	84532     Base-Sepolia testnet
-//
-// Operational constraints
-// -----------------------
-//
-//   - Stop the Railway gateway service before running with --dry-run=false.
-//     BadgerDB is single-writer; the tool opens the same db_path the
-//     gateway uses.
-//   - ALWAYS run with --dry-run first against an rsync'd copy of the
-//     gateway DB. Inspect per-prefix counts and collisions before
-//     touching the real volume.
-//   - The tool uses skip-if-exists semantics: every Set is preceded by
-//     Exist; nothing the gateway has already written is ever overwritten,
-//     with ONE deliberate exception — `execution_index_counter:` uses a
-//     max-on-collision policy and will overwrite the gateway value when
-//     the donor counter is strictly larger (necessary so the gateway does
-//     not re-issue execution indices that the donor already consumed).
-//     Both kinds of writes are surfaced in the summary: brand-new keys
-//     show under "Copied", overwrites under "CollRes". Do NOT replace
-//     setIfAbsent with storage.Storage.Load — Load is bulk upsert and
-//     will silently clobber live data.
-//   - Take a fresh pre-merge backup of the gateway volume immediately
-//     before the merge runs. That backup is the only rollback target.
-//
-// Per-prefix policy
-// -----------------
-// Documented in docs/Operator.md and in the avs-infra change-log
-// `docs/changes/20260604-hetzner-data-restore-plan.md`. The dispatch
-// table in handlers.go is the source of truth for what each prefix
-// does — refer there before editing this comment.
+// For chain IDs, operational constraints, the per-prefix policy matrix,
+// and the full production runbook, see:
+//   - core/migration/hetznermerge/handlers.go (policy matrix)
+//   - scripts/migration/merge_hetzner_into_gateway/README.md
+//   - avs-infra/docs/changes/20260604-hetzner-data-restore-plan.md
+//   - avs-infra/docs/changes/20260605-hetzner-merge-production-runbook.md
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"sort"
-	"time"
 
-	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/migration/hetznermerge"
 )
 
-// supportedChainIDs gates --donor-chain-id to avoid fat-finger merges
-// (e.g. accidentally importing the Sepolia donor with chain-id 1).
-var supportedChainIDs = map[int64]string{
-	1:        "ethereum",
-	8453:     "base",
-	11155111: "sepolia",
-	84532:    "base-sepolia",
-}
+// stdoutWriter satisfies hetznermerge.Writer for the standalone CLI.
+type stdoutWriter struct{}
+
+func (stdoutWriter) Println(args ...any)               { fmt.Println(args...) }
+func (stdoutWriter) Printf(format string, args ...any) { fmt.Printf(format, args...) }
 
 func main() {
 	donorPath := flag.String("donor-path", "", "Path to the donor BadgerDB directory (the Hetzner aggregator's db_path)")
-	donorChainID := flag.Int64("donor-chain-id", 0, "Chain ID for the donor — must match the chain the donor aggregator was serving")
+	donorChainID := flag.Int64("donor-chain-id", 0, "Chain ID for the donor — must match the chain the donor aggregator was serving (1 / 8453 / 11155111 / 84532)")
 	gatewayPath := flag.String("gateway-path", "", "Path to the Railway gateway BadgerDB directory (the merge destination)")
 	dryRun := flag.Bool("dry-run", true, "Print what would change without writing to the gateway. Defaults to TRUE; pass --dry-run=false to apply.")
 	verbose := flag.Bool("verbose", false, "Print one line per key processed")
 	failOnUnknownPrefix := flag.Bool("fail-on-unknown-prefix", true, "Hard-fail if the donor has keys with a prefix this tool does not recognize. Default true — disabling is for emergency-recovery investigation only.")
 	flag.Parse()
 
-	if *donorPath == "" {
-		dieUsage("--donor-path is required")
-	}
-	if *gatewayPath == "" {
-		dieUsage("--gateway-path is required")
-	}
-	if *donorChainID == 0 {
-		dieUsage("--donor-chain-id is required")
-	}
-	chainName, ok := supportedChainIDs[*donorChainID]
-	if !ok {
-		dieUsage(fmt.Sprintf("--donor-chain-id %d is not a supported chain (allowed: %s)", *donorChainID, supportedChainList()))
-	}
-	if *donorPath == *gatewayPath {
-		log.Fatalf("--donor-path and --gateway-path are the same (%s) — refusing to merge a DB into itself", *donorPath)
+	opts := hetznermerge.Options{
+		DonorPath:           *donorPath,
+		DonorChainID:        *donorChainID,
+		GatewayPath:         *gatewayPath,
+		DryRun:              *dryRun,
+		Verbose:             *verbose,
+		FailOnUnknownPrefix: *failOnUnknownPrefix,
 	}
 
-	fmt.Println("Hetzner → gateway merge")
-	fmt.Println("=======================")
-	fmt.Printf("Donor path:     %s\n", *donorPath)
-	fmt.Printf("Donor chain:    %d (%s)\n", *donorChainID, chainName)
-	fmt.Printf("Gateway path:   %s\n", *gatewayPath)
-	fmt.Printf("Mode:           %s\n", modeLabel(*dryRun))
-	fmt.Printf("Started at:     %s\n", time.Now().UTC().Format(time.RFC3339))
-	fmt.Println()
-
-	donor, err := storage.NewWithPath(*donorPath)
-	if err != nil {
-		log.Fatalf("open donor BadgerDB at %s: %v\n\nWas the donor aggregator stopped before snapshotting?", *donorPath, err)
-	}
-	defer donor.Close()
-
-	gateway, err := storage.NewWithPath(*gatewayPath)
-	if err != nil {
-		log.Fatalf("open gateway BadgerDB at %s: %v\n\nThe tool opens Badger in read-write mode (it needs the write lock even for --dry-run, since dry-run still acquires the lock to guarantee no other writer is racing it). If the Railway gateway service is still running against this volume, stop it before re-running.", *gatewayPath, err)
-	}
-	defer gateway.Close()
-
-	mergeStats := newStats()
-
-	// Walk every prefix the dispatcher recognizes. Hard-fail when we see
-	// a key with an unknown prefix UNLESS --fail-on-unknown-prefix=false
-	// (which only emergency-recovery investigations should ever pass).
-	//
-	// Important: dedupe outer-loop prefixes to skip strict extensions of
-	// another known prefix (e.g. `t:seq` is covered by `t:`, `q:seq:` by
-	// `q:`). Without this, every t:seq key gets iterated twice: once via
-	// GetByPrefix("t:") and once via GetByPrefix("t:seq") — bloating the
-	// scanned count and confusingly attributing the second pass to the
-	// shorter-prefix row of the summary. The dispatch table inside
-	// handlers.go still has the more specific entries first, so the
-	// correct (drop) handler still fires.
-	allPrefixes := outerLoopPrefixes(knownPrefixes())
-	sort.Strings(allPrefixes) // deterministic output ordering
-
-	for _, prefix := range allPrefixes {
-		stat := mergeStats.forPrefix(prefix)
-
-		// Drop-only prefixes don't need values — stream keys via the
-		// constant-memory IterateKeysOnly to avoid materializing every
-		// K/V into a slice. The q: family alone has 7–10M entries per
-		// mainnet donor; loading all of them at once is ~GBs of value
-		// payload that gets thrown away by handleDrop anyway.
-		if isDropOnly(prefix) {
-			err := donor.IterateKeysOnly([]byte(prefix), func(key []byte) error {
-				stat.scanned++
-				stat.dropped++
-				if *verbose {
-					fmt.Printf("  [drop] %q\n", string(key))
-				}
-				return nil
-			})
-			if err != nil {
-				log.Fatalf("stream-scan donor prefix %q: %v", prefix, err)
-			}
-			continue
-		}
-
-		items, err := donor.GetByPrefix([]byte(prefix))
-		if err != nil {
-			log.Fatalf("scan donor prefix %q: %v", prefix, err)
-		}
-		for _, kv := range items {
-			stat.scanned++
-			if err := dispatch(donor, gateway, *donorChainID, kv, stat, *dryRun, *verbose); err != nil {
-				stat.errored++
-				log.Printf("ERROR on key %q: %v", string(kv.Key), err)
-			}
-		}
+	if err := opts.Validate(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr)
+		flag.Usage()
+		os.Exit(2)
 	}
 
-	// Unknown-prefix scan: anything in the donor whose key doesn't start
-	// with one of the prefixes we know about is by definition unhandled.
-	// This catches future schema additions that drop in without the merge
-	// tool being updated.
-	unknown, err := scanForUnknownPrefixes(donor, allPrefixes)
-	if err != nil {
-		log.Fatalf("scan for unknown prefixes: %v", err)
+	if _, err := hetznermerge.Run(opts, stdoutWriter{}); err != nil {
+		log.Fatalf("merge failed: %v", err)
 	}
-	if len(unknown) > 0 {
-		fmt.Println()
-		fmt.Printf("⚠️  Donor has keys with %d prefix(es) not recognized by this tool:\n", len(unknown))
-		for prefix, count := range unknown {
-			fmt.Printf("    %q  (%d keys)\n", prefix, count)
-		}
-		fmt.Println()
-		if *failOnUnknownPrefix {
-			log.Fatalf("Hard-failing per --fail-on-unknown-prefix=true. Either extend handlers.go with policy for these prefixes, or pass --fail-on-unknown-prefix=false (NOT recommended — silently drops data).")
-		}
-		fmt.Println("Continuing because --fail-on-unknown-prefix=false. The unknown-prefix keys have been DROPPED from this merge.")
-	}
-
-	fmt.Println()
-	mergeStats.print(*donorChainID, chainName)
-
-	if *dryRun {
-		fmt.Println()
-		fmt.Println("DRY RUN — no changes written. Re-run with --dry-run=false to apply.")
-	}
-}
-
-// scanForUnknownPrefixes walks every key in the donor via the storage
-// streaming iterator (KeysOnly — values are never fetched and no
-// per-key slice is built, so memory stays constant in the size of the
-// donor). Bucketizes any key whose prefix is not in `knownPrefixes`.
-//
-// Returned label is everything up to and including the first ':' in the
-// unknown key (e.g. "newprefix:") — matches the schema's naming
-// convention. Keys without a colon are bucketed under the full key.
-//
-// Avoids `string(key)` on every key — that would allocate millions of
-// short strings just to immediately discard them when the key matches
-// a known prefix (which is the overwhelmingly common case). Compares
-// against pre-encoded []byte prefixes and only converts to string when
-// bucketing an actual unknown key.
-func scanForUnknownPrefixes(donor storage.Storage, knownPrefixes []string) (map[string]int, error) {
-	knownPrefixesBytes := make([][]byte, len(knownPrefixes))
-	for i, p := range knownPrefixes {
-		knownPrefixesBytes[i] = []byte(p)
-	}
-
-	unknown := map[string]int{}
-	err := donor.IterateKeysOnly([]byte(""), func(key []byte) error {
-		for _, pb := range knownPrefixesBytes {
-			if bytes.HasPrefix(key, pb) {
-				return nil
-			}
-		}
-		// Unknown — pay the string-alloc cost only for the bucketing label.
-		k := string(key)
-		label := k
-		for i := 0; i < len(k); i++ {
-			if k[i] == ':' {
-				label = k[:i+1]
-				break
-			}
-		}
-		unknown[label]++
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return unknown, nil
-}
-
-// outerLoopPrefixes returns the subset of `all` that should drive the
-// outer GetByPrefix loop in main: for any two prefixes A and B in the
-// input where A is a strict prefix of B, only A is returned. This keeps
-// keys from being processed twice when the dispatch table contains
-// both a general and a more-specific entry for the same family (e.g.
-// `t:` and `t:seq`).
-func outerLoopPrefixes(all []string) []string {
-	out := make([]string, 0, len(all))
-nextCandidate:
-	for _, candidate := range all {
-		for _, other := range all {
-			if other == candidate {
-				continue
-			}
-			if len(other) < len(candidate) && candidate[:len(other)] == other {
-				// `other` is a strict prefix of `candidate` — skip `candidate`.
-				continue nextCandidate
-			}
-		}
-		out = append(out, candidate)
-	}
-	return out
-}
-
-func supportedChainList() string {
-	parts := make([]string, 0, len(supportedChainIDs))
-	for id, name := range supportedChainIDs {
-		parts = append(parts, fmt.Sprintf("%d=%s", id, name))
-	}
-	sort.Strings(parts)
-	out := ""
-	for i, p := range parts {
-		if i > 0 {
-			out += ", "
-		}
-		out += p
-	}
-	return out
-}
-
-func dieUsage(msg string) {
-	fmt.Fprintln(os.Stderr, msg)
-	fmt.Fprintln(os.Stderr)
-	flag.Usage()
-	os.Exit(2)
-}
-
-func modeLabel(dryRun bool) string {
-	if dryRun {
-		return "DRY RUN (no writes)"
-	}
-	return "APPLY (writes to gateway)"
 }


### PR DESCRIPTION
## Summary

Wraps the existing `scripts/migration/merge_hetzner_into_gateway/` standalone
script as a Cobra subcommand on the production `ap-avs` binary so the
Hetzner → Railway data merge can be invoked via Railway's CMD override
on the gateway service. Removes the need to publish a separate migration
image (and the corresponding image-build PR) just to run a one-shot tool
that already exists.

- `core/migration/hetznermerge/` — new library package. `handlers.go`,
  `handlers_test.go`, and `stats.go` moved here verbatim from
  `scripts/migration/merge_hetzner_into_gateway/` (git renames, 99% / 99%
  / 85% similarity — the stats.go diff is just `fmt.Print*` → `w.Print*`
  for the new injected `Writer`). `hetznermerge.go` is the new library
  entry point exposing `Options`, `Validate()`, `Run(opts, Writer)`,
  `Result`, `Writer`, `SupportedChainIDs`, and the small helpers
  (`scanForUnknownPrefixes`, `outerLoopPrefixes`, `supportedChainList`,
  `modeLabel`).
- `cmd/migrateHetzner.go` — Cobra subcommand registered on `rootCmd`.
  Same six flags as the standalone (`--donor-path`, `--donor-chain-id`,
  `--gateway-path`, `--dry-run`, `--verbose`, `--fail-on-unknown-prefix`),
  forwards them to `hetznermerge.Run` with an `os.Stdout` writer.
- `scripts/migration/merge_hetzner_into_gateway/main.go` — reduced from
  ~300 lines to ~70 lines, now a thin flag-parsing wrapper around
  `hetznermerge.Run`. The `go run scripts/migration/merge_hetzner_into_gateway`
  workflow still works for ad-hoc / non-prod use.

**No behavior change.** Same flags, same per-prefix policy matrix, same
dispatch order, same dry-run semantics. The merge tool just becomes
reachable through two entry points instead of one.

## Why this matters now

This is the **blocking pre-flight item** from the avs-infra production
runbook (`20260605-hetzner-merge-production-runbook.md`). The runbook
plan was:

1. Stop the Railway gateway service (window opens).
2. Snapshot the gateway volume.
3. Upload the four Hetzner donor BadgerDBs to the gateway volume.
4. **Run the merge once per chain via a temporary CMD override on the
   gateway service** — i.e. `ap-avs migrate-hetzner --donor-path … --donor-chain-id … --gateway-path …`.
5. Backfill the `wsalt:` secondary index.
6. Restore the default CMD, restart, smoke-test.

Step 4 needs this subcommand to exist on the `ap-avs` image. Without
it, we either have to (a) publish a one-off `migrate-hetzner` image —
extra build / release / approval surface for a single-use tool — or
(b) `kubectl exec` / `railway ssh` into the gateway container and
`go run` the script, which means shipping the Go toolchain inside the
production image. Both options are worse than just exposing the tool
via the binary that's already there.

## Test plan

- [x] `go build ./...` clean
- [x] `make build` produces `./out/ap` with `migrate-hetzner` in the
      subcommand list (`./out/ap | grep migrate-hetzner`)
- [x] `./out/ap migrate-hetzner --help` shows all six flags + the
      operational-constraints docstring
- [x] `go test -count=1 ./core/migration/hetznermerge/...` passes
      (the moved `handlers_test.go` still runs against the relocated
      handler dispatch table)
- [x] `go run scripts/migration/merge_hetzner_into_gateway --help`
      still works — the standalone CLI is preserved
- [ ] **Pre-merge rehearsal (separate task, runbook open question #6):**
      run `ap-avs migrate-hetzner --dry-run=true` on the staging Railway
      gateway against an rsync'd copy of the production gateway DB +
      the four donor DBs. Confirms the CMD-override mechanism works in
      the Railway environment before the production window opens.

## Out of scope

- The `wsalt:` backfill (already exists as `ap-avs backfill-wallet-salt-index`).
- The Railway CMD-override deploy scripts (lives in avs-infra runbook).
- Donor upload tooling (manual `rsync` per the runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
