### PR TITLE
ci: bump JS actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -42,14 +42,14 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Checkout code
         id: checkout_code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # push event: github.ref is already correct (staging branch)
@@ -140,7 +140,7 @@ jobs:
         shell: bash
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: 'linux/arm64'
         if: steps.platforms.outputs.fast != 'true'
@@ -150,7 +150,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: avaprotocol/avs-dev
           tags: |

--- a/.github/workflows/publish-prod-docker.yml
+++ b/.github/workflows/publish-prod-docker.yml
@@ -104,14 +104,14 @@ jobs:
           echo "✓ $TAG is a published (non-draft, non-prerelease) GitHub release"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Checkout code at the release tag
         id: checkout_code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.git_tag }}
@@ -146,7 +146,7 @@ jobs:
         shell: bash
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: "linux/arm64"
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: avaprotocol/ap-avs
           tags: |

--- a/.github/workflows/release-on-pr-close.yml
+++ b/.github/workflows/release-on-pr-close.yml
@@ -19,7 +19,7 @@ jobs:
       packages: write # If you use GitHub Packages for Docker images (good to have)
     steps:
       - name: Checkout repository with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Fetch all history so go-semantic-release can determine the version based on all commits
           fetch-depth: 0

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0 # Fetch all history for comparing changes
@@ -80,7 +80,7 @@ jobs:
     if: needs.check-changes.outputs.should_run == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           ref: ${{ github.event.inputs.branch || github.ref }}
@@ -142,7 +142,7 @@ jobs:
           - operator
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           ref: ${{ github.event.inputs.branch || github.ref }}

--- a/.github/workflows/token-catalog-drift.yml
+++ b/.github/workflows/token-catalog-drift.yml
@@ -26,7 +26,7 @@ jobs:
     name: token_whitelist matches @avaprotocol/protocols
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

The prod Docker workflow for `v3.5.0` emitted this annotation:

> Node.js 20 actions are deprecated. … `actions/checkout@v4`, `docker/login-action@v3`, `docker/metadata-action@v5`, `docker/setup-qemu-action@v3`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Today (2026-06-12) we're 4 days from the force-switch. Bumping the four called-out actions to majors that ship Node 24 cleans up the deprecation annotation and avoids surprise behavior when GitHub flips the default.

## Mappings

| Action | Before | After | Why this major |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | v5.0.0 (2025-08-11) is where Node 24 first landed. v6 is fine too but adds a persist-credentials refactor that isn't relevant here — v5 is the minimal change. |
| `docker/login-action` | v3 | **v4** | Latest major, Node 24. |
| `docker/setup-qemu-action` | v3 | **v4** | Latest major, Node 24. |
| `docker/metadata-action` | v5 | **v6** | Latest major, Node 24. |

`useblacksmith/setup-docker-builder@v1` and `useblacksmith/build-push-action@v2` weren't in the deprecation warning, so they're untouched.

## Files touched (8 workflow files, mechanical replacement only)

```
 .github/workflows/claude-code-review.yml  | 2 +-
 .github/workflows/claude.yml              | 2 +-
 .github/workflows/publish-dev-docker.yml  | 8 ++++----
 .github/workflows/publish-prod-docker.yml | 8 ++++----
 .github/workflows/release-on-pr-close.yml | 2 +-
 .github/workflows/run-test-on-pr.yml      | 6 +++---
 .github/workflows/token-catalog-drift.yml | 2 +-
```

Only `uses:` lines changed. No logic or input changes.

## Test plan

- [x] `grep -rnE "actions/checkout@v4|docker/login-action@v3|docker/setup-qemu-action@v3|docker/metadata-action@v5" .github/workflows/` returns no matches.
- [ ] PR check `Lint` + `Unit Test (...)` matrix passes — confirms the bumped checkout still works.
- [ ] Next release: confirm the prod + dev docker workflows no longer emit the Node 20 deprecation annotation.

## Note on `actions/checkout@v6` if you want to be more aggressive

v6 (released 2025-11-20) is the current latest and would arguably be the right call for a fresh repo. I went with v5 because the v6 release notes call out a credentials-persistence refactor — implementation detail, almost certainly fine, but the smallest-change-that-fixes-the-annotation principle pointed at v5. Easy to bump again later if you want.
