### PR TITLE
ci: require git_tag = published GitHub release for publish-prod-docker

### DIFF
--- a/.github/scripts/promote-and-publish.sh
+++ b/.github/scripts/promote-and-publish.sh
@@ -265,12 +265,15 @@ if [ "$SKIP_DOCKER" = false ]; then
     # Wait between workflows to avoid rate limiting
     sleep 2
     
-    # Trigger production Docker workflow
+    # Trigger production Docker workflow.
+    # The prod workflow only accepts `git_tag` (REQUIRED — must be a published
+    # GitHub release) and `tag_latest`. Branch/commit-only paths were removed
+    # so version.semver always matches a real release tag — see the workflow's
+    # top-of-file comment for rationale.
     echo -e "${BLUE}   🏭 Production Docker build...${NC}"
     gh workflow run "publish-prod-docker.yml" \
         --repo "$REPO" \
         --field git_tag="$DOCKER_RELEASE" \
-        --field branch_name="main" \
         --field tag_latest="$TAG_LATEST"
     
     if [ $? -eq 0 ]; then

--- a/.github/scripts/promote-and-publish.sh
+++ b/.github/scripts/promote-and-publish.sh
@@ -266,10 +266,18 @@ if [ "$SKIP_DOCKER" = false ]; then
     sleep 2
     
     # Trigger production Docker workflow.
