### PR TITLE
fix: emit canonical REST camelCase values for NodeCOGS / ValueFee enums

### DIFF
--- a/aggregator/rest/mapping/fee_enums_drift_test.go
+++ b/aggregator/rest/mapping/fee_enums_drift_test.go
@@ -1,0 +1,86 @@
+package mapping
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+)
+
+// TestFeeEnumsDriftFromOpenAPI guards the engine-side canonical
+// enum constants (core/taskengine/fee_enums.go) against the
+// OpenAPI-generated REST enum types in this package's `generated`
+// sibling. If either side adds/removes/renames a value, this test
+// fails — which is the intended catch.
+//
+// Background: NodeCOGS.cost_type, ValueFee.classification_method,
+// and FeeDiscount.discount_type are declared as protobuf `string`
+// fields, not protobuf enums. protojson camelCases field NAMES but
+// passes field VALUES through verbatim. So the canonical wire
+// value is whatever the engine literally writes into the field —
+// and the only way to keep that aligned with the REST contract
+// (which DOES typed-enum these fields) is to source the strings
+// from one canonical place and assert the sets match.
+func TestFeeEnumsDriftFromOpenAPI(t *testing.T) {
+	cases := []struct {
+		name    string
+		openAPI []string
+		engine  []string
+	}{
+		{
+			name: "NodeCOGS.costType",
+			openAPI: []string{
+				string(generated.Gas),
+				string(generated.ExternalApi),
+				string(generated.WalletCreation),
+			},
+			engine: []string{
+				taskengine.CostTypeGas,
+				taskengine.CostTypeExternalAPI,
+				taskengine.CostTypeWalletCreation,
+			},
+		},
+		{
+			name: "ValueFee.classificationMethod",
+			openAPI: []string{
+				string(generated.RuleBased),
+				string(generated.Llm),
+			},
+			engine: []string{
+				taskengine.ClassificationMethodRuleBased,
+				taskengine.ClassificationMethodLLM,
+			},
+		},
+		{
+			name: "FeeDiscount.discountType",
+			openAPI: []string{
+				string(generated.NewUser),
+				string(generated.Volume),
+				string(generated.Promotional),
+				string(generated.BetaProgram),
+			},
+			engine: []string{
+				taskengine.DiscountTypeNewUser,
+				taskengine.DiscountTypeVolume,
+				taskengine.DiscountTypePromotional,
+				taskengine.DiscountTypeBetaProgram,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			openAPI := append([]string(nil), c.openAPI...)
+			engine := append([]string(nil), c.engine...)
+			sort.Strings(openAPI)
+			sort.Strings(engine)
+			assert.Equal(t, openAPI, engine,
+				"%s: engine constants in core/taskengine/fee_enums.go diverged from OpenAPI enum in api/openapi.yaml. Update one side to match.",
+				c.name,
+			)
+		})
+	}
+}

--- a/aggregator/rest/mapping/fee_enums_drift_test.go
+++ b/aggregator/rest/mapping/fee_enums_drift_test.go
@@ -1,10 +1,15 @@
 package mapping
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
@@ -82,5 +87,69 @@ func TestFeeEnumsDriftFromOpenAPI(t *testing.T) {
 				c.name,
 			)
 		})
