### PR TITLE
refactor: CHAIN_ENDPOINT rename + Node 24 GHA bump + worker-RPC delegation plan

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -42,14 +42,14 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Checkout code
         id: checkout_code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # push event: github.ref is already correct (staging branch)
@@ -140,7 +140,7 @@ jobs:
         shell: bash
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: 'linux/arm64'
         if: steps.platforms.outputs.fast != 'true'
@@ -150,7 +150,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: avaprotocol/avs-dev
           tags: |

--- a/.github/workflows/publish-prod-docker.yml
+++ b/.github/workflows/publish-prod-docker.yml
@@ -104,14 +104,14 @@ jobs:
           echo "✓ $TAG is a published (non-draft, non-prerelease) GitHub release"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Checkout code at the release tag
         id: checkout_code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.git_tag }}
@@ -146,7 +146,7 @@ jobs:
         shell: bash
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: "linux/arm64"
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: avaprotocol/ap-avs
           tags: |

--- a/.github/workflows/release-on-pr-close.yml
+++ b/.github/workflows/release-on-pr-close.yml
@@ -19,7 +19,7 @@ jobs:
       packages: write # If you use GitHub Packages for Docker images (good to have)
     steps:
       - name: Checkout repository with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Fetch all history so go-semantic-release can determine the version based on all commits
           fetch-depth: 0

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0 # Fetch all history for comparing changes
@@ -80,7 +80,7 @@ jobs:
     if: needs.check-changes.outputs.should_run == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           ref: ${{ github.event.inputs.branch || github.ref }}
@@ -142,7 +142,7 @@ jobs:
           - operator
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           ref: ${{ github.event.inputs.branch || github.ref }}

--- a/.github/workflows/token-catalog-drift.yml
+++ b/.github/workflows/token-catalog-drift.yml
@@ -26,7 +26,7 @@ jobs:
     name: token_whitelist matches @avaprotocol/protocols
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/config/operator-ethereum-railway.yaml
+++ b/config/operator-ethereum-railway.yaml
@@ -4,7 +4,7 @@
 # layout but points at the Railway gateway over private networking.
 # Secrets are injected via Railway sealed environment variables — set
 # these on the `operator-ethereum` service:
-#   ETHEREUM_RPC (HTTPS; WS derived in code)
+#   CHAIN_ENDPOINT (HTTPS; WS derived in code)
 #   ECDSA_KEY_JSON, BLS_KEY_JSON  (operator-entrypoint.sh writes these
 #                                   to /app/keys/ at startup)
 #   OPERATOR_BLS_KEY_PASSWORD, OPERATOR_ECDSA_KEY_PASSWORD
@@ -17,7 +17,7 @@ avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
 operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
 # EigenLayer chain RPC (Ethereum mainnet)
-eth_rpc_url: ${ETHEREUM_RPC}
+eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Key files — written at startup by scripts/operator-entrypoint.sh
 ecdsa_private_key_store_path: /app/keys/ecdsa.key.json
@@ -45,7 +45,7 @@ server_name: "operator-ethereum-railway"
 
 # Destination chain — Ethereum mainnet
 target_chain:
-  eth_rpc_url: ${ETHEREUM_RPC}
+  eth_rpc_url: ${CHAIN_ENDPOINT}
 
 enabled_features:
   event_trigger: true

--- a/config/operator-railway.yaml
+++ b/config/operator-railway.yaml
@@ -10,8 +10,8 @@ operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
 
 # EigenLayer chain RPC (Sepolia) — driven by env var so the key can
 # be rotated without redeploying. Set on the operator service:
-#   SEPOLIA_RPC (HTTPS; WS derived in code)
-eth_rpc_url: ${SEPOLIA_RPC}
+#   CHAIN_ENDPOINT (HTTPS; WS derived in code)
+eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Key files — written at startup by scripts/operator-entrypoint.sh
 # Set ECDSA_KEY_JSON and BLS_KEY_JSON env vars in Railway
@@ -40,7 +40,7 @@ server_name: "operator-railway"
 
 # Destination chain - Sepolia
 target_chain:
-  eth_rpc_url: ${SEPOLIA_RPC}
+  eth_rpc_url: ${CHAIN_ENDPOINT}
 
 enabled_features:
   event_trigger: true

