### PR TITLE
fix: route per-step contractWrite tokenMetadata through catalog fallback

### DIFF
--- a/core/taskengine/summarizer_context_memory.go
+++ b/core/taskengine/summarizer_context_memory.go
@@ -534,14 +534,20 @@ func (c *ContextMemorySummarizer) buildRequest(vm *VM, currentStepName, status, 
 				if stepChainID == 0 {
 					stepChainID = workflowChainID
 				}
-				if tokenService := resolveTokenServiceForChain(stepChainID); tokenService != nil {
-					if metadata, err := tokenService.GetTokenMetadata(resolvedContractAddress); err == nil && metadata != nil {
-						step.TokenMetadata = &contextMemoryTokenMetadata{
-							Symbol:   metadata.Symbol,
-							Decimals: metadata.Decimals,
-							Name:     metadata.Name,
-						}
-					}
+				// Route through resolveTokenMetadataWithCatalog so the per-step
+				// metadata picks up the cross-chain catalog fallback when the
+				// bound TokenEnrichmentService returns UNKNOWN. Without this
+				// the request payload ships {Symbol:"UNKNOWN", Decimals:18} at
+				// the step level for cross-chain dev scenarios, which is
+				// harmless today (resolveTokenMeta on the TS side resolves
+				// via the top-level tokenMetadata map first) but is the kind
+				// of staleness that masks real bugs in the long run.
+				var lg sdklogging.Logger
+				if vm != nil {
+					lg = vm.logger
+				}
+				if meta := resolveTokenMetadataWithCatalog(resolveTokenServiceForChain(stepChainID), resolvedContractAddress, stepChainID, lg); meta != nil {
+					step.TokenMetadata = meta
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Followup to #562. The per-step `tokenMetadata` populated at `summarizer_context_memory.go:537` for ERC20 contractWrite steps (including loop runners) bypassed the catalog fallback I added in #562 — it called `tokenService.GetTokenMetadata` directly. For cross-chain dev scenarios (Sepolia gateway running a mainnet-targeted workflow), that meant the per-step entry shipped as `{Symbol:"UNKNOWN", Decimals:18}` even though the trigger payload and the top-level tokenMetadata map both already had the right values.

Spotted via the local USDC Revenue Splitter simulation: `loop1.tokenMetadata = {UNKNOWN, 18}` in the `[Summarize] Request Body` even after everything else resolved correctly. Harmless today (`resolveTokenMeta` on the TS side prefers the top-level map at step 1; per-step is step 5 of 5), but the kind of inconsistency that masks real bugs.

Fix: route through the existing `resolveTokenMetadataWithCatalog` helper.

## Test plan

- [x] `go test ./core/taskengine/ -race -run "Catalog|Summarize|TokenMetadata"` passes
- [ ] Reviewer: confirm local USDC Revenue Splitter simulation shows `loop1.tokenMetadata = {symbol:"USDC", decimals:6, name:"USD Coin"}` in the next request body after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
