### PR TITLE
chore: derive version semver from git tag at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,18 @@ RUN go mod download
 # Copy source
 COPY . .
 
-# Build with version info
-ARG GIT_REVISION=unknown
-RUN go build \
-    -o ./ap \
-    -ldflags "-X github.com/AvaProtocol/EigenLayer-AVS/version.revision=${GIT_REVISION}"
+# Build with version metadata. SEMVER + REVISION are derived from git
+# inside the builder (the build context retains .git — see .dockerignore).
+# CI workflows can still inject explicit overrides via --build-arg, e.g.
+# `docker build --build-arg SEMVER=3.2.0 --build-arg REVISION=abc1234`.
+ARG SEMVER=
+ARG REVISION=
+RUN SEMVER="${SEMVER:-$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo dev)}" && \
+    REVISION="${REVISION:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}" && \
+    echo "Building with semver=${SEMVER} revision=${REVISION}" && \
+    go build \
+      -o ./ap \
+      -ldflags "-X 'github.com/AvaProtocol/EigenLayer-AVS/version.semver=${SEMVER}' -X 'github.com/AvaProtocol/EigenLayer-AVS/version.revision=${REVISION}'"
 
 # Runtime image
 FROM debian:bookworm-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ COPY . .
 # `docker build --build-arg SEMVER=3.2.0 --build-arg REVISION=abc1234`.
 ARG SEMVER=
 ARG REVISION=
-RUN SEMVER="${SEMVER:-$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo dev)}" && \
-    REVISION="${REVISION:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}" && \
+RUN _git_tag=$(git describe --tags --abbrev=0 2>/dev/null); \
+    SEMVER="${SEMVER:-$([ -n "${_git_tag}" ] && echo "${_git_tag#v}" || echo dev)}"; \
+    REVISION="${REVISION:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"; \
     echo "Building with semver=${SEMVER} revision=${REVISION}" && \
     go build \
       -o ./ap \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BINARY_NAME ?= ap
 # when git is missing or there are no tags (e.g. a CI shallow-clone).
 #
 # Override from the environment when needed: `make build SEMVER=4.0.0`.
-SEMVER ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo dev)
+SEMVER ?= $(shell _tag=$$(git describe --tags --abbrev=0 2>/dev/null); [ -n "$$_tag" ] && echo "$$_tag" | sed 's/^v//' || echo dev)
 REVISION ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 VERSION_LDFLAGS := -X 'github.com/AvaProtocol/EigenLayer-AVS/version.semver=$(SEMVER)' -X 'github.com/AvaProtocol/EigenLayer-AVS/version.revision=$(REVISION)'
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,16 @@ ROOT_DIR := $(shell pwd)
 MAIN_PACKAGE_PATH ?= ./
 BINARY_NAME ?= ap
 
+# Version metadata stamped into the binary via -ldflags. Derived from git
+# so /health and telemetry reflect the actual checkout instead of the
+# stale default in version/version.go. Both fields fall back gracefully
+# when git is missing or there are no tags (e.g. a CI shallow-clone).
+#
+# Override from the environment when needed: `make build SEMVER=4.0.0`.
+SEMVER ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo dev)
+REVISION ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+VERSION_LDFLAGS := -X 'github.com/AvaProtocol/EigenLayer-AVS/version.semver=$(SEMVER)' -X 'github.com/AvaProtocol/EigenLayer-AVS/version.revision=$(REVISION)'
+
 # ==================================================================================== #
 # HELPERS
 # ==================================================================================== #
@@ -81,7 +91,7 @@ endif
 ## build-prod: build the application for production
 .PHONY: build-prod
 build-prod:
-	go build -ldflags="-X 'github.com/AvaProtocol/EigenLayer-AVS/version.semver=dev' -X 'github.com/AvaProtocol/EigenLayer-AVS/version.revision=dev'" -o=/tmp/bin/${BINARY_NAME} ${MAIN_PACKAGE_PATH}
+	go build -ldflags="$(VERSION_LDFLAGS)" -o=/tmp/bin/${BINARY_NAME} ${MAIN_PACKAGE_PATH}
 
 .PHONY: run
 run: build-prod
@@ -164,7 +174,7 @@ build:
 	mkdir out || true
 	go build \
 		-o ./out/ap \