+	}
+}
+
+// TestFeeEnumsDriftCountFromGeneratedSource parses the OpenAPI-generated
+// types file directly and confirms the explicit enumeration in
+// TestFeeEnumsDriftFromOpenAPI above covers EVERY const of each typed
+// enum the spec declares — not just the ones a maintainer remembered
+// to list.
+//
+// Without this count check, OpenAPI could grow a new value (e.g. add
+// "studentDiscount" to FeeDiscountDiscountType), regen
+// aggregator/rest/generated, and the value-level drift test above
+// would keep passing — silently, because nobody added it to the
+// explicit slice. This test catches that by counting `const`
+// declarations of each typed enum and comparing to what the value
+// test enumerates.
+func TestFeeEnumsDriftCountFromGeneratedSource(t *testing.T) {
+	fset := token.NewFileSet()
+	src := filepath.Join("..", "generated", "types.gen.go")
+	file, err := parser.ParseFile(fset, src, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "failed to parse %s", src)
+
+	// Expected count per typed enum — must match the explicit slices
+	// above. Update both together.
+	targets := map[string]int{
+		"NodeCOGSCostType":             3, // gas, externalApi, walletCreation
+		"ValueFeeClassificationMethod": 2, // ruleBased, llm
+		"FeeDiscountDiscountType":      4, // newUser, volume, promotional, betaProgram
+	}
+	found := map[string]int{}
+
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		// Const specs in the same group inherit the previous spec's
+		// type when omitted (canonical Go behavior). The generated file
+		// today spells the type on every spec, but track lastType in
+		// case the generator changes.
+		var lastType string
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			if vs.Type != nil {
+				if id, ok := vs.Type.(*ast.Ident); ok {
+					lastType = id.Name
+				} else {
+					lastType = ""
+				}
+			}
+			if _, isTarget := targets[lastType]; isTarget {
+				found[lastType] += len(vs.Names)
+			}
+		}
+	}
+
+	for name, expected := range targets {
+		assert.Equalf(t, expected, found[name],
+			"%s has %d const(s) in aggregator/rest/generated/types.gen.go but TestFeeEnumsDriftFromOpenAPI enumerates %d. Update BOTH the engine constants in core/taskengine/fee_enums.go AND the explicit slices in TestFeeEnumsDriftFromOpenAPI above (and bump the count in `targets`).",
+			name, found[name], expected,
+		)
 	}
 }

--- a/core/taskengine/fee_enums.go
+++ b/core/taskengine/fee_enums.go
@@ -14,7 +14,9 @@ package taskengine
 // sets in aggregator/rest/generated.
 
 // CostType values for NodeCOGS.cost_type. Mirrors the OpenAPI enum
