### PR TITLE
fix: validateWalletOwnership uses per-chain SmartWalletConfig

### DIFF
--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -855,16 +855,39 @@ func sanitizeInterface(x interface{}) interface{} {
 	}
 }
 
+// resolveSmartWalletConfig returns the per-chain smart-wallet config when
+// the executor is wired to a gateway-mode engine, falling back to the
+// executor's default config in single-chain mode (or when called without
+// an engine, e.g. tests). The shared async executor created at aggregator
+// startup carries the gateway-default config; a multi-chain task whose
+// validation calls reach the factory must use the TASK's chain config
+// (different chain → different factory address → different derived
+// wallet), otherwise validateDerivedWallet derives against the wrong
+// chain and the RPC- fallback path always misses.
+func (x *WorkflowExecutor) resolveSmartWalletConfig(chainID int64) *config.SmartWalletConfig {
+	if x.engine != nil {
+		if cfg := x.engine.ResolveSmartWalletConfig(chainID); cfg != nil {
+			return cfg
+		}
+	}
+	return x.smartWalletConfig
+}
+
 // validateWalletOwnership performs comprehensive wallet ownership validation
 // This handles default wallets (salt:0), stored wallets, and legitimately derived wallets
 func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.User, smartWalletAddr common.Address) (bool, error) {
-	// Step 1: Load the user's default smart wallet address (salt:0) for comparison
-	if x.smartWalletConfig != nil && x.smartWalletConfig.EthRpcUrl != "" {
-		if rpcClient, err := ethclient.Dial(x.smartWalletConfig.EthRpcUrl); err == nil {
+	swCfg := x.resolveSmartWalletConfig(chainID)
+
+	// Step 1: Load the user's default smart wallet address (salt:0) for comparison.
+	// Must use the task's chain config — deriving against the gateway's default
+	// chain factory produces a different wallet than the task's chain factory
+	// and the comparison will spuriously miss.
+	if swCfg != nil && swCfg.EthRpcUrl != "" {
+		if rpcClient, err := ethclient.Dial(swCfg.EthRpcUrl); err == nil {
 			// Load the default smart wallet address (salt:0)
 			if err := user.LoadDefaultSmartWallet(rpcClient); err != nil {
 				x.logger.Warn("Failed to load default smart wallet for validation",
-					"owner", user.Address.Hex(), "error", err)
+					"owner", user.Address.Hex(), "chain_id", chainID, "error", err)
 			}
 			rpcClient.Close()
 		}
@@ -875,19 +898,21 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 		return true, nil
 	} else if err != nil {
 		x.logger.Debug("ValidWalletOwner check failed", "owner", user.Address.Hex(),
-			"wallet", smartWalletAddr.Hex(), "error", err)
+			"wallet", smartWalletAddr.Hex(), "chain_id", chainID, "error", err)
 	}
 
-	// Step 3: Enhanced validation - check if this is a legitimately derived wallet
-	// This handles cases where the wallet was derived but not stored in the database
-	if x.smartWalletConfig != nil && x.smartWalletConfig.EthRpcUrl != "" {
-		if isValid, err := x.validateDerivedWallet(user.Address, smartWalletAddr); err == nil && isValid {
+	// Step 3: Enhanced validation - check if this is a legitimately derived wallet.
+	// Handles factory-upgrade scenarios where the original wallet record was
+	// never written for the post-upgrade derived address. MUST use the task's
+	// per-chain config — see resolveSmartWalletConfig above.
+	if swCfg != nil && swCfg.EthRpcUrl != "" {
+		if isValid, err := x.validateDerivedWallet(swCfg, user.Address, smartWalletAddr); err == nil && isValid {
 			x.logger.Info("Wallet validated as legitimate derived wallet",
-				"owner", user.Address.Hex(), "wallet", smartWalletAddr.Hex())
+				"owner", user.Address.Hex(), "wallet", smartWalletAddr.Hex(), "chain_id", chainID)
 			return true, nil
 		} else if err != nil {
 			x.logger.Debug("Derived wallet validation failed", "owner", user.Address.Hex(),
-				"wallet", smartWalletAddr.Hex(), "error", err)
+				"wallet", smartWalletAddr.Hex(), "chain_id", chainID, "error", err)
 		}
 	}
 
@@ -895,19 +920,22 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 }
 
 // validateDerivedWallet checks if a wallet address can be legitimately derived
