### PR TITLE
fix(trigger): rollback partial EventTrigger subscriptions and surface rebuild metrics

### DIFF
--- a/core/taskengine/trigger/event.go
+++ b/core/taskengine/trigger/event.go
@@ -92,6 +92,8 @@ type QueryInfo struct {
 	MaxEventsPerBlock uint32
 }
 
+type subscribeFilterLogsFunc func(context.Context, ethereum.FilterQuery, chan<- types.Log) (ethereum.Subscription, error)
+
 type EventTrigger struct {
 	*CommonTrigger
 
@@ -136,6 +138,10 @@ type EventTrigger struct {
 
 	// Token enrichment service for enriching Transfer events
 	tokenEnrichmentService *taskengine.TokenEnrichmentService
+
+	subscribeFilterLogs         subscribeFilterLogsFunc
+	setSubscriptionCounts       func(active, desired int)
+	incSubscriptionRebuildError func()
 }
 
 type SubscriptionInfo struct {
@@ -188,6 +194,9 @@ func NewEventTrigger(o *RpcOption, triggerCh chan TriggerMetadata[EventMark], lo
 	if err != nil {
 		panic(err)
 	}
+	b.subscribeFilterLogs = func(ctx context.Context, query ethereum.FilterQuery, logs chan<- types.Log) (ethereum.Subscription, error) {
+		return b.wsEthClient.SubscribeFilterLogs(ctx, query, logs)
+	}
 
 	// Use global TokenEnrichmentService or initialize if not set
 	if taskengine.GetTokenEnrichmentService() == nil {
@@ -211,6 +220,187 @@ func NewEventTrigger(o *RpcOption, triggerCh chan TriggerMetadata[EventMark], lo
 	b.tokenEnrichmentService = taskengine.GetTokenEnrichmentService()
 
 	return &b
+}
+
+func (t *EventTrigger) SetSubscriptionMetrics(setCounts func(active, desired int), incRebuildError func()) {
+	t.setSubscriptionCounts = setCounts
+	t.incSubscriptionRebuildError = incRebuildError
+}
+
+func (t *EventTrigger) desiredSubscriptionCount(queries []QueryInfo) int {
+	keys := make(map[string]struct{}, len(queries))
+	for _, queryInfo := range queries {
+		keys[t.createQueryKey(queryInfo.Query)] = struct{}{}
+	}
+	return len(keys)
+}
+
+func (t *EventTrigger) updateSubscriptionMetrics(desired int) {
+	if t.setSubscriptionCounts == nil {
+		return
+	}
+	t.subsMutex.RLock()
+	active := len(t.querySubscriptions)
+	t.subsMutex.RUnlock()
+	t.setSubscriptionCounts(active, desired)
+}
+
+func (t *EventTrigger) rebuildSubscriptions(
+	ctx context.Context,
+	queries []QueryInfo,
+	logs chan<- types.Log,
+	errorCh chan<- error,
+) error {
+	rebuilt := make([]SubscriptionInfo, 0, len(queries))
+	for _, queryInfo := range queries {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		sub, err := t.subscribeFilterLogs(timeoutCtx, queryInfo.Query, logs)
+		cancel()
+		if err != nil {
+			for _, subInfo := range rebuilt {
+				subInfo.subscription.Unsubscribe()
+			}
+			return fmt.Errorf("recreate subscription %q: %w", queryInfo.Description, err)
+		}
+		rebuilt = append(rebuilt, SubscriptionInfo{
+			subscription: sub,
+			query:        queryInfo.Query,
+			description:  queryInfo.Description,
+			taskID:       queryInfo.TaskID,
+			queryIndex:   queryInfo.QueryIndex,
+		})
+	}
+
+	t.subsMutex.Lock()
+	t.subscriptions = rebuilt
+	t.populateQuerySubscriptions()
+	for _, managedSub := range t.querySubscriptions {
+		go func(sub ethereum.Subscription) {
+			if err := <-sub.Err(); err != nil {
+				errorCh <- err
+			}
+		}(managedSub.subscription)
+	}
+	t.subsMutex.Unlock()
+	return nil
+}
+
+// addSubscriptions adds all currently-missing desired subscriptions.
+// Must be called with subsMutex held.
+// On any subscribe failure, it rolls back newly-added subscriptions and returns an error
+// so the caller can escalate to a full reconnect.
+func (t *EventTrigger) addSubscriptions(
+	ctx context.Context,
+	desiredByKey map[string][]QueryInfo,
+	logs chan<- types.Log,
+	errorCh chan<- error,
+) error {
+	type addedSubscription struct {
+		key   string
+		query ethereum.FilterQuery
+		desc  string
+		sub   ethereum.Subscription
+	}
+
+	added := make([]addedSubscription, 0)
+	for key, queryInfos := range desiredByKey {
+		if _, exists := t.querySubscriptions[key]; exists {
+			continue
+		}
+
+		// Use the first queryInfo for the shared subscription.
+		qi := queryInfos[0]
+		timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		sub, subErr := t.subscribeFilterLogs(timeoutCtx, qi.Query, logs)
+		cancel()
+		if subErr != nil {
+			for _, created := range added {
+				created.sub.Unsubscribe()
+				delete(t.querySubscriptions, created.key)
+			}
+			return fmt.Errorf("create subscription during incremental update %q: %w", qi.Description, subErr)
+		}
+
+		taskIDs := make(map[string]bool)
+		for _, q := range queryInfos {
+			taskIDs[q.TaskID] = true
+		}
+
+		t.querySubscriptions[key] = &managedSubscription{
+			subscription: sub,
+			query:        qi.Query,
+			description:  qi.Description,
+			taskIDs:      taskIDs,
+			queryIndex:   qi.QueryIndex,
+		}
+
+		added = append(added, addedSubscription{
+			key:   key,
+			query: qi.Query,
+			desc:  qi.Description,
+			sub:   sub,
+		})
+
+		t.logger.Info("✅ Created new subscription during incremental update",
+			"key", key,
+			"description", qi.Description,
+			"task_ids", taskIDs,
+			"addresses", qi.Query.Addresses,
+			"topics", qi.Query.Topics)
+	}
+
+	for _, created := range added {
+		// DIAGNOSTIC: one-shot historical FilterLogs cross-check
+		// of the WS subscription against the last ~50 blocks via
+		// the HTTP RPC client. This goroutine fires ONCE per
+		// newly created subscription (not per event, not on a
+		// timer), so the cost is bounded by subscription churn
+		// rather than chain throughput. It runs when a task is
+		// added or after an error-driven resubscribe — not on
+		// every block. If FilterLogs returns >0 events but the
+		// WS subscription delivers 0 (heartbeat shows 0
+		// received), the WS layer is the problem, not the filter.
+		go func(q ethereum.FilterQuery, desc string) {
+			headerCtx, headerCancel := context.WithTimeout(ctx, 5*time.Second)
+			defer headerCancel()
+			header, herr := t.ethClient.HeaderByNumber(headerCtx, nil)
+			if herr != nil || header == nil {
+				t.logger.Warn("🩺 FilterLogs cross-check: failed to get latest block",
+					"description", desc, "error", herr)
+				return
+			}
+			latest := header.Number.Uint64()
+			var from uint64
+			if latest > 50 {
+				from = latest - 50
+			}
+			q.FromBlock = new(big.Int).SetUint64(from)
+			q.ToBlock = new(big.Int).SetUint64(latest)
+			filterCtx, filterCancel := context.WithTimeout(ctx, 10*time.Second)
+			defer filterCancel()
+			matches, ferr := t.ethClient.FilterLogs(filterCtx, q)
+			if ferr != nil {
+				t.logger.Warn("🩺 FilterLogs cross-check: query failed",
+					"description", desc,
+					"from_block", from, "to_block", latest,
+					"error", ferr)
+				return
+			}
+			t.logger.Info("🩺 FilterLogs cross-check completed",
+				"description", desc,
+				"from_block", from, "to_block", latest,
+				"historical_matches", len(matches))
+		}(created.query, created.desc)
+
+		// Start error monitoring for new subscription.
+		go func(s ethereum.Subscription) {
+			if errSub := <-s.Err(); errSub != nil {
+				errorCh <- errSub
+			}
+		}(created.sub)
+	}
+
+	return nil
 }
 
 // rebuildSubscriptionSlice derives the flat t.subscriptions slice from t.querySubscriptions.
@@ -475,6 +665,7 @@ func (t *EventTrigger) Run(ctx context.Context) error {
 	}
 	t.populateQuerySubscriptions()
 	t.subsMutex.Unlock()
+	t.updateSubscriptionMetrics(t.desiredSubscriptionCount(queries))
 
 	// Create error channel that collects errors from all subscriptions
 	errorCh := make(chan error, 100) // Buffered to handle multiple subscription errors
@@ -642,91 +833,19 @@ func (t *EventTrigger) Run(ctx context.Context) error {
 				}
 
 				// ADD: new subscriptions needed
-				for key, queryInfos := range desiredByKey {
-					if _, exists := t.querySubscriptions[key]; !exists {
-						// Use the first queryInfo for the subscription
-						qi := queryInfos[0]
-						timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-						sub, subErr := t.wsEthClient.SubscribeFilterLogs(timeoutCtx, qi.Query, logs)
-						cancel()
-						if subErr != nil {
-							t.logger.Error("❌ Failed to create subscription during incremental update",
-								"key", key,
-								"description", qi.Description,
-								"error", subErr)
-							continue
-						}
-
-						taskIDs := make(map[string]bool)
-						for _, q := range queryInfos {
-							taskIDs[q.TaskID] = true
-						}
-
-						t.querySubscriptions[key] = &managedSubscription{
-							subscription: sub,
-							query:        qi.Query,
-							description:  qi.Description,
-							taskIDs:      taskIDs,
-							queryIndex:   qi.QueryIndex,
-						}
-
-						t.logger.Info("✅ Created new subscription during incremental update",
-							"key", key,
-							"description", qi.Description,
-							"task_ids", taskIDs,
-							"addresses", qi.Query.Addresses,
-							"topics", qi.Query.Topics)
-
-						// DIAGNOSTIC: one-shot historical FilterLogs cross-check
-						// of the WS subscription against the last ~50 blocks via
-						// the HTTP RPC client. This goroutine fires ONCE per
-						// newly created subscription (not per event, not on a
-						// timer), so the cost is bounded by subscription churn
-						// rather than chain throughput. It runs when a task is
-						// added or after an error-driven resubscribe — not on
-						// every block. If FilterLogs returns >0 events but the
-						// WS subscription delivers 0 (heartbeat shows 0
-						// received), the WS layer is the problem, not the filter.
-						go func(q ethereum.FilterQuery, desc string) {
-							headerCtx, headerCancel := context.WithTimeout(ctx, 5*time.Second)
-							defer headerCancel()
-							header, herr := t.ethClient.HeaderByNumber(headerCtx, nil)
-							if herr != nil || header == nil {
-								t.logger.Warn("🩺 FilterLogs cross-check: failed to get latest block",
-									"description", desc, "error", herr)
-								return
-							}
-							latest := header.Number.Uint64()
-							var from uint64
-							if latest > 50 {
-								from = latest - 50
-							}
-							q.FromBlock = new(big.Int).SetUint64(from)
-							q.ToBlock = new(big.Int).SetUint64(latest)
-							filterCtx, filterCancel := context.WithTimeout(ctx, 10*time.Second)
-							defer filterCancel()
-							matches, ferr := t.ethClient.FilterLogs(filterCtx, q)
-							if ferr != nil {
-								t.logger.Warn("🩺 FilterLogs cross-check: query failed",
-									"description", desc,
-									"from_block", from, "to_block", latest,
-									"error", ferr)
-								return
-							}
-							t.logger.Info("🩺 FilterLogs cross-check completed",
-								"description", desc,
-								"from_block", from, "to_block", latest,
-								"historical_matches", len(matches))
-						}(qi.Query, qi.Description)
-
-						// Start error monitoring for new subscription
-						go func(s ethereum.Subscription, d string) {
-							errSub := <-s.Err()
-							if errSub != nil {
-								errorCh <- errSub
-							}
-						}(sub, qi.Description)
+				if err := t.addSubscriptions(ctx, desiredByKey, logs, errorCh); err != nil {
+					t.subsMutex.Unlock()
+					t.updateSubscriptionMetrics(t.desiredSubscriptionCount(newQueries))
+					if t.incSubscriptionRebuildError != nil {
+						t.incSubscriptionRebuildError()
 					}
+					t.logger.Warn("Failed to create all subscriptions during incremental update; forcing reconnect", "error", err)
+					select {
+					case errorCh <- err:
+					default:
+						t.logger.Warn("Incremental update reconnect signal dropped because error channel is full", "error", err)
+					}
+					continue
 				}
 
 				// UPDATE taskIDs: refresh task sets for existing subscriptions
@@ -747,6 +866,7 @@ func (t *EventTrigger) Run(ctx context.Context) error {
 				t.logger.Info("🔄 Incremental subscription update completed",
 					"active_subscriptions", activeCount,
 					"desired_queries", len(newQueries))
+				t.updateSubscriptionMetrics(t.desiredSubscriptionCount(newQueries))
 
 			case err := <-errorCh:
 				if err == nil {
@@ -754,56 +874,51 @@ func (t *EventTrigger) Run(ctx context.Context) error {
 				}
 				t.logger.Warn("🔥 Subscription error, attempting reconnection", "error", err)
 
-				// Attempt to reconnect
-				if err := t.retryConnectToRpc(); err != nil {
-					t.logger.Error("❌ Failed to reconnect to RPC", "error", err)
-					continue
-				}
-
-				// Rebuild and resubscribe
-				t.logger.Info("🔌 Reconnected, rebuilding subscriptions")
 				newQueries := t.buildFilterQueries()
-
 				t.subsMutex.Lock()
-				// Clean up old managed subscriptions
 				for _, ms := range t.querySubscriptions {
 					ms.subscription.Unsubscribe()
 				}
 				t.querySubscriptions = make(map[string]*managedSubscription)
-				t.subscriptions = make([]SubscriptionInfo, 0, len(newQueries))
+				t.subscriptions = nil
+				t.subsMutex.Unlock()
+				desiredCount := t.desiredSubscriptionCount(newQueries)
+				t.updateSubscriptionMetrics(desiredCount)
+				t.wsEthClient.Close()
 
-				// Create new subscriptions
-				for i, queryInfo := range newQueries {
-					// Use timeout context to prevent indefinite blocking during reconnection
-					timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-					sub, subErr := t.wsEthClient.SubscribeFilterLogs(timeoutCtx, queryInfo.Query, logs)
-					cancel() // Clean up timeout context
-					if subErr != nil {
-						t.logger.Error("❌ Failed to recreate subscription", "index", i, "error", subErr)
-						continue
+				backoff := time.Second
+				for {
+					if err := t.retryConnectToRpc(); err != nil {
+						t.logger.Error("❌ Failed to reconnect to RPC", "error", err)
+						break
+					}
+					t.logger.Info("🔌 Reconnected, rebuilding subscriptions")
+					if err := t.rebuildSubscriptions(ctx, newQueries, logs, errorCh); err == nil {
+						t.updateSubscriptionMetrics(desiredCount)
+						t.logger.Info("🔌 Reconnection completed",
+							"active_subscriptions", desiredCount,
+							"desired_subscriptions", desiredCount)
+						break
+					} else {
+						if t.incSubscriptionRebuildError != nil {
+							t.incSubscriptionRebuildError()
+						}
+						t.logger.Warn("Failed to rebuild all subscriptions; reconnecting",
+							"error", err, "retry_in", backoff)
+						t.wsEthClient.Close()
 					}
 
-					t.subscriptions = append(t.subscriptions, SubscriptionInfo{
-						subscription: sub,
-						query:        queryInfo.Query,
-						description:  queryInfo.Description,
-						taskID:       queryInfo.TaskID,
-						queryIndex:   queryInfo.QueryIndex,
-					})
-
-					// Restart error monitoring for this subscription
-					go func(idx int, s ethereum.Subscription, d string) {
-						errSub := <-s.Err()
-						if errSub != nil {
-							errorCh <- errSub
-						}
-					}(i, sub, queryInfo.Description)
+					timer := time.NewTimer(backoff)
+					select {
+					case <-ctx.Done():
+						timer.Stop()
+						return
+					case <-timer.C:
+					}
+					if backoff < 15*time.Second {
+						backoff *= 2
+					}
 				}
-				// Rebuild querySubscriptions from the new flat subscriptions
-				t.populateQuerySubscriptions()
-				t.subsMutex.Unlock()
-
-				t.logger.Info("🔌 Reconnection completed", "active_subscriptions", len(newQueries))
 			}
 		}
 	}()

--- a/core/taskengine/trigger/event.go
+++ b/core/taskengine/trigger/event.go
@@ -888,9 +888,9 @@ func (t *EventTrigger) Run(ctx context.Context) error {
 
 				backoff := time.Second
 				for {
-					if err := t.retryConnectToRpc(); err != nil {
-						t.logger.Error("❌ Failed to reconnect to RPC", "error", err)
-						break
+					t.retryConnectToRpc()
+					if t.shutdown {
+						return
 					}
 					t.logger.Info("🔌 Reconnected, rebuilding subscriptions")
 					if err := t.rebuildSubscriptions(ctx, newQueries, logs, errorCh); err == nil {

--- a/core/taskengine/trigger/event_test.go
+++ b/core/taskengine/trigger/event_test.go
@@ -1,6 +1,8 @@
 package trigger
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -999,6 +1001,84 @@ func newTestEventTrigger() *EventTrigger {
 		processedEvents:          make(map[string]bool),
 		lastTriggerTime:          make(map[string]time.Time),
 	}
+}
+
+func TestRebuildSubscriptionsDoesNotCommitPartialSet(t *testing.T) {
+	trigger := newTestEventTrigger()
+	firstSub := newMockSubscription()
+	callCount := 0
+	trigger.subscribeFilterLogs = func(context.Context, ethereum.FilterQuery, chan<- types.Log) (ethereum.Subscription, error) {
+		callCount++
+		if callCount == 1 {
+			return firstSub, nil
+		}
+		return nil, errors.New("transient subscribe failure")
+	}
+
+	queries := []QueryInfo{
+		{Query: ethereum.FilterQuery{}, Description: "first", TaskID: "task-1"},
+		{
+			Query: ethereum.FilterQuery{
+				Addresses: []common.Address{common.HexToAddress("0x1")},
+			},
+			Description: "second",
+			TaskID:      "task-2",
+		},
+	}
+
+	err := trigger.rebuildSubscriptions(
+		context.Background(),
+		queries,
+		make(chan types.Log, 1),
+		make(chan error, 1),
+	)
+
+	assert.Error(t, err)
+	assert.True(t, firstSub.unsubscribed, "successful partial subscriptions must be cleaned up")
+	assert.Empty(t, trigger.subscriptions)
+	assert.Empty(t, trigger.querySubscriptions)
+}
+
+func TestAddSubscriptionsRollsBackOnError(t *testing.T) {
+	trigger := newTestEventTrigger()
+	firstSub := newMockSubscription()
+	callCount := 0
+	trigger.subscribeFilterLogs = func(context.Context, ethereum.FilterQuery, chan<- types.Log) (ethereum.Subscription, error) {
+		callCount++
+		if callCount == 1 {
+			return firstSub, nil
+		}
+		return nil, errors.New("transient subscribe failure")
+	}
+
+	desiredByKey := map[string][]QueryInfo{
+		"key-1": {{
+			Query:       ethereum.FilterQuery{},
+			Description: "first",
+			TaskID:      "task-1",
+		}},
+		"key-2": {{
+			Query: ethereum.FilterQuery{
+				Addresses: []common.Address{common.HexToAddress("0x1")},
+			},
+			Description: "second",
+			TaskID:      "task-2",
+		}},
+	}
+
+	trigger.subsMutex.Lock()
+	err := trigger.addSubscriptions(
+		context.Background(),
+		desiredByKey,
+		make(chan types.Log, 1),
+		make(chan error, 1),
+	)
+	trigger.subsMutex.Unlock()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "second")
+	assert.True(t, firstSub.unsubscribed, "successful partial subscriptions must be cleaned up")
+	assert.Empty(t, trigger.querySubscriptions)
 }
 
 func TestIncrementalAdd_OnlyNewSubsCreated(t *testing.T) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -35,6 +35,8 @@ type MetricsGenerator interface {
 	// staleness threshold.
 	SetChainAdvertised(chainID int64, advertised bool)
 	SetChainHeadLagSeconds(chainID int64, lagSeconds float64)
+	SetEventSubscriptions(chainID int64, active, desired int)
+	IncEventSubscriptionRebuildFailures(chainID int64)
 }
 
 // AvsMetrics contains instrumented metrics that should be incremented by the avs node using the methods below
@@ -55,6 +57,9 @@ type AvsAndEigenMetrics struct {
 
 	chainAdvertised    *prometheus.GaugeVec
 	chainHeadLagSecond *prometheus.GaugeVec
+	eventSubsActive    *prometheus.GaugeVec
+	eventSubsDesired   *prometheus.GaugeVec
+	eventRebuildErrors *prometheus.CounterVec
 
 	operatorAddress string
 	version         string
@@ -129,6 +134,27 @@ func NewAvsAndEigenMetrics(avsName, operatorAddress, version string, eigenMetric
 				Help:      "Seconds elapsed since the operator last observed a new block head on this chain. Rising values indicate a degrading or hung subscription before it crosses the staleness threshold and is dropped from advertising.",
 			}, []string{"operator", "version", "chain_id"}),
 
+		eventSubsActive: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: apNamespace,
+				Name:      "event_subscriptions_active",
+				Help:      "The number of active unique event subscriptions.",
+			}, []string{"operator", "version", "chain_id"}),
+
+		eventSubsDesired: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: apNamespace,
+				Name:      "event_subscriptions_desired",
+				Help:      "The number of desired unique event subscriptions.",
+			}, []string{"operator", "version", "chain_id"}),
+
+		eventRebuildErrors: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: apNamespace,
+				Name:      "event_subscription_rebuild_failures_total",
+				Help:      "The number of failed full event subscription rebuild attempts.",
+			}, []string{"operator", "version", "chain_id"}),
+
 		operatorAddress: operatorAddress,
 		version:         version,
 	}
@@ -172,4 +198,14 @@ func (m *AvsAndEigenMetrics) SetChainAdvertised(chainID int64, advertised bool) 
 
 func (m *AvsAndEigenMetrics) SetChainHeadLagSeconds(chainID int64, lagSeconds float64) {
 	m.chainHeadLagSecond.WithLabelValues(m.operatorAddress, m.version, strconv.FormatInt(chainID, 10)).Set(lagSeconds)
+}
+
+func (m *AvsAndEigenMetrics) SetEventSubscriptions(chainID int64, active, desired int) {
+	labels := []string{m.operatorAddress, m.version, strconv.FormatInt(chainID, 10)}
+	m.eventSubsActive.WithLabelValues(labels...).Set(float64(active))
+	m.eventSubsDesired.WithLabelValues(labels...).Set(float64(desired))
+}
+
+func (m *AvsAndEigenMetrics) IncEventSubscriptionRebuildFailures(chainID int64) {
+	m.eventRebuildErrors.WithLabelValues(m.operatorAddress, m.version, strconv.FormatInt(chainID, 10)).Inc()
 }

--- a/operator/worker_loop.go
+++ b/operator/worker_loop.go
@@ -257,6 +257,14 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 		perChainEventCh := make(chan triggerengine.TriggerMetadata[triggerengine.EventMark], 1000)
 		et := triggerengine.NewEventTrigger(&rpcOpt, perChainEventCh, o.logger,
 			o.config.GetMaxEventsPerQueryPerBlock(), o.config.GetMaxTotalEventsPerBlock())
+		et.SetSubscriptionMetrics(
+			func(active, desired int) {
+				o.metrics.SetEventSubscriptions(detectedID, active, desired)
+			},
+			func() {
+				o.metrics.IncEventSubscriptionRebuildFailures(detectedID)
+			},
+		)
 		et.SetOverloadAlertCallback(func(alert *avspb.EventOverloadAlert) {
 			o.logger.Warn("🚨 Sending event overload alert to aggregator",
 				"task_id", alert.TaskId,


### PR DESCRIPTION
Fixes #570 

This PR fixes the EventTrigger resubscribe path so a single SubscribeFilterLogs failure no longer leaves the trigger running in a silent partial state. Incremental subscription updates now roll back any newly created subscriptions and escalate into the reconnect loop, which retries the full rebuild instead of continuing with missing subscriptions.

It also wires chain-level subscription telemetry into the operator so we can see active vs desired subscription counts and count rebuild failures. A regression test covers the rollback behaviour for both the incremental add path and the full rebuild path.

Validation:
- Targeted tests passed for TestRebuildSubscriptionsDoesNotCommitPartialSet and TestAddSubscriptionsRollsBackOnError
- Touched files compiled cleanly