-    	-ldflags "-X github.com/AvaProtocol/EigenLayer-AVS/version.revision=$(shell  git rev-parse HEAD)"
+		-ldflags "$(VERSION_LDFLAGS)"
 
 ## aggregator: show usage for aggregator commands
 .PHONY: aggregator aggregator-sepolia aggregator-ethereum aggregator-base aggregator-base-sepolia

--- a/version/version.go
+++ b/version/version.go
@@ -1,12 +1,16 @@
 package version
 
 var (
-	// Bumped manually on each release to match the current main tag — see
-	// docs/Release.md. ldflags overrides this for properly-built Docker
-	// images (publish-prod-docker.yml), but Railway's source-build path
-	// does not pass -ldflags, so this default is what telemetry/health
-	// endpoints report for Railway-deployed services.
-	semver   = "3.0.0"
+	// Default values stamped into the binary when -ldflags doesn't
+	// override them. Both Makefile targets (`make build`, `make build-prod`)
+	// and the Dockerfile now derive these from `git describe` / `git rev-parse`
+	// at compile time, so these defaults only fire when the build path
+	// bypasses both (e.g. a one-off `go build ./...` without ldflags).
+	//
+	// Keep `semver` here roughly in sync with the latest release tag as a
+	// safety net — if a build slips through without ldflags, /health will
+	// still report something plausible rather than ancient history.
+	semver   = "3.2.0"
 	revision = "unknown"
 )
 


### PR DESCRIPTION
## Summary

Fixes the stale-version bug surfaced by Position D's wallet-popup display. The chain of stale was:

1. `version/version.go` hardcoded `semver = "3.0.0"` as the source-level default
2. `make build` only injected `-X version.revision`, never `-X version.semver`
3. `Dockerfile` likewise only consumed `ARG GIT_REVISION`, never a semver build-arg
4. Railway's source-build path (no Makefile, no ldflags overrides) therefore reported `version: "3.0.0"` for every release from v3.0.0 through v3.2.0

Position D's SDK now stamps the user's signed message with whatever `/health` returns. So a stale version isn't only a telemetry annoyance anymore — it shows up in the wallet popup of every user who signs in. Real production gateways were telling users they were signing against `3.0.0` when they were actually talking to v3.2.0.

## The fix in three places

So the default value never has to be the right answer:

| File | Change |
|---|---|
| `Makefile` | New `SEMVER` + `REVISION` vars derived from `git describe --tags --abbrev=0` and `git rev-parse --short HEAD` (with `echo dev`/`echo unknown` fallbacks). Shared `VERSION_LDFLAGS` consumed by both `build` and `build-prod` targets — can't drift apart. Override-friendly: `make build SEMVER=4.0.0` still works. |
| `Dockerfile` | Same derivation runs inside the builder stage (`.git` is in the build context per `.dockerignore`). Optional `ARG SEMVER` / `ARG REVISION` let CI inject explicit overrides via `--build-arg`, but the no-arg path does the right thing — which is the path Railway uses today. |
| `version/version.go` | Default bumped `3.0.0` → `3.2.0` as a safety net for builds that bypass both Makefile and Dockerfile (e.g. a one-off `go build ./...`). Comment now describes the actual policy. |

## Verification

```bash
$ make -n build
go build -o ./out/ap -ldflags "-X 'github.com/AvaProtocol/EigenLayer-AVS/version.semver=3.2.0' -X 'github.com/AvaProtocol/EigenLayer-AVS/version.revision=212dc07'"

$ make build
$ go version -m ./out/ap | grep ldflags
  build  -ldflags="-X 'github.com/AvaProtocol/EigenLayer-AVS/version.semver=3.2.0' -X 'github.com/AvaProtocol/EigenLayer-AVS/version.revision=212dc07'"

$ ./out/ap aggregator --config=config/gateway-dev.yaml &
$ curl -s http://localhost:8080/api/v1/health
{"chainId":11155111,"status":"ok","version":"3.2.0"}
```

(was `"version":"3.0.0"` pre-fix.)

## Test plan

- [x] `make -n build` shows the derived ldflags
- [x] `make build` produces a binary stamped with both via `go version -m`
- [x] Local `/health` returns `3.2.0` after rebuild
- [ ] Railway redeploy of staging — verify `/health` reports the actual gateway version (whatever `git describe` says on the deploy commit), not the hardcoded `3.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
