### PR TITLE
fix: silence Sentry floods from markJobDone race and validation retries

### DIFF
--- a/core/apqueue/queue.go
+++ b/core/apqueue/queue.go
@@ -193,7 +193,9 @@ func (q *Queue) markJobDone(job *Job, status jobStatus) error {
 
 // isKeyNotFound reports whether err is BadgerDB's "Key not found". The
 // storage.Storage interface surfaces the badger error verbatim from Move,
-// so direct equality and substring match both cover wrapped variants.
+// so errors.Is catches the sentinel and the string-equality fallback
+// covers cases where a wrapper has flattened the error into a plain
+// errors.New with the same message.
 func isKeyNotFound(err error) bool {
 	if err == nil {
 		return false

--- a/core/apqueue/queue.go
+++ b/core/apqueue/queue.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	badger "github.com/dgraph-io/badger/v4"
 )
 
 type Queue struct {
@@ -165,7 +166,13 @@ func (q *Queue) Dequeue() (*Job, error) {
 	return j, err
 }
 
-// markJobDone moves a job from the inprogress status to complete/failed
+// markJobDone moves a job from the inprogress status to complete/failed.
+//
+// If the inprogress key is missing, that means CleanupOrphanedJobs (which
+// scans pending/inprogress/failed for jobs whose task no longer exists)
+// already deleted it out from under us — the task was removed while this
+// worker held the job. Treat that as a benign no-op so the caller doesn't
+// log Error and trigger a Sentry capture for an expected race.
 func (q *Queue) markJobDone(job *Job, status jobStatus) error {
 	id := job.ID
 	if status != jobComplete && status != jobFailed {
@@ -178,7 +185,23 @@ func (q *Queue) markJobDone(job *Job, status jobStatus) error {
 	defer q.dbLock.Unlock()
 
 	err := q.db.Move(src, dest)
+	if err != nil && isKeyNotFound(err) {
+		return nil
+	}
 	return err
+}
+
+// isKeyNotFound reports whether err is BadgerDB's "Key not found". The
+// storage.Storage interface surfaces the badger error verbatim from Move,
+// so direct equality and substring match both cover wrapped variants.
+func isKeyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return true
+	}
+	return err.Error() == badger.ErrKeyNotFound.Error()
 }
 
 func (q *Queue) getQueueKeyPrefix(status jobStatus) []byte {

--- a/core/apqueue/queue_test.go
+++ b/core/apqueue/queue_test.go
@@ -1,0 +1,84 @@
+package apqueue
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+)
+
+// TestMarkJobDoneTreatsKeyNotFoundAsNoOp covers the race between the worker
+// and CleanupOrphanedJobs (cleanup.go): cleanup can delete an in-progress
+// job's key when the underlying task is removed mid-execution, so the
+// worker's eventual markJobDone(complete) hits a missing src key. That
+// must NOT bubble up — bubbling logs Error at worker.go and floods Sentry
+// (EIGENLAYER-AVS-1T).
+func TestMarkJobDoneTreatsKeyNotFoundAsNoOp(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	q := New(db, testutil.GetLogger(), &QueueOption{Prefix: "test"})
+	if err := q.MustStart(); err != nil {
+		t.Fatalf("queue start failed: %v", err)
+	}
+	defer func() { _ = q.Stop() }()
+
+	id, err := q.Enqueue("test_job", "task-1", []byte("payload"))
+	if err != nil {
+		t.Fatalf("enqueue failed: %v", err)
+	}
+	job, err := q.Dequeue()
+	if err != nil || job == nil {
+		t.Fatalf("dequeue failed: job=%v err=%v", job, err)
+	}
+	if job.ID != id {
+		t.Fatalf("dequeued unexpected job id: want %d got %d", id, job.ID)
+	}
+
+	// Simulate CleanupOrphanedJobs deleting the in-progress key while the
+	// worker still holds the job in memory.
+	inProgressKey := q.getJobKey(jobInProgress, job.ID)
+	if err := db.Delete(inProgressKey); err != nil {
+		t.Fatalf("simulating cleanup delete failed: %v", err)
+	}
+
+	if err := q.markJobDone(job, jobComplete); err != nil {
+		t.Fatalf("markJobDone(jobComplete) should swallow Key-not-found, got: %v", err)
+	}
+	if err := q.markJobDone(job, jobFailed); err != nil {
+		t.Fatalf("markJobDone(jobFailed) should swallow Key-not-found, got: %v", err)
+	}
+}
+
+// TestMarkJobDoneHappyPath asserts the normal Move(inprogress → complete)
+// still works after the Key-not-found short-circuit landed.
+func TestMarkJobDoneHappyPath(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	q := New(db, testutil.GetLogger(), &QueueOption{Prefix: "test"})
+	if err := q.MustStart(); err != nil {
+		t.Fatalf("queue start failed: %v", err)
+	}
+	defer func() { _ = q.Stop() }()
+
+	if _, err := q.Enqueue("test_job", "task-1", []byte("payload")); err != nil {
+		t.Fatalf("enqueue failed: %v", err)
+	}
+	job, err := q.Dequeue()
+	if err != nil || job == nil {
+		t.Fatalf("dequeue failed: job=%v err=%v", job, err)
+	}
+
+	if err := q.markJobDone(job, jobComplete); err != nil {
+		t.Fatalf("markJobDone(jobComplete) failed: %v", err)
+	}
+
+	completeKey := q.getJobKey(jobComplete, job.ID)
+	if _, err := db.GetKey(completeKey); err != nil {
+		t.Fatalf("expected complete key to exist after markJobDone, got: %v", err)
+	}
+	inProgressKey := q.getJobKey(jobInProgress, job.ID)
+	if _, err := db.GetKey(inProgressKey); err == nil {
+		t.Fatalf("expected in-progress key to be gone after markJobDone")
+	}
+}

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -961,10 +961,16 @@ func (x *WorkflowExecutor) validateDerivedWallet(swCfg *config.SmartWalletConfig
 }
 
 // persistFailedExecution persists a failed execution record to the database
-// This ensures that failed executions (like wallet validation failures) are recorded for troubleshooting
+// This ensures that failed executions (like wallet validation failures) are recorded for troubleshooting.
+//
+// Logs at Warn rather than Error: a validation failure is an expected outcome
+// (misconfigured task, ownership mismatch) that recurs every time the trigger
+// fires until the task is fixed or disabled. The execution record itself is
+// persisted with Status=FAILED and Error=<reason>, so users can still
+// troubleshoot from it. Using Error would route every tick through
+// SentryLogger.captureToSentry and flood Sentry — see EIGENLAYER-AVS-1V.
 func (x *WorkflowExecutor) persistFailedExecution(task *model.Workflow, execution *avsproto.Execution, initialTaskStatus avsproto.TaskStatus) {
-	// Log the failure for debugging
-	x.logger.Error("task execution failed during validation",
+	x.logger.Warn("task execution failed during validation",
 		"error", execution.Error,
 		"task_id", task.Id,
 		"execution_id", execution.Id,

--- a/core/taskengine/executor_validation_log_level_test.go
+++ b/core/taskengine/executor_validation_log_level_test.go
@@ -1,0 +1,84 @@
+package taskengine
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+)
+
+// captureLogger spies on which level a message was logged at. We only need
+// Error vs Warn for this fix — everything else delegates to no-op.
+type captureLogger struct {
+	mu       sync.Mutex
+	errorMsg []string
+	warnMsg  []string
+}
+
+func (l *captureLogger) record(bucket *[]string, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	*bucket = append(*bucket, msg)
+}
+
+func (l *captureLogger) Debug(msg string, _ ...interface{})    {}
+func (l *captureLogger) Debugf(string, ...interface{})         {}
+func (l *captureLogger) Info(msg string, _ ...interface{})     {}
+func (l *captureLogger) Infof(string, ...interface{})          {}
+func (l *captureLogger) Warn(msg string, _ ...interface{})     { l.record(&l.warnMsg, msg) }
+func (l *captureLogger) Warnf(string, ...interface{})          {}
+func (l *captureLogger) Error(msg string, _ ...interface{})    { l.record(&l.errorMsg, msg) }
+func (l *captureLogger) Errorf(string, ...interface{})         {}
+func (l *captureLogger) Fatal(string, ...interface{})          {}
+func (l *captureLogger) Fatalf(string, ...interface{})         {}
+func (l *captureLogger) With(...interface{}) sdklogging.Logger { return l }
+
+// TestPersistFailedExecutionLogsAtWarnNotError protects EIGENLAYER-AVS-1V:
+// validation failures (e.g. smart wallet does not belong to owner) recur on
+// every trigger tick until the task is fixed. They must log at Warn so
+// SentryLogger.Error -> sentry.CaptureException is not invoked per tick.
+func TestPersistFailedExecutionLogsAtWarnNotError(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	spy := &captureLogger{}
+	executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, spy)
+
+	task := &model.Workflow{
+		Task: &avsproto.Task{
+			Id:                 "task-validation-test",
+			Owner:              "0x0000000000000000000000000000000000000001",
+			SmartWalletAddress: "0x0000000000000000000000000000000000000002",
+		},
+	}
+	exec := &avsproto.Execution{
+		Id:     "exec-validation-test",
+		Error:  "task smart wallet address does not belong to owner",
+		Status: avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED,
+	}
+
+	executor.persistFailedExecution(task, exec, avsproto.TaskStatus_Enabled)
+
+	const wantMsg = "task execution failed during validation"
+	foundWarn := false
+	for _, m := range spy.warnMsg {
+		if strings.Contains(m, wantMsg) {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("expected Warn log containing %q, got warn=%v error=%v", wantMsg, spy.warnMsg, spy.errorMsg)
+	}
+	for _, m := range spy.errorMsg {
+		if strings.Contains(m, wantMsg) {
+			t.Fatalf("validation-failure message must not log at Error (would trigger Sentry capture every tick); got: %q", m)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Cuts two Sentry floods from the staging aggregator.

- **EIGENLAYER-AVS-1T** (`Key not found — failed to mark job complete`, 159 events / 8d). `CleanupOrphanedJobs` (`core/apqueue/cleanup.go:29`) scans `pending`/`inprogress`/`failed` and deletes any job whose task no longer exists across all chain buckets. When a task is deleted **mid-execution**, the worker still finishes with the in-memory `task` and calls `markJobDone(complete)` → `db.Move(inprogress, complete)` → `txn.Get(src)` returns `badger.ErrKeyNotFound` → `worker.go:78` logs `Error` → `SentryLogger.captureToSentry` (`pkg/logger/sentry_logger.go:40`) fires a `sentry.CaptureException` per occurrence. Now `markJobDone` swallows `ErrKeyNotFound` as a benign no-op — the cleanup already removed the source key, there is nothing else to do.

- **EIGENLAYER-AVS-1V** (`task execution failed during validation — smart wallet address does not belong to owner`, 2,979 events / 6d). `WorkflowExecutor.RunTask` returns `execution, nil` for validation failures, so the queue side correctly marks the job complete and does not retry. But the **task** stays `Enabled`, so its trigger keeps re-enqueuing it — every tick logs `x.logger.Error("task execution failed during validation"…)` from `persistFailedExecution`, and SentryLogger captures each one. Downgrading that single log to `Warn` stops the Sentry flood while the execution record is still persisted with `Status=FAILED` and `Error=<reason>` for troubleshooting.

Both fixes are minimal and surgical: one swallowed error in the queue, one log-level downgrade in the executor.

## Test plan

- [x] `go test ./core/apqueue/ -run TestMarkJobDone -count=1` (covers both Key-not-found and happy path)
- [x] `go test ./core/taskengine/ -run TestPersistFailedExecutionLogsAtWarnNotError -count=1`
- [x] `go test ./core/apqueue/... -count=1` (full apqueue suite, no regressions)
- [ ] Watch staging Sentry after merge — confirm 1T and 1V stop accruing new events
- [ ] Confirm execution records for validation-failed tasks still appear in the SDK (`yarn start getExecution <task_id> <exec_id>`) with `Status=FAILED` and the same `Error` string