--- a/config/worker-base-railway.yaml
+++ b/config/worker-base-railway.yaml
@@ -3,8 +3,8 @@
 # Secrets are injected via Railway sealed environment variables and
 # expanded at startup (see core/config.ReadYamlConfig). Set these on
 # the `worker-base` Railway service:
-#   BASE_RPC (HTTPS; WS derived in code)
-#   BASE_BUNDLER_URL
+#   CHAIN_ENDPOINT (HTTPS; WS derived in code)
+#   BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
 environment: production
@@ -24,10 +24,10 @@ health_address: "0.0.0.0:8080"
 # dials in. Workers only listen on `listen_address`.
 
 # Chain RPC endpoints (Base mainnet)
-eth_rpc_url: ${BASE_RPC}
+eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Third-party bundler (self-hosted Voltaire)
-bundler_url: ${BASE_BUNDLER_URL}
+bundler_url: ${BUNDLER_URL}
 
 # Smart wallet config
 smart_wallet:

--- a/config/worker-base-sepolia-railway.yaml
+++ b/config/worker-base-sepolia-railway.yaml
@@ -2,8 +2,8 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-base-sepolia` service:
-#   BASE_SEPOLIA_RPC (HTTPS; WS derived in code)
-#   BASE_SEPOLIA_BUNDLER_URL
+#   CHAIN_ENDPOINT (HTTPS; WS derived in code)
+#   BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
 environment: production
@@ -22,10 +22,10 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints (Base Sepolia)
-eth_rpc_url: ${BASE_SEPOLIA_RPC}
+eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Third-party bundler (self-hosted Voltaire)
-bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}
+bundler_url: ${BUNDLER_URL}
 
 # Smart wallet config
 smart_wallet:

--- a/config/worker-bnb-mainnet-railway.yaml
+++ b/config/worker-bnb-mainnet-railway.yaml
@@ -11,8 +11,8 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-bnb-mainnet` service:
-#   BNB_RPC (HTTPS; WS derived in code)
-#   BNB_BUNDLER_URL          — optional for connectivity-only; can be
+#   CHAIN_ENDPOINT (HTTPS; WS derived in code)
+#   BUNDLER_URL          — optional for connectivity-only; can be
 #                              left unset (the YAML expansion will
 #                              produce an empty string and bundler
 #                              calls would no-op)
@@ -35,12 +35,12 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints
-eth_rpc_url: ${BNB_RPC}
+eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Bundler — left as an env var expansion. Unset in connectivity-only
 # mode; populate once a 4337 bundler provider with BNB support is in
 # place.
-bundler_url: ${BNB_BUNDLER_URL}
+bundler_url: ${BUNDLER_URL}
 
 # Smart wallet config
 smart_wallet:

--- a/config/worker-ethereum-railway.yaml
+++ b/config/worker-ethereum-railway.yaml
@@ -3,8 +3,8 @@
 # Secrets are injected via Railway sealed environment variables and
 # expanded at startup (see core/config.ReadYamlConfig). Set these on
 # the `worker-ethereum` Railway service:
-#   ETHEREUM_RPC (HTTPS; WS derived in code)
-#   ETHEREUM_BUNDLER_URL
+#   CHAIN_ENDPOINT (HTTPS; WS derived in code)
+#   BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
 environment: production
@@ -24,10 +24,10 @@ health_address: "0.0.0.0:8080"
 # and dials in. Workers only listen on `listen_address`.
 
 # Chain RPC endpoints (Ethereum mainnet)
-eth_rpc_url: ${ETHEREUM_RPC}
+eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Third-party bundler (self-hosted Voltaire)
-bundler_url: ${ETHEREUM_BUNDLER_URL}
+bundler_url: ${BUNDLER_URL}
 
 # Smart wallet config
 smart_wallet:

--- a/config/worker-sepolia-railway.yaml
+++ b/config/worker-sepolia-railway.yaml
@@ -2,8 +2,8 @@
 #
 # Secrets are injected via Railway sealed env vars and expanded at
 # startup. Set these on the `worker-sepolia` service:
-#   SEPOLIA_RPC (HTTPS; WS derived in code)
-#   SEPOLIA_BUNDLER_URL
+#   CHAIN_ENDPOINT (HTTPS; WS derived in code)
+#   BUNDLER_URL
 #   CONTROLLER_PRIVATE_KEY
 #   PAYMASTER_ADDRESS
 environment: production
@@ -22,10 +22,10 @@ health_address: "0.0.0.0:8080"
 # listen on `listen_address`.
 
 # Chain RPC endpoints
