### PR TITLE
fix: bundle configs into prod docker image

### DIFF
--- a/dockerfiles/aggregator.Dockerfile
+++ b/dockerfiles/aggregator.Dockerfile
@@ -25,4 +25,17 @@ RUN useradd -ms /bin/bash ava && \
 
 COPY --from=builder /ava /ava
 
+# Bundle the in-repo configs so the image is self-contained: the Railway
+# gateway service can run with no external mount, and operators reach
+# config/operator_sample.yaml from inside the container if they want.
+# Without this, `/ava aggregator --config=config/gateway-railway.yaml`
+# fails with "file not found" — see EigenLayer-AVS gateway switchover.
+COPY --from=builder /app/config ./config
+
 ENTRYPOINT ["/ava"]
+
+# Default to the Railway gateway role. Operators (and any other use of
+# this image) override by passing their subcommand + args, e.g.
+# `docker run avaprotocol/ap-avs operator --config=...` — args
+# completely replace CMD per Docker semantics.
+CMD ["aggregator", "--config=config/gateway-railway.yaml"]

--- a/dockerfiles/aggregator.Dockerfile
+++ b/dockerfiles/aggregator.Dockerfile
@@ -34,8 +34,9 @@ COPY --from=builder /app/config /app/config
 
 ENTRYPOINT ["/ava"]
 
-# Default to the Railway gateway role. Operators (and any other use of
-# this image) override by passing their subcommand + args, e.g.
-# `docker run avaprotocol/ap-avs operator --config=...` — args
-# completely replace CMD per Docker semantics.
-CMD ["aggregator", "--config=/app/config/gateway-railway.yaml"]
+# No default CMD: this image is shared with external operators, and
+# silently flipping a no-args invocation from cobra-help-exit-0 to
+# aggregator-boot-fail would change exit codes / monitoring signals
+# for their existing setups. Callers always pass a subcommand:
+#   - Operators: `docker run avaprotocol/ap-avs operator --config=...`
+#   - Railway gateway: Start Command set in the Railway dashboard.

--- a/dockerfiles/aggregator.Dockerfile
+++ b/dockerfiles/aggregator.Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /ava /ava
 # config/operator_sample.yaml from inside the container if they want.
 # Without this, `/ava aggregator --config=config/gateway-railway.yaml`
 # fails with "file not found" — see EigenLayer-AVS gateway switchover.
-COPY --from=builder /app/config ./config
+COPY --from=builder /app/config /app/config
 
 ENTRYPOINT ["/ava"]
 
@@ -38,4 +38,4 @@ ENTRYPOINT ["/ava"]
 # this image) override by passing their subcommand + args, e.g.
 # `docker run avaprotocol/ap-avs operator --config=...` — args
 # completely replace CMD per Docker semantics.
-CMD ["aggregator", "--config=config/gateway-railway.yaml"]
+CMD ["aggregator", "--config=/app/config/gateway-railway.yaml"]

--- a/dockerfiles/operator.Dockerfile
+++ b/dockerfiles/operator.Dockerfile
@@ -25,4 +25,17 @@ RUN useradd -ms /bin/bash ava && \
 
 COPY --from=builder /ava /ava
 
+# Bundle the in-repo configs so the image is self-contained: the Railway
+# gateway service can run with no external mount, and operators reach
+# config/operator_sample.yaml from inside the container if they want.
+# Without this, `/ava aggregator --config=config/gateway-railway.yaml`
+# fails with "file not found" — see EigenLayer-AVS gateway switchover.
+COPY --from=builder /app/config ./config
+
 ENTRYPOINT ["/ava"]
+
+# Default to the Railway gateway role. Operators (and any other use of
+# this image) override by passing their subcommand + args, e.g.
+# `docker run avaprotocol/ap-avs operator --config=...` — args
+# completely replace CMD per Docker semantics.
+CMD ["aggregator", "--config=config/gateway-railway.yaml"]

--- a/dockerfiles/operator.Dockerfile
+++ b/dockerfiles/operator.Dockerfile
@@ -34,8 +34,9 @@ COPY --from=builder /app/config /app/config
 
 ENTRYPOINT ["/ava"]
 
-# Default to the Railway gateway role. Operators (and any other use of
-# this image) override by passing their subcommand + args, e.g.
-# `docker run avaprotocol/ap-avs operator --config=...` — args
-# completely replace CMD per Docker semantics.
-CMD ["aggregator", "--config=/app/config/gateway-railway.yaml"]
+# No default CMD: this image is shared with external operators, and
+# silently flipping a no-args invocation from cobra-help-exit-0 to
+# aggregator-boot-fail would change exit codes / monitoring signals
+# for their existing setups. Callers always pass a subcommand:
+#   - Operators: `docker run avaprotocol/ap-avs operator --config=...`
+#   - Railway gateway: Start Command set in the Railway dashboard.