-    # The prod workflow only accepts `git_tag` (REQUIRED — must be a published
-    # GitHub release) and `tag_latest`. Branch/commit-only paths were removed
-    # so version.semver always matches a real release tag — see the workflow's
-    # top-of-file comment for rationale.
+    # The prod workflow only accepts `git_tag` (REQUIRED — must be a published,
+    # non-draft, non-prerelease GitHub release) and `tag_latest`. Skip dispatch
+    # entirely when DOCKER_RELEASE is a pre-release (e.g. user chose to publish
+    # without promoting the pre-release) — the workflow would reject it anyway,
+    # but skipping avoids a misleading "✅ workflow triggered" line followed by
+    # a CI failure.
+    if [[ ! "$DOCKER_RELEASE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo -e "${YELLOW}   ⏭️  Skipping prod Docker build: ${DOCKER_RELEASE} looks like a pre-release.${NC}"
+        echo -e "${YELLOW}      Prod images must come from a full release tag (vX.Y.Z). Promote the${NC}"
+        echo -e "${YELLOW}      pre-release first via this script's promotion step, then re-run.${NC}"
+        DOCKER_SUCCESS=false
+    else
     echo -e "${BLUE}   🏭 Production Docker build...${NC}"
     gh workflow run "publish-prod-docker.yml" \
         --repo "$REPO" \
@@ -287,6 +295,7 @@ if [ "$SKIP_DOCKER" = false ]; then
         echo -e "${RED}   ❌ Failed to trigger production Docker workflow for ${DOCKER_RELEASE}${NC}"
         DOCKER_SUCCESS=false
     fi
+    fi  # close the prerelease-skip guard
 else
     echo -e "${BLUE}⏭️  Skipping Docker publishing${NC}"
     DOCKER_SUCCESS=true

--- a/.github/workflows/publish-prod-docker.yml
+++ b/.github/workflows/publish-prod-docker.yml
@@ -1,23 +1,35 @@
 name: Publish Production Docker Image
 
+# Source-of-truth rule:
+#
+#   The image's `version.semver` (which operators report via /telemetry)
+#   MUST equal a published GitHub release tag. There is no path through
+#   this workflow that produces a "main-<sha>" or commit-only RELEASE_TAG —
+#   that would mislabel operator telemetry and make support harder.
+#
+# Trigger paths:
+#
+#   1. `./scripts/release.sh` (the canonical release flow) — promotes the
+#      latest semantic-release pre-release tag to a full GitHub release,
+#      then dispatches this workflow with --field git_tag=vX.Y.Z.
+#
+#   2. Manual dashboard dispatch — for back-fills or re-publishes against
+#      an existing release tag. You must type the release tag (e.g. v3.2.0).
+#      Workflow hard-fails if the tag isn't a published GitHub release.
+#
+# If you need to ship something that isn't at a release yet, create the
+# release first (via release.sh or `gh release create`), then dispatch
+# this workflow against the new tag.
+
 on:
   workflow_dispatch:
     inputs:
-      branch_name:
-        description: "Branch to build from (must be main). Used if no git_tag or commit_hash is provided."
-        required: false
-        type: string
-        default: "main"
-      commit_hash:
-        description: "Specific commit SHA to build (optional). Overrides branch_name for checkout if provided. git_tag takes precedence over this."
-        required: false
-        type: string
       git_tag:
-        description: "Specific Git tag to build (e.g., v1.6.0). Overrides commit_hash and branch_name for checkout."
-        required: false
+        description: "Git tag of a published GitHub release (e.g., v3.2.0). REQUIRED — this becomes version.semver in the binary, which operators report via /telemetry."
+        required: true
         type: string
       tag_latest:
-        description: "Automatically tag the image with 'latest' tag in addition to the primary tag."
+        description: "Also push avaprotocol/ap-avs:latest pointing at this image. Set true for the most-recent release; leave false for back-fills."
         required: false
         type: boolean
         default: false
@@ -26,88 +38,82 @@ jobs:
   publish-prod-build:
     name: Publish production docker image to dockerhub
     runs-on: "blacksmith-4vcpu-ubuntu-2404"
+    permissions:
+      contents: read
     steps:
+      - name: Validate git_tag is a published GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.git_tag }}"
+
+          # gh release view returns 0 for non-existent tags AND for draft
+          # releases that exist but haven't been published. Query --json so
+          # we can distinguish them and reject both.
+          META=$(gh release view "$TAG" --repo "${{ github.repository }}" \
+            --json tagName,isDraft,isPrerelease 2>&1) || META=""
+          if [[ -z "$META" ]] || ! echo "$META" | jq empty 2>/dev/null; then
+            echo "::error::git_tag '$TAG' is not a GitHub release at all."
+            FAIL=1
+          else
+            IS_DRAFT=$(echo "$META" | jq -r '.isDraft')
+            IS_PRE=$(echo "$META" | jq -r '.isPrerelease')
+            if [[ "$IS_DRAFT" == "true" ]]; then
+              echo "::error::git_tag '$TAG' is a DRAFT release (not published). Production images must be"
+              echo "::error::built from a published release. Publish the draft first, then re-dispatch."
+              FAIL=1
+            elif [[ "$IS_PRE" == "true" ]]; then
+              # Semantic-release intentionally creates prereleases (rc.N) before
+              # promotion. Refuse to build prod images from those — release.sh
+              # promotes them to full releases first.
+              echo "::error::git_tag '$TAG' is a PRE-RELEASE. Production images must be built from"
+              echo "::error::full releases (semantic-release pre-releases get promoted by release.sh)."
+              FAIL=1
+            fi
+          fi
+
+          if [[ "${FAIL:-0}" == "1" ]]; then
+            echo "::error::"
+            echo "::error::Production images must be built from a published release so version.semver"
+            echo "::error::matches what operators report in /telemetry. To resolve:"
+            echo "::error::"
+            echo "::error::  1. Run ./scripts/release.sh (promotes the latest pre-release to a full release"
+            echo "::error::     and dispatches this workflow automatically), OR"
+            echo "::error::"
+            echo "::error::  2. Pick an existing published release from"
+            echo "::error::     https://github.com/${{ github.repository }}/releases"
+            exit 1
+          fi
+          echo "✓ $TAG is a published (non-draft, non-prerelease) GitHub release"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Checkout code
+      - name: Checkout code at the release tag
         id: checkout_code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.git_tag && format('refs/tags/{0}', github.event.inputs.git_tag) || github.event.inputs.commit_hash || github.event.inputs.branch_name }}
+          ref: refs/tags/${{ inputs.git_tag }}
 