-eth_rpc_url: ${SEPOLIA_RPC}
+eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Third-party bundler (self-hosted Voltaire)
-bundler_url: ${SEPOLIA_BUNDLER_URL}
+bundler_url: ${BUNDLER_URL}
 
 # Smart wallet config
 smart_wallet:

--- a/docs/changes/20260612-delegate-chain-rpc-to-workers.md
+++ b/docs/changes/20260612-delegate-chain-rpc-to-workers.md
@@ -1,0 +1,179 @@
+# Delegate chain RPC reads to workers; drop per-chain RPC config from the gateway
+
+## Why
+
+The gateway today holds direct `*ethclient.Client` connections to every
+chain (`SEPOLIA_RPC`, `BASE_RPC`, `ETHEREUM_RPC`, `BASE_SEPOLIA_RPC`,
+`BNB_RPC`) so it can run `TokenEnrichmentService.GetTokenMetadata` for
+ERC-20 lookups during execution. This duplicates state already
+maintained by the chain workers (each worker owns one chain RPC), and
+forces the gateway to track 5 RPC URLs + 5 sets of credentials when it
+should logically only need its own AVS-chain RPC.
+
+Pain that surfaced operationally:
+
+- A dead Dwellir BNB host took the gateway through a noisy boot warn
+  on every restart, even though BNB workflows weren't running on the
+  gateway — the gateway was just trying to init its own BNB token
+  service.
+- A rotated key requires updating 6 services' env vars; really only
+  one (the worker for that chain) needs to change.
+- Gateway config (`gateway-railway.yaml`) maintains 5 `chains:`
+  entries — half of which (RPC URL, bundler URL) duplicate what each
+  worker already has in its own `*-railway.yaml`.
+
+## Today's state
+
+Worker-side gRPC surface (`protobuf/worker.proto`) — already exposes
+chain-state methods:
+
+```
+service ChainWorker {
+  rpc WorkerHealthCheck(...)
+  rpc ExecuteUserOp(...)
+  rpc GetNonce(...)
+  rpc GetSmartWalletAddress(...)
+  rpc GetTokenMetadata(WorkerGetTokenMetadataReq) returns (WorkerGetTokenMetadataResp);
+}
+```
+
+`worker/server.go:143-159` implements `GetTokenMetadata` by calling
+the worker's local `tokenService.GetTokenMetadata(addr)`. So the
+worker can already answer token-metadata queries — but the gateway
+doesn't call it.
+
+Gateway-side direct chain reads we want to eliminate:
+
+| File:line | Call | Replacement |
+|---|---|---|
+| `core/taskengine/engine.go:4964` | `Engine.GetTokenMetadata(user, payload)` → `n.tokenEnrichmentService.GetTokenMetadata(addr)` | Route to worker for `payload.ChainId`, call `ChainWorker.GetTokenMetadata` |
+| `core/taskengine/shared_event_enrichment.go:237` | `tokenService.GetTokenMetadata(contractAddr)` | Same — chain comes from event log context |
+| `core/taskengine/run_node_immediately.go:1626,2167` | `n.tokenEnrichmentService.GetTokenMetadata(addr)` | Same — chain from task |
+| `core/taskengine/summarizer_context_memory.go:733` | `tokenService.GetTokenMetadata(address)` | Same — chain from execution context |
+
+All five call sites already have access to the chain context (the
+task's `ChainId` is the canonical source), so the routing layer is
+straightforward.
+
+## Plan
+
+### Phase 1 — introduce a `ChainTokenLookup` indirection in the gateway
+
+New type in `core/taskengine/`:
+
+```go
+// ChainTokenLookup resolves token metadata for a given chain.
+// Production implementation routes via the chain's worker gRPC;
+// tests can swap in a fake.
+type ChainTokenLookup interface {
+    GetTokenMetadata(ctx context.Context, chainID uint64, addr string) (*TokenMetadata, error)
+}
+```
+
+Two implementations:
+
+1. **Worker-routed** (prod): looks up the worker for `chainID` from
+   the `ChainRegistry` already maintained at `aggregator/chain_registry.go`,
+   calls `ChainWorker.GetTokenMetadata` over the existing gRPC
+   connection. The registry already knows the mapping
+   (`worker-bnb-mainnet.railway.internal:50051` → chain 56 etc.) —
+   we'd just expose a getter.
+2. **Local-fallback** (single-binary, integration tests): falls back
+   to the existing `TokenEnrichmentService` for callers that don't
+   pass through the gateway.
+
+### Phase 2 — replace the five call sites
+
+Each of the five gateway-side callsites already has the chain ID in
+scope. Convert them in one PR:
+
+```go
+// before
+md, err := n.tokenEnrichmentService.GetTokenMetadata(addr)
+
+// after
+md, err := n.chainTokenLookup.GetTokenMetadata(ctx, task.ChainId, addr)
+```
+
+`TokenEnrichmentService` itself stays — the **worker** uses it
+unchanged. We're only changing who *invokes* it.
+
+### Phase 3 — drop per-chain RPC config from the gateway
+
+Once Phase 2 is live and confirmed in production:
+
+1. Remove the per-chain RPC + bundler entries from
+   `gateway-railway.yaml`'s `chains:` block. Each entry collapses to
+   just `worker_addr: worker-X.railway.internal:50051` + the static
+   AVS contract addresses.
+2. Delete `SEPOLIA_RPC`, `BASE_RPC`, `ETHEREUM_RPC`, `BASE_SEPOLIA_RPC`,
+   `BNB_RPC` env vars from the **gateway** Railway service. (The
+   single `eth_rpc_url` at the top of the config — the AVS-registered
+   chain, currently Sepolia — stays.)
+3. Workers keep `CHAIN_ENDPOINT` (post-rename from PR landing today).
+
+### Phase 4 — audit other gateway direct-RPC paths
+
+Token metadata is the easiest one because the worker gRPC is already
+in place. Other direct-RPC consumers in the gateway worth auditing:
+
+- **`aggregator/task_engine.go`** chain config bootstrap — currently
+  loads paymaster, factory, entrypoint addresses for every chain.
+  These are static (not RPC-read), so they don't need delegation,
+  but the config layout should reflect that they're chain-static and
+  not RPC-dependent.
+- **`aggregator/chain_registry.go`** — already routes via worker
+  for chain-specific calls. Confirm there's no fallback path that
+  dials chain RPC directly from the gateway.
+- **ETH transfer / contract-write nodes** that resolve sender,
+  estimate gas, sign userops — likely already go through worker
+  `ExecuteUserOp` + `GetNonce` + `GetSmartWalletAddress`. Trace and
+  confirm.
+
+If any direct-RPC paths surface in Phase 4 that the worker doesn't
+already cover, extend the worker gRPC surface as needed before
+ripping out the gateway's RPC config.
+
+## Risks & rollback
+
+- **Worker-routed lookup latency**: adds 1 gRPC round-trip per token
+  lookup. Workers are on Railway's private network (`<svc>.railway.internal`),
+  so single-digit milliseconds. The local
+  `TokenEnrichmentService` cache lives on the worker side now —
+  consider whether the gateway also needs a thin LRU in front to
+  collapse repeated lookups per execution.
+- **Worker availability**: a dead worker makes token lookups for its
+  chain fail. Already true today for other worker calls (nonce,
+  userop) — the gateway already handles worker-unreachable gracefully.
+  No new failure mode introduced.
+- **Rollback**: revert the Phase 2 PR. The
+  `TokenEnrichmentService` and gateway env vars stay in place
+  through Phase 2, so there's no flag-day. Phase 3 (deleting gateway
+  RPC config) is the irreversible step — only do it after Phase 2
+  has been stable in prod for at least one release cycle.
+
+## Out of scope
+
+- Refactoring `TokenEnrichmentService` itself. It's the right
+  internal API; just executed at the wrong layer.
+- Cross-chain token metadata (a token at the same address on two
+  chains). Each lookup already carries `chainID`; no design change
+  needed.
+- Removing the `SEPOLIA_RPC` env var on the gateway (the AVS-RPC,
+  not a chains[] entry). The gateway still needs to talk to the
+  EigenLayer/AVS contracts on its registered chain.
+
+## Concrete sequencing
+
+1. **PR A**: introduce `ChainTokenLookup` interface + worker-routed
+   implementation. No call-site changes; type sits unused except for
+   tests.
+2. **PR B**: migrate the five call sites to use `ChainTokenLookup`.
+   Behavior-preserving — production switches to worker-routed lookups.
+3. **One full release cycle on Phase 2** to confirm no regressions
+   (Sentry should stay quiet on token lookups).
+4. **PR C**: strip per-chain RPC entries from `gateway-railway.yaml`;
+   delete corresponding env vars from the gateway Railway service.
+
+PR A + B can land in the same release. PR C waits for the safety
+cycle.