--- a/dockerfiles/operator.Dockerfile
+++ b/dockerfiles/operator.Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /ava /ava
 # config/operator_sample.yaml from inside the container if they want.
 # Without this, `/ava aggregator --config=config/gateway-railway.yaml`
 # fails with "file not found" — see EigenLayer-AVS gateway switchover.
-COPY --from=builder /app/config ./config
+COPY --from=builder /app/config /app/config
 
 ENTRYPOINT ["/ava"]
 
@@ -38,4 +38,4 @@ ENTRYPOINT ["/ava"]
 # this image) override by passing their subcommand + args, e.g.
 # `docker run avaprotocol/ap-avs operator --config=...` — args
 # completely replace CMD per Docker semantics.
-CMD ["aggregator", "--config=config/gateway-railway.yaml"]
+CMD ["aggregator", "--config=/app/config/gateway-railway.yaml"]


### PR DESCRIPTION
## Summary

Bundle the in-repo configs into the published `avaprotocol/ap-avs` Docker image so the Railway gateway service can point at it directly and read `gateway-railway.yaml` from inside the container. No default CMD — operators using this image keep their existing exit-code / startup behavior.

Bundled commits:
- **fix: bundle configs + default CMD so prod docker image is self-contained** — `8450c36` (initial commit)
- **refactor: use absolute paths in dockerfile COPY and CMD** — `4bec9ce` (Copilot review feedback)
- **refactor: drop default CMD to stay backward-compatible with operators** — `a4aadf6`

## Backward-compat audit (operators)

`avaprotocol/ap-avs` is shared with external operators. Verified each entry below before merging:

| Operator invocation | Before | After |
|---|---|---|
| `docker run … operator --config=…` | works | works (args replace CMD per Docker semantics) |
| `docker run … --help` / `version` | works | works |
| docker-compose with `command:` set | works | works |
| docker-compose with operator-mounted volume at `/app/config` | works | works (volume overlays in-image content) |
| `docker run … ` with **no args** | cobra help + exit 0 | cobra help + exit 0 (no CMD set) |

ENTRYPOINT (`/ava`), WORKDIR (`/app`), binary path, image arches — all unchanged. The only image-level addition is `COPY /app/config /app/config`, which is purely additive (~50KB of YAML); nothing reads those files unless `--config=…` points at them.

## What it took to land here

- `COPY --from=builder /app/config /app/config` — absolute paths per Copilot review; runtime layout independent of `WORKDIR`.
- No default `CMD` — initially added one targeting the Railway gateway, dropped after auditing operator backward-compat.

## After this ships

1. `./scripts/release.sh` builds + pushes the next prod image (e.g. `v3.3.0`).
2. Railway gateway service Source: `Docker Image → avaprotocol/ap-avs:v3.3.0`.
3. Railway gateway **Start Command** (required, since there's no default CMD): `aggregator --config=/app/config/gateway-railway.yaml`
4. Same pattern for worker services — flip Source, set Start Command to `worker --config=/app/config/worker-<chain>-railway.yaml`.
5. `version.semver` / `version.revision` are correctly stamped via ldflags, so Sentry events arrive with `release: X.Y.Z@<sha>` instead of `dev@unknown`. EIGENLAYER-AVS-1T and -1V can then be resolved in next release.

## Test plan

- [ ] Merge: `release.sh` promotes the new pre-release and triggers `publish-prod-docker.yml`. Confirm `avaprotocol/ap-avs:vX.Y.Z` lands on Docker Hub.
- [ ] `docker run --rm avaprotocol/ap-avs:vX.Y.Z` — should still print cobra help and exit 0 (operator backward-compat).
- [ ] `docker run --rm avaprotocol/ap-avs:vX.Y.Z ls /app/config` — should list `gateway-railway.yaml`, `worker-*-railway.yaml`, etc.
- [ ] `docker run --rm avaprotocol/ap-avs:vX.Y.Z aggregator --config=/app/config/gateway-railway.yaml --help` — should print aggregator subcommand help (proves the config path resolves).
- [ ] Switch Railway gateway to `avaprotocol/ap-avs:vX.Y.Z` with the Start Command from step 3 above. Confirm `railway logs` shows aggregator startup.
- [ ] Confirm Sentry events arrive tagged `release: X.Y.Z@<sha>`.
- [ ] Resolve EIGENLAYER-AVS-1T and -1V in Sentry as "resolved in next release".
