### PR TITLE
feat: route gateway fee-estimator + nonce reads through workers (Phase 3)

### DIFF
--- a/aggregator/rest/handlers_wallets.go
+++ b/aggregator/rest/handlers_wallets.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
-	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/avsclient"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
@@ -274,14 +274,24 @@ func (s *Server) GetWalletNonce(ctx echo.Context, address generated.EthereumAddr
 	} else if authed := restmw.UserFromContext(ctx); authed != nil {
 		chainID = authed.ChainID
 	}
-	rpc, _ := s.resolveSmartWalletForChain(chainID)
-	if rpc == nil {
-		return &restmw.HTTPError{
-			Status: http.StatusServiceUnavailable,
-			Code:   "NONCE_UNAVAILABLE",
-			Title:  "Smart wallet RPC not configured",
-			Detail: "This aggregator instance was started without a smart-wallet RPC client for the requested chain.",
+	// Prefer the per-chain ChainStateReader — in gateway mode this is
+	// a worker-routed reader so the gateway no longer issues the
+	// EntryPoint nonce eth_call itself. Falls back to the direct-RPC
+	// reader (single-chain mode) or, if the registry is empty, to a
+	// fresh direct reader wrapping resolveSmartWalletForChain's
+	// ethclient (transitional belt-and-braces).
+	chainReader := taskengine.GetChainStateReaderForChain(uint64(chainID))
+	if chainReader == nil {
+		rpc, _ := s.resolveSmartWalletForChain(chainID)
+		if rpc == nil {
+			return &restmw.HTTPError{
+				Status: http.StatusServiceUnavailable,
+				Code:   "NONCE_UNAVAILABLE",
+				Title:  "Smart wallet RPC not configured",
+				Detail: "This aggregator instance was started without a smart-wallet RPC client for the requested chain.",
+			}
 		}
+		chainReader = taskengine.NewDirectChainStateReader(rpc, chainID)
 	}
 
 	// Ownership check — the engine's GetWalletFromDB lookup is the
@@ -296,7 +306,7 @@ func (s *Server) GetWalletNonce(ctx echo.Context, address generated.EthereumAddr
 		}
 	}
 
-	nonce, err := aa.GetNonce(rpc, walletAddr, big.NewInt(0))
+	nonce, err := chainReader.GetEntryPointNonce(ctx.Request().Context(), walletAddr, big.NewInt(0))
 	if err != nil {
 		return fmt.Errorf("entrypoint nonce read failed: %w", err)
 	}

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/mapping"
 	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
@@ -375,14 +376,32 @@ func (s *Server) EstimateWorkflowFees(ctx echo.Context) error {
 	if body.ChainId != nil {
 		reqChainID = *body.ChainId
 	}
-	rpc, smartWalletCfg := s.resolveSmartWalletForChain(reqChainID)
-	if rpc == nil {
+	_, smartWalletCfg := s.resolveSmartWalletForChain(reqChainID)
+	if smartWalletCfg == nil {
 		return &restmw.HTTPError{
 			Status: http.StatusServiceUnavailable,
 			Code:   "FEES_UNAVAILABLE",
 			Title:  "Fee estimator not configured",
-			Detail: "This aggregator instance was started without a smart-wallet RPC client for the requested chain.",
+			Detail: "This aggregator instance has no smart-wallet config for the requested chain.",
 		}
+	}
+
+	// Resolve the per-chain ChainStateReader. In gateway mode this is a
+	// worker-routed reader (the gateway no longer holds direct chain-RPC
+	// connections for fee-estimator reads). In single-chain mode it's a
+	// direct reader wrapping the aggregator's own ethclient.
+	chainReader := taskengine.GetChainStateReaderForChain(uint64(reqChainID))
+	if chainReader == nil {
+		rpc, _ := s.resolveSmartWalletForChain(reqChainID)
+		if rpc == nil {
+			return &restmw.HTTPError{
+				Status: http.StatusServiceUnavailable,
+				Code:   "FEES_UNAVAILABLE",
+				Title:  "Fee estimator not configured",
+				Detail: "This aggregator instance was started without a chain-state reader for the requested chain.",
+			}
+		}
+		chainReader = taskengine.NewDirectChainStateReader(rpc, reqChainID)
 	}
 
 	trigger, err := mapping.OpenAPIToProtoTrigger(body.Trigger)
@@ -425,18 +444,14 @@ func (s *Server) EstimateWorkflowFees(ctx echo.Context) error {
 		req.ChainId = *body.ChainId
 	}
 
-	var estimator *taskengine.FeeEstimator
-	if s.config != nil && s.config.FeeRates != nil {
-		estimator = taskengine.NewFeeEstimatorWithConfig(
-			s.logger, rpc, s.engine.GetTenderlyClient(),
-			smartWalletCfg, s.priceService, s.config.FeeRates,
-		)
-	} else {
-		estimator = taskengine.NewFeeEstimator(
-			s.logger, rpc, s.engine.GetTenderlyClient(),
-			smartWalletCfg, s.priceService,
-		)
+	var feeRatesCfg *config.FeeRatesConfig
+	if s.config != nil {
+		feeRatesCfg = s.config.FeeRates
 	}
+	estimator := taskengine.NewFeeEstimatorWithChainReader(
+		s.logger, chainReader, s.engine.GetTenderlyClient(),
+		smartWalletCfg, s.priceService, feeRatesCfg,
+	)
 
 	resp, err := estimator.EstimateFees(ctx.Request().Context(), req)
 	if err != nil {

--- a/aggregator/task_engine.go
+++ b/aggregator/task_engine.go
@@ -104,12 +104,15 @@ func (agg *Aggregator) startTaskEngine(ctx context.Context) {
 				continue
 			}
 			// We still dial the chain RPC for smartWalletRpcByChain — the
-			// gateway uses it for things like balance reads in the
-			// withdraw flow that haven't been routed through workers yet
-			// (tracked in docs/changes/20260612-delegate-chain-rpc-to-workers.md).
-			// Token-metadata lookups, however, now route through the chain
-			// worker so we don't need direct RPC for them. The dial here
-			// is therefore unchanged for now — Phase B drops it.
+			// gateway uses it for ERC-20 balance reads in the withdraw
+			// flow (rpc_server.go:ExecuteWithdraw) that haven't been
+			// routed through workers yet. Phase 3 of the design doc
+			// migrated FeeEstimator + EntryPoint-nonce reads off this
+			// client and onto worker-routed ChainStateReaders below;
+			// the dial here is the last remaining direct chain-RPC
+			// dependency and gets removed in the withdraw-migration
+			// follow-up (Phase 4) tracked in
+			// docs/changes/20260612-delegate-chain-rpc-to-workers.md.
 			chainRpc, err := ethclient.Dial(chain.SmartWallet.EthRpcUrl)
 			if err != nil {
 				agg.logger.Warn("Failed to dial chain RPC",
@@ -158,6 +161,29 @@ func (agg *Aggregator) startTaskEngine(ctx context.Context) {
 				"chainID", chainTokenService.GetChainID(),
 				"whitelistTokens", chainTokenService.GetCacheSize(),
 				"worker_routed", workerRouted)
+
+			// Register a ChainStateReader for this chain. In gateway mode
+			// we prefer the worker-routed reader so the gateway itself
+			// doesn't need to keep a chain-RPC connection alive for gas
+			// price / EstimateGas / CodeAt / EntryPoint-nonce reads.
+			// Fall back to the direct-RPC reader if the worker isn't
+			// reachable (mirrors the TokenEnrichmentService fallback above).
+			var chainStateReader taskengine.ChainStateReader
+			chainStateWorkerRouted := false
+			if agg.chainRegistry != nil {
+				if entry, err := agg.chainRegistry.GetWorker(chain.ChainID); err == nil {
+					chainStateReader = taskengine.NewWorkerChainStateReader(entry.Client, chain.ChainID, 10*time.Second)
+					chainStateWorkerRouted = true
+				}
+			}
+			if chainStateReader == nil {
+				chainStateReader = taskengine.NewDirectChainStateReader(chainRpc, chain.ChainID)
+			}
+			taskengine.RegisterChainStateReader(uint64(chain.ChainID), chainStateReader)
+			agg.logger.Info("Chain ChainStateReader registered",
+				"chain", chain.Name,
+				"chain_id", chain.ChainID,
+				"worker_routed", chainStateWorkerRouted)
 		}
 	}
 
@@ -179,6 +205,16 @@ func (agg *Aggregator) startTaskEngine(ctx context.Context) {
 				agg.logger.Info("Global TokenEnrichmentService initialized",
 					"chainID", tokenService.GetChainID(),
 					"cacheSize", tokenService.GetCacheSize())
+				// Also register a ChainStateReader for this chain so the
+				// REST handlers' per-chain lookup hits an entry in
+				// single-chain mode too. chainID is detected via the
+				// reader's lazy ChainID() call — we register here under
+				// the freshly-initialized tokenService's chainID.
+				if cid := tokenService.GetChainID(); cid != 0 {
+					taskengine.RegisterChainStateReader(cid, taskengine.NewDirectChainStateReader(rpcClient, int64(cid)))
+					agg.logger.Info("Global ChainStateReader registered",
+						"chain_id", cid)
+				}
 			}
 		}
 	}

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -61,27 +61,47 @@ type ChainStateReader interface {
 // what the gateway currently does for every chain it knows about. Kept
 // for non-gateway callers (single-chain mode, tests) and as the
 // fall-back when the worker for a chain isn't reachable.
+//
+// Instances are stored in the global registry and shared across
+// concurrent HTTP requests, so the lazy-ChainID cache must be
+// goroutine-safe — see detectOnce.
 type directChainStateReader struct {
-	client  *ethclient.Client
-	chainID int64 // 0 means "detect on first call"
+	client *ethclient.Client
+
+	// chainID + detectOnce guard the lazy chain-ID detection. Once
+	// set (either at construction or by the first detect-on-demand
+	// call), chainID is immutable. detectOnce ensures only one
+	// goroutine ever issues the eth_chainId RPC.
+	chainID    int64
+	detectOnce sync.Once
+	detectErr  error
 }
 
 // NewDirectChainStateReader wraps an existing ethclient.Client.
 // chainID may be 0 (will be detected on first ChainID call); pass a
 // known chainID to avoid the round-trip if you have one.
 func NewDirectChainStateReader(client *ethclient.Client, chainID int64) ChainStateReader {
-	return &directChainStateReader{client: client, chainID: chainID}
+	r := &directChainStateReader{client: client, chainID: chainID}
+	if chainID != 0 {
+		// Pre-marking detectOnce as done lets ChainID return the
+		// constructor-supplied value without entering the once-block.
+		r.detectOnce.Do(func() {})
+	}
+	return r
 }
 
 func (d *directChainStateReader) ChainID(ctx context.Context) (int64, error) {
-	if d.chainID != 0 {
-		return d.chainID, nil
+	d.detectOnce.Do(func() {
+		id, err := d.client.ChainID(ctx)
+		if err != nil {
+			d.detectErr = fmt.Errorf("ChainID: %w", err)
+			return
+		}
+		d.chainID = id.Int64()
+	})
+	if d.detectErr != nil {
+		return 0, d.detectErr
 	}
-	id, err := d.client.ChainID(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("ChainID: %w", err)
-	}
-	d.chainID = id.Int64()
 	return d.chainID, nil
 }
 
@@ -157,13 +177,19 @@ func (w *workerChainStateReader) SuggestGasPrice(ctx context.Context) (*big.Int,
 }
 
 func (w *workerChainStateReader) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	// Refuse to silently fan out a missing To as "contract deployment"
+	// — this reader is exclusively used by the fee estimator, which
+	// always has a destination (factory address, contract address).
+	// A nil To here is a caller bug we'd rather surface than mask.
+	if msg.To == nil {
+		return 0, fmt.Errorf("EstimateGas: msg.To is required (deployment estimation not supported via this path)")
+	}
+
 	ctx, cancel := w.withTimeout(ctx)
 	defer cancel()
 	req := &avsproto.WorkerEstimateGasReq{
+		To:   msg.To.Hex(),
 		Data: msg.Data,
-	}
-	if msg.To != nil {
-		req.To = msg.To.Hex()
 	}
 	if (msg.From != common.Address{}) {
 		req.From = msg.From.Hex()
@@ -209,10 +235,13 @@ func (w *workerChainStateReader) GetEntryPointNonce(ctx context.Context, walletA
 	return v, nil
 }
 
+// withTimeout caps the gRPC call's wall time. context.WithTimeout
+// honors whichever deadline is sooner (parent or now+w.timeout), so
+// it's always safe to call — we no longer special-case the
+// already-has-deadline path. That used to let an HTTP handler's
+// 30-60s server-write deadline override our 10s worker-call cap,
+// stalling the gateway when a worker hung.
 func (w *workerChainStateReader) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	if _, ok := ctx.Deadline(); ok {
-		return ctx, func() {}
-	}
 	return context.WithTimeout(ctx, w.timeout)
 }
 

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -1,0 +1,264 @@
+package taskengine
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// ChainStateReader is the small set of chain-RPC operations the gateway
+// needs to perform on a chain that's NOT the gateway's own AVS chain.
+// The gateway used to dial each chain's RPC directly to satisfy these
+// calls; this interface lets us route them through the chain worker's
+// gRPC instead (see WorkerChainStateReader below).
+//
+// Methods are intentionally narrow — only what FeeEstimator and the REST
+// nonce handler actually call. Adding a method here requires extending
+// worker.proto + worker/server.go too, so prefer adding to existing
+// methods or composing them when possible.
+//
+// Context is propagated so graceful-shutdown cancellation can short-
+// circuit in-flight chain reads — unlike the original TokenEnrichmentService
+// fetcher (which we deferred ctx propagation on as a Phase A tradeoff),
+// FeeEstimator already takes ctx everywhere it makes chain calls, so we
+// thread it through here cleanly from the start.
+type ChainStateReader interface {
+	// ChainID returns the chain this reader is bound to. Cached/known
+	// a priori in the worker-routed implementation; detected on first
+	// call in the direct-RPC implementation.
+	ChainID(ctx context.Context) (int64, error)
+
+	// SuggestGasPrice returns a suggested gas price in wei for this chain.
+	SuggestGasPrice(ctx context.Context) (*big.Int, error)
+
+	// EstimateGas returns the estimated gas units for the given message.
+	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
+
+	// CodeAt returns the contract bytecode at addr, latest block.
+	// nil-equivalent blockNumber per ethclient semantics.
+	CodeAt(ctx context.Context, addr common.Address) ([]byte, error)
+
+	// GetEntryPointNonce reads the ERC-4337 EntryPoint nonce for the
+	// given smart wallet address. key is the 192-bit nonce-space key
+	// (typically 0 for the default space). Mirrors aa.GetNonce.
+	GetEntryPointNonce(ctx context.Context, walletAddr common.Address, key *big.Int) (*big.Int, error)
+}
+
+// ---------------------------------------------------------------------
+// Direct-RPC implementation
+// ---------------------------------------------------------------------
+
+// directChainStateReader is the legacy path: the gateway holds an
+// ethclient.Client per chain and calls each method directly. This is
+// what the gateway currently does for every chain it knows about. Kept
+// for non-gateway callers (single-chain mode, tests) and as the
+// fall-back when the worker for a chain isn't reachable.
+type directChainStateReader struct {
+	client  *ethclient.Client
+	chainID int64 // 0 means "detect on first call"
+}
+
+// NewDirectChainStateReader wraps an existing ethclient.Client.
+// chainID may be 0 (will be detected on first ChainID call); pass a
+// known chainID to avoid the round-trip if you have one.
+func NewDirectChainStateReader(client *ethclient.Client, chainID int64) ChainStateReader {
+	return &directChainStateReader{client: client, chainID: chainID}
+}
+
+func (d *directChainStateReader) ChainID(ctx context.Context) (int64, error) {
+	if d.chainID != 0 {
+		return d.chainID, nil
+	}
+	id, err := d.client.ChainID(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("ChainID: %w", err)
+	}
+	d.chainID = id.Int64()
+	return d.chainID, nil
+}
+
+func (d *directChainStateReader) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	return d.client.SuggestGasPrice(ctx)
+}
+
+func (d *directChainStateReader) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	return d.client.EstimateGas(ctx, msg)
+}
+
+func (d *directChainStateReader) CodeAt(ctx context.Context, addr common.Address) ([]byte, error) {
+	return d.client.CodeAt(ctx, addr, nil)
+}
+
+func (d *directChainStateReader) GetEntryPointNonce(_ context.Context, walletAddr common.Address, key *big.Int) (*big.Int, error) {
+	// aa.GetNonce uses bind.CallOpts internally; it doesn't take ctx
+	// (legacy signature). Context cancellation here is therefore a
+	// best-effort no-op — the underlying eth_call may still be in
+	// flight when the caller cancels. Worth fixing in aa as a
+	// separate follow-up; out of scope for this layer.
+	return getEntryPointNonceDirect(d.client, walletAddr, key)
+}
+
+// ---------------------------------------------------------------------
+// Worker-routed implementation
+// ---------------------------------------------------------------------
+
+// workerChainStateReader routes each call to the chain's worker via
+// gRPC. This is what the gateway uses in gateway mode — the gateway
+// itself no longer holds chain-RPC connections (other than its own
+// AVS chain).
+//
+// chainID is explicit because the worker doesn't expose a ChainID RPC
+// (would be wasteful — the gateway already knows which chain it's
+// dialing). Construct one of these per chain via NewWorkerChainStateReader.
+type workerChainStateReader struct {
+	client  avsproto.ChainWorkerClient
+	chainID int64
+	timeout time.Duration
+}
+
+// NewWorkerChainStateReader returns a ChainStateReader that delegates
+// every call to the supplied chain worker. timeout caps each gRPC
+// call's wall time; 10s is a reasonable default — workers are on
+// Railway's private network, so well under a second is typical.
+func NewWorkerChainStateReader(client avsproto.ChainWorkerClient, chainID int64, timeout time.Duration) ChainStateReader {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &workerChainStateReader{client: client, chainID: chainID, timeout: timeout}
+}
+
+func (w *workerChainStateReader) ChainID(_ context.Context) (int64, error) {
+	if w.chainID == 0 {
+		return 0, fmt.Errorf("worker-routed reader constructed without chainID")
+	}
+	return w.chainID, nil
+}
+
+func (w *workerChainStateReader) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	resp, err := w.client.SuggestGasPrice(ctx, &avsproto.WorkerSuggestGasPriceReq{})
+	if err != nil {
+		return nil, fmt.Errorf("worker SuggestGasPrice (chain %d): %w", w.chainID, err)
+	}
+	v, ok := new(big.Int).SetString(resp.GasPriceWei, 10)
+	if !ok {
+		return nil, fmt.Errorf("worker returned malformed gas price %q for chain %d", resp.GasPriceWei, w.chainID)
+	}
+	return v, nil
+}
+
+func (w *workerChainStateReader) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	req := &avsproto.WorkerEstimateGasReq{
+		Data: msg.Data,
+	}
+	if msg.To != nil {
+		req.To = msg.To.Hex()
+	}
+	if (msg.From != common.Address{}) {
+		req.From = msg.From.Hex()
+	}
+	if msg.Value != nil {
+		req.Value = msg.Value.String()
+	}
+	resp, err := w.client.EstimateGas(ctx, req)
+	if err != nil {
+		return 0, fmt.Errorf("worker EstimateGas (chain %d): %w", w.chainID, err)
+	}
+	return resp.Gas, nil
+}
+
+func (w *workerChainStateReader) CodeAt(ctx context.Context, addr common.Address) ([]byte, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	resp, err := w.client.GetCode(ctx, &avsproto.WorkerGetCodeReq{Address: addr.Hex()})
+	if err != nil {
+		return nil, fmt.Errorf("worker GetCode (chain %d): %w", w.chainID, err)
+	}
+	return resp.Code, nil
+}
+
+func (w *workerChainStateReader) GetEntryPointNonce(ctx context.Context, walletAddr common.Address, key *big.Int) (*big.Int, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	keyStr := "0"
+	if key != nil {
+		keyStr = key.String()
+	}
+	resp, err := w.client.GetNonceByAddress(ctx, &avsproto.WorkerGetNonceByAddressReq{
+		WalletAddress: walletAddr.Hex(),
+		NonceKey:      keyStr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("worker GetNonceByAddress (chain %d): %w", w.chainID, err)
+	}
+	v, ok := new(big.Int).SetString(resp.Nonce, 10)
+	if !ok {
+		return nil, fmt.Errorf("worker returned malformed nonce %q for %s on chain %d", resp.Nonce, walletAddr.Hex(), w.chainID)
+	}
+	return v, nil
+}
+
+func (w *workerChainStateReader) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, w.timeout)
+}
+
+// ---------------------------------------------------------------------
+// Per-chain registry
+// ---------------------------------------------------------------------
+
+// chainStateReaderRegistry holds ChainStateReader instances keyed by chain ID.
+// Populated at startup by the aggregator: in gateway mode it gets one
+// worker-routed reader per chain in chains[]; in single-chain mode it gets
+// exactly one direct-RPC reader. Mirrors tokenServiceRegistry so callers
+// that already know which chain a workflow targets can resolve the right
+// reader via GetChainStateReaderForChain.
+var (
+	chainStateReaderRegistry      = make(map[uint64]ChainStateReader)
+	chainStateReaderRegistryMutex sync.RWMutex
+)
+
+// RegisterChainStateReader stores reader under chainID so callers can look
+// it up later via GetChainStateReaderForChain. Idempotent: re-registering
+// the same chain replaces the prior entry. chainID 0 is rejected.
+func RegisterChainStateReader(chainID uint64, reader ChainStateReader) {
+	if reader == nil || chainID == 0 {
+		return
+	}
+	chainStateReaderRegistryMutex.Lock()
+	chainStateReaderRegistry[chainID] = reader
+	chainStateReaderRegistryMutex.Unlock()
+}
+
+// GetChainStateReaderForChain returns the registered reader for the given
+// chain ID, or nil when none is registered. Returns nil for chainID 0.
+func GetChainStateReaderForChain(chainID uint64) ChainStateReader {
+	if chainID == 0 {
+		return nil
+	}
+	chainStateReaderRegistryMutex.RLock()
+	defer chainStateReaderRegistryMutex.RUnlock()
+	return chainStateReaderRegistry[chainID]
+}
+
+// ClearChainStateReaderRegistry wipes the registry. Test-only helper —
+// production code never calls this. Mirrors the lifecycle of
+// tokenServiceRegistry which assumes startup-once registration.
+func ClearChainStateReaderRegistry() {
+	chainStateReaderRegistryMutex.Lock()
+	chainStateReaderRegistry = make(map[uint64]ChainStateReader)
+	chainStateReaderRegistryMutex.Unlock()
+}