### PR DESCRIPTION
## Summary

Three commits bundled into this staging→main release:

- `c579f3a` **ci: bump JS actions to Node 24-compatible majors**
- `a56acd7` **refactor: rename per-chain envs to CHAIN_ENDPOINT on single-chain services**
- `e14f7a5` **docs: plan for delegating chain RPC reads to workers**

## 1. Node 24 GHA bump (time-sensitive)

GitHub force-switches JS actions to Node 24 on **2026-06-16 (Monday)**. After that, the v3.5.0 prod docker workflow's `actions/checkout@v4`, `docker/login-action@v3`, `docker/setup-qemu-action@v3`, `docker/metadata-action@v5` would either get auto-migrated or break outright. Bumping them now:

| Action | v3.5 → v3.6 |
|---|---|
| `actions/checkout` | v4 → v5 |
| `docker/login-action` | v3 → v4 |
| `docker/setup-qemu-action` | v3 → v4 |
| `docker/metadata-action` | v5 → v6 |

8 workflow files; `uses:` lines only, no logic changes.

## 2. CHAIN_ENDPOINT rename

Workers and operators each serve exactly one chain. Encoding the chain in env-var names (`SEPOLIA_RPC`, `BASE_RPC`, …) was redundant — the chain is already in the service name. Renamed on each single-chain service config:

