### PR TITLE
feat: route GetWallet derivation through chain workers (VM Phase 1)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc20"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
@@ -60,6 +61,11 @@ type ChainStateReader interface {
 	// GetTokenBalance reads the raw ERC-20 balance (no decimals applied)
 	// of owner for the given token contract. Mirrors erc20.BalanceOf.
 	GetTokenBalance(ctx context.Context, token, owner common.Address) (*big.Int, error)
+
+	// GetSmartWalletAddress derives the CREATE2 smart-wallet address for
+	// (owner, salt) under the given factory on this chain. Mirrors
+	// aa.GetSenderAddressForFactory.
+	GetSmartWalletAddress(ctx context.Context, owner, factory common.Address, salt *big.Int) (common.Address, error)
 }
 
 // ---------------------------------------------------------------------
@@ -146,6 +152,17 @@ func (d *directChainStateReader) GetTokenBalance(ctx context.Context, token, own
 		return nil, fmt.Errorf("erc20 binding for %s: %w", token.Hex(), err)
 	}
 	return contract.BalanceOf(&bind.CallOpts{Context: ctx}, owner)
+}
+
+func (d *directChainStateReader) GetSmartWalletAddress(_ context.Context, owner, factory common.Address, salt *big.Int) (common.Address, error) {
+	addr, err := aa.GetSenderAddressForFactory(d.client, owner, factory, salt)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if addr == nil {
+		return common.Address{}, fmt.Errorf("nil sender address for owner=%s factory=%s salt=%s", owner.Hex(), factory.Hex(), salt)
+	}
+	return *addr, nil
 }
 
 // ---------------------------------------------------------------------
@@ -286,6 +303,27 @@ func (w *workerChainStateReader) GetTokenBalance(ctx context.Context, token, own
 		return nil, fmt.Errorf("worker returned malformed token balance %q for token=%s owner=%s on chain %d", resp.Balance, token.Hex(), owner.Hex(), w.chainID)
 	}
 	return v, nil
+}
+
+func (w *workerChainStateReader) GetSmartWalletAddress(ctx context.Context, owner, factory common.Address, salt *big.Int) (common.Address, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	saltStr := "0"
+	if salt != nil {
+		saltStr = salt.String()
+	}
+	resp, err := w.client.GetSmartWalletAddress(ctx, &avsproto.WorkerGetSmartWalletAddressReq{
+		Owner:          owner.Hex(),
+		Salt:           saltStr,
+		FactoryAddress: factory.Hex(),
+	})
+	if err != nil {
+		return common.Address{}, fmt.Errorf("worker GetSmartWalletAddress (chain %d): %w", w.chainID, err)
+	}
+	if !common.IsHexAddress(resp.Address) {
+		return common.Address{}, fmt.Errorf("worker returned malformed address %q for owner=%s on chain %d", resp.Address, owner.Hex(), w.chainID)
+	}
+	return common.HexToAddress(resp.Address), nil
 }
 
 // withTimeout caps the gRPC call's wall time. context.WithTimeout

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -155,12 +155,17 @@ func (d *directChainStateReader) GetTokenBalance(ctx context.Context, token, own
 }
 
 func (d *directChainStateReader) GetSmartWalletAddress(_ context.Context, owner, factory common.Address, salt *big.Int) (common.Address, error) {
+	// Normalize nil salt to 0 so the direct and worker-routed paths derive
+	// identical addresses (the worker path serializes nil as "0").
+	if salt == nil {
+		salt = big.NewInt(0)
+	}
 	addr, err := aa.GetSenderAddressForFactory(d.client, owner, factory, salt)
 	if err != nil {
 		return common.Address{}, err
 	}
 	if addr == nil {
-		return common.Address{}, fmt.Errorf("nil sender address for owner=%s factory=%s salt=%s", owner.Hex(), factory.Hex(), salt)
+		return common.Address{}, fmt.Errorf("nil sender address for owner=%s factory=%s salt=%s", owner.Hex(), factory.Hex(), salt.String())
 	}
 	return *addr, nil
 }