--- a/core/taskengine/chain_state_reader_aa.go
+++ b/core/taskengine/chain_state_reader_aa.go
@@ -1,0 +1,18 @@
+package taskengine
+
+import (
+	"math/big"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// getEntryPointNonceDirect bridges directChainStateReader.GetEntryPointNonce
+// to aa.GetNonce. Lives in its own file to keep chain_state_reader.go
+// free of the aa package dependency — that lets us mock-out the aa
+// path more cleanly in tests (link a shim in a test-only file when
+// needed) and keeps the interface-level reader logic readable.
+func getEntryPointNonceDirect(client *ethclient.Client, walletAddr common.Address, key *big.Int) (*big.Int, error) {
+	return aa.GetNonce(client, walletAddr, key)
+}

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -250,6 +251,65 @@ func TestWorkerChainStateReader_GetEntryPointNonce_Malformed(t *testing.T) {
 	if _, err := r.GetEntryPointNonce(context.Background(), common.HexToAddress("0xab"), nil); err == nil {
 		t.Fatalf("expected malformed-nonce error")
 	}
+}
+
+// TestWorkerChainStateReader_EstimateGas_NilToRejected: gateway-side
+// callers always have a destination (factory address / contract address).
+// A nil msg.To means the caller has a bug; we'd rather surface it than
+// silently forward as a deployment estimate (which is what the worker
+// server's CallMsg{To: nil} would imply to ethclient).
+func TestWorkerChainStateReader_EstimateGas_NilToRejected(t *testing.T) {
+	r := NewWorkerChainStateReader(&chainStateFakeClient{}, 1, time.Second)
+	_, err := r.EstimateGas(context.Background(), ethereum.CallMsg{Data: []byte{0xaa}})
+	if err == nil {
+		t.Fatalf("expected error for nil msg.To")
+	}
+	if !strings.Contains(err.Error(), "msg.To is required") {
+		t.Fatalf("error should mention msg.To: got %v", err)
+	}
+}
+
+// TestDirectChainStateReader_ChainID_FromConstructor: the constructor
+// chainID short-circuits the eth_chainId RPC. Important because the
+// gateway always supplies a known chainID via the chain config.
+func TestDirectChainStateReader_ChainID_FromConstructor(t *testing.T) {
+	r := NewDirectChainStateReader(nil, 8453)
+	id, err := r.ChainID(context.Background())
+	if err != nil {
+		t.Fatalf("ChainID: %v", err)
+	}
+	if id != 8453 {
+		t.Fatalf("ChainID: got %d, want 8453", id)
+	}
+}
+
+// TestDirectChainStateReader_ChainID_RaceSafe spins up N concurrent
+// callers on a single direct reader and confirms only one of them
+// races to a successful ChainID read. The lazy detect path used to
+// have an unsynchronized read+write — sync.Once now guards it.
+// Tested via the same reader instance across goroutines, which is
+// how the global registry exposes it.
+func TestDirectChainStateReader_ChainID_RaceSafe(t *testing.T) {
+	// We can't construct an ethclient.Client without a network, so
+	// we just confirm the cached-chainID path (constructor != 0)
+	// is safe under concurrency — that's the production hot path
+	// for direct readers, since chainID=0 only ever happens in the
+	// global-fallback init in task_engine.go, and even there the
+	// detected value is registered as a fully-formed reader.
+	r := NewDirectChainStateReader(nil, 11155111)
+	var wg sync.WaitGroup
+	const N = 32
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			id, err := r.ChainID(context.Background())
+			if err != nil || id != 11155111 {
+				t.Errorf("concurrent ChainID: got (%d, %v) want (11155111, nil)", id, err)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // TestChainStateReaderRegistry: register-then-lookup happy path + the

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -1,0 +1,286 @@
+package taskengine
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"google.golang.org/grpc"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// chainStateFakeClient is a fully-typed ChainWorkerClient stub for
+// workerChainStateReader tests. Each field controls one method's response;
+// the test sets only the ones it exercises and leaves others zero.
+type chainStateFakeClient struct {
+	// SuggestGasPrice
+	gasPriceResp *avsproto.WorkerSuggestGasPriceResp
+	gasPriceErr  error
+
+	// EstimateGas
+	estimateGasReq  *avsproto.WorkerEstimateGasReq
+	estimateGasResp *avsproto.WorkerEstimateGasResp
+	estimateGasErr  error
+
+	// GetCode
+	getCodeReq  *avsproto.WorkerGetCodeReq
+	getCodeResp *avsproto.WorkerGetCodeResp
+	getCodeErr  error
+
+	// GetNonceByAddress
+	getNonceReq  *avsproto.WorkerGetNonceByAddressReq
+	getNonceResp *avsproto.WorkerGetNonceResp
+	getNonceErr  error
+}
+
+func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
+	panic("unused")
+}
+func (f *chainStateFakeClient) ExecuteUserOp(context.Context, *avsproto.ExecuteUserOpReq, ...grpc.CallOption) (*avsproto.ExecuteUserOpResp, error) {
+	panic("unused")
+}
+func (f *chainStateFakeClient) GetNonce(context.Context, *avsproto.WorkerGetNonceReq, ...grpc.CallOption) (*avsproto.WorkerGetNonceResp, error) {
+	panic("unused")
+}
+func (f *chainStateFakeClient) GetSmartWalletAddress(context.Context, *avsproto.WorkerGetSmartWalletAddressReq, ...grpc.CallOption) (*avsproto.WorkerGetSmartWalletAddressResp, error) {
+	panic("unused")
+}
+func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
+	panic("unused")
+}
+
+func (f *chainStateFakeClient) SuggestGasPrice(_ context.Context, _ *avsproto.WorkerSuggestGasPriceReq, _ ...grpc.CallOption) (*avsproto.WorkerSuggestGasPriceResp, error) {
+	return f.gasPriceResp, f.gasPriceErr
+}
+func (f *chainStateFakeClient) EstimateGas(_ context.Context, req *avsproto.WorkerEstimateGasReq, _ ...grpc.CallOption) (*avsproto.WorkerEstimateGasResp, error) {
+	f.estimateGasReq = req
+	return f.estimateGasResp, f.estimateGasErr
+}
+func (f *chainStateFakeClient) GetCode(_ context.Context, req *avsproto.WorkerGetCodeReq, _ ...grpc.CallOption) (*avsproto.WorkerGetCodeResp, error) {
+	f.getCodeReq = req
+	return f.getCodeResp, f.getCodeErr
+}
+func (f *chainStateFakeClient) GetNonceByAddress(_ context.Context, req *avsproto.WorkerGetNonceByAddressReq, _ ...grpc.CallOption) (*avsproto.WorkerGetNonceResp, error) {
+	f.getNonceReq = req
+	return f.getNonceResp, f.getNonceErr
+}
+
+// TestWorkerChainStateReader_ChainID confirms the worker-routed reader
+// returns its constructor-injected chainID without round-tripping to the
+// worker — the worker doesn't expose a ChainID RPC and the gateway knows
+// the chain a priori.
+func TestWorkerChainStateReader_ChainID(t *testing.T) {
+	r := NewWorkerChainStateReader(&chainStateFakeClient{}, 11155111, 0)
+	id, err := r.ChainID(context.Background())
+	if err != nil {
+		t.Fatalf("ChainID: %v", err)
+	}
+	if id != 11155111 {
+		t.Fatalf("ChainID: got %d, want 11155111", id)
+	}
+}
+
+// TestWorkerChainStateReader_ChainID_ZeroErrors: misconfiguration (no
+// chainID passed to the constructor) must surface, not silently return 0.
+func TestWorkerChainStateReader_ChainID_ZeroErrors(t *testing.T) {
+	r := NewWorkerChainStateReader(&chainStateFakeClient{}, 0, 0)
+	if _, err := r.ChainID(context.Background()); err == nil {
+		t.Fatalf("expected error for missing chainID")
+	}
+}
+
+// TestWorkerChainStateReader_SuggestGasPrice: happy path returns the
+// big.Int parsed from the worker's string response.
+func TestWorkerChainStateReader_SuggestGasPrice(t *testing.T) {
+	fake := &chainStateFakeClient{
+		gasPriceResp: &avsproto.WorkerSuggestGasPriceResp{GasPriceWei: "21000000000"},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	got, err := r.SuggestGasPrice(context.Background())
+	if err != nil {
+		t.Fatalf("SuggestGasPrice: %v", err)
+	}
+	want, _ := new(big.Int).SetString("21000000000", 10)
+	if got.Cmp(want) != 0 {
+		t.Fatalf("SuggestGasPrice: got %s, want %s", got, want)
+	}
+}
+
+// TestWorkerChainStateReader_SuggestGasPrice_Malformed: a malformed
+// numeric string from the worker must error, not silently coerce to 0.
+func TestWorkerChainStateReader_SuggestGasPrice_Malformed(t *testing.T) {
+	fake := &chainStateFakeClient{
+		gasPriceResp: &avsproto.WorkerSuggestGasPriceResp{GasPriceWei: "not-a-number"},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	if _, err := r.SuggestGasPrice(context.Background()); err == nil {
+		t.Fatalf("expected malformed-gas-price error")
+	}
+}
+
+// TestWorkerChainStateReader_SuggestGasPrice_Err: gRPC transport error
+// propagates with the chain ID in the wrap for triage.
+func TestWorkerChainStateReader_SuggestGasPrice_Err(t *testing.T) {
+	fake := &chainStateFakeClient{gasPriceErr: errors.New("transport closed")}
+	r := NewWorkerChainStateReader(fake, 42, time.Second)
+	_, err := r.SuggestGasPrice(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "chain 42") {
+		t.Fatalf("expected chain-id-wrapped error, got %v", err)
+	}
+}
+
+// TestWorkerChainStateReader_EstimateGas: confirm proto request payload
+// matches CallMsg field-for-field, including the optional From / Value
+// fields that the worker treats as chain defaults when empty.
+func TestWorkerChainStateReader_EstimateGas(t *testing.T) {
+	fake := &chainStateFakeClient{
+		estimateGasResp: &avsproto.WorkerEstimateGasResp{Gas: 123456},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	to := common.HexToAddress("0x000000000022D473030F116dDEE9F6B43aC78BA3")
+	from := common.HexToAddress("0xDEADbeef00000000000000000000000000000000")
+	msg := ethereum.CallMsg{
+		From:  from,
+		To:    &to,
+		Value: big.NewInt(1000),
+		Data:  []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+	gas, err := r.EstimateGas(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("EstimateGas: %v", err)
+	}
+	if gas != 123456 {
+		t.Fatalf("EstimateGas: got %d, want 123456", gas)
+	}
+	if fake.estimateGasReq.To != to.Hex() {
+		t.Fatalf("To not propagated: got %q want %q", fake.estimateGasReq.To, to.Hex())
+	}
+	if fake.estimateGasReq.From != from.Hex() {
+		t.Fatalf("From not propagated: got %q want %q", fake.estimateGasReq.From, from.Hex())
+	}
+	if fake.estimateGasReq.Value != "1000" {
+		t.Fatalf("Value not propagated as decimal string: %q", fake.estimateGasReq.Value)
+	}
+}
+
+// TestWorkerChainStateReader_EstimateGas_NoFromValue: From/Value omitted
+// from CallMsg must arrive as empty strings, not "0x0000...0000" or "0".
+// The worker side treats empty as "chain default applies".
+func TestWorkerChainStateReader_EstimateGas_NoFromValue(t *testing.T) {
+	fake := &chainStateFakeClient{
+		estimateGasResp: &avsproto.WorkerEstimateGasResp{Gas: 1},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	to := common.HexToAddress("0xaa")
+	_, err := r.EstimateGas(context.Background(), ethereum.CallMsg{To: &to, Data: []byte{0x00}})
+	if err != nil {
+		t.Fatalf("EstimateGas: %v", err)
+	}
+	if fake.estimateGasReq.From != "" {
+		t.Fatalf("From should be empty when CallMsg.From is zero address: %q", fake.estimateGasReq.From)
+	}
+	if fake.estimateGasReq.Value != "" {
+		t.Fatalf("Value should be empty when CallMsg.Value is nil: %q", fake.estimateGasReq.Value)
+	}
+}
+
+// TestWorkerChainStateReader_CodeAt: the address is hex-encoded for the
+// worker; raw bytes come back unchanged.
+func TestWorkerChainStateReader_CodeAt(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getCodeResp: &avsproto.WorkerGetCodeResp{Code: []byte{0x60, 0x80}},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	code, err := r.CodeAt(context.Background(), addr)
+	if err != nil {
+		t.Fatalf("CodeAt: %v", err)
+	}
+	if len(code) != 2 || code[0] != 0x60 || code[1] != 0x80 {
+		t.Fatalf("CodeAt: unexpected code %x", code)
+	}
+	if fake.getCodeReq.Address != addr.Hex() {
+		t.Fatalf("address not propagated: got %q want %q", fake.getCodeReq.Address, addr.Hex())
+	}
+}
+
+// TestWorkerChainStateReader_GetEntryPointNonce: nil key defaults to "0",
+// non-nil keys serialize as base-10 decimals (matching worker's parse).
+func TestWorkerChainStateReader_GetEntryPointNonce(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getNonceResp: &avsproto.WorkerGetNonceResp{Nonce: "42"},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	addr := common.HexToAddress("0xfeedface")
+	nonce, err := r.GetEntryPointNonce(context.Background(), addr, nil)
+	if err != nil {
+		t.Fatalf("GetEntryPointNonce nil key: %v", err)
+	}
+	if nonce.Cmp(big.NewInt(42)) != 0 {
+		t.Fatalf("nonce: got %s want 42", nonce)
+	}
+	if fake.getNonceReq.NonceKey != "0" {
+		t.Fatalf("nil key should serialize as \"0\": got %q", fake.getNonceReq.NonceKey)
+	}
+	if fake.getNonceReq.WalletAddress != addr.Hex() {
+		t.Fatalf("wallet not propagated: %q", fake.getNonceReq.WalletAddress)
+	}
+
+	// Non-nil key uses base-10 decimal serialization.
+	_, _ = r.GetEntryPointNonce(context.Background(), addr, big.NewInt(7))
+	if fake.getNonceReq.NonceKey != "7" {
+		t.Fatalf("non-nil key should be base-10: got %q", fake.getNonceReq.NonceKey)
+	}
+}
+
+// TestWorkerChainStateReader_GetEntryPointNonce_Malformed: a non-numeric
+// nonce string from the worker is a contract violation; surface it
+// rather than silently returning 0.
+func TestWorkerChainStateReader_GetEntryPointNonce_Malformed(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getNonceResp: &avsproto.WorkerGetNonceResp{Nonce: "garbage"},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	if _, err := r.GetEntryPointNonce(context.Background(), common.HexToAddress("0xab"), nil); err == nil {
+		t.Fatalf("expected malformed-nonce error")
+	}
+}
+
+// TestChainStateReaderRegistry: register-then-lookup happy path + the
+// idempotent re-register semantics tokenServiceRegistry guarantees, so
+// gateway-mode startup can call us redundantly without leaking state.
+func TestChainStateReaderRegistry(t *testing.T) {
+	ClearChainStateReaderRegistry()
+	defer ClearChainStateReaderRegistry()
+
+	r1 := NewWorkerChainStateReader(&chainStateFakeClient{}, 1, 0)
+	RegisterChainStateReader(1, r1)
+	if got := GetChainStateReaderForChain(1); got != r1 {
+		t.Fatalf("registered reader not returned")
+	}
+
+	// Re-register replaces.
+	r2 := NewWorkerChainStateReader(&chainStateFakeClient{}, 1, 0)
+	RegisterChainStateReader(1, r2)
+	if got := GetChainStateReaderForChain(1); got != r2 {
+		t.Fatalf("re-register should replace, got prior reader")
+	}
+
+	// chainID 0 → nil; unregistered chain → nil; nil reader rejected.
+	if GetChainStateReaderForChain(0) != nil {
+		t.Fatalf("chainID 0 should return nil")
+	}
+	if GetChainStateReaderForChain(99) != nil {
+		t.Fatalf("unregistered chain should return nil")
+	}
+	RegisterChainStateReader(2, nil)
+	if GetChainStateReaderForChain(2) != nil {
+		t.Fatalf("nil reader should be rejected")
+	}
+}

--- a/core/taskengine/fee_estimator.go
+++ b/core/taskengine/fee_estimator.go
@@ -14,10 +14,17 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-// FeeEstimator handles comprehensive fee estimation for workflows
+// FeeEstimator handles comprehensive fee estimation for workflows.
+//
+// The chain field is a ChainStateReader — the gateway-mode wiring
+// constructs a worker-routed implementation so FeeEstimator no longer
+// holds a direct chain-RPC connection. Single-chain mode and the
+// non-gateway-mode REST callers continue to use a directChainStateReader
+// wrapping an *ethclient.Client (existing constructors take care of
+// this transparently).
 type FeeEstimator struct {
 	logger            sdklogging.Logger
-	ethClient         *ethclient.Client
+	chain             ChainStateReader
 	tenderlyClient    *TenderlyClient
 	smartWalletConfig *config.SmartWalletConfig
 	chainID           int64 // Cached after first detection
@@ -84,8 +91,11 @@ type GasEstimationResult struct {
 	Error            string
 }
 
-// NewFeeEstimator creates a new fee estimator instance
-// Chain ID will be detected automatically from the eth client
+// NewFeeEstimator creates a new fee estimator instance.
+// Wraps the supplied ethClient in a DirectChainStateReader so the
+// chain ID will be detected from the client on first use. Gateway
+// callers should prefer NewFeeEstimatorWithChainReader to inject a
+// worker-routed reader and avoid the direct chain-RPC dependency.
 func NewFeeEstimator(
 	logger sdklogging.Logger,
 	ethClient *ethclient.Client,
@@ -93,20 +103,18 @@ func NewFeeEstimator(
 	smartWalletConfig *config.SmartWalletConfig,
 	priceService PriceService,
 ) *FeeEstimator {
-	return &FeeEstimator{
-		logger:            logger,
-		ethClient:         ethClient,
-		tenderlyClient:    tenderlyClient,
-		smartWalletConfig: smartWalletConfig,
-		chainID:           0, // Will be detected on first use
-		priceService:      priceService,
-		feeRates:          getDefaultFeeRates(),
-		discountRules:     getDefaultDiscountRules(),
-	}
+	return newFeeEstimator(
+		logger,
+		NewDirectChainStateReader(ethClient, 0),
+		tenderlyClient,
+		smartWalletConfig,
+		priceService,
+		getDefaultFeeRates(),
+	)
 }
 
-// NewFeeEstimatorWithConfig creates a new fee estimator instance with configurable rates
-// Chain ID will be detected automatically from the eth client
+// NewFeeEstimatorWithConfig is NewFeeEstimator with explicit fee-rate
+// configuration. Same backward-compatible direct-RPC wrapping.
 func NewFeeEstimatorWithConfig(
 	logger sdklogging.Logger,
 	ethClient *ethclient.Client,
@@ -115,14 +123,51 @@ func NewFeeEstimatorWithConfig(
 	priceService PriceService,
 	feeRatesConfig *config.FeeRatesConfig,
 ) *FeeEstimator {
+	return newFeeEstimator(
+		logger,
+		NewDirectChainStateReader(ethClient, 0),
+		tenderlyClient,
+		smartWalletConfig,
+		priceService,
+		convertFeeRatesConfig(feeRatesConfig),
+	)
+}
+
+// NewFeeEstimatorWithChainReader is the gateway-mode entry point.
+// chain is typically a workerChainStateReader (gateway routes chain-RPC
+// calls through the chain's worker) but any ChainStateReader works.
+func NewFeeEstimatorWithChainReader(
+	logger sdklogging.Logger,
+	chain ChainStateReader,
+	tenderlyClient *TenderlyClient,
+	smartWalletConfig *config.SmartWalletConfig,
+	priceService PriceService,
+	feeRatesConfig *config.FeeRatesConfig,
+) *FeeEstimator {
+	rates := getDefaultFeeRates()
+	if feeRatesConfig != nil {
+		rates = convertFeeRatesConfig(feeRatesConfig)
+	}
+	return newFeeEstimator(logger, chain, tenderlyClient, smartWalletConfig, priceService, rates)
+}
+
+// newFeeEstimator is the internal shared constructor.
+func newFeeEstimator(
+	logger sdklogging.Logger,
+	chain ChainStateReader,
+	tenderlyClient *TenderlyClient,
+	smartWalletConfig *config.SmartWalletConfig,
+	priceService PriceService,
+	rates *FeeRates,
+) *FeeEstimator {
 	return &FeeEstimator{
 		logger:            logger,
-		ethClient:         ethClient,
+		chain:             chain,
 		tenderlyClient:    tenderlyClient,
 		smartWalletConfig: smartWalletConfig,
-		chainID:           0, // Will be detected on first use
+		chainID:           0,
 		priceService:      priceService,
-		feeRates:          convertFeeRatesConfig(feeRatesConfig),
+		feeRates:          rates,
 		discountRules:     getDefaultDiscountRules(),
 	}
 }
@@ -134,15 +179,16 @@ func (fe *FeeEstimator) getChainID(ctx context.Context) (int64, error) {
 		return fe.chainID, nil
 	}
 
-	// Detect chain ID from eth client
-	chainID, err := fe.ethClient.ChainID(ctx)
+	// Detect chain ID from the underlying reader. Worker-routed
+	// readers know the ID a priori; direct-RPC readers will issue an
+	// eth_chainId on first call and cache.
+	chainID, err := fe.chain.ChainID(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get chain ID from eth client: %w", err)
+		return 0, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
-	// Cache the result
-	fe.chainID = chainID.Int64()
-	fe.logger.Info("🔗 Detected chain ID from eth client", "chain_id", fe.chainID)
+	fe.chainID = chainID
+	fe.logger.Info("🔗 Resolved chain ID", "chain_id", fe.chainID)
 
 	return fe.chainID, nil
 }
@@ -270,7 +316,7 @@ func (fe *FeeEstimator) resolveRunnerAndWalletCreation(ctx context.Context, req 
 
 	// Check if smart wallet already exists.
 	// On RPC failure, assume wallet exists to avoid blocking fee estimation during transient outages.
-	code, err := fe.ethClient.CodeAt(ctx, runnerAddress, nil)
+	code, err := fe.chain.CodeAt(ctx, runnerAddress)
 	if err != nil {
 		fe.logger.Warn("Failed to check smart wallet deployment status, assuming wallet exists",
 			"address", runnerAddress.Hex(), "error", err)
@@ -300,7 +346,7 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 	const fallbackCreationGas = int64(500000) // Conservative fallback for ERC-6900 wallet deployment
 
 	// Get current gas price
-	gasPrice, err := fe.ethClient.SuggestGasPrice(ctx)
+	gasPrice, err := fe.chain.SuggestGasPrice(ctx)
 	if err != nil {
 		fe.logger.Warn("Failed to get current gas price for wallet creation", "error", err)
 		gasPrice = big.NewInt(int64(DefaultGasPrice))
@@ -324,7 +370,7 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 	calldata := initCodeBytes[20:]
 
 	// Estimate gas via eth_estimateGas against the factory contract
-	estimatedGas, err := fe.ethClient.EstimateGas(ctx, ethereum.CallMsg{
+	estimatedGas, err := fe.chain.EstimateGas(ctx, ethereum.CallMsg{
 		To:   &factoryAddress,
 		Data: calldata,
 	})
@@ -354,7 +400,7 @@ func (fe *FeeEstimator) estimateCOGS(ctx context.Context, req *avsproto.Estimate
 
 	var cogsList []*avsproto.NodeCOGS
 
-	gasPrice, err := fe.ethClient.SuggestGasPrice(ctx)
+	gasPrice, err := fe.chain.SuggestGasPrice(ctx)
 	if err != nil {
 		fe.logger.Warn("Failed to get current gas price, using fallback", "error", err)
 		gasPrice = big.NewInt(int64(DefaultGasPrice))

--- a/core/taskengine/worker_token_fetcher_test.go
+++ b/core/taskengine/worker_token_fetcher_test.go
@@ -45,6 +45,18 @@ func (f *fakeChainWorkerClient) GetNonce(context.Context, *avsproto.WorkerGetNon
 func (f *fakeChainWorkerClient) GetSmartWalletAddress(context.Context, *avsproto.WorkerGetSmartWalletAddressReq, ...grpc.CallOption) (*avsproto.WorkerGetSmartWalletAddressResp, error) {
 	panic("unused")
 }
+func (f *fakeChainWorkerClient) GetNonceByAddress(context.Context, *avsproto.WorkerGetNonceByAddressReq, ...grpc.CallOption) (*avsproto.WorkerGetNonceResp, error) {
+	panic("unused")
+}
+func (f *fakeChainWorkerClient) SuggestGasPrice(context.Context, *avsproto.WorkerSuggestGasPriceReq, ...grpc.CallOption) (*avsproto.WorkerSuggestGasPriceResp, error) {
+	panic("unused")
+}
+func (f *fakeChainWorkerClient) EstimateGas(context.Context, *avsproto.WorkerEstimateGasReq, ...grpc.CallOption) (*avsproto.WorkerEstimateGasResp, error) {
+	panic("unused")
+}
+func (f *fakeChainWorkerClient) GetCode(context.Context, *avsproto.WorkerGetCodeReq, ...grpc.CallOption) (*avsproto.WorkerGetCodeResp, error) {
+	panic("unused")
+}
 
 // TestWorkerRoutedFetcher_HappyPath confirms a successful worker response
 // gets mapped to a TokenMetadata correctly — name, symbol, decimals, source

--- a/docs/changes/20260612-delegate-chain-rpc-to-workers.md
+++ b/docs/changes/20260612-delegate-chain-rpc-to-workers.md
@@ -177,3 +177,66 @@ ripping out the gateway's RPC config.
 
 PR A + B can land in the same release. PR C waits for the safety
 cycle.
+
+## Delivered
+
+### Phase A — `ChainTokenLookup` via fetcher injection (PR #579, v3.6.0)
+
+Landed Phase 1 + Phase 2 in one PR using a slimmer pattern than the
+original sketch: instead of a new `ChainTokenLookup` interface
+threaded through five callsites, we added an optional `fetcher`
+field to `TokenEnrichmentService` and a `NewWorkerRoutedTokenEnrichmentService`
+constructor. Existing callers keep working unchanged; the gateway
+constructs the worker-routed variant per chain at startup
+(`aggregator/task_engine.go:127`), and `tokenServiceRegistry`
+keys-by-chain so each lookup hits the right whitelist + the right
+worker.
+
+Verified in prod (v3.6.0 logs):
+`TokenEnrichmentService initializing mode=worker-routed` for every
+chain; the BNB Dwellir-dead-host startup warn is gone.
+
+### Phase 3 — `ChainStateReader` for FeeEstimator + EntryPoint nonce
+
+Extended `worker.proto` with four new RPCs covering the chain-state
+ops the gateway still issued direct-RPC for:
+
+- `GetNonceByAddress` — EntryPoint nonce by wallet address (used by
+  the REST `GetWalletNonce` handler).
+- `SuggestGasPrice`, `EstimateGas`, `GetCode` — used by FeeEstimator
+  for gas pricing and wallet-creation detection.
+
+Mirrored the worker-routed token pattern: introduced
+`ChainStateReader` interface (`core/taskengine/chain_state_reader.go`)
+with two implementations (`directChainStateReader` wrapping
+`ethclient.Client`, `workerChainStateReader` routing each call via
+gRPC). Added a per-chain registry (`RegisterChainStateReader` /
+`GetChainStateReaderForChain`) populated at startup the same way
+`tokenServiceRegistry` is.
+
+`FeeEstimator`'s `*ethclient.Client` field was replaced with a
+`ChainStateReader`; existing constructors wrap the supplied client
+with `NewDirectChainStateReader` for source compatibility, and a
+new `NewFeeEstimatorWithChainReader` constructor takes a reader
+directly (used by the REST fees handler in gateway mode).
+
+REST handlers migrated:
+
+- `handlers_workflows.go:EstimateFees` builds the FeeEstimator from
+  the per-chain reader; falls back to a direct-RPC reader if the
+  registry doesn't have an entry (single-chain mode / edge cases).
+- `handlers_wallets.go:GetWalletNonce` calls
+  `chainReader.GetEntryPointNonce` instead of `aa.GetNonce(rpc, ...)`.
+
+### Phase 4 (open) — drop the per-chain `ethclient.Dial`
+
+Step 7+8 of the Phase 3 plan were deferred: the gateway's
+`smartWalletRpcByChain` map is still used by `ExecuteWithdraw`
+(`aggregator/rpc_server.go:115`) for ERC-20 balance reads. Until
+withdraw is migrated through a worker RPC, the per-chain RPC URLs
+in `gateway-railway.yaml` (and the `<CHAIN>_RPC` env vars on the
+gateway service) have to stay. Migration sketch:
+
+1. Add `GetTokenBalance(chainID, owner, token)` to `worker.proto`.
+2. Replace the balance call in `ExecuteWithdraw` with a worker RPC.
+3. Then strip the per-chain dial and the dead env vars.

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -594,6 +594,342 @@ func (x *WorkerGetTokenMetadataResp) GetSource() string {
 	return ""
 }
 
+// Nonce query by smart wallet address (companion to GetNonce-by-owner)
+type WorkerGetNonceByAddressReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WalletAddress string                 `protobuf:"bytes,1,opt,name=wallet_address,json=walletAddress,proto3" json:"wallet_address,omitempty"` // Smart wallet address (hex)
+	NonceKey      string                 `protobuf:"bytes,2,opt,name=nonce_key,json=nonceKey,proto3" json:"nonce_key,omitempty"`                // 192-bit key for the EntryPoint nonce space
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetNonceByAddressReq) Reset() {
+	*x = WorkerGetNonceByAddressReq{}
+	mi := &file_worker_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetNonceByAddressReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetNonceByAddressReq) ProtoMessage() {}
+
+func (x *WorkerGetNonceByAddressReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetNonceByAddressReq.ProtoReflect.Descriptor instead.
+func (*WorkerGetNonceByAddressReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *WorkerGetNonceByAddressReq) GetWalletAddress() string {
+	if x != nil {
+		return x.WalletAddress
+	}
+	return ""
+}
+
+func (x *WorkerGetNonceByAddressReq) GetNonceKey() string {
+	if x != nil {
+		return x.NonceKey
+	}
+	return ""
+}
+
+// Gas price
+type WorkerSuggestGasPriceReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerSuggestGasPriceReq) Reset() {
+	*x = WorkerSuggestGasPriceReq{}
+	mi := &file_worker_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerSuggestGasPriceReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerSuggestGasPriceReq) ProtoMessage() {}
+
+func (x *WorkerSuggestGasPriceReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerSuggestGasPriceReq.ProtoReflect.Descriptor instead.
+func (*WorkerSuggestGasPriceReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{11}
+}
+
+type WorkerSuggestGasPriceResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	GasPriceWei   string                 `protobuf:"bytes,1,opt,name=gas_price_wei,json=gasPriceWei,proto3" json:"gas_price_wei,omitempty"` // big.Int as string
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerSuggestGasPriceResp) Reset() {
+	*x = WorkerSuggestGasPriceResp{}
+	mi := &file_worker_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerSuggestGasPriceResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerSuggestGasPriceResp) ProtoMessage() {}
+
+func (x *WorkerSuggestGasPriceResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerSuggestGasPriceResp.ProtoReflect.Descriptor instead.
+func (*WorkerSuggestGasPriceResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *WorkerSuggestGasPriceResp) GetGasPriceWei() string {
+	if x != nil {
+		return x.GasPriceWei
+	}
+	return ""
+}
+
+// Gas estimate (mirrors ethereum.CallMsg fields the estimator uses)
+type WorkerEstimateGasReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	From          string                 `protobuf:"bytes,1,opt,name=from,proto3" json:"from,omitempty"`   // Sender (hex). Optional; chain default if empty.
+	To            string                 `protobuf:"bytes,2,opt,name=to,proto3" json:"to,omitempty"`       // Destination contract (hex).
+	Value         string                 `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"` // Wei (big.Int as string); empty/zero for no value.
+	Data          []byte                 `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`   // Calldata.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerEstimateGasReq) Reset() {
+	*x = WorkerEstimateGasReq{}
+	mi := &file_worker_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerEstimateGasReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerEstimateGasReq) ProtoMessage() {}
+
+func (x *WorkerEstimateGasReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerEstimateGasReq.ProtoReflect.Descriptor instead.
+func (*WorkerEstimateGasReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *WorkerEstimateGasReq) GetFrom() string {
+	if x != nil {
+		return x.From
+	}
+	return ""
+}
+
+func (x *WorkerEstimateGasReq) GetTo() string {
+	if x != nil {
+		return x.To
+	}
+	return ""
+}
+
+func (x *WorkerEstimateGasReq) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *WorkerEstimateGasReq) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type WorkerEstimateGasResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Gas           uint64                 `protobuf:"varint,1,opt,name=gas,proto3" json:"gas,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerEstimateGasResp) Reset() {
+	*x = WorkerEstimateGasResp{}
+	mi := &file_worker_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerEstimateGasResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerEstimateGasResp) ProtoMessage() {}
+
+func (x *WorkerEstimateGasResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerEstimateGasResp.ProtoReflect.Descriptor instead.
+func (*WorkerEstimateGasResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *WorkerEstimateGasResp) GetGas() uint64 {
+	if x != nil {
+		return x.Gas
+	}
+	return 0
+}
+
+// CodeAt
+type WorkerGetCodeReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Address       string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"` // Contract address (hex).
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetCodeReq) Reset() {
+	*x = WorkerGetCodeReq{}
+	mi := &file_worker_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetCodeReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetCodeReq) ProtoMessage() {}
+
+func (x *WorkerGetCodeReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetCodeReq.ProtoReflect.Descriptor instead.
+func (*WorkerGetCodeReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *WorkerGetCodeReq) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+type WorkerGetCodeResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Code          []byte                 `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"` // Raw bytecode (empty if not deployed).
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetCodeResp) Reset() {
+	*x = WorkerGetCodeResp{}
+	mi := &file_worker_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetCodeResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetCodeResp) ProtoMessage() {}
+
+func (x *WorkerGetCodeResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetCodeResp.ProtoReflect.Descriptor instead.
+func (*WorkerGetCodeResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *WorkerGetCodeResp) GetCode() []byte {
+	if x != nil {
+		return x.Code
+	}
+	return nil
+}
+
 var File_worker_proto protoreflect.FileDescriptor
 
 const file_worker_proto_rawDesc = "" +
@@ -638,13 +974,34 @@ const file_worker_proto_rawDesc = "" +
 	"\x06symbol\x18\x02 \x01(\tR\x06symbol\x12\x1a\n" +
 	"\bdecimals\x18\x03 \x01(\rR\bdecimals\x12\x14\n" +
 	"\x05found\x18\x04 \x01(\bR\x05found\x12\x16\n" +
-	"\x06source\x18\x05 \x01(\tR\x06source2\xd5\x03\n" +
+	"\x06source\x18\x05 \x01(\tR\x06source\"`\n" +
+	"\x1aWorkerGetNonceByAddressReq\x12%\n" +
+	"\x0ewallet_address\x18\x01 \x01(\tR\rwalletAddress\x12\x1b\n" +
+	"\tnonce_key\x18\x02 \x01(\tR\bnonceKey\"\x1a\n" +
+	"\x18WorkerSuggestGasPriceReq\"?\n" +
+	"\x19WorkerSuggestGasPriceResp\x12\"\n" +
+	"\rgas_price_wei\x18\x01 \x01(\tR\vgasPriceWei\"d\n" +
+	"\x14WorkerEstimateGasReq\x12\x12\n" +
+	"\x04from\x18\x01 \x01(\tR\x04from\x12\x0e\n" +
+	"\x02to\x18\x02 \x01(\tR\x02to\x12\x14\n" +
+	"\x05value\x18\x03 \x01(\tR\x05value\x12\x12\n" +
+	"\x04data\x18\x04 \x01(\fR\x04data\")\n" +
+	"\x15WorkerEstimateGasResp\x12\x10\n" +
+	"\x03gas\x18\x01 \x01(\x04R\x03gas\",\n" +
+	"\x10WorkerGetCodeReq\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"'\n" +
+	"\x11WorkerGetCodeResp\x12\x12\n" +
+	"\x04code\x18\x01 \x01(\fR\x04code2\xae\x06\n" +
 	"\vChainWorker\x12X\n" +
 	"\x11WorkerHealthCheck\x12 .aggregator.WorkerHealthCheckReq\x1a!.aggregator.WorkerHealthCheckResp\x12L\n" +
 	"\rExecuteUserOp\x12\x1c.aggregator.ExecuteUserOpReq\x1a\x1d.aggregator.ExecuteUserOpResp\x12I\n" +
 	"\bGetNonce\x12\x1d.aggregator.WorkerGetNonceReq\x1a\x1e.aggregator.WorkerGetNonceResp\x12p\n" +
 	"\x15GetSmartWalletAddress\x12*.aggregator.WorkerGetSmartWalletAddressReq\x1a+.aggregator.WorkerGetSmartWalletAddressResp\x12a\n" +
-	"\x10GetTokenMetadata\x12%.aggregator.WorkerGetTokenMetadataReq\x1a&.aggregator.WorkerGetTokenMetadataRespB\fZ\n" +
+	"\x10GetTokenMetadata\x12%.aggregator.WorkerGetTokenMetadataReq\x1a&.aggregator.WorkerGetTokenMetadataResp\x12[\n" +
+	"\x11GetNonceByAddress\x12&.aggregator.WorkerGetNonceByAddressReq\x1a\x1e.aggregator.WorkerGetNonceResp\x12^\n" +
+	"\x0fSuggestGasPrice\x12$.aggregator.WorkerSuggestGasPriceReq\x1a%.aggregator.WorkerSuggestGasPriceResp\x12R\n" +
+	"\vEstimateGas\x12 .aggregator.WorkerEstimateGasReq\x1a!.aggregator.WorkerEstimateGasResp\x12F\n" +
+	"\aGetCode\x12\x1c.aggregator.WorkerGetCodeReq\x1a\x1d.aggregator.WorkerGetCodeRespB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (
@@ -659,7 +1016,7 @@ func file_worker_proto_rawDescGZIP() []byte {
 	return file_worker_proto_rawDescData
 }
 
-var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_worker_proto_goTypes = []any{
 	(*WorkerHealthCheckReq)(nil),            // 0: aggregator.WorkerHealthCheckReq
 	(*WorkerHealthCheckResp)(nil),           // 1: aggregator.WorkerHealthCheckResp
@@ -671,23 +1028,38 @@ var file_worker_proto_goTypes = []any{
 	(*WorkerGetSmartWalletAddressResp)(nil), // 7: aggregator.WorkerGetSmartWalletAddressResp
 	(*WorkerGetTokenMetadataReq)(nil),       // 8: aggregator.WorkerGetTokenMetadataReq
 	(*WorkerGetTokenMetadataResp)(nil),      // 9: aggregator.WorkerGetTokenMetadataResp
+	(*WorkerGetNonceByAddressReq)(nil),      // 10: aggregator.WorkerGetNonceByAddressReq
+	(*WorkerSuggestGasPriceReq)(nil),        // 11: aggregator.WorkerSuggestGasPriceReq
+	(*WorkerSuggestGasPriceResp)(nil),       // 12: aggregator.WorkerSuggestGasPriceResp
+	(*WorkerEstimateGasReq)(nil),            // 13: aggregator.WorkerEstimateGasReq
+	(*WorkerEstimateGasResp)(nil),           // 14: aggregator.WorkerEstimateGasResp
+	(*WorkerGetCodeReq)(nil),                // 15: aggregator.WorkerGetCodeReq
+	(*WorkerGetCodeResp)(nil),               // 16: aggregator.WorkerGetCodeResp
 }
 var file_worker_proto_depIdxs = []int32{
-	0, // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
-	2, // 1: aggregator.ChainWorker.ExecuteUserOp:input_type -> aggregator.ExecuteUserOpReq
-	4, // 2: aggregator.ChainWorker.GetNonce:input_type -> aggregator.WorkerGetNonceReq
-	6, // 3: aggregator.ChainWorker.GetSmartWalletAddress:input_type -> aggregator.WorkerGetSmartWalletAddressReq
-	8, // 4: aggregator.ChainWorker.GetTokenMetadata:input_type -> aggregator.WorkerGetTokenMetadataReq
-	1, // 5: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
-	3, // 6: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
-	5, // 7: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
-	7, // 8: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
-	9, // 9: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
-	5, // [5:10] is the sub-list for method output_type
-	0, // [0:5] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0,  // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
+	2,  // 1: aggregator.ChainWorker.ExecuteUserOp:input_type -> aggregator.ExecuteUserOpReq
+	4,  // 2: aggregator.ChainWorker.GetNonce:input_type -> aggregator.WorkerGetNonceReq
+	6,  // 3: aggregator.ChainWorker.GetSmartWalletAddress:input_type -> aggregator.WorkerGetSmartWalletAddressReq
+	8,  // 4: aggregator.ChainWorker.GetTokenMetadata:input_type -> aggregator.WorkerGetTokenMetadataReq
+	10, // 5: aggregator.ChainWorker.GetNonceByAddress:input_type -> aggregator.WorkerGetNonceByAddressReq
+	11, // 6: aggregator.ChainWorker.SuggestGasPrice:input_type -> aggregator.WorkerSuggestGasPriceReq
+	13, // 7: aggregator.ChainWorker.EstimateGas:input_type -> aggregator.WorkerEstimateGasReq
+	15, // 8: aggregator.ChainWorker.GetCode:input_type -> aggregator.WorkerGetCodeReq
+	1,  // 9: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
+	3,  // 10: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
+	5,  // 11: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
+	7,  // 12: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
+	9,  // 13: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
+	5,  // 14: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
+	12, // 15: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
+	14, // 16: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
+	16, // 17: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
+	9,  // [9:18] is the sub-list for method output_type
+	0,  // [0:9] is the sub-list for method input_type
+	0,  // [0:0] is the sub-list for extension type_name
+	0,  // [0:0] is the sub-list for extension extendee
+	0,  // [0:0] is the sub-list for field type_name
 }
 
 func init() { file_worker_proto_init() }
@@ -701,7 +1073,7 @@ func file_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -22,6 +22,27 @@ service ChainWorker {
 
   // Get token metadata (enrichment) for a contract address on this chain
   rpc GetTokenMetadata(WorkerGetTokenMetadataReq) returns (WorkerGetTokenMetadataResp);
+
+  // Get the nonce for an arbitrary smart wallet address on this chain.
+  // Differs from GetNonce in that the caller already knows the wallet
+  // address (looked up from gateway storage) and doesn't want to re-derive
+  // it from (owner, salt). Used by REST handlers that read the nonce
+  // directly off the EntryPoint contract.
+  rpc GetNonceByAddress(WorkerGetNonceByAddressReq) returns (WorkerGetNonceResp);
+
+  // Suggest a gas price for this chain. Wraps ethclient.SuggestGasPrice.
+  // Used by the fee estimator to price UserOps.
+  rpc SuggestGasPrice(WorkerSuggestGasPriceReq) returns (WorkerSuggestGasPriceResp);
+
+  // Estimate gas for a contract call on this chain. Wraps
+  // ethclient.EstimateGas with the same CallMsg shape ethclient takes.
+  // Used by the fee estimator to gas-budget UserOp executions.
+  rpc EstimateGas(WorkerEstimateGasReq) returns (WorkerEstimateGasResp);
+
+  // Read the bytecode at a contract address. Wraps ethclient.CodeAt.
+  // Used by the fee estimator to detect whether the runner contract is
+  // deployed before issuing UserOps against it.
+  rpc GetCode(WorkerGetCodeReq) returns (WorkerGetCodeResp);
 }
 
 // Health check
@@ -82,4 +103,39 @@ message WorkerGetTokenMetadataResp {
   uint32 decimals = 3;
   bool found = 4;       // Whether the token was found
   string source = 5;    // "whitelist", "rpc", or "native"
+}
+
+// Nonce query by smart wallet address (companion to GetNonce-by-owner)
+message WorkerGetNonceByAddressReq {
+  string wallet_address = 1;  // Smart wallet address (hex)
+  string nonce_key = 2;       // 192-bit key for the EntryPoint nonce space
+                              // (big.Int as string; "0" for the default space)
+}
+
+// Gas price
+message WorkerSuggestGasPriceReq {}
+
+message WorkerSuggestGasPriceResp {
+  string gas_price_wei = 1;   // big.Int as string
+}
+
+// Gas estimate (mirrors ethereum.CallMsg fields the estimator uses)
+message WorkerEstimateGasReq {
+  string from = 1;     // Sender (hex). Optional; chain default if empty.
+  string to = 2;       // Destination contract (hex).
+  string value = 3;    // Wei (big.Int as string); empty/zero for no value.
+  bytes data = 4;      // Calldata.
+}
+
+message WorkerEstimateGasResp {
+  uint64 gas = 1;
+}
+
+// CodeAt
+message WorkerGetCodeReq {
+  string address = 1;  // Contract address (hex).
+}
+
+message WorkerGetCodeResp {
+  bytes code = 1;      // Raw bytecode (empty if not deployed).
 }

--- a/protobuf/worker_grpc.pb.go
+++ b/protobuf/worker_grpc.pb.go
@@ -24,6 +24,10 @@ const (
 	ChainWorker_GetNonce_FullMethodName              = "/aggregator.ChainWorker/GetNonce"
 	ChainWorker_GetSmartWalletAddress_FullMethodName = "/aggregator.ChainWorker/GetSmartWalletAddress"
 	ChainWorker_GetTokenMetadata_FullMethodName      = "/aggregator.ChainWorker/GetTokenMetadata"
+	ChainWorker_GetNonceByAddress_FullMethodName     = "/aggregator.ChainWorker/GetNonceByAddress"
+	ChainWorker_SuggestGasPrice_FullMethodName       = "/aggregator.ChainWorker/SuggestGasPrice"
+	ChainWorker_EstimateGas_FullMethodName           = "/aggregator.ChainWorker/EstimateGas"
+	ChainWorker_GetCode_FullMethodName               = "/aggregator.ChainWorker/GetCode"
 )
 
 // ChainWorkerClient is the client API for ChainWorker service.
@@ -45,6 +49,23 @@ type ChainWorkerClient interface {
 	GetSmartWalletAddress(ctx context.Context, in *WorkerGetSmartWalletAddressReq, opts ...grpc.CallOption) (*WorkerGetSmartWalletAddressResp, error)
 	// Get token metadata (enrichment) for a contract address on this chain
 	GetTokenMetadata(ctx context.Context, in *WorkerGetTokenMetadataReq, opts ...grpc.CallOption) (*WorkerGetTokenMetadataResp, error)
+	// Get the nonce for an arbitrary smart wallet address on this chain.
+	// Differs from GetNonce in that the caller already knows the wallet
+	// address (looked up from gateway storage) and doesn't want to re-derive
+	// it from (owner, salt). Used by REST handlers that read the nonce
+	// directly off the EntryPoint contract.
+	GetNonceByAddress(ctx context.Context, in *WorkerGetNonceByAddressReq, opts ...grpc.CallOption) (*WorkerGetNonceResp, error)
+	// Suggest a gas price for this chain. Wraps ethclient.SuggestGasPrice.
+	// Used by the fee estimator to price UserOps.
+	SuggestGasPrice(ctx context.Context, in *WorkerSuggestGasPriceReq, opts ...grpc.CallOption) (*WorkerSuggestGasPriceResp, error)
+	// Estimate gas for a contract call on this chain. Wraps
+	// ethclient.EstimateGas with the same CallMsg shape ethclient takes.
+	// Used by the fee estimator to gas-budget UserOp executions.
+	EstimateGas(ctx context.Context, in *WorkerEstimateGasReq, opts ...grpc.CallOption) (*WorkerEstimateGasResp, error)
+	// Read the bytecode at a contract address. Wraps ethclient.CodeAt.
+	// Used by the fee estimator to detect whether the runner contract is
+	// deployed before issuing UserOps against it.
+	GetCode(ctx context.Context, in *WorkerGetCodeReq, opts ...grpc.CallOption) (*WorkerGetCodeResp, error)
 }
 
 type chainWorkerClient struct {
@@ -105,6 +126,46 @@ func (c *chainWorkerClient) GetTokenMetadata(ctx context.Context, in *WorkerGetT
 	return out, nil
 }
 
+func (c *chainWorkerClient) GetNonceByAddress(ctx context.Context, in *WorkerGetNonceByAddressReq, opts ...grpc.CallOption) (*WorkerGetNonceResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerGetNonceResp)
+	err := c.cc.Invoke(ctx, ChainWorker_GetNonceByAddress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *chainWorkerClient) SuggestGasPrice(ctx context.Context, in *WorkerSuggestGasPriceReq, opts ...grpc.CallOption) (*WorkerSuggestGasPriceResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerSuggestGasPriceResp)
+	err := c.cc.Invoke(ctx, ChainWorker_SuggestGasPrice_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *chainWorkerClient) EstimateGas(ctx context.Context, in *WorkerEstimateGasReq, opts ...grpc.CallOption) (*WorkerEstimateGasResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerEstimateGasResp)
+	err := c.cc.Invoke(ctx, ChainWorker_EstimateGas_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *chainWorkerClient) GetCode(ctx context.Context, in *WorkerGetCodeReq, opts ...grpc.CallOption) (*WorkerGetCodeResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerGetCodeResp)
+	err := c.cc.Invoke(ctx, ChainWorker_GetCode_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ChainWorkerServer is the server API for ChainWorker service.
 // All implementations must embed UnimplementedChainWorkerServer
 // for forward compatibility.
@@ -124,6 +185,23 @@ type ChainWorkerServer interface {
 	GetSmartWalletAddress(context.Context, *WorkerGetSmartWalletAddressReq) (*WorkerGetSmartWalletAddressResp, error)
 	// Get token metadata (enrichment) for a contract address on this chain
 	GetTokenMetadata(context.Context, *WorkerGetTokenMetadataReq) (*WorkerGetTokenMetadataResp, error)
+	// Get the nonce for an arbitrary smart wallet address on this chain.
+	// Differs from GetNonce in that the caller already knows the wallet
+	// address (looked up from gateway storage) and doesn't want to re-derive
+	// it from (owner, salt). Used by REST handlers that read the nonce
+	// directly off the EntryPoint contract.
+	GetNonceByAddress(context.Context, *WorkerGetNonceByAddressReq) (*WorkerGetNonceResp, error)
+	// Suggest a gas price for this chain. Wraps ethclient.SuggestGasPrice.
+	// Used by the fee estimator to price UserOps.
+	SuggestGasPrice(context.Context, *WorkerSuggestGasPriceReq) (*WorkerSuggestGasPriceResp, error)
+	// Estimate gas for a contract call on this chain. Wraps
+	// ethclient.EstimateGas with the same CallMsg shape ethclient takes.
+	// Used by the fee estimator to gas-budget UserOp executions.
+	EstimateGas(context.Context, *WorkerEstimateGasReq) (*WorkerEstimateGasResp, error)
+	// Read the bytecode at a contract address. Wraps ethclient.CodeAt.
+	// Used by the fee estimator to detect whether the runner contract is
+	// deployed before issuing UserOps against it.
+	GetCode(context.Context, *WorkerGetCodeReq) (*WorkerGetCodeResp, error)
 	mustEmbedUnimplementedChainWorkerServer()
 }
 
@@ -148,6 +226,18 @@ func (UnimplementedChainWorkerServer) GetSmartWalletAddress(context.Context, *Wo
 }
 func (UnimplementedChainWorkerServer) GetTokenMetadata(context.Context, *WorkerGetTokenMetadataReq) (*WorkerGetTokenMetadataResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTokenMetadata not implemented")
+}
+func (UnimplementedChainWorkerServer) GetNonceByAddress(context.Context, *WorkerGetNonceByAddressReq) (*WorkerGetNonceResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNonceByAddress not implemented")
+}
+func (UnimplementedChainWorkerServer) SuggestGasPrice(context.Context, *WorkerSuggestGasPriceReq) (*WorkerSuggestGasPriceResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SuggestGasPrice not implemented")
+}
+func (UnimplementedChainWorkerServer) EstimateGas(context.Context, *WorkerEstimateGasReq) (*WorkerEstimateGasResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EstimateGas not implemented")
+}
+func (UnimplementedChainWorkerServer) GetCode(context.Context, *WorkerGetCodeReq) (*WorkerGetCodeResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetCode not implemented")
 }
 func (UnimplementedChainWorkerServer) mustEmbedUnimplementedChainWorkerServer() {}
 func (UnimplementedChainWorkerServer) testEmbeddedByValue()                     {}
@@ -260,6 +350,78 @@ func _ChainWorker_GetTokenMetadata_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ChainWorker_GetNonceByAddress_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerGetNonceByAddressReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).GetNonceByAddress(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_GetNonceByAddress_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).GetNonceByAddress(ctx, req.(*WorkerGetNonceByAddressReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ChainWorker_SuggestGasPrice_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerSuggestGasPriceReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).SuggestGasPrice(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_SuggestGasPrice_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).SuggestGasPrice(ctx, req.(*WorkerSuggestGasPriceReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ChainWorker_EstimateGas_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerEstimateGasReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).EstimateGas(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_EstimateGas_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).EstimateGas(ctx, req.(*WorkerEstimateGasReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ChainWorker_GetCode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerGetCodeReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).GetCode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_GetCode_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).GetCode(ctx, req.(*WorkerGetCodeReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ChainWorker_ServiceDesc is the grpc.ServiceDesc for ChainWorker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -286,6 +448,22 @@ var ChainWorker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetTokenMetadata",
 			Handler:    _ChainWorker_GetTokenMetadata_Handler,
+		},
+		{
+			MethodName: "GetNonceByAddress",
+			Handler:    _ChainWorker_GetNonceByAddress_Handler,
+		},
+		{
+			MethodName: "SuggestGasPrice",
+			Handler:    _ChainWorker_SuggestGasPrice_Handler,
+		},
+		{
+			MethodName: "EstimateGas",
+			Handler:    _ChainWorker_EstimateGas_Handler,
+		},
+		{
+			MethodName: "GetCode",
+			Handler:    _ChainWorker_GetCode_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/worker/server.go
+++ b/worker/server.go
@@ -6,12 +6,32 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
+
+// ethereumCallMsgFromProto maps a WorkerEstimateGasReq into the CallMsg
+// shape ethclient.EstimateGas takes. From is optional (chain default
+// applies when empty). Value defaults to 0.
+func ethereumCallMsgFromProto(req *avsproto.WorkerEstimateGasReq, to common.Address) ethereum.CallMsg {
+	msg := ethereum.CallMsg{
+		To:   &to,
+		Data: req.Data,
+	}
+	if req.From != "" {
+		msg.From = common.HexToAddress(req.From)
+	}
+	if req.Value != "" {
+		if v, ok := new(big.Int).SetString(req.Value, 10); ok {
+			msg.Value = v
+		}
+	}
+	return msg
+}
 
 type Server struct {
 	avsproto.UnimplementedChainWorkerServer
@@ -160,5 +180,75 @@ func (s *Server) GetTokenMetadata(ctx context.Context, req *avsproto.WorkerGetTo
 		Decimals: metadata.Decimals,
 		Found:    true,
 		Source:   metadata.Source,
+	}, nil
+}
+
+// GetNonceByAddress reads the EntryPoint nonce for an arbitrary smart
+// wallet address. REST callers know the address from gateway storage
+// and don't want to re-derive (owner, salt). The pre-existing GetNonce
+// happens to do the same thing (its param is misnamed "owner" but is
+// passed to EntryPoint.getNonce as the sender) — but exposing a clearly
+// named alias keeps the gateway-side caller honest about what it's
+// querying.
+func (s *Server) GetNonceByAddress(ctx context.Context, req *avsproto.WorkerGetNonceByAddressReq) (*avsproto.WorkerGetNonceResp, error) {
+	walletAddr := common.HexToAddress(req.WalletAddress)
+
+	key := big.NewInt(0)
+	if req.NonceKey != "" {
+		parsed, ok := new(big.Int).SetString(req.NonceKey, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid nonce_key %q (expected base-10 big.Int string)", req.NonceKey)
+		}
+		key = parsed
+	}
+
+	nonce, err := aa.GetNonce(s.worker.rpcClient, walletAddr, key)
+	if err != nil {
+		return nil, fmt.Errorf("getting nonce for %s: %w", req.WalletAddress, err)
+	}
+
+	return &avsproto.WorkerGetNonceResp{
+		Nonce: nonce.String(),
+	}, nil
+}
+
+// SuggestGasPrice wraps ethclient.SuggestGasPrice for the chain this
+// worker is bound to. Used by the gateway's fee estimator.
+func (s *Server) SuggestGasPrice(ctx context.Context, req *avsproto.WorkerSuggestGasPriceReq) (*avsproto.WorkerSuggestGasPriceResp, error) {
+	price, err := s.worker.rpcClient.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("SuggestGasPrice on chain %d: %w", s.worker.config.ChainID, err)
+	}
+	return &avsproto.WorkerSuggestGasPriceResp{
+		GasPriceWei: price.String(),
+	}, nil
+}
+
+// EstimateGas wraps ethclient.EstimateGas. Used by the fee estimator
+// to budget UserOp executions before submitting to the bundler.
+func (s *Server) EstimateGas(ctx context.Context, req *avsproto.WorkerEstimateGasReq) (*avsproto.WorkerEstimateGasResp, error) {
+	to := common.HexToAddress(req.To)
+	msg := ethereumCallMsgFromProto(req, to)
+
+	gas, err := s.worker.rpcClient.EstimateGas(ctx, msg)
+	if err != nil {
+		return nil, fmt.Errorf("EstimateGas on chain %d to %s: %w", s.worker.config.ChainID, req.To, err)
+	}
+	return &avsproto.WorkerEstimateGasResp{
+		Gas: gas,
+	}, nil
+}
+
+// GetCode wraps ethclient.CodeAt(addr, nil). Used by the fee estimator
+// to detect whether the runner contract is deployed before issuing a
+// UserOp against it.
+func (s *Server) GetCode(ctx context.Context, req *avsproto.WorkerGetCodeReq) (*avsproto.WorkerGetCodeResp, error) {
+	addr := common.HexToAddress(req.Address)
+	code, err := s.worker.rpcClient.CodeAt(ctx, addr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("CodeAt on chain %d for %s: %w", s.worker.config.ChainID, req.Address, err)
+	}
+	return &avsproto.WorkerGetCodeResp{
+		Code: code,
 	}, nil
 }

--- a/worker/server.go
+++ b/worker/server.go
@@ -16,21 +16,29 @@ import (
 
 // ethereumCallMsgFromProto maps a WorkerEstimateGasReq into the CallMsg
 // shape ethclient.EstimateGas takes. From is optional (chain default
-// applies when empty). Value defaults to 0.
-func ethereumCallMsgFromProto(req *avsproto.WorkerEstimateGasReq, to common.Address) ethereum.CallMsg {
+// applies when empty). Value defaults to 0. The caller is responsible
+// for validating req.To and supplying the parsed address as `to`; we
+// pass `to` straight through as *Address so the contract-deployment
+// case (To == nil) can be expressed by passing toPtr == nil.
+func ethereumCallMsgFromProto(req *avsproto.WorkerEstimateGasReq, toPtr *common.Address) (ethereum.CallMsg, error) {
 	msg := ethereum.CallMsg{
-		To:   &to,
+		To:   toPtr,
 		Data: req.Data,
 	}
 	if req.From != "" {
+		if !common.IsHexAddress(req.From) {
+			return ethereum.CallMsg{}, fmt.Errorf("invalid from address %q", req.From)
+		}
 		msg.From = common.HexToAddress(req.From)
 	}
 	if req.Value != "" {
-		if v, ok := new(big.Int).SetString(req.Value, 10); ok {
-			msg.Value = v
+		v, ok := new(big.Int).SetString(req.Value, 10)
+		if !ok {
+			return ethereum.CallMsg{}, fmt.Errorf("invalid value %q (expected base-10 big.Int string)", req.Value)
 		}
+		msg.Value = v
 	}
-	return msg
+	return msg, nil
 }
 
 type Server struct {
@@ -191,6 +199,9 @@ func (s *Server) GetTokenMetadata(ctx context.Context, req *avsproto.WorkerGetTo
 // named alias keeps the gateway-side caller honest about what it's
 // querying.
 func (s *Server) GetNonceByAddress(ctx context.Context, req *avsproto.WorkerGetNonceByAddressReq) (*avsproto.WorkerGetNonceResp, error) {
+	if !common.IsHexAddress(req.WalletAddress) {
+		return nil, fmt.Errorf("invalid wallet_address %q", req.WalletAddress)
+	}
 	walletAddr := common.HexToAddress(req.WalletAddress)
 
 	key := big.NewInt(0)
@@ -198,6 +209,12 @@ func (s *Server) GetNonceByAddress(ctx context.Context, req *avsproto.WorkerGetN
 		parsed, ok := new(big.Int).SetString(req.NonceKey, 10)
 		if !ok {
 			return nil, fmt.Errorf("invalid nonce_key %q (expected base-10 big.Int string)", req.NonceKey)
+		}
+		// EntryPoint.getNonce takes a 192-bit key; negative values
+		// underflow the contract's uint192 cast and would either
+		// revert or read an unrelated nonce space. Reject up front.
+		if parsed.Sign() < 0 {
+			return nil, fmt.Errorf("invalid nonce_key %q (must be non-negative)", req.NonceKey)
 		}
 		key = parsed
 	}
@@ -214,10 +231,14 @@ func (s *Server) GetNonceByAddress(ctx context.Context, req *avsproto.WorkerGetN
 
 // SuggestGasPrice wraps ethclient.SuggestGasPrice for the chain this
 // worker is bound to. Used by the gateway's fee estimator.
+//
+// The gateway-side ChainStateReader wrap already includes the chain ID
+// in its error message ("worker SuggestGasPrice (chain N): ..."), so
+// we don't duplicate it here.
 func (s *Server) SuggestGasPrice(ctx context.Context, req *avsproto.WorkerSuggestGasPriceReq) (*avsproto.WorkerSuggestGasPriceResp, error) {
 	price, err := s.worker.rpcClient.SuggestGasPrice(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("SuggestGasPrice on chain %d: %w", s.worker.config.ChainID, err)
+		return nil, fmt.Errorf("SuggestGasPrice: %w", err)
 	}
 	return &avsproto.WorkerSuggestGasPriceResp{
 		GasPriceWei: price.String(),
@@ -226,13 +247,29 @@ func (s *Server) SuggestGasPrice(ctx context.Context, req *avsproto.WorkerSugges
 
 // EstimateGas wraps ethclient.EstimateGas. Used by the fee estimator
 // to budget UserOp executions before submitting to the bundler.
+//
+// An empty req.To means "contract deployment" (ethclient.CallMsg.To ==
+// nil); we forward that intent to ethclient rather than silently
+// estimating against the zero address. Same for req.From: empty means
+// "chain default sender", not "0x0...0".
 func (s *Server) EstimateGas(ctx context.Context, req *avsproto.WorkerEstimateGasReq) (*avsproto.WorkerEstimateGasResp, error) {
-	to := common.HexToAddress(req.To)
-	msg := ethereumCallMsgFromProto(req, to)
+	var toPtr *common.Address
+	if req.To != "" {
+		if !common.IsHexAddress(req.To) {
+			return nil, fmt.Errorf("invalid to address %q", req.To)
+		}
+		addr := common.HexToAddress(req.To)
+		toPtr = &addr
+	}
+
+	msg, err := ethereumCallMsgFromProto(req, toPtr)
+	if err != nil {
+		return nil, err
+	}
 
 	gas, err := s.worker.rpcClient.EstimateGas(ctx, msg)
 	if err != nil {
-		return nil, fmt.Errorf("EstimateGas on chain %d to %s: %w", s.worker.config.ChainID, req.To, err)
+		return nil, fmt.Errorf("EstimateGas to %s: %w", req.To, err)
 	}
 	return &avsproto.WorkerEstimateGasResp{
 		Gas: gas,
@@ -243,10 +280,13 @@ func (s *Server) EstimateGas(ctx context.Context, req *avsproto.WorkerEstimateGa
 // to detect whether the runner contract is deployed before issuing a
 // UserOp against it.
 func (s *Server) GetCode(ctx context.Context, req *avsproto.WorkerGetCodeReq) (*avsproto.WorkerGetCodeResp, error) {
+	if !common.IsHexAddress(req.Address) {
+		return nil, fmt.Errorf("invalid address %q", req.Address)
+	}
 	addr := common.HexToAddress(req.Address)
 	code, err := s.worker.rpcClient.CodeAt(ctx, addr, nil)
 	if err != nil {
-		return nil, fmt.Errorf("CodeAt on chain %d for %s: %w", s.worker.config.ChainID, req.Address, err)
+		return nil, fmt.Errorf("CodeAt for %s: %w", req.Address, err)
 	}
 	return &avsproto.WorkerGetCodeResp{
 		Code: code,


### PR DESCRIPTION
## Summary

Phase 3 of the gateway → chain-RPC delegation work (design doc:
`docs/changes/20260612-delegate-chain-rpc-to-workers.md`). The gateway
no longer issues direct chain-RPC calls for fee estimation or
EntryPoint nonce reads — both now route through the chain worker's
gRPC.

- **worker.proto**: adds `GetNonceByAddress`, `SuggestGasPrice`,
  `EstimateGas`, `GetCode` (covers everything the gateway's
  FeeEstimator + REST nonce handler used to call directly via
  `*ethclient.Client`).
- **`core/taskengine/chain_state_reader.go`**: introduces a
  `ChainStateReader` interface with two implementations —
  `directChainStateReader` (legacy / single-chain mode) and
  `workerChainStateReader` (gateway mode, routes via worker gRPC).
  Per-chain registry mirrors `tokenServiceRegistry`.
- **FeeEstimator**: field swap from `*ethclient.Client` to
  `ChainStateReader`. Existing constructors (`NewFeeEstimator`,
  `NewFeeEstimatorWithConfig`) keep their signatures and wrap the
  client internally — no caller breakage. New
  `NewFeeEstimatorWithChainReader` is used by the REST fees handler
  in gateway mode.
- **REST handlers**:
  - `EstimateFees` builds the FeeEstimator from the per-chain
    `ChainStateReader`, falling back to a direct-RPC reader if the
    registry has no entry.
  - `GetWalletNonce` calls `chainReader.GetEntryPointNonce` instead
    of `aa.GetNonce(rpc, ...)`.
- **Gateway startup** (`aggregator/task_engine.go`): registers a
  worker-routed `ChainStateReader` per chain when the worker is
  reachable; falls back to direct-RPC when it isn't (same pattern
  as the TokenEnrichmentService wiring from Phase A).

External operators are unaffected — they keep their direct
`ethclient.Client`-backed paths through the unchanged constructors.

## Out of scope (Phase 4)

The gateway still dials chain RPCs at startup (`smartWalletRpcByChain`)
because `ExecuteWithdraw` reads ERC-20 balances directly. Until that
call migrates through a worker RPC (sketched in the design doc), the
per-chain `eth_rpc_url`/`bundler_url` entries in `gateway-railway.yaml`
and the corresponding `<CHAIN>_RPC` env vars on the gateway service
must stay.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./core/taskengine/... ./worker/... ./aggregator/...` clean
- [x] Targeted tests: `go test ./core/taskengine/ -run 'FeeEstimator|ChainStateReader|WorkerChainStateReader|WorkerRoutedFetcher|WorkerRoutedTokenEnrichmentService|TokenEnrichment'` — all pass
- [x] `go test ./aggregator/rest/` — pass
- [ ] After merge to staging: observe gateway logs for `Chain ChainStateReader registered worker_routed=true` on every chain in `gateway-railway.yaml`
- [ ] Smoke-test `POST /api/v1/workflows:estimateFees` against a Sepolia + Base task (worker-routed gas price / wallet-creation gas estimate paths)
- [ ] Smoke-test `GET /api/v1/wallets/{address}:getNonce?chainId=...` against multiple chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
