### PR TITLE
feat: route contractRead eth_call through chain workers (VM Phase 2)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -66,6 +66,10 @@ type ChainStateReader interface {
 	// (owner, salt) under the given factory on this chain. Mirrors
 	// aa.GetSenderAddressForFactory.
 	GetSmartWalletAddress(ctx context.Context, owner, factory common.Address, salt *big.Int) (common.Address, error)
+
+	// CallContract executes a read-only contract call (eth_call) at the
+	// given block (nil = latest). Mirrors ethclient.CallContract.
+	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 }
 
 // ---------------------------------------------------------------------
@@ -168,6 +172,10 @@ func (d *directChainStateReader) GetSmartWalletAddress(_ context.Context, owner,
 		return common.Address{}, fmt.Errorf("nil sender address for owner=%s factory=%s salt=%s", owner.Hex(), factory.Hex(), salt.String())
 	}
 	return *addr, nil
+}
+
+func (d *directChainStateReader) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return d.client.CallContract(ctx, msg, blockNumber)
 }
 
 // ---------------------------------------------------------------------
@@ -332,6 +340,38 @@ func (w *workerChainStateReader) GetSmartWalletAddress(ctx context.Context, owne
 		return common.Address{}, fmt.Errorf("worker returned malformed address %q for owner=%s on chain %d", resp.Address, owner.Hex(), w.chainID)
 	}
 	return common.HexToAddress(resp.Address), nil
+}
+
+func (w *workerChainStateReader) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	// eth_call without a destination is a contract-deployment probe, which
+	// the contractRead path never issues. Surface a nil To rather than
+	// forwarding an ambiguous request to the worker.
+	if msg.To == nil {
+		return nil, fmt.Errorf("CallContract: msg.To is required")
+	}
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	req := &avsproto.WorkerCallContractReq{
+		To:   msg.To.Hex(),
+		Data: msg.Data,
+	}
+	if (msg.From != common.Address{}) {
+		req.From = msg.From.Hex()
+	}
+	if msg.Value != nil {
+		req.Value = msg.Value.String()
+	}
+	if blockNumber != nil {
+		req.BlockNumber = blockNumber.String()
+	}
+	resp, err := w.client.CallContract(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("worker CallContract (chain %d): %w", w.chainID, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("worker returned nil response for CallContract to %s on chain %d", msg.To.Hex(), w.chainID)
+	}
+	return resp.Result, nil
 }
 
 // withTimeout caps the gRPC call's wall time. context.WithTimeout

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -53,6 +53,11 @@ type chainStateFakeClient struct {
 	getSmartWalletReq  *avsproto.WorkerGetSmartWalletAddressReq
 	getSmartWalletResp *avsproto.WorkerGetSmartWalletAddressResp
 	getSmartWalletErr  error
+
+	// CallContract
+	callContractReq  *avsproto.WorkerCallContractReq
+	callContractResp *avsproto.WorkerCallContractResp
+	callContractErr  error
 }
 
 func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