-      - name: Determine Tags and Build Args
+      - name: Resolve build args
         id: vars
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          PRIMARY_DOCKER_TAG=""
-          BRANCH_FOR_CONTEXT="" 
-          RELEASE_TAG_ARG=""
-
-          if [[ -z "${{ github.event.inputs.git_tag }}" && -z "${{ github.event.inputs.commit_hash }}" ]]; then
-            if [[ "${{ github.event.inputs.branch_name }}" != "main" ]]; then
-              echo "Error: Production builds without a git_tag or commit_hash must be from the main branch."
-              exit 1
-            fi
-          fi
-
-          if [[ -n "${{ github.event.inputs.git_tag }}" ]]; then
-            echo "Source: Git Tag (${{ github.event.inputs.git_tag }})"
-            PRIMARY_DOCKER_TAG="${{ github.event.inputs.git_tag }}"
-            RELEASE_TAG_ARG="${{ github.event.inputs.git_tag }}"
-            # BRANCH_FOR_CONTEXT remains empty for git_tag builds to ensure no short SHA tag is added by meta
-          elif [[ -n "${{ github.event.inputs.commit_hash }}" ]]; then
-            echo "Source: Commit SHA (${{ github.event.inputs.commit_hash }})"
-            RAW_BRANCH_CTX="${{ github.event.inputs.branch_name }}" # Should be main for prod if specified with commit
-            SANITIZED_BRANCH_CTX=$(echo "$RAW_BRANCH_CTX" | sed 's|/|-|g' | tr -cs 'a-zA-Z0-9.-_' '-' | sed 's/--\+/-/g' | sed 's/^-*//;s/-*$//')
-            if [[ -n "$SANITIZED_BRANCH_CTX" ]]; then
-              PRIMARY_DOCKER_TAG="$SANITIZED_BRANCH_CTX-$SHORT_SHA"
-              BRANCH_FOR_CONTEXT="$SANITIZED_BRANCH_CTX"
-              RELEASE_TAG_ARG="$SANITIZED_BRANCH_CTX-$SHORT_SHA"
-            else
-              # This case should ideally not be hit if branch validation is effective
-              PRIMARY_DOCKER_TAG="$SHORT_SHA" 
-              RELEASE_TAG_ARG="$SHORT_SHA"
-            fi
-          else
-            # Source: Branch Name (no git_tag, no commit_hash, must be 'main' due to earlier check)
-            RAW_BRANCH_NAME="${{ github.event.inputs.branch_name }}"
-            echo "Source: Branch ($RAW_BRANCH_NAME)"
-            SANITIZED_BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed 's|/|-|g' | tr -cs 'a-zA-Z0-9.-_' '-' | sed 's/--\+/-/g' | sed 's/^-*//;s/-*$//')
-            PRIMARY_DOCKER_TAG="$SANITIZED_BRANCH_NAME-$SHORT_SHA" 
-            BRANCH_FOR_CONTEXT="$SANITIZED_BRANCH_NAME"
-            RELEASE_TAG_ARG="$SANITIZED_BRANCH_NAME-$SHORT_SHA"
-          fi
-
-          echo "PRIMARY_DOCKER_TAG=${PRIMARY_DOCKER_TAG}" >> $GITHUB_OUTPUT
           echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_OUTPUT
-          echo "BRANCH_FOR_CONTEXT=${BRANCH_FOR_CONTEXT}" >> $GITHUB_OUTPUT
-          echo "RELEASE_TAG_ARG=${RELEASE_TAG_ARG}" >> $GITHUB_OUTPUT
 
