### PR TITLE
feat: auto-disable tasks after N consecutive validation failures

### DIFF
--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -17,6 +17,7 @@ import (
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/getsentry/sentry-go"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/apqueue"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
@@ -544,6 +545,15 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 		}
 	}
 
+	// Reaching this point means every validation gate above passed. Clear any
+	// prior consecutive-failure state so a future transient blip doesn't keep
+	// counting from a stale baseline. Persisted by the task write at the end
+	// of RunTask.
+	if task.ConsecutiveValidationFailures != 0 || task.LastValidationError != "" {
+		task.ConsecutiveValidationFailures = 0
+		task.LastValidationError = ""
+	}
+
 	var runTaskErr error = nil
 	if err = vm.Compile(); err != nil {
 		x.logger.Error("error compile task", "error", err, "edges", task.Edges, "node", task.Nodes, "task trigger data", task.Trigger, "task trigger metadata", queueData)
@@ -960,6 +970,35 @@ func (x *WorkflowExecutor) validateDerivedWallet(swCfg *config.SmartWalletConfig
 	return false, fmt.Errorf("wallet address cannot be derived from owner with factory %s (checked %d salts)", factoryAddr.Hex(), maxWallets)
 }
 
+// validationFailureDisableThreshold is the number of consecutive permanent
+// validation failures (see permanentValidationErrorPrefixes) tolerated before
+// the executor auto-disables the task. Matches the maxConsecutiveFailures
+// constant used elsewhere (core/taskengine/vm.go) for symmetry.
+const validationFailureDisableThreshold uint32 = 10
+
+// permanentValidationErrorPrefixes lists execution.Error prefixes that will
+// not self-resolve without user intervention — wallet misconfiguration or a
+// structurally broken task graph. Transient errors (RPC failures while
+// validating ownership, insufficient credit) are deliberately excluded:
+// they can clear on the next tick when the chain is reachable or the user
+// tops up.
+var permanentValidationErrorPrefixes = []string{
+	"invalid or missing task smart wallet address",
+	"task smart wallet address does not belong to owner",
+	"failed to create VM:",
+}
+
+// isPermanentValidationError reports whether execution.Error matches one of
+// the prefixes that should count toward auto-disable.
+func isPermanentValidationError(errorMsg string) bool {
+	for _, prefix := range permanentValidationErrorPrefixes {
+		if strings.HasPrefix(errorMsg, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // persistFailedExecution persists a failed execution record to the database
 // This ensures that failed executions (like wallet validation failures) are recorded for troubleshooting.
 //
@@ -969,12 +1008,27 @@ func (x *WorkflowExecutor) validateDerivedWallet(swCfg *config.SmartWalletConfig
 // persisted with Status=FAILED and Error=<reason>, so users can still
 // troubleshoot from it. Using Error would route every tick through
 // SentryLogger.captureToSentry and flood Sentry — see EIGENLAYER-AVS-1V.
+//
+// When the same task has hit validationFailureDisableThreshold consecutive
+// *permanent* validation rejections, this also flips the task to Disabled
+// and fires exactly one Sentry event (CaptureMessage, fingerprinted by
+// task_id) so an operator gets a single high-signal alert per broken task
+// instead of a per-tick flood.
 func (x *WorkflowExecutor) persistFailedExecution(task *model.Workflow, execution *avsproto.Execution, initialTaskStatus avsproto.TaskStatus) {
 	x.logger.Warn("task execution failed during validation",
 		"error", execution.Error,
 		"task_id", task.Id,
 		"execution_id", execution.Id,
 		"reason", "validation_failure")
+
+	task.LastValidationError = execution.Error
+	if isPermanentValidationError(execution.Error) {
+		task.ConsecutiveValidationFailures++
+		if task.Status == avsproto.TaskStatus_Enabled && task.ConsecutiveValidationFailures >= validationFailureDisableThreshold {
+			task.Status = avsproto.TaskStatus_Disabled
+			x.reportTaskAutoDisabled(task, execution.Error)
+		}
+	}
 
 	// Ensure no NaN/Inf sneak into protobuf Values (which reject them)
 	sanitizeExecutionForPersistence(execution)
@@ -1011,4 +1065,28 @@ func (x *WorkflowExecutor) persistFailedExecution(task *model.Workflow, executio
 			x.logger.Error("error cleaning up old task status", "task_id", task.Id, "error", err)
 		}
 	}
+}
+
+// reportTaskAutoDisabled fires exactly one Sentry event when a task is
+// auto-disabled by validationFailureDisableThreshold. The fingerprint is
+// scoped to the task ID so each broken workflow gets its own Sentry issue
+// rather than rolling into a single noisy one. The event is logged at Warn
+// in addition; SentryLogger.Warn does not double-capture.
+func (x *WorkflowExecutor) reportTaskAutoDisabled(task *model.Workflow, reason string) {
+	x.logger.Warn("task auto-disabled after consecutive validation failures",
+		"task_id", task.Id,
+		"chain_id", task.ChainId,
+		"consecutive_failures", task.ConsecutiveValidationFailures,
+		"reason", reason)
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("event", "task_auto_disabled")
+		scope.SetTag("task_id", task.Id)
+		scope.SetTag("chain_id", strconv.FormatInt(task.ChainId, 10))
+		scope.SetExtra("consecutive_failures", task.ConsecutiveValidationFailures)
+		scope.SetExtra("reason", reason)
+		scope.SetFingerprint([]string{"task-auto-disabled", task.Id})
+		sentry.CaptureMessage(fmt.Sprintf(
+			"Task %s auto-disabled after %d consecutive validation failures: %s",
+			task.Id, task.ConsecutiveValidationFailures, reason))
+	})
 }

--- a/core/taskengine/executor_validation_autodisable_test.go
+++ b/core/taskengine/executor_validation_autodisable_test.go
@@ -7,12 +7,17 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
 )
 
-func newTaskForAutoDisable(id string) *model.Workflow {
+// newTaskForAutoDisable returns a task with a ULID id. Task IDs flow through
+// storage keys whose schema uses ":" as a delimiter, so embedding arbitrary
+// text (e.g. an error message) into the id is unsafe and unrepresentative.
+func newTaskForAutoDisable() *model.Workflow {
 	return &model.Workflow{
 		Task: &avsproto.Task{
-			Id:                 id,
+			Id:                 ulid.Make().String(),
 			Owner:              "0x0000000000000000000000000000000000000001",
 			SmartWalletAddress: "0x0000000000000000000000000000000000000002",
 			Status:             avsproto.TaskStatus_Enabled,
@@ -42,7 +47,7 @@ func TestPermanentValidationErrorIncrementsCounter(t *testing.T) {
 			defer storage.Destroy(db.(*storage.BadgerStorage))
 
 			executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
-			task := newTaskForAutoDisable("task-perm-" + errMsg)
+			task := newTaskForAutoDisable()
 
 			executor.persistFailedExecution(task, newFailedExecution("e1", errMsg), avsproto.TaskStatus_Enabled)
 
@@ -72,7 +77,7 @@ func TestTransientValidationErrorDoesNotIncrementCounter(t *testing.T) {
 			defer storage.Destroy(db.(*storage.BadgerStorage))
 
 			executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
-			task := newTaskForAutoDisable("task-trans-" + errMsg)
+			task := newTaskForAutoDisable()
 
 			executor.persistFailedExecution(task, newFailedExecution("e1", errMsg), avsproto.TaskStatus_Enabled)
 
@@ -96,7 +101,7 @@ func TestAutoDisableOnThreshold(t *testing.T) {
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 
 	executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
-	task := newTaskForAutoDisable("task-threshold")
+	task := newTaskForAutoDisable()
 
 	const errMsg = "task smart wallet address does not belong to owner"
 	for i := uint32(1); i <= validationFailureDisableThreshold; i++ {
@@ -119,6 +124,73 @@ func TestAutoDisableOnThreshold(t *testing.T) {
 	executor.persistFailedExecution(task, newFailedExecution("e", errMsg), avsproto.TaskStatus_Disabled)
 	if task.Status != avsproto.TaskStatus_Disabled {
 		t.Fatalf("status should remain Disabled, got %v", task.Status)
+	}
+}
+
+// TestCounterResetOnValidationPassThrough covers the executor.go reset path:
+// once a task makes it past every validation gate, both
+// ConsecutiveValidationFailures and LastValidationError must be cleared so a
+// future transient blip cannot inherit a stale baseline.
+func TestCounterResetOnValidationPassThrough(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	// Empty Owner is the documented test escape hatch — see
+	// core/taskengine/executor.go where wallet validation is gated on
+	// task.Owner != "". This lets us exercise the post-validation reset path
+	// without standing up a real chain.
+	task := &model.Workflow{
+		Task: &avsproto.Task{
+			Id:                            ulid.Make().String(),
+			Owner:                         "",
+			Status:                        avsproto.TaskStatus_Enabled,
+			LastValidationError:           "stale message from a prior tick",
+			ConsecutiveValidationFailures: 5,
+			Trigger: &avsproto.TaskTrigger{
+				Id:   "trigger1",
+				Name: "manualTrigger",
+				Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+				TriggerType: &avsproto.TaskTrigger_Manual{
+					Manual: &avsproto.ManualTrigger{
+						Config: &avsproto.ManualTrigger_Config{},
+					},
+				},
+			},
+			Nodes: []*avsproto.TaskNode{{
+				Id:   "node1",
+				Name: "noop",
+				Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+				TaskType: &avsproto.TaskNode_CustomCode{
+					CustomCode: &avsproto.CustomCodeNode{
+						Config: &avsproto.CustomCodeNode_Config{
+							Lang:   avsproto.Lang_LANG_JAVASCRIPT,
+							Source: "return 'ok'",
+						},
+					},
+				},
+			}},
+			Edges: []*avsproto.TaskEdge{{
+				Id:     "edge1",
+				Source: "trigger1",
+				Target: "node1",
+			}},
+		},
+	}
+
+	executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
+	exec, err := executor.RunTask(task, &QueueExecutionData{
+		ExecutionID:   ulid.Make().String(),
+		TriggerType:   avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+		TriggerOutput: &avsproto.ManualTrigger_Output{},
+	})
+	require.NoError(t, err, "RunTask should succeed once validation is bypassed")
+	require.NotNil(t, exec)
+
+	if task.ConsecutiveValidationFailures != 0 {
+		t.Fatalf("counter should reset on validation pass-through, got %d", task.ConsecutiveValidationFailures)
+	}
+	if task.LastValidationError != "" {
+		t.Fatalf("LastValidationError should reset on validation pass-through, got %q", task.LastValidationError)
 	}
 }
 

--- a/core/taskengine/executor_validation_autodisable_test.go
+++ b/core/taskengine/executor_validation_autodisable_test.go
@@ -1,0 +1,149 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+func newTaskForAutoDisable(id string) *model.Workflow {
+	return &model.Workflow{
+		Task: &avsproto.Task{
+			Id:                 id,
+			Owner:              "0x0000000000000000000000000000000000000001",
+			SmartWalletAddress: "0x0000000000000000000000000000000000000002",
+			Status:             avsproto.TaskStatus_Enabled,
+		},
+	}
+}
+
+func newFailedExecution(id, errMsg string) *avsproto.Execution {
+	return &avsproto.Execution{
+		Id:     id,
+		Error:  errMsg,
+		Status: avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED,
+	}
+}
+
+// TestPermanentValidationErrorIncrementsCounter covers the three permanent
+// rejection prefixes that should count toward auto-disable.
+func TestPermanentValidationErrorIncrementsCounter(t *testing.T) {
+	cases := []string{
+		"invalid or missing task smart wallet address for deployed run",
+		"task smart wallet address does not belong to owner",
+		"failed to create VM: some compile error",
+	}
+	for _, errMsg := range cases {
+		t.Run(errMsg, func(t *testing.T) {
+			db := testutil.TestMustDB()
+			defer storage.Destroy(db.(*storage.BadgerStorage))
+
+			executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
+			task := newTaskForAutoDisable("task-perm-" + errMsg)
+
+			executor.persistFailedExecution(task, newFailedExecution("e1", errMsg), avsproto.TaskStatus_Enabled)
+
+			if task.ConsecutiveValidationFailures != 1 {
+				t.Fatalf("counter should be 1 after one permanent failure, got %d", task.ConsecutiveValidationFailures)
+			}
+			if task.LastValidationError != errMsg {
+				t.Fatalf("LastValidationError = %q, want %q", task.LastValidationError, errMsg)
+			}
+			if task.Status != avsproto.TaskStatus_Enabled {
+				t.Fatalf("task should still be Enabled after one failure, got %v", task.Status)
+			}
+		})
+	}
+}
+
+// TestTransientValidationErrorDoesNotIncrementCounter — RPC errors and
+// credit-limit blocks are recoverable and must not push toward auto-disable.
+func TestTransientValidationErrorDoesNotIncrementCounter(t *testing.T) {
+	cases := []string{
+		"failed to validate wallet ownership for owner 0xabc: dial tcp: i/o timeout",
+		"[INSUFFICIENT_CREDIT] outstanding value fees (1000 wei) exceed credit limit",
+	}
+	for _, errMsg := range cases {
+		t.Run(errMsg, func(t *testing.T) {
+			db := testutil.TestMustDB()
+			defer storage.Destroy(db.(*storage.BadgerStorage))
+
+			executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
+			task := newTaskForAutoDisable("task-trans-" + errMsg)
+
+			executor.persistFailedExecution(task, newFailedExecution("e1", errMsg), avsproto.TaskStatus_Enabled)
+
+			if task.ConsecutiveValidationFailures != 0 {
+				t.Fatalf("transient error should not increment counter, got %d", task.ConsecutiveValidationFailures)
+			}
+			if task.LastValidationError != errMsg {
+				t.Fatalf("LastValidationError should still be recorded for visibility, got %q", task.LastValidationError)
+			}
+			if task.Status != avsproto.TaskStatus_Enabled {
+				t.Fatalf("transient errors must never auto-disable, got status %v", task.Status)
+			}
+		})
+	}
+}
+
+// TestAutoDisableOnThreshold drives the counter to validationFailureDisableThreshold
+// and asserts the task flips to Disabled exactly once.
+func TestAutoDisableOnThreshold(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, testutil.GetLogger())
+	task := newTaskForAutoDisable("task-threshold")
+
+	const errMsg = "task smart wallet address does not belong to owner"
+	for i := uint32(1); i <= validationFailureDisableThreshold; i++ {
+		executor.persistFailedExecution(task, newFailedExecution("e", errMsg), avsproto.TaskStatus_Enabled)
+		if i < validationFailureDisableThreshold {
+			if task.Status != avsproto.TaskStatus_Enabled {
+				t.Fatalf("status flipped early at i=%d, want Enabled got %v", i, task.Status)
+			}
+		}
+	}
+	if task.ConsecutiveValidationFailures != validationFailureDisableThreshold {
+		t.Fatalf("counter at threshold tick = %d, want %d", task.ConsecutiveValidationFailures, validationFailureDisableThreshold)
+	}
+	if task.Status != avsproto.TaskStatus_Disabled {
+		t.Fatalf("expected Disabled after %d permanent failures, got %v", validationFailureDisableThreshold, task.Status)
+	}
+
+	// One more failure after disable should not panic, change status, or
+	// double-trigger the Sentry capture (status is no longer Enabled).
+	executor.persistFailedExecution(task, newFailedExecution("e", errMsg), avsproto.TaskStatus_Disabled)
+	if task.Status != avsproto.TaskStatus_Disabled {
+		t.Fatalf("status should remain Disabled, got %v", task.Status)
+	}
+}
+
+// TestIsPermanentValidationErrorClassification protects the classifier from
+// drift when error strings get edited in executor.go.
+func TestIsPermanentValidationErrorClassification(t *testing.T) {
+	permanent := []string{
+		"invalid or missing task smart wallet address for deployed run",
+		"task smart wallet address does not belong to owner",
+		"failed to create VM: cycle detected",
+	}
+	for _, m := range permanent {
+		if !isPermanentValidationError(m) {
+			t.Errorf("expected permanent: %q", m)
+		}
+	}
+	transient := []string{
+		"failed to validate wallet ownership for owner 0xabc: rpc unreachable",
+		"[INSUFFICIENT_CREDIT] outstanding value fees (1 wei) exceed credit limit",
+		"",
+		"some unrelated error",
+	}
+	for _, m := range transient {
+		if isPermanentValidationError(m) {
+			t.Errorf("expected transient: %q", m)
+		}
+	}
+}

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -2249,9 +2249,21 @@ type Task struct {
 	InputVariables map[string]*structpb.Value `protobuf:"bytes,15,rep,name=input_variables,json=inputVariables,proto3" json:"input_variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Target chain for this task's execution (e.g., 11155111 for Sepolia, 84532 for Base Sepolia).
 	// 0 means use the aggregator's default chain (backward compatible with single-chain mode).
-	ChainId       int64 `protobuf:"varint,16,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ChainId int64 `protobuf:"varint,16,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	// last_validation_error is the most recent message from a validation
+	// rejection (e.g. "task smart wallet address does not belong to owner").
+	// Empty when the task has never been rejected, or when a later execution
+	// made it past validation and reset the counter below.
+	LastValidationError string `protobuf:"bytes,17,opt,name=last_validation_error,json=lastValidationError,proto3" json:"last_validation_error,omitempty"`
+	// consecutive_validation_failures counts trigger ticks where validation
+	// rejected this task with a *permanent* error (bad wallet config, VM
+	// construction failure). Transient errors (RPC timeouts, credit limit)
+	// do not increment. Resets to 0 the next time an execution gets past
+	// validation. Past the threshold defined in core/taskengine/executor.go,
+	// the task is automatically flipped to Disabled.
+	ConsecutiveValidationFailures uint32 `protobuf:"varint,18,opt,name=consecutive_validation_failures,json=consecutiveValidationFailures,proto3" json:"consecutive_validation_failures,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *Task) Reset() {
@@ -2392,6 +2404,20 @@ func (x *Task) GetInputVariables() map[string]*structpb.Value {
 func (x *Task) GetChainId() int64 {
 	if x != nil {
 		return x.ChainId
+	}
+	return 0
+}
+
+func (x *Task) GetLastValidationError() string {
+	if x != nil {
+		return x.LastValidationError
+	}
+	return ""
+}
+
+func (x *Task) GetConsecutiveValidationFailures() uint32 {
+	if x != nil {
+		return x.ConsecutiveValidationFailures
 	}
 	return 0
 }
@@ -6485,7 +6511,7 @@ func (x *NativeToken) GetDecimals() int32 {
 type NodeCOGS struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NodeId        string                 `protobuf:"bytes,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
-	CostType      string                 `protobuf:"bytes,2,opt,name=cost_type,json=costType,proto3" json:"cost_type,omitempty"` // "gas", "external_api", "wallet_creation"
+	CostType      string                 `protobuf:"bytes,2,opt,name=cost_type,json=costType,proto3" json:"cost_type,omitempty"` // canonical REST values: "gas", "externalApi", "walletCreation" — see core/taskengine/fee_enums.go and OpenAPI enum NodeCOGSCostType
 	Fee           *Fee                   `protobuf:"bytes,3,opt,name=fee,proto3" json:"fee,omitempty"`                           // Cost in WEI
 	GasUnits      string                 `protobuf:"bytes,4,opt,name=gas_units,json=gasUnits,proto3" json:"gas_units,omitempty"` // Gas units (for gas costs only)
 	unknownFields protoimpl.UnknownFields
@@ -6557,7 +6583,7 @@ type ValueFee struct {
 	Fee                  *Fee                   `protobuf:"bytes,1,opt,name=fee,proto3" json:"fee,omitempty"`                                                               // { amount: "0.03", unit: "PERCENTAGE" }
 	Tier                 ExecutionTier          `protobuf:"varint,2,opt,name=tier,proto3,enum=aggregator.ExecutionTier" json:"tier,omitempty"`                              // Pricing group (TIER_1, TIER_2, TIER_3)
 	ValueBase            string                 `protobuf:"bytes,3,opt,name=value_base,json=valueBase,proto3" json:"value_base,omitempty"`                                  // What the percentage applies to (e.g., "input_token_value")
-	ClassificationMethod string                 `protobuf:"bytes,4,opt,name=classification_method,json=classificationMethod,proto3" json:"classification_method,omitempty"` // "rule_based" (V1) or "llm" (V2)
+	ClassificationMethod string                 `protobuf:"bytes,4,opt,name=classification_method,json=classificationMethod,proto3" json:"classification_method,omitempty"` // canonical REST values: "ruleBased" (V1) or "llm" (V2) — see core/taskengine/fee_enums.go and OpenAPI enum ValueFeeClassificationMethod
 	Confidence           float32                `protobuf:"fixed32,5,opt,name=confidence,proto3" json:"confidence,omitempty"`                                               // Classification confidence (0.0–1.0)
 	Reason               string                 `protobuf:"bytes,6,opt,name=reason,proto3" json:"reason,omitempty"`                                                         // Why this tier was assigned
 	unknownFields        protoimpl.UnknownFields
@@ -6639,7 +6665,7 @@ func (x *ValueFee) GetReason() string {
 // Promotional discount
 type FeeDiscount struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	DiscountType  string                 `protobuf:"bytes,1,opt,name=discount_type,json=discountType,proto3" json:"discount_type,omitempty"` // "new_user", "volume", "promotional", "beta_program"
+	DiscountType  string                 `protobuf:"bytes,1,opt,name=discount_type,json=discountType,proto3" json:"discount_type,omitempty"` // canonical REST values: "newUser", "volume", "promotional", "betaProgram" — see core/taskengine/fee_enums.go and OpenAPI enum FeeDiscountDiscountType
 	DiscountName  string                 `protobuf:"bytes,2,opt,name=discount_name,json=discountName,proto3" json:"discount_name,omitempty"`
 	Discount      *Fee                   `protobuf:"bytes,3,opt,name=discount,proto3" json:"discount,omitempty"` // Discount amount or percentage
 	ExpiryDate    string                 `protobuf:"bytes,4,opt,name=expiry_date,json=expiryDate,proto3" json:"expiry_date,omitempty"`
@@ -9945,7 +9971,7 @@ const file_avs_proto_rawDesc = "" +
 	"\abalance\x18\x1e \x01(\v2\x1e.aggregator.BalanceNode.OutputH\x00R\abalance\x12\x19\n" +
 	"\bstart_at\x18\x0e \x01(\x03R\astartAt\x12\x15\n" +
 	"\x06end_at\x18\x0f \x01(\x03R\x05endAtB\r\n" +
-	"\voutput_data\"\xbd\x05\n" +
+	"\voutput_data\"\xb9\x06\n" +
 	"\x04Task\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05owner\x18\x02 \x01(\tR\x05owner\x120\n" +
@@ -9964,7 +9990,9 @@ const file_avs_proto_rawDesc = "" +
 	"\x05nodes\x18\r \x03(\v2\x14.aggregator.TaskNodeR\x05nodes\x12*\n" +
 	"\x05edges\x18\x0e \x03(\v2\x14.aggregator.TaskEdgeR\x05edges\x12M\n" +
 	"\x0finput_variables\x18\x0f \x03(\v2$.aggregator.Task.InputVariablesEntryR\x0einputVariables\x12\x19\n" +
-	"\bchain_id\x18\x10 \x01(\x03R\achainId\x1aY\n" +
+	"\bchain_id\x18\x10 \x01(\x03R\achainId\x122\n" +
+	"\x15last_validation_error\x18\x11 \x01(\tR\x13lastValidationError\x12F\n" +
+	"\x1fconsecutive_validation_failures\x18\x12 \x01(\rR\x1dconsecutiveValidationFailures\x1aY\n" +
 	"\x13InputVariablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
 	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"\x8d\x04\n" +

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -815,6 +815,20 @@ message Task {
   // Target chain for this task's execution (e.g., 11155111 for Sepolia, 84532 for Base Sepolia).
   // 0 means use the aggregator's default chain (backward compatible with single-chain mode).
   int64 chain_id = 16;
+
+  // last_validation_error is the most recent message from a validation
+  // rejection (e.g. "task smart wallet address does not belong to owner").
+  // Empty when the task has never been rejected, or when a later execution
+  // made it past validation and reset the counter below.
+  string last_validation_error = 17;
+
+  // consecutive_validation_failures counts trigger ticks where validation
+  // rejected this task with a *permanent* error (bad wallet config, VM
+  // construction failure). Transient errors (RPC timeouts, credit limit)
+  // do not increment. Resets to 0 the next time an execution gets past
+  // validation. Past the threshold defined in core/taskengine/executor.go,
+  // the task is automatically flipped to Disabled.
+  uint32 consecutive_validation_failures = 18;
 }
 
 


### PR DESCRIPTION
## Summary

Follow-up to #571. After the Warn downgrade silenced the Sentry flood, the underlying broken task could still re-trigger forever and pile up FAILED execution records — invisible unless someone checks `getWorkflow`. This PR closes that gap with a small, surgical state machine.

- **New Task proto fields** (`protobuf/avs.proto:817-832`):
  - `last_validation_error` (17) — last rejection message; visible in SDK output.
  - `consecutive_validation_failures` (18) — counter, resets when an execution passes validation.
- **Classifier** in `core/taskengine/executor.go`:
  - **Permanent** prefixes (count toward auto-disable): `invalid or missing task smart wallet address`, `task smart wallet address does not belong to owner`, `failed to create VM:`.
  - **Transient** errors (do NOT increment): RPC failures during wallet validation (`failed to validate wallet ownership for owner …`) and `[INSUFFICIENT_CREDIT]`. These can clear on the next tick.
- **Auto-disable** at `validationFailureDisableThreshold = 10` consecutive permanent failures (matches `maxConsecutiveFailures` in `vm.go:2007`):
  - Flips `task.Status` → `Disabled` (existing persistence + old-status cleanup at `executor.go:1054-1057` handles the storage transition).
  - Fires **one** `sentry.CaptureMessage` with `SetFingerprint([]string{"task-auto-disabled", task.Id})` — each broken workflow gets its own Sentry issue, not a single mega-issue.
  - The Warn log line stays as-is (does not double-capture via SentryLogger; only Error does).
- **Counter reset** at `executor.go:548-554`: once an execution makes it past every validation gate, both counter and `last_validation_error` are cleared. So a transient blip later doesn't inherit a stale baseline.

## Why fingerprint by task_id

`sentry.CaptureMessage` would otherwise group all "task auto-disabled" events into one issue — useless for triage. With `SetFingerprint([]string{"task-auto-disabled", task.Id})` each broken task surfaces as a distinct, addressable Sentry issue.

## What users will see

- Their task in the SDK / dashboard shows `status: Disabled` and `lastValidationError` explaining why.
- Operators get one Sentry event per broken task, fingerprinted by task ID — easy to triage, doesn't recur per tick.

## Test plan

- [x] `go test ./core/taskengine/ -run 'TestPersistFailedExecutionLogsAtWarnNotError|TestPermanentValidationErrorIncrementsCounter|TestTransientValidationErrorDoesNotIncrementCounter|TestAutoDisableOnThreshold|TestIsPermanentValidationErrorClassification' -count=1`
- [x] `go test ./core/taskengine/ -run TestExecutor -count=1` (no regressions in existing executor tests; 22s)
- [ ] After staging→main release reaches Railway: watch Sentry for `task-auto-disabled` events grouped by task ID; confirm 1V stops accruing per-tick events.

## Notes for reviewers

- The `protoc-gen` diff in `protobuf/avs.pb.go` is purely the two new field accessors + struct slots — no toolchain churn.
- Threshold is a const, not yet config-driven. Easy to lift to `aggregator.yaml` later if env tuning is needed.
- This is additive: existing tasks with `consecutive_validation_failures` unset default to 0 (proto3 zero-value), so behavior on upgrade is "as if no prior failures had been counted."