-// NodeCOGSCostType in api/openapi.yaml.
+// NodeCOGSCostType in api/openapi.yaml. CostTypeExternalAPI has no
+// emit sites yet — declared here so the future restApi/graphql-cost
+// path picks the right value the first time.
 const (
 	CostTypeGas            = "gas"
 	CostTypeExternalAPI    = "externalApi"

--- a/core/taskengine/fee_enums.go
+++ b/core/taskengine/fee_enums.go
@@ -1,0 +1,40 @@
+package taskengine
+
+// Canonical string values for the proto-string-typed enum fields the
+// fee estimator emits into NodeCOGS, ValueFee, and FeeDiscount. These
+// values are the wire format the REST surface advertises in
+// api/openapi.yaml (e.g. NodeCOGS.costType ∈ {gas, externalApi,
+// walletCreation}). Field NAMES are camelCased automatically by
+// protojson on the way out; field VALUES are passed through
+// verbatim, so any engine emit site has to spell the canonical
+// camelCase form itself — there's no implicit translation layer.
+//
+// The aggregator/rest/mapping package owns a drift-check test that
+// fails the build if these diverge from the OpenAPI-generated enum
+// sets in aggregator/rest/generated.
+
+// CostType values for NodeCOGS.cost_type. Mirrors the OpenAPI enum
+// NodeCOGSCostType in api/openapi.yaml.
+const (
+	CostTypeGas            = "gas"
+	CostTypeExternalAPI    = "externalApi"
+	CostTypeWalletCreation = "walletCreation"
+)
+
+// ClassificationMethod values for ValueFee.classification_method.
+// Mirrors the OpenAPI enum ValueFeeClassificationMethod.
+const (
+	ClassificationMethodRuleBased = "ruleBased"
+	ClassificationMethodLLM       = "llm"
+)
+
+// DiscountType values for FeeDiscount.discount_type. Mirrors the
+// OpenAPI enum FeeDiscountDiscountType. No emit sites today
+// (Discounts is always returned as an empty slice), but constants
+// land here so future wiring spells the right value the first time.
+const (
+	DiscountTypeNewUser     = "newUser"
+	DiscountTypeVolume      = "volume"
+	DiscountTypePromotional = "promotional"
+	DiscountTypeBetaProgram = "betaProgram"
+)

--- a/core/taskengine/fee_estimator.go
+++ b/core/taskengine/fee_estimator.go
@@ -202,7 +202,7 @@ func (fe *FeeEstimator) EstimateFees(ctx context.Context, req *avsproto.Estimate
 	if walletCreationNeeded {
 		cogs = append(cogs, &avsproto.NodeCOGS{
 			NodeId:   "_wallet_creation",
-			CostType: "wallet_creation",
+			CostType: CostTypeWalletCreation,
 			Fee:      &avsproto.Fee{Amount: walletCreationGasWei.String(), Unit: "WEI"},
 		})
 	}
@@ -377,7 +377,7 @@ func (fe *FeeEstimator) estimateCOGS(ctx context.Context, req *avsproto.Estimate
 		if gasResult != nil {
 			cogsList = append(cogsList, &avsproto.NodeCOGS{
 				NodeId:   gasResult.NodeID,
-				CostType: "gas",
+				CostType: CostTypeGas,
 				Fee:      &avsproto.Fee{Amount: gasResult.TotalCost.String(), Unit: "WEI"},
 				GasUnits: gasResult.GasUnits.String(),
 			})
@@ -511,7 +511,7 @@ func (fe *FeeEstimator) classifyWorkflowValue(req *avsproto.EstimateFeesReq) *av
 			Fee:                  &avsproto.Fee{Amount: "0", Unit: "PERCENTAGE"},
 			Tier:                 avsproto.ExecutionTier_EXECUTION_TIER_UNSPECIFIED,
 			ValueBase:            "",
-			ClassificationMethod: "rule_based",
+			ClassificationMethod: ClassificationMethodRuleBased,
 			Confidence:           1.0,
 			Reason:               "Workflow has no on-chain execution nodes — no value-capture fee",
 		}
@@ -523,7 +523,7 @@ func (fe *FeeEstimator) classifyWorkflowValue(req *avsproto.EstimateFeesReq) *av
 		Fee:                  &avsproto.Fee{Amount: fmt.Sprintf("%.2f", fe.feeRates.Tier1FeePercentage), Unit: "PERCENTAGE"},
 		Tier:                 avsproto.ExecutionTier_EXECUTION_TIER_1,
 		ValueBase:            "input_token_value",
-		ClassificationMethod: "rule_based",
+		ClassificationMethod: ClassificationMethodRuleBased,
 		Confidence:           1.0,
 		Reason:               "V1 default: workflow contains on-chain execution nodes",
 	}
@@ -604,7 +604,7 @@ func buildValueFee(nodes []*avsproto.TaskNode, feeRatesConfig *config.FeeRatesCo
 		return &avsproto.ValueFee{
 			Fee:                  &avsproto.Fee{Amount: "0", Unit: "PERCENTAGE"},
 			Tier:                 avsproto.ExecutionTier_EXECUTION_TIER_UNSPECIFIED,
-			ClassificationMethod: "rule_based",
+			ClassificationMethod: ClassificationMethodRuleBased,
 			Confidence:           1.0,
 			Reason:               "Workflow has no on-chain execution nodes",
 		}
@@ -614,7 +614,7 @@ func buildValueFee(nodes []*avsproto.TaskNode, feeRatesConfig *config.FeeRatesCo
 		Fee:                  &avsproto.Fee{Amount: fmt.Sprintf("%.2f", rates.Tier1FeePercentage), Unit: "PERCENTAGE"},
 		Tier:                 avsproto.ExecutionTier_EXECUTION_TIER_1,
 		ValueBase:            "input_token_value",
-		ClassificationMethod: "rule_based",
+		ClassificationMethod: ClassificationMethodRuleBased,
 		Confidence:           1.0,
 		Reason:               "V1 default: workflow contains on-chain execution nodes",
 	}
@@ -640,7 +640,7 @@ func buildCOGSFromSteps(steps []*avsproto.Execution_Step) []*avsproto.NodeCOGS {
 
 		cogsList = append(cogsList, &avsproto.NodeCOGS{
 			NodeId:   step.Id,
-			CostType: "gas",
+			CostType: CostTypeGas,
 			Fee:      &avsproto.Fee{Amount: step.TotalGasCost, Unit: "WEI"},
 			GasUnits: step.GasUsed,
 		})

--- a/core/taskengine/fee_estimator_test.go
+++ b/core/taskengine/fee_estimator_test.go
@@ -209,7 +209,7 @@ func TestClassifyWorkflowValue_WithOnChainNodes(t *testing.T) {
 	assert.Equal(t, "0.03", valueFee.Fee.Amount)
 	assert.Equal(t, "PERCENTAGE", valueFee.Fee.Unit)
 	assert.Equal(t, "input_token_value", valueFee.ValueBase)
-	assert.Equal(t, "rule_based", valueFee.ClassificationMethod)
+	assert.Equal(t, ClassificationMethodRuleBased, valueFee.ClassificationMethod)
 	assert.Equal(t, float32(1.0), valueFee.Confidence)
 }
 

--- a/core/taskengine/summarizer_deterministic.go
+++ b/core/taskengine/summarizer_deterministic.go
@@ -106,7 +106,7 @@ type FeeAmount struct {
 type NodeCOGS struct {
 	NodeID   string
 	StepName string // joined from steps[]; empty for synthetic entries (e.g. _wallet_creation)
-	CostType string // "gas" | "external_api" | "wallet_creation"
+	CostType string // canonical REST values: "gas" | "externalApi" | "walletCreation" — see fee_enums.go and OpenAPI enum NodeCOGSCostType
 	Fee      *FeeAmount
 	GasUnits string // present when CostType == "gas"
 	TxHash   string // joined from steps[].outputData; deployed-gas only

--- a/docs/changes/20260406-fee-estimation.md
+++ b/docs/changes/20260406-fee-estimation.md
@@ -56,7 +56,7 @@ Default gas estimates:
 - `eth_transfer` — 50,000 gas units
 - `loop` — 300,000 gas units
 
-Smart wallet creation (if the user's wallet doesn't exist yet) is included as a COGS entry with `cost_type: "wallet_creation"`.
+Smart wallet creation (if the user's wallet doesn't exist yet) is included as a COGS entry with `cost_type: "walletCreation"` (canonical REST value — see `core/taskengine/fee_enums.go` and OpenAPI enum `NodeCOGSCostType`).
 
 **External API costs (future):** When a workflow calls a paid external API (e.g., X/Twitter search), that COGS will be estimated and included in the `cogs[]` array.
 
@@ -153,7 +153,7 @@ message NativeToken {
 
 message NodeCOGS {
   string node_id = 1;
-  string cost_type = 2; // "gas", "external_api", "wallet_creation"
+  string cost_type = 2; // "gas", "externalApi", "walletCreation" (canonical REST values)
   Fee fee = 3;           // {amount: "150000000000000", unit: "WEI"}
   string gas_units = 4;
 }
@@ -182,7 +182,7 @@ message ValueFee {
     "fee": { "amount": "0", "unit": "PERCENTAGE" },
     "tier": "EXECUTION_TIER_UNSPECIFIED",
     "value_base": "",
-    "classification_method": "rule_based",
+    "classification_method": "ruleBased",
     "confidence": 1.0,
     "reason": "Workflow has no on-chain execution nodes — no value-capture fee"
   },
@@ -210,7 +210,7 @@ message ValueFee {
     "fee": { "amount": "0.03", "unit": "PERCENTAGE" },
     "tier": "EXECUTION_TIER_1",
     "value_base": "input_token_value",
-    "classification_method": "rule_based",
+    "classification_method": "ruleBased",
     "confidence": 1.0,
     "reason": "V1 default: workflow contains on-chain execution nodes"
   },
@@ -241,7 +241,7 @@ message ValueFee {
     },
     {
       "node_id": "_wallet_creation",
-      "cost_type": "wallet_creation",
+      "cost_type": "walletCreation",
       "fee": { "amount": "6730592094800", "unit": "WEI" }
     }
   ],
@@ -249,7 +249,7 @@ message ValueFee {
     "fee": { "amount": "0.03", "unit": "PERCENTAGE" },
     "tier": "EXECUTION_TIER_1",
     "value_base": "input_token_value",
-    "classification_method": "rule_based",
+    "classification_method": "ruleBased",
     "confidence": 1.0,
     "reason": "V1 default: workflow contains on-chain execution nodes"
   },

--- a/docs/changes/20260406-fee-estimation.md
+++ b/docs/changes/20260406-fee-estimation.md
@@ -162,7 +162,7 @@ message ValueFee {
   Fee fee = 1;                       // {amount: "0.03", unit: "PERCENTAGE"}
   ExecutionTier tier = 2;
   string value_base = 3;            // "input_token_value"
-  string classification_method = 4; // "rule_based" or "llm"
+  string classification_method = 4; // "ruleBased" or "llm" (canonical REST values)
   float confidence = 5;
   string reason = 6;
 }

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -1375,7 +1375,7 @@ message NativeToken {
 // Per-node cost of goods sold (gas, external API costs, etc.)
 message NodeCOGS {
   string node_id = 1;
-  string cost_type = 2;             // "gas", "external_api", "wallet_creation"
+  string cost_type = 2;             // canonical REST values: "gas", "externalApi", "walletCreation" — see core/taskengine/fee_enums.go and OpenAPI enum NodeCOGSCostType
   Fee fee = 3;                       // Cost in WEI
   string gas_units = 4;             // Gas units (for gas costs only)
 }
@@ -1386,14 +1386,14 @@ message ValueFee {
   Fee fee = 1;                       // { amount: "0.03", unit: "PERCENTAGE" }
   ExecutionTier tier = 2;            // Pricing group (TIER_1, TIER_2, TIER_3)
   string value_base = 3;            // What the percentage applies to (e.g., "input_token_value")
-  string classification_method = 4;  // "rule_based" (V1) or "llm" (V2)
+  string classification_method = 4;  // canonical REST values: "ruleBased" (V1) or "llm" (V2) — see core/taskengine/fee_enums.go and OpenAPI enum ValueFeeClassificationMethod
   float confidence = 5;              // Classification confidence (0.0–1.0)
   string reason = 6;                 // Why this tier was assigned
 }
 
 // Promotional discount
 message FeeDiscount {
-  string discount_type = 1;         // "new_user", "volume", "promotional", "beta_program"
+  string discount_type = 1;         // canonical REST values: "newUser", "volume", "promotional", "betaProgram" — see core/taskengine/fee_enums.go and OpenAPI enum FeeDiscountDiscountType
   string discount_name = 2;
   Fee discount = 3;                  // Discount amount or percentage
   string expiry_date = 4;


### PR DESCRIPTION
## Summary

Fee estimator emits canonical REST camelCase values, not snake_case. Sourced from new shared constants so it stays that way.

| Field | Before | After |
|---|---|---|
| `NodeCOGS.cost_type` | `"wallet_creation"` | `"walletCreation"` |
| `ValueFee.classification_method` | `"rule_based"` | `"ruleBased"` |
| `NodeCOGS.cost_type` (gas) | `"gas"` (already correct, now constant-sourced) | `CostTypeGas` |

OpenAPI advertises these as camelCase enums (`NodeCOGSCostType ∈ {gas, externalApi, walletCreation}`, `ValueFeeClassificationMethod ∈ {ruleBased, llm}`). The REST mapper in `aggregator/rest/mapping/fees.go` translates field **names** via protojson camelCase but passes field **values** through verbatim, so the engine's raw snake_case strings were leaking straight to REST clients. Latent through PR #538; surfaced now that the [ava-sdk-js E2E suite is actually executing](https://github.com/AvaProtocol/ava-sdk-js/commit/c2b4f01) against the gateway.

## Test that caught it

`tests/v4/executions/estimateFees.test.ts` in ava-sdk-js:

```ts
expect(["gas", "externalApi", "walletCreation"]).toContain(c.costType);
// before this PR:
//   Expected value: "wallet_creation"
//   Received array: ["gas", "externalApi", "walletCreation"]
```

`classification_method` drift was latent — no SDK test exercises it yet — but it would have surfaced the same way the moment one did.

## What's in the PR

- **`core/taskengine/fee_enums.go`** (new) — canonical string constants for the four enum classes the engine emits into REST-visible proto string fields. `CostType{Gas, ExternalAPI, WalletCreation}`, `ClassificationMethod{RuleBased, LLM}`, `DiscountType{NewUser, Volume, Promotional, BetaProgram}`. The discount-type constants are preemptive — no emit sites today (`Discounts: []` in `fee_estimator.go:238`), but landing them now means future wiring spells the right value the first time.

- **`core/taskengine/fee_estimator.go`** — every raw-string emit (six sites) replaced with the constants.

- **`aggregator/rest/mapping/fee_enums_drift_test.go`** (new) — fail-build test that compares the engine constants against `generated.*` enum values in this package's `generated` sibling. Fails loudly if either side adds/renames/removes a value without updating the other. **This is the load-bearing piece** — it's what prevents the next engineer from forgetting to mirror an OpenAPI change in the constants.

- Comment cleanup so the documented canonical values match what the engine emits: `protobuf/avs.proto:1378,1389,1396`, `core/taskengine/summarizer_deterministic.go:109`, `docs/changes/20260406-fee-estimation.md` (5 spots).

## Test plan

- [x] `go test ./core/taskengine/` — passes (fee_estimator + summarizer + classifier tests)
- [x] `go test ./aggregator/rest/mapping/` — drift check + mapping tests pass
- [x] Sanity-check the drift test by temporarily reverting `CostTypeWalletCreation` to `"wallet_creation"` — the test failed with a clear diff (`+ wallet_creation / - walletCreation`), then I restored the change.
- [ ] After merge: confirm `publish-dev-docker.yml` rebuilds `avs-dev:latest` (the proto comment edit trips the `paths: ['protobuf/avs.proto']` filter — no manual `workflow_dispatch` needed)
- [ ] After image rebuild: the ava-sdk-js `E2E / executions` matrix shard goes green ([currently red on this one assertion](https://github.com/AvaProtocol/ava-sdk-js/actions/runs/27031353496))

## Downstream impact

- **REST clients on the v4 SDK contract** — including ava-sdk-js, the only in-tree consumer today — start receiving the correct `walletCreation` / `ruleBased` values. The ava-sdk-js `executions` shard goes green at that point.
- **gRPC clients pinning the snake_case `cost_type` value** would break. There is no such client in-tree: the v3 archive doesn't read fee fields, and v4 talks REST exclusively.

## Proto change

Comment-only — `cost_type`, `classification_method`, and `discount_type` are `string` fields, not protobuf enums, so no `protoc-gen` regen is needed. The proto-touch is deliberate: `publish-dev-docker.yml` auto-rebuilds `avs-dev:latest` on push to staging when `protobuf/avs.proto` changes, which is how the SDK's `:latest` pull picks up the fix.