-          echo "Checked out commit short SHA: $SHORT_SHA"
-          echo "Primary Docker tag will be: $PRIMARY_DOCKER_TAG"
-          echo "Branch context for tagging (if any): $BRANCH_FOR_CONTEXT"
-          echo "RELEASE_TAG build argument will be: $RELEASE_TAG_ARG"
-        shell: bash
-
-      - name: Print Determined Tags and Args
-        run: |
-          echo "---- Debug: Values from vars step (Production Workflow) ----"
-          echo "Primary Docker Tag: ${{ steps.vars.outputs.PRIMARY_DOCKER_TAG }}"
-          echo "Short SHA: ${{ steps.vars.outputs.SHORT_SHA }}"
-          echo "Branch for Context: ${{ steps.vars.outputs.BRANCH_FOR_CONTEXT }}"
-          echo "Release Tag Arg for Build: ${{ steps.vars.outputs.RELEASE_TAG_ARG }}"
-          echo "Tag Latest: ${{ inputs.tag_latest }}"
+          echo "---- Build context ----"
+          echo "Release tag (becomes version.semver): ${{ inputs.git_tag }}"
+          echo "Commit short SHA:                     $SHORT_SHA"
           if [[ "${{ inputs.tag_latest }}" == "true" ]]; then
-            echo "✅ Latest tag will be applied: avaprotocol/ap-avs:latest"
+            echo "✓ Will also push avaprotocol/ap-avs:latest"
           else
-            echo "❌ Latest tag will NOT be applied (default production behavior)"
+            echo "  Will push avaprotocol/ap-avs:${{ inputs.git_tag }} only (not :latest)"
           fi
-          echo "---- End Debug ----"
+          echo "-----------------------"
         shell: bash
 
       - name: Set up QEMU
@@ -122,23 +128,20 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: avaprotocol/ap-avs # Production image name
+          images: avaprotocol/ap-avs
           tags: |
-            # Primary tag (e.g., v1.6.0 or main-<sha>)
-            type=raw,value=${{ steps.vars.outputs.PRIMARY_DOCKER_TAG }}
-
-            # Conditionally add latest tag based on input
+            type=raw,value=${{ inputs.git_tag }}
             ${{ inputs.tag_latest && 'type=raw,value=latest' || '# Latest tag disabled' }}
 
       - name: Build and push production docker image
         uses: useblacksmith/build-push-action@v2
         with:
           build-args: |
-            RELEASE_TAG=${{ steps.vars.outputs.RELEASE_TAG_ARG }}
+            RELEASE_TAG=${{ inputs.git_tag }}
             COMMIT_SHA=${{ steps.vars.outputs.SHORT_SHA }}
           platforms: linux/amd64,linux/arm64
           context: .
-          file: dockerfiles/operator.Dockerfile # Assuming prod also uses operator.Dockerfile
+          file: dockerfiles/operator.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-prod-docker.yml
+++ b/.github/workflows/publish-prod-docker.yml
@@ -45,22 +45,35 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -u
           TAG="${{ inputs.git_tag }}"
 
-          # gh release view returns 0 for non-existent tags AND for draft
-          # releases that exist but haven't been published. Query --json so
-          # we can distinguish them and reject both.
-          META=$(gh release view "$TAG" --repo "${{ github.repository }}" \
-            --json tagName,isDraft,isPrerelease 2>&1) || META=""
-          if [[ -z "$META" ]] || ! echo "$META" | jq empty 2>/dev/null; then
-            echo "::error::git_tag '$TAG' is not a GitHub release at all."
+          # Step 1: existence/auth check. Stderr stays on stderr so an
+          # auth or tool error surfaces verbatim in the Actions log; we
+          # only care about the exit code here.
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null; then
+            # gh exits non-zero for "tag not found" AND for transient
+            # auth/network errors. Don't conflate them — the stderr the
+            # user sees right above will tell them which. The error
+            # message we emit covers the most common case (typo or
+            # unpublished draft).
+            echo "::error::git_tag '$TAG' is not retrievable as a release."
+            echo "::error::This is usually because (a) the tag does not exist, (b) it has only"
+            echo "::error::a draft release that hasn't been published yet, or (c) gh auth/network"
+            echo "::error::issues — see the stderr line(s) immediately above for the exact cause."
             FAIL=1
           else