-// from the owner using the configured factory (for any salt value)
-func (x *WorkflowExecutor) validateDerivedWallet(owner common.Address, smartWalletAddr common.Address) (bool, error) {
-	rpcClient, err := ethclient.Dial(x.smartWalletConfig.EthRpcUrl)
+// from the owner using the supplied chain's factory (for any salt value).
+// The swCfg argument is the per-chain config resolved by the caller —
+// passing it in (rather than reading x.smartWalletConfig) is what makes
+// this work in gateway mode where the executor is shared across chains.
+func (x *WorkflowExecutor) validateDerivedWallet(swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
+	rpcClient, err := ethclient.Dial(swCfg.EthRpcUrl)
 	if err != nil {
 		return false, fmt.Errorf("failed to connect to RPC: %w", err)
 	}
 	defer rpcClient.Close()
 
-	factoryAddr := x.smartWalletConfig.FactoryAddress
+	factoryAddr := swCfg.FactoryAddress
 
 	// Try salt values from 0 to max_wallets_per_owner to see if any produce the target wallet address
 	// This uses the configured limit from aggregator.yaml
-	maxWallets := int64(x.smartWalletConfig.MaxWalletsPerOwner)
+	maxWallets := int64(swCfg.MaxWalletsPerOwner)
 
 	for salt := int64(0); salt < maxWallets; salt++ {
 		derivedAddr, err := aa.GetSenderAddressForFactory(rpcClient, owner, factoryAddr, big.NewInt(salt))

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -863,7 +863,7 @@ func sanitizeInterface(x interface{}) interface{} {
 // validation calls reach the factory must use the TASK's chain config
 // (different chain → different factory address → different derived
 // wallet), otherwise validateDerivedWallet derives against the wrong
-// chain and the RPC- fallback path always misses.
+// chain and the RPC-derive fallback path always misses.
 func (x *WorkflowExecutor) resolveSmartWalletConfig(chainID int64) *config.SmartWalletConfig {
 	if x.engine != nil {
 		if cfg := x.engine.ResolveSmartWalletConfig(chainID); cfg != nil {

--- a/scripts/dev/inspect_donor/main.go
+++ b/scripts/dev/inspect_donor/main.go
@@ -1,0 +1,49 @@
+// Tiny one-off BadgerDB inspector. Opens a Badger directory read-only
+// and prints keys matching a prefix. Used to confirm what migrate-hetzner
+// wrote vs what the validator expects.
+//
+//	go run ./scripts/dev/inspect_donor <db_path> <prefix>
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	badger "github.com/dgraph-io/badger/v4"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		log.Fatalf("usage: %s <db_path> <prefix>", os.Args[0])
+	}
+	dbPath := os.Args[1]
+	prefix := []byte(os.Args[2])
+
+	opts := badger.DefaultOptions(dbPath).WithLogger(nil).WithReadOnly(true)
+	db, err := badger.Open(opts)
+	if err != nil {
+		log.Fatalf("open %s: %v", dbPath, err)
+	}
+	defer db.Close()
+
+	count := 0
+	err = db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			k := string(it.Item().KeyCopy(nil))
+			fmt.Println(k)
+			count++
+			if count > 500 {
+				fmt.Fprintln(os.Stderr, "(truncated at 500 keys)")
+				break
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("iter: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "%d keys with prefix %q\n", count, string(prefix))
+}

--- a/scripts/dev/inspect_donor/main.go
+++ b/scripts/dev/inspect_donor/main.go
@@ -27,18 +27,23 @@ func main() {
 	}
 	defer db.Close()
 
+	const maxKeys = 500
+	// Keys-only scan — skip value prefetch so the iterator doesn't pull
+	// payload bytes off disk for every match (the tool prints only keys).
+	iterOpts := badger.DefaultIteratorOptions
+	iterOpts.PrefetchValues = false
 	count := 0
 	err = db.View(func(txn *badger.Txn) error {
-		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		it := txn.NewIterator(iterOpts)
 		defer it.Close()
 		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if count >= maxKeys {
+				fmt.Fprintf(os.Stderr, "(truncated at %d keys)\n", maxKeys)
+				break
+			}
 			k := string(it.Item().KeyCopy(nil))
 			fmt.Println(k)
 			count++
-			if count > 500 {
-				fmt.Fprintln(os.Stderr, "(truncated at 500 keys)")
-				break
-			}
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary

Fixes the post-merge production regression where 12 cron tasks on
**ethereum mainnet** continue to fail with `task smart wallet address
does not belong to owner` even after the 2026-06-05 Hetzner→Railway
data merge brought in all available wallet records.

**Root cause: multi-chain bug in `validateWalletOwnership`.** The
async (queue-driven) `WorkflowExecutor` is created once at aggregator
startup (`aggregator/task_engine.go:175`) with the
gateway-DEFAULT `SmartWalletConfig` (i.e. whatever `chains[0]` is —
sepolia in the Railway production config). All cron-task executions
go through that single shared executor regardless of their chain.
Both `validateWalletOwnership` Step 1 (`LoadDefaultSmartWallet`) and
Step 3 (`validateDerivedWallet`) were calling `x.smartWalletConfig`
directly — so for any task whose chain isn't `chains[0]`, both the
default-wallet derive AND the RPC-derive fallback compute against the
WRONG chain's factory and miss.

The 12 failing tasks are all the same shape: a factory upgrade on
ethereum mainnet left them referencing post-upgrade derived wallet
addresses that the OLD aggregator never wrote as primary `w:` records.
Pre-#543's chain-implicit storage masked the bug (Step 2 succeeded
for any chain). Post-#543 strict chain-scoped lookup catches it, and
the RPC-derive fallback that exists EXACTLY to handle this case was
broken for non-default chains.

## Changes

- **`core/taskengine/executor.go`**
  - New helper `resolveSmartWalletConfig(chainID)` on `WorkflowExecutor`:
    consults `engine.ResolveSmartWalletConfig(chainID)` when wired to
    a gateway-mode engine, falls back to `x.smartWalletConfig` in
    single-chain mode (or in tests with no engine).
  - `validateWalletOwnership` resolves the per-chain config once at
    the top and uses it for Step 1 (`LoadDefaultSmartWallet`) AND
    Step 3 (`validateDerivedWallet`).
  - `validateDerivedWallet` now takes the per-chain `SmartWalletConfig`
    as an explicit parameter (instead of reading `x.smartWalletConfig`),
    making chain correctness obvious at the call site.
  - All four affected log lines now include `chain_id` so future
    failures of this shape are easier to triage from operator-side
    logs.

- **`scripts/dev/inspect_donor/main.go`** — small one-off BadgerDB
  prefix-iterator used to diagnose this bug (confirmed the failing
  wallet `0xf81be…` was absent from the donor for owner `0x804e49`,
  which is what pointed us at the factory-upgrade scenario). Kept
  under `scripts/dev/` for future ad-hoc DB debugging.

## Why this isn't covered by an existing test

The validateDerivedWallet path is RPC-dependent — it needs a live
chain to derive. The existing `validation_test.go` only exercises
the Step 2 DB-lookup path with `chainID=1` against a memory DB.
Adding a gateway-mode multi-chain test would require either a mock
of `Engine.ResolveSmartWalletConfig` or an RPC mock; both are
worthwhile follow-ups but out of scope for this hotfix.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 -run 'TestValid|TestExecutor|TestWallet' ./core/taskengine/...` passes (9.9s)
- [ ] **Production smoke after merge + dev-docker rebuild + redeploy**:
      tail `railway logs --service gateway` for 10 min and confirm:
      - the 12 task IDs that were failing every ~30s emit
        `[INFO] Wallet validated as legitimate derived wallet`
        on their next execution (Step 3 hit)
      - `error="task smart wallet address does not belong to owner"`
        drops to zero
      - new task creation/execution still works on all four chains
        (no false-negative on legitimate wallets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
