### PR TITLE
chore: gateway prod sentry env + drop stale PAYMASTER_ADDRESS

### DIFF
--- a/config/gateway-railway.yaml
+++ b/config/gateway-railway.yaml
@@ -66,12 +66,9 @@ rest_rate_limit_burst: 500
 
 server_name: "gateway-railway"
 sentry_dsn: https://d304c8708d5097f7787eeb664e4098c6@o1156669.ingest.us.sentry.io/4509386759733248
-# This branch (feature/rest-api-migration) is the testnet/staging gateway,
-# NOT production. Keep its Sentry events out of the production issue
-# board so paging + triage stay clean. When this branch merges to main
-# and the production gateway is rebuilt, drop this field (or set it to
-# "production" explicitly) — default is "production".
-sentry_environment: staging
+# Production gateway (api.avaprotocol.org). Sentry events tag as
+# "production" so they surface on the prod paging + triage board.
+sentry_environment: production
 
 tenderly_account: "chrisli"
 tenderly_project: "default"


### PR DESCRIPTION
## What

Two gateway-config hygiene fixes surfaced while auditing the worker-RPC migration (#578-#581):

1. **`sentry_environment: production`** — the production gateway (`api.avaprotocol.org`) was still tagging Sentry events as `staging` (leftover from the `feature/rest-api-migration` branch), hiding prod issues from the prod paging/triage board.
2. **Dropped the stale `PAYMASTER_ADDRESS` reference** — the gateway config only uses `PAYMASTER_ADDRESS_MAINNET`/`_TESTNET`; the bare `PAYMASTER_ADDRESS` was dead on the gateway service and has been removed from the gateway Railway service (it stays on the worker services, which reference it).

## Not included

Per-chain `*_RPC` env vars on the gateway **cannot** be removed yet — `ExecuteWithdraw` still does direct ERC-20 `BalanceOf` reads via the per-chain ethclient (`aggregator/rpc_server.go:347,365`). That's Phase 4 of the delegation plan (add `GetTokenBalance` to `worker.proto` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