+            # Step 2: it exists and we could read it. Now fetch the JSON
+            # for the draft/prerelease check. Keep stdout pure JSON
+            # (NO 2>&1) so jq can't be derailed by warnings interleaved
+            # into the stream.
+            META=$(gh release view "$TAG" --repo "${{ github.repository }}" \
+              --json tagName,isDraft,isPrerelease)
             IS_DRAFT=$(echo "$META" | jq -r '.isDraft')
             IS_PRE=$(echo "$META" | jq -r '.isPrerelease')
             if [[ "$IS_DRAFT" == "true" ]]; then
-              echo "::error::git_tag '$TAG' is a DRAFT release (not published). Production images must be"
-              echo "::error::built from a published release. Publish the draft first, then re-dispatch."
+              echo "::error::git_tag '$TAG' is a DRAFT release (not published). Production images must"
+              echo "::error::be built from a published release. Publish the draft first, then re-dispatch."
               FAIL=1
             elif [[ "$IS_PRE" == "true" ]]; then
               # Semantic-release intentionally creates prereleases (rc.N) before


### PR DESCRIPTION
## Summary

Closes the `main-<sha>` operator-telemetry foot-gun. The prod docker workflow had three code paths for `RELEASE_TAG` (which becomes `version.semver` in the binary, and is what operators report in /telemetry):

| Trigger inputs | Resulting `version.semver` |
|---|---|
| `git_tag=v3.2.0` | `v3.2.0` ✓ |
| `commit_hash=abc1234` | `main-abc1234` ✗ |
| only `branch_name=main` (default) | `main-<sha>` ✗ |

When someone dispatched the workflow from the dashboard with just the default inputs (no `git_tag`), it published an image with `version.semver=main-<sha>`. Operators pulling that image (or pulling `:latest` while it pointed at that build) end up reporting `main-0ca0834`-style versions in /telemetry, which doesn't map back to any GitHub release. That makes "which build is operator X actually running" surprisingly hard to answer.

## Changes

- **`.github/workflows/publish-prod-docker.yml`** — `git_tag` is now REQUIRED. Workflow validates it's a published GitHub release (not just a random git tag) before doing anything else. The `commit_hash` and `branch_name` inputs are removed along with their `RELEASE_TAG` derivation paths. Net: there's no syntactic path through the workflow that produces `version.semver=main-<sha>`.

- **`.github/scripts/promote-and-publish.sh`** — drop the now-unused `--field branch_name="main"` from the publish-prod-docker invocation. The release.sh canonical flow continues to work end-to-end.

## Doesn't apply to dev images

`publish-dev-docker.yml` is unchanged. Dev images are intentionally allowed to build from branches (the `:latest` dev tag rolls forward on every staging merge), so `version.semver=main-<sha>` is acceptable there.

## Operator-side impact (zero, by design)

This change only prevents FUTURE non-tagged publishes. Operators currently running `avaprotocol/ap-avs:main-<sha>` continue to work — they just keep reporting the misleading version until they upgrade to `:latest` (which is now `v3.2.0`, properly tagged). The operator outreach committed in `avs-infra@a7f1a31` already asks operators to pull `:latest`.

## Test plan

- [x] Workflow YAML syntactically valid (`gh workflow view publish-prod-docker.yml --yaml` parses)
- [x] `./scripts/release.sh` still wires correctly: it already passes `--field git_tag="$DOCKER_RELEASE"` (verified) and the now-removed `--field branch_name="main"` has been dropped from promote-and-publish.sh
- [ ] **Post-merge sanity** (you do this on the next release):
  1. Make a release via `./scripts/release.sh`
  2. Confirm publish-prod-docker run shows "✓ vX.Y.Z is a published GitHub release" in its first step
  3. Confirm the resulting image's `version.semver` matches the release tag (`docker run --rm avaprotocol/ap-avs:vX.Y.Z --version` or hit /telemetry)
- [ ] **Post-merge dashboard sanity**: trying to dispatch the workflow without filling in `git_tag` should now error out at the "Validate git_tag is a published GitHub release" step with a clear pointer to release.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