@@ -67,6 +72,10 @@ func (f *chainStateFakeClient) GetNonce(context.Context, *avsproto.WorkerGetNonc
 func (f *chainStateFakeClient) GetSmartWalletAddress(_ context.Context, req *avsproto.WorkerGetSmartWalletAddressReq, _ ...grpc.CallOption) (*avsproto.WorkerGetSmartWalletAddressResp, error) {
 	f.getSmartWalletReq = req
 	return f.getSmartWalletResp, f.getSmartWalletErr
+}
+func (f *chainStateFakeClient) CallContract(_ context.Context, req *avsproto.WorkerCallContractReq, _ ...grpc.CallOption) (*avsproto.WorkerCallContractResp, error) {
+	f.callContractReq = req
+	return f.callContractResp, f.callContractErr
 }
 func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
 	panic("unused")
@@ -493,5 +502,66 @@ func TestWorkerChainStateReader_GetSmartWalletAddress_Malformed(t *testing.T) {
 	r := NewWorkerChainStateReader(fake, 1, time.Second)
 	if _, err := r.GetSmartWalletAddress(context.Background(), common.HexToAddress("0xaa"), common.HexToAddress("0xbb"), big.NewInt(0)); err == nil {
 		t.Fatalf("expected malformed-address error")
+	}
+}
+
+// TestWorkerChainStateReader_CallContract: To/Data propagate; From/Value/
+// block default to empty when unset; raw result bytes round-trip.
+func TestWorkerChainStateReader_CallContract(t *testing.T) {
+	fake := &chainStateFakeClient{
+		callContractResp: &avsproto.WorkerCallContractResp{Result: []byte{0x01, 0x02, 0x03}},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	to := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	out, err := r.CallContract(context.Background(), ethereum.CallMsg{To: &to, Data: []byte{0xab}}, nil)
+	if err != nil {
+		t.Fatalf("CallContract: %v", err)
+	}
+	if len(out) != 3 || out[0] != 0x01 {
+		t.Fatalf("unexpected result %x", out)
+	}
+	if fake.callContractReq.To != to.Hex() {
+		t.Fatalf("To not propagated: %q", fake.callContractReq.To)
+	}
+	if fake.callContractReq.From != "" {
+		t.Fatalf("From should be empty: %q", fake.callContractReq.From)
+	}
+	if fake.callContractReq.Value != "" {
+		t.Fatalf("Value should be empty: %q", fake.callContractReq.Value)
+	}
+	if fake.callContractReq.BlockNumber != "" {
+		t.Fatalf("BlockNumber should be empty: %q", fake.callContractReq.BlockNumber)
+	}
+}
+
+// TestWorkerChainStateReader_CallContract_FieldsPropagate: From/Value/block
+// serialize when set.
+func TestWorkerChainStateReader_CallContract_FieldsPropagate(t *testing.T) {
+	fake := &chainStateFakeClient{callContractResp: &avsproto.WorkerCallContractResp{}}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	to := common.HexToAddress("0x00")
+	from := common.HexToAddress("0xDEADBEEF00000000000000000000000000000000")
+	_, err := r.CallContract(context.Background(),
+		ethereum.CallMsg{To: &to, From: from, Value: big.NewInt(99), Data: []byte{0x1}}, big.NewInt(12345))
+	if err != nil {
+		t.Fatalf("CallContract: %v", err)
+	}
+	if fake.callContractReq.From != from.Hex() {
+		t.Fatalf("From: %q", fake.callContractReq.From)
+	}
+	if fake.callContractReq.Value != "99" {
+		t.Fatalf("Value: %q", fake.callContractReq.Value)
+	}
+	if fake.callContractReq.BlockNumber != "12345" {
+		t.Fatalf("BlockNumber: %q", fake.callContractReq.BlockNumber)
+	}
+}
+
+// TestWorkerChainStateReader_CallContract_NilToRejected: a nil destination
+// (deployment probe) is a caller bug the contractRead path never makes.
+func TestWorkerChainStateReader_CallContract_NilToRejected(t *testing.T) {
+	r := NewWorkerChainStateReader(&chainStateFakeClient{}, 1, time.Second)
+	if _, err := r.CallContract(context.Background(), ethereum.CallMsg{Data: []byte{0x1}}, nil); err == nil {
+		t.Fatalf("expected error for nil msg.To")
 	}
 }

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -523,6 +523,9 @@ func TestWorkerChainStateReader_CallContract(t *testing.T) {
 	if fake.callContractReq.To != to.Hex() {
 		t.Fatalf("To not propagated: %q", fake.callContractReq.To)
 	}
+	if len(fake.callContractReq.Data) != 1 || fake.callContractReq.Data[0] != 0xab {
+		t.Fatalf("Data not propagated: %x", fake.callContractReq.Data)
+	}
 	if fake.callContractReq.From != "" {
 		t.Fatalf("From should be empty: %q", fake.callContractReq.From)
 	}

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1479,24 +1479,33 @@ func (v *VM) runContractRead(taskNode *avsproto.TaskNode) (*avsproto.Execution_S
 		executionLog.EndAt = time.Now().UnixMilli()
 		return executionLog, err
 	}
-	rpcClient, err := ethclient.Dial(swConfig.EthRpcUrl)
-	if err != nil {
-		executionLog = v.createExecutionStep(stepID, false, fmt.Sprintf("failed to dial ETH RPC: %v", err), "", time.Now().UnixMilli())
-		executionLog.EndAt = time.Now().UnixMilli()
-		return executionLog, err
-	}
-	defer rpcClient.Close()
 
-	processor := NewContractReadProcessor(v, rpcClient)
+	// Prefer the per-chain ChainStateReader — worker-routed in gateway mode,
+	// so the gateway issues no direct eth_call. Fall back to a direct dial
+	// only when no reader is registered for the chain (single-chain mode /
+	// unconfigured chain).
+	chainReader := GetChainStateReaderForChain(uint64(node.Config.GetChainId()))
+	if chainReader == nil {
+		rpcClient, err := ethclient.Dial(swConfig.EthRpcUrl)
+		if err != nil {
+			executionLog = v.createExecutionStep(stepID, false, fmt.Sprintf("failed to dial ETH RPC: %v", err), "", time.Now().UnixMilli())
+			executionLog.EndAt = time.Now().UnixMilli()
+			return executionLog, err
+		}
+		defer rpcClient.Close()
+		chainReader = NewDirectChainStateReader(rpcClient, node.Config.GetChainId())
+	}
+
+	processor := NewContractReadProcessor(v, chainReader)
 	processor.CommonProcessor.SetTaskNode(taskNode)
-	executionLog, err = processor.Execute(stepID, node)
+	executionLog, execErr := processor.Execute(stepID, node)
 	v.mu.Lock()
 	if executionLog != nil {
 		executionLog.Inputs = v.collectInputKeysForLog(stepID)
 	}
 	v.mu.Unlock()
 	// v.addExecutionLog(executionLog)
-	return executionLog, err
+	return executionLog, execErr
 }
 
 func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_Step, error) {

--- a/core/taskengine/vm_runner_contract_read.go
+++ b/core/taskengine/vm_runner_contract_read.go
@@ -13,16 +13,19 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type ContractReadProcessor struct {
 	*CommonProcessor
-	client *ethclient.Client
+	// client is the per-chain ChainStateReader — worker-routed in gateway
+	// mode (the gateway issues no direct eth_call), a direct-RPC reader in
+	// single-chain mode. nil for the empty-config error path, which never
+	// reaches a chain call.
+	client ChainStateReader
 }
 
-func NewContractReadProcessor(vm *VM, client *ethclient.Client) *ContractReadProcessor {
+func NewContractReadProcessor(vm *VM, client ChainStateReader) *ContractReadProcessor {
 	return &ContractReadProcessor{
 		CommonProcessor: &CommonProcessor{
 			vm: vm,
@@ -308,7 +311,7 @@ func (r *ContractReadProcessor) executeMethodCallWithoutFormatting(ctx context.C
 		chainID, _ := r.client.ChainID(ctx)
 
 		// Check if contract has code (exists)
-		code, _ := r.client.CodeAt(ctx, contractAddress, nil)
+		code, _ := r.client.CodeAt(ctx, contractAddress)
 
 		r.vm.logger.Debug("Contract call executed",
 			"contract_address", contractAddress.Hex(),
@@ -346,7 +349,7 @@ func (r *ContractReadProcessor) executeMethodCallWithoutFormatting(ctx context.C
 	// Handle empty contract response
 	if len(output) == 0 {
 		// Check if contract exists to provide better error message
-		code, _ := r.client.CodeAt(ctx, contractAddress, nil)
+		code, _ := r.client.CodeAt(ctx, contractAddress)
 		chainID, _ := r.client.ChainID(ctx)
 
 		var errorMsg string
@@ -963,7 +966,7 @@ func (r *ContractReadProcessor) executeMethodCallWithDecimalFormatting(ctx conte
 		chainID, _ := r.client.ChainID(ctx)
 
 		// Check if contract has code (exists)
-		code, _ := r.client.CodeAt(ctx, contractAddress, nil)
+		code, _ := r.client.CodeAt(ctx, contractAddress)
 
 		r.vm.logger.Debug("Contract call executed",
 			"contract_address", contractAddress.Hex(),
@@ -1001,7 +1004,7 @@ func (r *ContractReadProcessor) executeMethodCallWithDecimalFormatting(ctx conte
 	// Handle empty contract response
 	if len(output) == 0 {
 		// Check if contract exists to provide better error message
-		code, _ := r.client.CodeAt(ctx, contractAddress, nil)
+		code, _ := r.client.CodeAt(ctx, contractAddress)
 		chainID, _ := r.client.ChainID(ctx)
 
 		var errorMsg string

--- a/core/taskengine/vm_runner_contract_read_test.go
+++ b/core/taskengine/vm_runner_contract_read_test.go
@@ -70,7 +70,7 @@ func TestContractReadSimpleReturn(t *testing.T) {
 		return
 	}
 
-	n := NewContractReadProcessor(vm, testutil.GetRpcClient())
+	n := NewContractReadProcessor(vm, NewDirectChainStateReader(testutil.GetRpcClient(), 0))
 
 	step, err := n.Execute("123", node)
 
@@ -175,7 +175,7 @@ func TestContractReadComplexReturn(t *testing.T) {
 		return
 	}
 
-	n := NewContractReadProcessor(vm, testutil.GetRpcClient())
+	n := NewContractReadProcessor(vm, NewDirectChainStateReader(testutil.GetRpcClient(), 0))
 	step, err := n.Execute("123abc", node)
 
 	if err != nil {
@@ -311,7 +311,7 @@ func TestContractReadWithDecimalFormatting(t *testing.T) {
 		return
 	}
 
-	n := NewContractReadProcessor(vm, testutil.GetRpcClient())
+	n := NewContractReadProcessor(vm, NewDirectChainStateReader(testutil.GetRpcClient(), 0))
 	step, err := n.Execute("123decimal", node)
 
 	if err != nil {

--- a/core/taskengine/worker_token_fetcher_test.go
+++ b/core/taskengine/worker_token_fetcher_test.go
@@ -63,6 +63,9 @@ func (f *fakeChainWorkerClient) GetBalance(context.Context, *avsproto.WorkerGetB
 func (f *fakeChainWorkerClient) GetTokenBalance(context.Context, *avsproto.WorkerGetTokenBalanceReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenBalanceResp, error) {
 	panic("unused")
 }
+func (f *fakeChainWorkerClient) CallContract(context.Context, *avsproto.WorkerCallContractReq, ...grpc.CallOption) (*avsproto.WorkerCallContractResp, error) {
+	panic("unused")
+}
 
 // TestWorkerRoutedFetcher_HappyPath confirms a successful worker response
 // gets mapped to a TokenMetadata correctly — name, symbol, decimals, source

--- a/docs/changes/20260614-route-vm-execution-through-workers.md
+++ b/docs/changes/20260614-route-vm-execution-through-workers.md
@@ -158,9 +158,17 @@ next — same migrate-then-verify discipline as Phases 2→4a.
    addresses match the gateway's per-request factory exactly. Added
    `GetSmartWalletAddress` to the `ChainStateReader` interface + both
    implementations. Removes the single most-hit per-chain dial.
-2. **PR 2 — `CallContract` worker RPC + contractRead.** New `CallContract`
-   proto + worker handler; add `CallContract` to `ChainReader`; migrate
-   `ContractReadProcessor` and the `run_node_immediately` eth_call sites.
+2. **PR 2 — `CallContract` worker RPC + contractRead (delivered).** Added
+   the `CallContract` worker RPC (from/to/value/data/block) + handler, and
+   `CallContract` to `ChainStateReader` (direct + worker-routed). Switched
+   `ContractReadProcessor`'s field from `*ethclient.Client` to
+   `ChainStateReader` — it used `CallContract`, `ChainID`, and `CodeAt`,
+   all now on the interface — and `runContractRead` resolves the per-chain
+   reader (worker-routed in gateway mode, direct-dial fallback otherwise).
+   Deferred: `callContractMethod` (`run_node_immediately.go`) reads
+   `decimals()` via the package-level `rpcConn` (the AVS-chain client, no
+   chainID param) — chain-ambiguous, so it moves with the event-enrichment
+   work (PR 3/5) where chain context is threaded through.
 3. **PR 3 — block context (`GetBlockNumber` / `GetBlockHeader`).** Migrate
    the trigger/enrichment block reads.
 4. **PR 4 — contractWrite / ethTransfer residual dials.** Fold gas

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -1124,6 +1124,128 @@ func (x *WorkerGetTokenBalanceResp) GetBalance() string {
 	return ""
 }
 
+// Read-only contract call (eth_call). Mirrors the ethereum.CallMsg fields
+// the contractRead path uses.
+type WorkerCallContractReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	From          string                 `protobuf:"bytes,1,opt,name=from,proto3" json:"from,omitempty"`                                  // Caller (hex). Optional; chain default if empty.
+	To            string                 `protobuf:"bytes,2,opt,name=to,proto3" json:"to,omitempty"`                                      // Target contract (hex). Required.
+	Value         string                 `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`                                // Wei (big.Int as string); empty/zero for none.
+	Data          []byte                 `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`                                  // ABI-encoded calldata.
+	BlockNumber   string                 `protobuf:"bytes,5,opt,name=block_number,json=blockNumber,proto3" json:"block_number,omitempty"` // Block height (big.Int as string); empty = latest.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerCallContractReq) Reset() {
+	*x = WorkerCallContractReq{}
+	mi := &file_worker_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerCallContractReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerCallContractReq) ProtoMessage() {}
+
+func (x *WorkerCallContractReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerCallContractReq.ProtoReflect.Descriptor instead.
+func (*WorkerCallContractReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *WorkerCallContractReq) GetFrom() string {
+	if x != nil {
+		return x.From
+	}
+	return ""
+}
+
+func (x *WorkerCallContractReq) GetTo() string {
+	if x != nil {
+		return x.To
+	}
+	return ""
+}
+
+func (x *WorkerCallContractReq) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *WorkerCallContractReq) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *WorkerCallContractReq) GetBlockNumber() string {
+	if x != nil {
+		return x.BlockNumber
+	}
+	return ""
+}
+
+type WorkerCallContractResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Result        []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"` // Raw ABI-encoded return bytes.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerCallContractResp) Reset() {
+	*x = WorkerCallContractResp{}
+	mi := &file_worker_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerCallContractResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerCallContractResp) ProtoMessage() {}
+
+func (x *WorkerCallContractResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerCallContractResp.ProtoReflect.Descriptor instead.
+func (*WorkerCallContractResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *WorkerCallContractResp) GetResult() []byte {
+	if x != nil {
+		return x.Result
+	}
+	return nil
+}
+
 var File_worker_proto protoreflect.FileDescriptor
 
 const file_worker_proto_rawDesc = "" +
@@ -1196,7 +1318,15 @@ const file_worker_proto_rawDesc = "" +
 	"\rtoken_address\x18\x01 \x01(\tR\ftokenAddress\x12#\n" +
 	"\rowner_address\x18\x02 \x01(\tR\fownerAddress\"5\n" +
 	"\x19WorkerGetTokenBalanceResp\x12\x18\n" +
-	"\abalance\x18\x01 \x01(\tR\abalance2\xdf\a\n" +
+	"\abalance\x18\x01 \x01(\tR\abalance\"\x88\x01\n" +
+	"\x15WorkerCallContractReq\x12\x12\n" +
+	"\x04from\x18\x01 \x01(\tR\x04from\x12\x0e\n" +
+	"\x02to\x18\x02 \x01(\tR\x02to\x12\x14\n" +
+	"\x05value\x18\x03 \x01(\tR\x05value\x12\x12\n" +
+	"\x04data\x18\x04 \x01(\fR\x04data\x12!\n" +
+	"\fblock_number\x18\x05 \x01(\tR\vblockNumber\"0\n" +
+	"\x16WorkerCallContractResp\x12\x16\n" +
+	"\x06result\x18\x01 \x01(\fR\x06result2\xb6\b\n" +
 	"\vChainWorker\x12X\n" +
 	"\x11WorkerHealthCheck\x12 .aggregator.WorkerHealthCheckReq\x1a!.aggregator.WorkerHealthCheckResp\x12L\n" +
 	"\rExecuteUserOp\x12\x1c.aggregator.ExecuteUserOpReq\x1a\x1d.aggregator.ExecuteUserOpResp\x12I\n" +
@@ -1209,7 +1339,8 @@ const file_worker_proto_rawDesc = "" +
 	"\aGetCode\x12\x1c.aggregator.WorkerGetCodeReq\x1a\x1d.aggregator.WorkerGetCodeResp\x12O\n" +
 	"\n" +
 	"GetBalance\x12\x1f.aggregator.WorkerGetBalanceReq\x1a .aggregator.WorkerGetBalanceResp\x12^\n" +
-	"\x0fGetTokenBalance\x12$.aggregator.WorkerGetTokenBalanceReq\x1a%.aggregator.WorkerGetTokenBalanceRespB\fZ\n" +
+	"\x0fGetTokenBalance\x12$.aggregator.WorkerGetTokenBalanceReq\x1a%.aggregator.WorkerGetTokenBalanceResp\x12U\n" +
+	"\fCallContract\x12!.aggregator.WorkerCallContractReq\x1a\".aggregator.WorkerCallContractRespB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (
@@ -1224,7 +1355,7 @@ func file_worker_proto_rawDescGZIP() []byte {
 	return file_worker_proto_rawDescData
 }
 
-var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_worker_proto_goTypes = []any{
 	(*WorkerHealthCheckReq)(nil),            // 0: aggregator.WorkerHealthCheckReq
 	(*WorkerHealthCheckResp)(nil),           // 1: aggregator.WorkerHealthCheckResp
@@ -1247,6 +1378,8 @@ var file_worker_proto_goTypes = []any{
 	(*WorkerGetBalanceResp)(nil),            // 18: aggregator.WorkerGetBalanceResp
 	(*WorkerGetTokenBalanceReq)(nil),        // 19: aggregator.WorkerGetTokenBalanceReq
 	(*WorkerGetTokenBalanceResp)(nil),       // 20: aggregator.WorkerGetTokenBalanceResp
+	(*WorkerCallContractReq)(nil),           // 21: aggregator.WorkerCallContractReq
+	(*WorkerCallContractResp)(nil),          // 22: aggregator.WorkerCallContractResp
 }
 var file_worker_proto_depIdxs = []int32{
 	0,  // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
@@ -1260,19 +1393,21 @@ var file_worker_proto_depIdxs = []int32{
 	15, // 8: aggregator.ChainWorker.GetCode:input_type -> aggregator.WorkerGetCodeReq
 	17, // 9: aggregator.ChainWorker.GetBalance:input_type -> aggregator.WorkerGetBalanceReq
 	19, // 10: aggregator.ChainWorker.GetTokenBalance:input_type -> aggregator.WorkerGetTokenBalanceReq
-	1,  // 11: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
-	3,  // 12: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
-	5,  // 13: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
-	7,  // 14: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
-	9,  // 15: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
-	5,  // 16: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
-	12, // 17: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
-	14, // 18: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
-	16, // 19: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
-	18, // 20: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
-	20, // 21: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
-	11, // [11:22] is the sub-list for method output_type
-	0,  // [0:11] is the sub-list for method input_type
+	21, // 11: aggregator.ChainWorker.CallContract:input_type -> aggregator.WorkerCallContractReq
+	1,  // 12: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
+	3,  // 13: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
+	5,  // 14: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
+	7,  // 15: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
+	9,  // 16: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
+	5,  // 17: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
+	12, // 18: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
+	14, // 19: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
+	16, // 20: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
+	18, // 21: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
+	20, // 22: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
+	22, // 23: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
+	12, // [12:24] is the sub-list for method output_type
+	0,  // [0:12] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -1289,7 +1424,7 @@ func file_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   21,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -53,6 +53,11 @@ service ChainWorker {
   // Used by the gateway's withdraw preflight to validate / size ERC-20
   // withdrawals.
   rpc GetTokenBalance(WorkerGetTokenBalanceReq) returns (WorkerGetTokenBalanceResp);
+
+  // Execute a read-only contract call (eth_call) on this chain. Wraps
+  // ethclient.CallContract. Used by the contractRead node so the gateway
+  // issues no direct eth_call against execution chains.
+  rpc CallContract(WorkerCallContractReq) returns (WorkerCallContractResp);
 }
 
 // Health check
@@ -171,4 +176,18 @@ message WorkerGetTokenBalanceReq {
 
 message WorkerGetTokenBalanceResp {
   string balance = 1;  // Raw token balance (big.Int as string, no decimals applied).
+}
+
+// Read-only contract call (eth_call). Mirrors the ethereum.CallMsg fields
+// the contractRead path uses.
+message WorkerCallContractReq {
+  string from = 1;          // Caller (hex). Optional; chain default if empty.
+  string to = 2;            // Target contract (hex). Required.
+  string value = 3;         // Wei (big.Int as string); empty/zero for none.
+  bytes data = 4;           // ABI-encoded calldata.
+  string block_number = 5;  // Block height (big.Int as string); empty = latest.
+}
+
+message WorkerCallContractResp {
+  bytes result = 1;         // Raw ABI-encoded return bytes.
 }

--- a/protobuf/worker_grpc.pb.go
+++ b/protobuf/worker_grpc.pb.go
@@ -30,6 +30,7 @@ const (
 	ChainWorker_GetCode_FullMethodName               = "/aggregator.ChainWorker/GetCode"
 	ChainWorker_GetBalance_FullMethodName            = "/aggregator.ChainWorker/GetBalance"
 	ChainWorker_GetTokenBalance_FullMethodName       = "/aggregator.ChainWorker/GetTokenBalance"
+	ChainWorker_CallContract_FullMethodName          = "/aggregator.ChainWorker/CallContract"
 )
 
 // ChainWorkerClient is the client API for ChainWorker service.
@@ -76,6 +77,10 @@ type ChainWorkerClient interface {
 	// Used by the gateway's withdraw preflight to validate / size ERC-20
 	// withdrawals.
 	GetTokenBalance(ctx context.Context, in *WorkerGetTokenBalanceReq, opts ...grpc.CallOption) (*WorkerGetTokenBalanceResp, error)
+	// Execute a read-only contract call (eth_call) on this chain. Wraps
+	// ethclient.CallContract. Used by the contractRead node so the gateway
+	// issues no direct eth_call against execution chains.
+	CallContract(ctx context.Context, in *WorkerCallContractReq, opts ...grpc.CallOption) (*WorkerCallContractResp, error)
 }
 
 type chainWorkerClient struct {
@@ -196,6 +201,16 @@ func (c *chainWorkerClient) GetTokenBalance(ctx context.Context, in *WorkerGetTo
 	return out, nil
 }
 
+func (c *chainWorkerClient) CallContract(ctx context.Context, in *WorkerCallContractReq, opts ...grpc.CallOption) (*WorkerCallContractResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerCallContractResp)
+	err := c.cc.Invoke(ctx, ChainWorker_CallContract_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ChainWorkerServer is the server API for ChainWorker service.
 // All implementations must embed UnimplementedChainWorkerServer
 // for forward compatibility.
@@ -240,6 +255,10 @@ type ChainWorkerServer interface {
 	// Used by the gateway's withdraw preflight to validate / size ERC-20
 	// withdrawals.
 	GetTokenBalance(context.Context, *WorkerGetTokenBalanceReq) (*WorkerGetTokenBalanceResp, error)
+	// Execute a read-only contract call (eth_call) on this chain. Wraps
+	// ethclient.CallContract. Used by the contractRead node so the gateway
+	// issues no direct eth_call against execution chains.
+	CallContract(context.Context, *WorkerCallContractReq) (*WorkerCallContractResp, error)
 	mustEmbedUnimplementedChainWorkerServer()
 }
 
@@ -282,6 +301,9 @@ func (UnimplementedChainWorkerServer) GetBalance(context.Context, *WorkerGetBala
 }
 func (UnimplementedChainWorkerServer) GetTokenBalance(context.Context, *WorkerGetTokenBalanceReq) (*WorkerGetTokenBalanceResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTokenBalance not implemented")
+}
+func (UnimplementedChainWorkerServer) CallContract(context.Context, *WorkerCallContractReq) (*WorkerCallContractResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CallContract not implemented")
 }
 func (UnimplementedChainWorkerServer) mustEmbedUnimplementedChainWorkerServer() {}
 func (UnimplementedChainWorkerServer) testEmbeddedByValue()                     {}
@@ -502,6 +524,24 @@ func _ChainWorker_GetTokenBalance_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ChainWorker_CallContract_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerCallContractReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).CallContract(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_CallContract_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).CallContract(ctx, req.(*WorkerCallContractReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ChainWorker_ServiceDesc is the grpc.ServiceDesc for ChainWorker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -552,6 +592,10 @@ var ChainWorker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetTokenBalance",
 			Handler:    _ChainWorker_GetTokenBalance_Handler,
+		},
+		{
+			MethodName: "CallContract",
+			Handler:    _ChainWorker_CallContract_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/worker/server.go
+++ b/worker/server.go
@@ -331,6 +331,50 @@ func (s *Server) GetCode(ctx context.Context, req *avsproto.WorkerGetCodeReq) (*
 	}, nil
 }
 
+// CallContract wraps ethclient.CallContract (eth_call). Used by the
+// contractRead node so the gateway issues no direct eth_call against
+// execution chains.
+func (s *Server) CallContract(ctx context.Context, req *avsproto.WorkerCallContractReq) (*avsproto.WorkerCallContractResp, error) {
+	if !common.IsHexAddress(req.To) {
+		return nil, fmt.Errorf("invalid to address %q", req.To)
+	}
+	to := common.HexToAddress(req.To)
+	msg := ethereum.CallMsg{
+		To:   &to,
+		Data: req.Data,
+	}
+	if req.From != "" {
+		if !common.IsHexAddress(req.From) {
+			return nil, fmt.Errorf("invalid from address %q", req.From)
+		}
+		msg.From = common.HexToAddress(req.From)
+	}
+	if req.Value != "" {
+		v, ok := new(big.Int).SetString(req.Value, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid value %q (expected base-10 big.Int string)", req.Value)
+		}
+		msg.Value = v
+	}
+
+	var blockNumber *big.Int
+	if req.BlockNumber != "" {
+		b, ok := new(big.Int).SetString(req.BlockNumber, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid block_number %q (expected base-10 big.Int string)", req.BlockNumber)
+		}
+		blockNumber = b
+	}
+
+	result, err := s.worker.rpcClient.CallContract(ctx, msg, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("CallContract to %s: %w", req.To, err)
+	}
+	return &avsproto.WorkerCallContractResp{
+		Result: result,
+	}, nil
+}
+
 // GetBalance wraps ethclient.BalanceAt(addr, latest). Used by the gateway's
 // withdraw preflight to validate / size native-coin withdrawals.
 func (s *Server) GetBalance(ctx context.Context, req *avsproto.WorkerGetBalanceReq) (*avsproto.WorkerGetBalanceResp, error) {

--- a/worker/server.go
+++ b/worker/server.go
@@ -354,6 +354,12 @@ func (s *Server) CallContract(ctx context.Context, req *avsproto.WorkerCallContr
 		if !ok {
 			return nil, fmt.Errorf("invalid value %q (expected base-10 big.Int string)", req.Value)
 		}
+		if v.Sign() < 0 {
+			return nil, fmt.Errorf("invalid value %q: must be non-negative", req.Value)
+		}
+		if v.BitLen() > 256 {
+			return nil, fmt.Errorf("invalid value %q: exceeds uint256", req.Value)
+		}
 		msg.Value = v
 	}
 
@@ -362,6 +368,9 @@ func (s *Server) CallContract(ctx context.Context, req *avsproto.WorkerCallContr
 		b, ok := new(big.Int).SetString(req.BlockNumber, 10)
 		if !ok {
 			return nil, fmt.Errorf("invalid block_number %q (expected base-10 big.Int string)", req.BlockNumber)
+		}
+		if b.Sign() < 0 {
+			return nil, fmt.Errorf("invalid block_number %q: must be non-negative", req.BlockNumber)
 		}
 		blockNumber = b
 	}


### PR DESCRIPTION
## What

PR 2 of [`docs/changes/20260614-route-vm-execution-through-workers.md`](docs/changes/20260614-route-vm-execution-through-workers.md). The contractRead node dialed `swCfg.EthRpcUrl` directly and issued `eth_call` against execution chains from the gateway — the largest remaining direct-RPC surface. This routes it through the chain worker.

## Changes

- **`worker.proto` / `worker/server.go`**: new `CallContract` RPC (`from`/`to`/`value`/`data`/`block_number`) wrapping `ethclient.CallContract`.
- **`ChainStateReader`**: add `CallContract` to the interface + both impls (direct wraps `ethclient.CallContract`; worker-routed rejects a nil `To` and guards a nil response).
- **`ContractReadProcessor`**: field changed from `*ethclient.Client` to `ChainStateReader`. It used `CallContract`, `ChainID`, and `CodeAt` — all now on the interface. `CodeAt` sites drop the trailing block arg (interface signature); `ChainID` now returns `int64` (used only for logging / error strings).
- **`vm.go` `runContractRead`**: resolve the per-chain `ChainStateReader` (worker-routed in gateway mode), falling back to a direct dial only when no reader is registered for the chain.

## Deferred (not this PR)

`callContractMethod` ([run_node_immediately.go](core/taskengine/run_node_immediately.go)) reads `decimals()` via the package-level `rpcConn` — the gateway's **AVS-chain** client, with no chainID parameter. It's chain-ambiguous, so it moves with the event-enrichment work (PR 3/5) where chain context is threaded through. Migrating it here would require reading a token's decimals on the wrong chain.

## Testing

- `go build ./...`, `go vet ./core/taskengine/ ./worker/` clean.
- New `CallContract` reader tests: To/Data propagation, From/Value/block default-empty + set-serialization, nil-To rejection.
- Existing `ContractRead*` processor tests pass (updated to wrap the test client in a `DirectChainStateReader`).

## Next

PR 3 — block context (`GetBlockNumber` / `GetBlockHeader`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