@@ -319,6 +324,9 @@ func (w *workerChainStateReader) GetSmartWalletAddress(ctx context.Context, owne
 	})
 	if err != nil {
 		return common.Address{}, fmt.Errorf("worker GetSmartWalletAddress (chain %d): %w", w.chainID, err)
+	}
+	if resp == nil {
+		return common.Address{}, fmt.Errorf("worker returned nil response for owner=%s on chain %d", owner.Hex(), w.chainID)
 	}
 	if !common.IsHexAddress(resp.Address) {
 		return common.Address{}, fmt.Errorf("worker returned malformed address %q for owner=%s on chain %d", resp.Address, owner.Hex(), w.chainID)

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -48,6 +48,11 @@ type chainStateFakeClient struct {
 	getTokenBalanceReq  *avsproto.WorkerGetTokenBalanceReq
 	getTokenBalanceResp *avsproto.WorkerGetTokenBalanceResp
 	getTokenBalanceErr  error
+
+	// GetSmartWalletAddress
+	getSmartWalletReq  *avsproto.WorkerGetSmartWalletAddressReq
+	getSmartWalletResp *avsproto.WorkerGetSmartWalletAddressResp
+	getSmartWalletErr  error
 }
 
 func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
@@ -59,8 +64,9 @@ func (f *chainStateFakeClient) ExecuteUserOp(context.Context, *avsproto.ExecuteU
 func (f *chainStateFakeClient) GetNonce(context.Context, *avsproto.WorkerGetNonceReq, ...grpc.CallOption) (*avsproto.WorkerGetNonceResp, error) {
 	panic("unused")
 }
-func (f *chainStateFakeClient) GetSmartWalletAddress(context.Context, *avsproto.WorkerGetSmartWalletAddressReq, ...grpc.CallOption) (*avsproto.WorkerGetSmartWalletAddressResp, error) {
-	panic("unused")
+func (f *chainStateFakeClient) GetSmartWalletAddress(_ context.Context, req *avsproto.WorkerGetSmartWalletAddressReq, _ ...grpc.CallOption) (*avsproto.WorkerGetSmartWalletAddressResp, error) {
+	f.getSmartWalletReq = req
+	return f.getSmartWalletResp, f.getSmartWalletErr
 }
 func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
 	panic("unused")
@@ -429,5 +435,63 @@ func TestWorkerChainStateReader_GetTokenBalance_Malformed(t *testing.T) {
 	r := NewWorkerChainStateReader(fake, 1, time.Second)
 	if _, err := r.GetTokenBalance(context.Background(), common.HexToAddress("0xaa"), common.HexToAddress("0xbb")); err == nil {
 		t.Fatalf("expected malformed-token-balance error")
+	}
+}
+
+// TestWorkerChainStateReader_GetSmartWalletAddress: owner/factory are
+// hex-encoded and the salt serializes as a base-10 string; a valid hex
+// address round-trips back.
+func TestWorkerChainStateReader_GetSmartWalletAddress(t *testing.T) {
+	want := common.HexToAddress("0xABCdEF0123456789012345678901234567890123")
+	fake := &chainStateFakeClient{
+		getSmartWalletResp: &avsproto.WorkerGetSmartWalletAddressResp{Address: want.Hex()},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	got, err := r.GetSmartWalletAddress(context.Background(), owner, factory, big.NewInt(7))
+	if err != nil {
+		t.Fatalf("GetSmartWalletAddress: %v", err)
+	}
+	if got != want {
+		t.Fatalf("address: got %s want %s", got.Hex(), want.Hex())
+	}
+	if fake.getSmartWalletReq.Owner != owner.Hex() {
+		t.Fatalf("owner not propagated: %q", fake.getSmartWalletReq.Owner)
+	}
+	if fake.getSmartWalletReq.FactoryAddress != factory.Hex() {
+		t.Fatalf("factory not propagated: %q", fake.getSmartWalletReq.FactoryAddress)
+	}
+	if fake.getSmartWalletReq.Salt != "7" {
+		t.Fatalf("salt should serialize base-10: got %q", fake.getSmartWalletReq.Salt)
+	}
+}
+
+// TestWorkerChainStateReader_GetSmartWalletAddress_NilSalt: a nil salt
+// serializes as "0" rather than panicking.
+func TestWorkerChainStateReader_GetSmartWalletAddress_NilSalt(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getSmartWalletResp: &avsproto.WorkerGetSmartWalletAddressResp{
+			Address: "0x2222222222222222222222222222222222222222",
+		},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	if _, err := r.GetSmartWalletAddress(context.Background(), common.HexToAddress("0xaa"), common.HexToAddress("0xbb"), nil); err != nil {
+		t.Fatalf("nil salt: %v", err)
+	}
+	if fake.getSmartWalletReq.Salt != "0" {
+		t.Fatalf("nil salt should serialize as \"0\": got %q", fake.getSmartWalletReq.Salt)
+	}
+}
+
+// TestWorkerChainStateReader_GetSmartWalletAddress_Malformed: a non-address
+// string from the worker is a contract violation; surface it.
+func TestWorkerChainStateReader_GetSmartWalletAddress_Malformed(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getSmartWalletResp: &avsproto.WorkerGetSmartWalletAddressResp{Address: "not-an-address"},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	if _, err := r.GetSmartWalletAddress(context.Background(), common.HexToAddress("0xaa"), common.HexToAddress("0xbb"), big.NewInt(0)); err == nil {
+		t.Fatalf("expected malformed-address error")
 	}
 }

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1265,7 +1265,25 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 		hash := crypto.Keccak256(concatenated)
 		mockAddr := common.BytesToAddress(hash[12:])
 		derivedSenderAddress = &mockAddr
+	} else if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
+		// Preferred path: derive via the per-chain ChainStateReader. In
+		// gateway mode this is worker-routed, so the gateway issues no
+		// direct chain RPC for wallet derivation; in single-chain mode it's
+		// a direct reader that reuses the existing client (no per-call dial).
+		addr, deriveErr := reader.GetSmartWalletAddress(context.Background(), user.Address, factoryAddr, saltBig)
+		if deriveErr != nil {
+			n.logger.Error("GetWallet: factory.getAddress() failed (worker-routed)",
+				"chain_id", chainID, "owner", user.Address.Hex(), "factory", factoryAddr.Hex(),
+				"salt", saltBig.String(), "error", deriveErr)
+			return nil, status.Errorf(codes.Unavailable,
+				"GetWallet: derive sender on chain %d via factory %s: %v",
+				chainID, factoryAddr.Hex(), deriveErr)
+		}
+		derivedSenderAddress = &addr
 	} else {
+		// Fallback: no ChainStateReader registered for this chain (single-
+		// chain startup edge / unconfigured chain). Dial the chain RPC
+		// directly, same as before the worker-routing migration.
 		if swCfg.EthRpcUrl == "" {
 			n.logger.Error("GetWallet: no EthRpcUrl configured for chain — refusing to derive (would risk persisting a mock address under a real chain)",
 				"chain_id", chainID, "owner", user.Address.Hex())

--- a/docs/changes/20260614-route-vm-execution-through-workers.md
+++ b/docs/changes/20260614-route-vm-execution-through-workers.md
@@ -148,10 +148,16 @@ fallback machinery Phases 3–4a built.
 Each phase is independently shippable and prod-verifiable before the
 next — same migrate-then-verify discipline as Phases 2→4a.
 
-1. **PR 1 — `GetWallet` → `GetSmartWalletAddress`.** No new proto.
-   Highest-traffic, lowest-risk. Route `engine.go:GetWallet`'s factory
-   derivation through the existing worker RPC; keep the direct dial as
-   fallback. Removes the single most-hit per-chain dial.
+1. **PR 1 — `GetWallet` → `GetSmartWalletAddress` (delivered).**
+   Highest-traffic, lowest-risk. Routed `engine.go:GetWallet`'s factory
+   derivation through the chain worker; the direct dial stays as the
+   no-reader fallback. The existing `GetSmartWalletAddress` worker RPC had
+   **zero callers**, so it was redefined (no back-compat needed): salt is
+   now a base-10 `string` (was `int64`, which couldn't carry a 256-bit
+   salt) and a `factory_address` override was added so worker-derived
+   addresses match the gateway's per-request factory exactly. Added
+   `GetSmartWalletAddress` to the `ChainStateReader` interface + both
+   implementations. Removes the single most-hit per-chain dial.
 2. **PR 2 — `CallContract` worker RPC + contractRead.** New `CallContract`
    proto + worker handler; add `CallContract` to `ChainReader`; migrate
    `ContractReadProcessor` and the `run_node_immediately` eth_call sites.

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -378,11 +378,12 @@ func (x *WorkerGetNonceResp) GetNonce() string {
 
 // Smart wallet address derivation
 type WorkerGetSmartWalletAddressReq struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Owner         string                 `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"` // Owner EOA address (hex)
-	Salt          int64                  `protobuf:"varint,2,opt,name=salt,proto3" json:"salt,omitempty"`  // Salt for CREATE2 derivation
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Owner          string                 `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`                                         // Owner EOA address (hex)
+	Salt           string                 `protobuf:"bytes,2,opt,name=salt,proto3" json:"salt,omitempty"`                                           // CREATE2 salt (big.Int as base-10 string)
+	FactoryAddress string                 `protobuf:"bytes,3,opt,name=factory_address,json=factoryAddress,proto3" json:"factory_address,omitempty"` // Factory override (hex). Empty = worker's
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *WorkerGetSmartWalletAddressReq) Reset() {
@@ -422,11 +423,18 @@ func (x *WorkerGetSmartWalletAddressReq) GetOwner() string {
 	return ""
 }
 
-func (x *WorkerGetSmartWalletAddressReq) GetSalt() int64 {
+func (x *WorkerGetSmartWalletAddressReq) GetSalt() string {
 	if x != nil {
 		return x.Salt
 	}
-	return 0
+	return ""
+}
+
+func (x *WorkerGetSmartWalletAddressReq) GetFactoryAddress() string {
+	if x != nil {
+		return x.FactoryAddress
+	}
+	return ""
 }
 
 type WorkerGetSmartWalletAddressResp struct {
@@ -1147,10 +1155,11 @@ const file_worker_proto_rawDesc = "" +
 	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
 	"\x04salt\x18\x02 \x01(\x03R\x04salt\"*\n" +
 	"\x12WorkerGetNonceResp\x12\x14\n" +
-	"\x05nonce\x18\x01 \x01(\tR\x05nonce\"J\n" +
+	"\x05nonce\x18\x01 \x01(\tR\x05nonce\"s\n" +
 	"\x1eWorkerGetSmartWalletAddressReq\x12\x14\n" +
 	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
-	"\x04salt\x18\x02 \x01(\x03R\x04salt\";\n" +
+	"\x04salt\x18\x02 \x01(\tR\x04salt\x12'\n" +
+	"\x0ffactory_address\x18\x03 \x01(\tR\x0efactoryAddress\";\n" +
 	"\x1fWorkerGetSmartWalletAddressResp\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\"F\n" +
 	"\x19WorkerGetTokenMetadataReq\x12)\n" +

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -94,8 +94,12 @@ message WorkerGetNonceResp {
 
 // Smart wallet address derivation
 message WorkerGetSmartWalletAddressReq {
-  string owner = 1;    // Owner EOA address (hex)
-  int64 salt = 2;      // Salt for CREATE2 derivation
+  string owner = 1;            // Owner EOA address (hex)
+  string salt = 2;             // CREATE2 salt (big.Int as base-10 string)
+  string factory_address = 3;  // Factory override (hex). Empty = worker's
+                               // configured factory. The gateway passes the
+                               // per-chain / per-request factory so derivation
+                               // matches GetWallet's direct-RPC path exactly.
 }
 
 message WorkerGetSmartWalletAddressResp {

--- a/worker/server.go
+++ b/worker/server.go
@@ -151,14 +151,33 @@ func (s *Server) GetSmartWalletAddress(ctx context.Context, req *avsproto.Worker
 	if s.worker.smartWalletCfg == nil {
 		return nil, fmt.Errorf("smart wallet config not initialized")
 	}
+	if !common.IsHexAddress(req.Owner) {
+		return nil, fmt.Errorf("invalid owner address %q", req.Owner)
+	}
 
 	ownerAddr := common.HexToAddress(req.Owner)
-	salt := big.NewInt(req.Salt)
+
+	salt, ok := new(big.Int).SetString(req.Salt, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid salt %q (expected base-10 big.Int string)", req.Salt)
+	}
+
+	// Honor the caller's factory override when provided; otherwise use the
+	// worker's configured factory. The gateway passes its per-chain /
+	// per-request factory so worker-derived addresses match the gateway's
+	// direct-RPC derivation exactly.
+	factory := s.worker.smartWalletCfg.FactoryAddress
+	if req.FactoryAddress != "" {
+		if !common.IsHexAddress(req.FactoryAddress) {
+			return nil, fmt.Errorf("invalid factory address %q", req.FactoryAddress)
+		}
+		factory = common.HexToAddress(req.FactoryAddress)
+	}
 
 	addr, err := aa.GetSenderAddressForFactory(
 		s.worker.rpcClient,
 		ownerAddr,
-		s.worker.smartWalletCfg.FactoryAddress,
+		factory,
 		salt,
 	)
 	if err != nil {

--- a/worker/server.go
+++ b/worker/server.go
@@ -157,9 +157,23 @@ func (s *Server) GetSmartWalletAddress(ctx context.Context, req *avsproto.Worker
 
 	ownerAddr := common.HexToAddress(req.Owner)
 
-	salt, ok := new(big.Int).SetString(req.Salt, 10)
-	if !ok {
-		return nil, fmt.Errorf("invalid salt %q (expected base-10 big.Int string)", req.Salt)
+	// Empty salt defaults to 0 (proto3 omits empty strings; this matches
+	// the gateway's nil-salt → "0" convention). CREATE2 salt is a uint256,
+	// so reject negative or >256-bit values rather than letting them
+	// overflow ABI encoding downstream.
+	salt := big.NewInt(0)
+	if req.Salt != "" {
+		parsed, ok := new(big.Int).SetString(req.Salt, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid salt %q (expected base-10 big.Int string)", req.Salt)
+		}
+		salt = parsed
+	}
+	if salt.Sign() < 0 {
+		return nil, fmt.Errorf("invalid salt %q: must be non-negative", req.Salt)
+	}
+	if salt.BitLen() > 256 {
+		return nil, fmt.Errorf("invalid salt %q: exceeds uint256", req.Salt)
 	}
 
 	// Honor the caller's factory override when provided; otherwise use the
@@ -182,6 +196,9 @@ func (s *Server) GetSmartWalletAddress(ctx context.Context, req *avsproto.Worker
 	)
 	if err != nil {
 		return nil, fmt.Errorf("getting smart wallet address for %s: %w", req.Owner, err)
+	}
+	if addr == nil {
+		return nil, fmt.Errorf("nil sender address for owner=%s factory=%s salt=%s", req.Owner, factory.Hex(), salt.String())
 	}
 
 	return &avsproto.WorkerGetSmartWalletAddressResp{


### PR DESCRIPTION
## What

PR 1 of [`docs/changes/20260614-route-vm-execution-through-workers.md`](docs/changes/20260614-route-vm-execution-through-workers.md) — routing the gateway's VM/wallet-derivation layer through chain workers so the gateway eventually talks to only its own AVS chain.

`GetWallet`'s CREATE2 address derivation ([engine.go:1275](core/taskengine/engine.go)) was the **single most-hit** gateway per-chain dial — every `getWallet` call did `ethclient.Dial(swCfg.EthRpcUrl)` + `factory.getAddress()`. This routes it through the chain worker instead. Highest-traffic, lowest-risk first step.

## Worker RPC redefinition

The worker's `GetSmartWalletAddress` RPC had **zero client-side callers** (implemented but never wired up), so it's redefined to match what `GetWallet` actually needs — no back-compat constraint:

- `salt` is now a base-10 **string** (was `int64`, which can't carry a 256-bit CREATE2 salt)
- added a `factory_address` override so worker-derived addresses match the gateway's per-request / per-chain factory exactly (GetWallet supports a per-call factory override)

## Changes

- **`worker.proto` / `worker/server.go`**: `WorkerGetSmartWalletAddressReq { owner, salt(string), factory_address }`; handler parses + validates owner/salt/factory and honors the override.
- **`ChainStateReader`**: add `GetSmartWalletAddress` to the interface + both impls (direct wraps `aa.GetSenderAddressForFactory`; worker routes via gRPC).
- **`engine.go` `GetWallet`**: derive via the per-chain `ChainStateReader` when one is registered — worker-routed in gateway mode, a direct reader (no per-call dial) in single-chain mode. Falls back to the direct `ethclient.Dial` only when no reader exists. The `rpcConn==nil` test/CI mock branch is unchanged.

## Testing

- `go build ./...`, `go vet ./core/taskengine/ ./worker/` clean.
- New `chain_state_reader_test.go` cases: `GetSmartWalletAddress` happy-path (owner/factory hex + base-10 salt propagation, address round-trip), nil-salt → `"0"`, malformed-address error.
- Existing `GetWallet` + `ChainStateReader` + `WorkerRoutedFetcher` tests pass.

## Next

PR 2: `CallContract` worker RPC + contractRead migration (the largest remaining surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
