### PR TITLE
fix: drop obsolete token_whitelist COPY breaking Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ WORKDIR /app
 
 COPY --from=builder /app/ap .
 COPY --from=builder /app/config ./config
-COPY --from=builder /app/token_whitelist ./token_whitelist
 COPY --from=builder /app/scripts/operator-entrypoint.sh ./scripts/
 
 ENTRYPOINT ["./ap"]


### PR DESCRIPTION
## Summary
- Removes `COPY --from=builder /app/token_whitelist ./token_whitelist` from `Dockerfile`. PR #566 moved the JSON files into `core/taskengine/tokenwhitelist/` and embedded them into the binary via `//go:embed *.json` (`core/taskengine/tokenwhitelist/fs.go`), so the runtime copy now points at a path that no longer exists.
- Restores Railway builds. Every Railway service deploy has failed since the merge of #566 (2026-06-06 07:13 UTC / 00:13 PDT) with:
  ```
  Build Failed: ... failed to calculate checksum of ref ...: "/app/token_whitelist": not found
  ```
  Previous successful images are still serving traffic, so this was not visible to users — but no new code can ship until this lands.

## Test plan
- [ ] CI build passes (Dockerfile build is the canary)
- [ ] After merge to staging, watch `railway status --json` for the next deploy of `gateway` / `worker-*` to flip from FAILED → SUCCESS
- [ ] Confirm token catalog still resolves at runtime (already covered by `core/taskengine/token_catalog_test.go` — embed-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)