- `${<CHAIN>_RPC}` → `${CHAIN_ENDPOINT}`
- `${<CHAIN>_BUNDLER_URL}` → `${BUNDLER_URL}`

Files touched: 5 `worker-*-railway.yaml` + 2 `operator-*-railway.yaml`. The gateway config (`gateway-railway.yaml`) keeps the per-chain names — it iterates over all chains and must distinguish them.

**Railway side is already prepared** — `CHAIN_ENDPOINT` and `BUNDLER_URL` have been upserted on all 7 single-chain services with references to the same shared variables (matching style preserved per service). Legacy `<CHAIN>_RPC` vars stay in place until the new image is fully rolled out.

## 3. Worker-RPC delegation design doc

`docs/changes/20260612-delegate-chain-rpc-to-workers.md` documents the next architecture step:

- Gateway today holds direct `ethclient.Client` connections to every chain just to run `TokenEnrichmentService.GetTokenMetadata`.
- `worker/server.go:143` already implements `GetTokenMetadata` over gRPC — workers can already answer this.
- Plan: route gateway's 5 callsites through a new `ChainTokenLookup` interface that delegates to the worker for that chain. Strip per-chain RPC entries from `gateway-railway.yaml` after one stable release cycle.

No code changes in this PR — design doc only. Phase A+B is a follow-up PR.

## Semantic-release behavior to be aware of

None of the three commits use `feat:` or `fix:` prefixes, so **semantic-release will not produce a new version tag** on merge. The CHAIN_ENDPOINT rename therefore won't take effect on Railway until the next `feat:`/`fix:` release ships and a new image rolls out with the renamed configs.

That's intentional — the Railway env vars are already set up to handle both the current `<CHAIN>_RPC` naming (which v3.5.0 still reads) and the new `CHAIN_ENDPOINT` naming (which the next image will read). Zero-downtime by design. If you want to force a release for this specific change, push a `feat: …` commit on top before merge.

## Test plan

- [x] `bash -n` clean on all touched files; lint matrix green on PR #577 (which merged this content to staging).
- [ ] After merge: no new version tag (expected per the semantic-release note above).
- [ ] Next `feat:`/`fix:` release: new image built; Railway flips via `./scripts/release.sh`; services pick up `CHAIN_ENDPOINT` cleanly from the dormant vars.
- [ ] Mon 2026-06-16 onward: no Node 20 deprecation annotation on GHA runs.

## Bundlers — separate, already handled

Three bundler services (base, base-sepolia, ethereum) crashed earlier today due to a latent broken cross-reference to deleted gateway `${{gateway.<CHAIN>_DWELLIR_RPC}}` vars (not related to this PR's content). Already fixed — repointed each `VOLTAIRE_ETHEREUM_NODE_URL` to `${{shared.<CHAIN>_RPC}}`. All bundlers back to SUCCESS. Documented separately.
