### PR TITLE
feat: route contractWrite receipt block-stamp through chain workers (VM Phase 3)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -197,6 +197,9 @@ func (d *directChainStateReader) HeaderByNumber(ctx context.Context, number *big
 	if err != nil {
 		return nil, err
 	}
+	if h == nil {
+		return nil, fmt.Errorf("HeaderByNumber returned nil header")
+	}
 	return &BlockHeader{Number: h.Number.Uint64(), Hash: h.Hash(), Time: h.Time}, nil
 }
 

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -70,6 +70,20 @@ type ChainStateReader interface {
 	// CallContract executes a read-only contract call (eth_call) at the
 	// given block (nil = latest). Mirrors ethclient.CallContract.
 	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+
+	// HeaderByNumber returns the block's number, hash, and timestamp for
+	// the given height (nil = latest). Returns the subset of header fields
+	// the gateway reads — a full types.Header can't be carried over gRPC
+	// faithfully (its hash depends on every field).
+	HeaderByNumber(ctx context.Context, number *big.Int) (*BlockHeader, error)
+}
+
+// BlockHeader is the subset of block-header fields the gateway reads:
+// number + hash (receipt stamping) and time (event-timestamp enrichment).
+type BlockHeader struct {
+	Number uint64
+	Hash   common.Hash
+	Time   uint64
 }
 
 // ---------------------------------------------------------------------
@@ -176,6 +190,14 @@ func (d *directChainStateReader) GetSmartWalletAddress(_ context.Context, owner,
 
 func (d *directChainStateReader) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	return d.client.CallContract(ctx, msg, blockNumber)
+}
+
+func (d *directChainStateReader) HeaderByNumber(ctx context.Context, number *big.Int) (*BlockHeader, error) {
+	h, err := d.client.HeaderByNumber(ctx, number)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockHeader{Number: h.Number.Uint64(), Hash: h.Hash(), Time: h.Time}, nil
 }
 
 // ---------------------------------------------------------------------
@@ -372,6 +394,27 @@ func (w *workerChainStateReader) CallContract(ctx context.Context, msg ethereum.
 		return nil, fmt.Errorf("worker returned nil response for CallContract to %s on chain %d", msg.To.Hex(), w.chainID)
 	}
 	return resp.Result, nil
+}
+
+func (w *workerChainStateReader) HeaderByNumber(ctx context.Context, number *big.Int) (*BlockHeader, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	req := &avsproto.WorkerGetBlockHeaderReq{}
+	if number != nil {
+		req.BlockNumber = number.String()
+	}
+	resp, err := w.client.GetBlockHeader(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("worker GetBlockHeader (chain %d): %w", w.chainID, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("worker returned nil response for GetBlockHeader on chain %d", w.chainID)
+	}
+	return &BlockHeader{
+		Number: resp.Number,
+		Hash:   common.HexToHash(resp.Hash),
+		Time:   resp.Time,
+	}, nil
 }
 
 // withTimeout caps the gRPC call's wall time. context.WithTimeout

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -58,6 +58,11 @@ type chainStateFakeClient struct {
 	callContractReq  *avsproto.WorkerCallContractReq
 	callContractResp *avsproto.WorkerCallContractResp
 	callContractErr  error
+
+	// GetBlockHeader
+	getBlockHeaderReq  *avsproto.WorkerGetBlockHeaderReq
+	getBlockHeaderResp *avsproto.WorkerGetBlockHeaderResp
+	getBlockHeaderErr  error
 }
 
 func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
@@ -76,6 +81,10 @@ func (f *chainStateFakeClient) GetSmartWalletAddress(_ context.Context, req *avs
 func (f *chainStateFakeClient) CallContract(_ context.Context, req *avsproto.WorkerCallContractReq, _ ...grpc.CallOption) (*avsproto.WorkerCallContractResp, error) {
 	f.callContractReq = req
 	return f.callContractResp, f.callContractErr
+}
+func (f *chainStateFakeClient) GetBlockHeader(_ context.Context, req *avsproto.WorkerGetBlockHeaderReq, _ ...grpc.CallOption) (*avsproto.WorkerGetBlockHeaderResp, error) {
+	f.getBlockHeaderReq = req
+	return f.getBlockHeaderResp, f.getBlockHeaderErr
 }
 func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
 	panic("unused")
@@ -566,5 +575,44 @@ func TestWorkerChainStateReader_CallContract_NilToRejected(t *testing.T) {
 	r := NewWorkerChainStateReader(&chainStateFakeClient{}, 1, time.Second)
 	if _, err := r.CallContract(context.Background(), ethereum.CallMsg{Data: []byte{0x1}}, nil); err == nil {
 		t.Fatalf("expected error for nil msg.To")
+	}
+}
+
+// TestWorkerChainStateReader_HeaderByNumber: a specific block number
+// serializes as base-10; the worker's number/hash/time map into BlockHeader.
+func TestWorkerChainStateReader_HeaderByNumber(t *testing.T) {
+	hash := common.HexToHash("0xabc123")
+	fake := &chainStateFakeClient{
+		getBlockHeaderResp: &avsproto.WorkerGetBlockHeaderResp{
+			Number: 19000000,
+			Hash:   hash.Hex(),
+			Time:   1700000000,
+		},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	h, err := r.HeaderByNumber(context.Background(), big.NewInt(19000000))
+	if err != nil {
+		t.Fatalf("HeaderByNumber: %v", err)
+	}
+	if h.Number != 19000000 || h.Hash != hash || h.Time != 1700000000 {
+		t.Fatalf("unexpected header %+v", h)
+	}
+	if fake.getBlockHeaderReq.BlockNumber != "19000000" {
+		t.Fatalf("block number not propagated: %q", fake.getBlockHeaderReq.BlockNumber)
+	}
+}
+
+// TestWorkerChainStateReader_HeaderByNumber_Latest: nil number sends an
+// empty block_number string (worker treats empty as "latest").
+func TestWorkerChainStateReader_HeaderByNumber_Latest(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getBlockHeaderResp: &avsproto.WorkerGetBlockHeaderResp{Number: 1, Hash: "0x00", Time: 1},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	if _, err := r.HeaderByNumber(context.Background(), nil); err != nil {
+		t.Fatalf("HeaderByNumber latest: %v", err)
+	}
+	if fake.getBlockHeaderReq.BlockNumber != "" {
+		t.Fatalf("nil number should send empty block_number: got %q", fake.getBlockHeaderReq.BlockNumber)
 	}
 }

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1522,13 +1522,20 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 		executionLog.EndAt = time.Now().UnixMilli()
 		return executionLog, err
 	}
-	rpcClient, err := ethclient.Dial(swConfig.EthRpcUrl)
-	if err != nil {
-		executionLog = v.createExecutionStep(stepID, false, fmt.Sprintf("failed to dial ETH RPC: %v", err), "", time.Now().UnixMilli())
-		executionLog.EndAt = time.Now().UnixMilli()
-		return executionLog, err
+	// Prefer the per-chain ChainStateReader (worker-routed in gateway mode)
+	// for receipt block stamping; fall back to a direct dial only when no
+	// reader is registered for the chain.
+	chainReader := GetChainStateReaderForChain(uint64(node.Config.GetChainId()))
+	if chainReader == nil {
+		rpcClient, dialErr := ethclient.Dial(swConfig.EthRpcUrl)
+		if dialErr != nil {
+			executionLog = v.createExecutionStep(stepID, false, fmt.Sprintf("failed to dial ETH RPC: %v", dialErr), "", time.Now().UnixMilli())
+			executionLog.EndAt = time.Now().UnixMilli()
+			return executionLog, dialErr
+		}
+		defer rpcClient.Close()
+		chainReader = NewDirectChainStateReader(rpcClient, node.Config.GetChainId())
 	}
-	defer rpcClient.Close()
 
 	v.logger.Info("🔍 VM DEBUG - Smart wallet config for contract write",
 		"has_config", swConfig != nil,
@@ -1563,16 +1570,16 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 		}
 	}
 
-	processor := NewContractWriteProcessor(v, rpcClient, swConfig, v.TaskOwner)
+	processor := NewContractWriteProcessor(v, chainReader, swConfig, v.TaskOwner)
 	processor.CommonProcessor.SetTaskNode(taskNode)
-	executionLog, err = processor.Execute(stepID, node)
+	executionLog, execErr := processor.Execute(stepID, node)
 	v.mu.Lock()
 	if executionLog != nil {
 		executionLog.Inputs = v.collectInputKeysForLog(stepID)
 	}
 	v.mu.Unlock()
 	// v.addExecutionLog(executionLog)
-	return executionLog, err
+	return executionLog, execErr
 }
 
 func (v *VM) runCustomCode(taskNode *avsproto.TaskNode) (*avsproto.Execution_Step, error) {

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -44,13 +44,16 @@ type SendUserOpFunc func(
 
 type ContractWriteProcessor struct {
 	*CommonProcessor
-	client            *ethclient.Client
+	// client is the per-chain ChainStateReader — worker-routed in gateway
+	// mode, a direct-RPC reader otherwise. Used to stamp simulation
+	// receipts with the latest block number/hash.
+	client            ChainStateReader
 	smartWalletConfig *config.SmartWalletConfig
 	owner             common.Address
 	sendUserOpFunc    SendUserOpFunc
 }
 
-func NewContractWriteProcessor(vm *VM, client *ethclient.Client, smartWalletConfig *config.SmartWalletConfig, owner common.Address) *ContractWriteProcessor {
+func NewContractWriteProcessor(vm *VM, client ChainStateReader, smartWalletConfig *config.SmartWalletConfig, owner common.Address) *ContractWriteProcessor {
 	r := &ContractWriteProcessor{
 		client:            client,
 		smartWalletConfig: smartWalletConfig,
@@ -553,8 +556,8 @@ func (r *ContractWriteProcessor) executeMethodCall(
 		if mr != nil && mr.Receipt != nil && r.client != nil {
 			if header, herr := r.client.HeaderByNumber(ctx, nil); herr == nil && header != nil {
 				if recMap, ok := mr.Receipt.AsInterface().(map[string]interface{}); ok {
-					recMap["blockNumber"] = fmt.Sprintf("0x%x", header.Number.Uint64())
-					recMap["blockHash"] = header.Hash().Hex()
+					recMap["blockNumber"] = fmt.Sprintf("0x%x", header.Number)
+					recMap["blockHash"] = header.Hash.Hex()
 					if newVal, err := structpb.NewValue(recMap); err == nil {
 						mr.Receipt = newVal
 					}

--- a/core/taskengine/worker_token_fetcher_test.go
+++ b/core/taskengine/worker_token_fetcher_test.go
@@ -66,6 +66,9 @@ func (f *fakeChainWorkerClient) GetTokenBalance(context.Context, *avsproto.Worke
 func (f *fakeChainWorkerClient) CallContract(context.Context, *avsproto.WorkerCallContractReq, ...grpc.CallOption) (*avsproto.WorkerCallContractResp, error) {
 	panic("unused")
 }
+func (f *fakeChainWorkerClient) GetBlockHeader(context.Context, *avsproto.WorkerGetBlockHeaderReq, ...grpc.CallOption) (*avsproto.WorkerGetBlockHeaderResp, error) {
+	panic("unused")
+}
 
 // TestWorkerRoutedFetcher_HappyPath confirms a successful worker response
 // gets mapped to a TokenMetadata correctly — name, symbol, decimals, source

--- a/docs/changes/20260614-route-vm-execution-through-workers.md
+++ b/docs/changes/20260614-route-vm-execution-through-workers.md
@@ -169,8 +169,20 @@ next — same migrate-then-verify discipline as Phases 2→4a.
    `decimals()` via the package-level `rpcConn` (the AVS-chain client, no
    chainID param) — chain-ambiguous, so it moves with the event-enrichment
    work (PR 3/5) where chain context is threaded through.
-3. **PR 3 — block context (`GetBlockNumber` / `GetBlockHeader`).** Migrate
-   the trigger/enrichment block reads.
+3. **PR 3 — `GetBlockHeader` + contractWrite block read (delivered).**
+   Added the `GetBlockHeader` worker RPC (number/hash/time) + a
+   `HeaderByNumber` method on `ChainStateReader` returning a lightweight
+   `BlockHeader` (a full `types.Header` can't be carried over gRPC — its
+   hash depends on every field). Switched `ContractWriteProcessor`'s field
+   from `*ethclient.Client` to `ChainStateReader` and migrated its
+   receipt-stamping block read (`vm_runner_contract_write.go:554`);
+   `runContractWrite` resolves the per-chain reader with a direct-dial
+   fallback. The remaining `rpcConn`-based block reads
+   (`run_node_immediately.go`, `engine.go`, `utils.go`) use the AVS-chain
+   client with no chainID param — they move with the `run_node_immediately`
+   chain-threading work alongside the deferred `callContractMethod`. The
+   contractWrite processor's two log-only/best-effort dials (`:715` sender
+   validation, `:784` balance logging) are deferred to PR 4.
 4. **PR 4 — contractWrite / ethTransfer residual dials.** Fold gas
    estimation into `ExecuteUserOp`'s response; drop log-only dials; add
    `GetTransactionReceipt` if a polling path needs it.

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -1246,6 +1246,113 @@ func (x *WorkerCallContractResp) GetResult() []byte {
 	return nil
 }
 
+// Block header (the subset of fields the gateway reads). A full
+// types.Header can't be reconstructed faithfully over gRPC — its hash
+// depends on every field — so the worker returns these explicit values.
+type WorkerGetBlockHeaderReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	BlockNumber   string                 `protobuf:"bytes,1,opt,name=block_number,json=blockNumber,proto3" json:"block_number,omitempty"` // big.Int as string; empty = latest.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetBlockHeaderReq) Reset() {
+	*x = WorkerGetBlockHeaderReq{}
+	mi := &file_worker_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetBlockHeaderReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetBlockHeaderReq) ProtoMessage() {}
+
+func (x *WorkerGetBlockHeaderReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetBlockHeaderReq.ProtoReflect.Descriptor instead.
+func (*WorkerGetBlockHeaderReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *WorkerGetBlockHeaderReq) GetBlockNumber() string {
+	if x != nil {
+		return x.BlockNumber
+	}
+	return ""
+}
+
+type WorkerGetBlockHeaderResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Number        uint64                 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"` // Block number.
+	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`      // 0x-prefixed block hash.
+	Time          uint64                 `protobuf:"varint,3,opt,name=time,proto3" json:"time,omitempty"`     // Unix timestamp (seconds).
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetBlockHeaderResp) Reset() {
+	*x = WorkerGetBlockHeaderResp{}
+	mi := &file_worker_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetBlockHeaderResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetBlockHeaderResp) ProtoMessage() {}
+
+func (x *WorkerGetBlockHeaderResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetBlockHeaderResp.ProtoReflect.Descriptor instead.
+func (*WorkerGetBlockHeaderResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *WorkerGetBlockHeaderResp) GetNumber() uint64 {
+	if x != nil {
+		return x.Number
+	}
+	return 0
+}
+
+func (x *WorkerGetBlockHeaderResp) GetHash() string {
+	if x != nil {
+		return x.Hash
+	}
+	return ""
+}
+
+func (x *WorkerGetBlockHeaderResp) GetTime() uint64 {
+	if x != nil {
+		return x.Time
+	}
+	return 0
+}
+
 var File_worker_proto protoreflect.FileDescriptor
 
 const file_worker_proto_rawDesc = "" +
@@ -1326,7 +1433,13 @@ const file_worker_proto_rawDesc = "" +
 	"\x04data\x18\x04 \x01(\fR\x04data\x12!\n" +
 	"\fblock_number\x18\x05 \x01(\tR\vblockNumber\"0\n" +
 	"\x16WorkerCallContractResp\x12\x16\n" +
-	"\x06result\x18\x01 \x01(\fR\x06result2\xb6\b\n" +
+	"\x06result\x18\x01 \x01(\fR\x06result\"<\n" +
+	"\x17WorkerGetBlockHeaderReq\x12!\n" +
+	"\fblock_number\x18\x01 \x01(\tR\vblockNumber\"Z\n" +
+	"\x18WorkerGetBlockHeaderResp\x12\x16\n" +
+	"\x06number\x18\x01 \x01(\x04R\x06number\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x12\n" +
+	"\x04time\x18\x03 \x01(\x04R\x04time2\x93\t\n" +
 	"\vChainWorker\x12X\n" +
 	"\x11WorkerHealthCheck\x12 .aggregator.WorkerHealthCheckReq\x1a!.aggregator.WorkerHealthCheckResp\x12L\n" +
 	"\rExecuteUserOp\x12\x1c.aggregator.ExecuteUserOpReq\x1a\x1d.aggregator.ExecuteUserOpResp\x12I\n" +
@@ -1340,7 +1453,8 @@ const file_worker_proto_rawDesc = "" +
 	"\n" +
 	"GetBalance\x12\x1f.aggregator.WorkerGetBalanceReq\x1a .aggregator.WorkerGetBalanceResp\x12^\n" +
 	"\x0fGetTokenBalance\x12$.aggregator.WorkerGetTokenBalanceReq\x1a%.aggregator.WorkerGetTokenBalanceResp\x12U\n" +
-	"\fCallContract\x12!.aggregator.WorkerCallContractReq\x1a\".aggregator.WorkerCallContractRespB\fZ\n" +
+	"\fCallContract\x12!.aggregator.WorkerCallContractReq\x1a\".aggregator.WorkerCallContractResp\x12[\n" +
+	"\x0eGetBlockHeader\x12#.aggregator.WorkerGetBlockHeaderReq\x1a$.aggregator.WorkerGetBlockHeaderRespB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (
@@ -1355,7 +1469,7 @@ func file_worker_proto_rawDescGZIP() []byte {
 	return file_worker_proto_rawDescData
 }
 
-var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_worker_proto_goTypes = []any{
 	(*WorkerHealthCheckReq)(nil),            // 0: aggregator.WorkerHealthCheckReq
 	(*WorkerHealthCheckResp)(nil),           // 1: aggregator.WorkerHealthCheckResp
@@ -1380,6 +1494,8 @@ var file_worker_proto_goTypes = []any{
 	(*WorkerGetTokenBalanceResp)(nil),       // 20: aggregator.WorkerGetTokenBalanceResp
 	(*WorkerCallContractReq)(nil),           // 21: aggregator.WorkerCallContractReq
 	(*WorkerCallContractResp)(nil),          // 22: aggregator.WorkerCallContractResp
+	(*WorkerGetBlockHeaderReq)(nil),         // 23: aggregator.WorkerGetBlockHeaderReq
+	(*WorkerGetBlockHeaderResp)(nil),        // 24: aggregator.WorkerGetBlockHeaderResp
 }
 var file_worker_proto_depIdxs = []int32{
 	0,  // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
@@ -1394,20 +1510,22 @@ var file_worker_proto_depIdxs = []int32{
 	17, // 9: aggregator.ChainWorker.GetBalance:input_type -> aggregator.WorkerGetBalanceReq
 	19, // 10: aggregator.ChainWorker.GetTokenBalance:input_type -> aggregator.WorkerGetTokenBalanceReq
 	21, // 11: aggregator.ChainWorker.CallContract:input_type -> aggregator.WorkerCallContractReq
-	1,  // 12: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
-	3,  // 13: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
-	5,  // 14: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
-	7,  // 15: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
-	9,  // 16: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
-	5,  // 17: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
-	12, // 18: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
-	14, // 19: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
-	16, // 20: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
-	18, // 21: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
-	20, // 22: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
-	22, // 23: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
-	12, // [12:24] is the sub-list for method output_type
-	0,  // [0:12] is the sub-list for method input_type
+	23, // 12: aggregator.ChainWorker.GetBlockHeader:input_type -> aggregator.WorkerGetBlockHeaderReq
+	1,  // 13: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
+	3,  // 14: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
+	5,  // 15: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
+	7,  // 16: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
+	9,  // 17: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
+	5,  // 18: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
+	12, // 19: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
+	14, // 20: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
+	16, // 21: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
+	18, // 22: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
+	20, // 23: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
+	22, // 24: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
+	24, // 25: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
+	13, // [13:26] is the sub-list for method output_type
+	0,  // [0:13] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -1424,7 +1542,7 @@ func file_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   23,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -58,6 +58,11 @@ service ChainWorker {
   // ethclient.CallContract. Used by the contractRead node so the gateway
   // issues no direct eth_call against execution chains.
   rpc CallContract(WorkerCallContractReq) returns (WorkerCallContractResp);
+
+  // Read a block header's number, hash, and timestamp. Wraps
+  // ethclient.HeaderByNumber. Used to stamp simulation receipts and
+  // enrich event timestamps without a gateway-side chain dial.
+  rpc GetBlockHeader(WorkerGetBlockHeaderReq) returns (WorkerGetBlockHeaderResp);
 }
 
 // Health check
@@ -190,4 +195,17 @@ message WorkerCallContractReq {
 
 message WorkerCallContractResp {
   bytes result = 1;         // Raw ABI-encoded return bytes.
+}
+
+// Block header (the subset of fields the gateway reads). A full
+// types.Header can't be reconstructed faithfully over gRPC — its hash
+// depends on every field — so the worker returns these explicit values.
+message WorkerGetBlockHeaderReq {
+  string block_number = 1;  // big.Int as string; empty = latest.
+}
+
+message WorkerGetBlockHeaderResp {
+  uint64 number = 1;        // Block number.
+  string hash = 2;          // 0x-prefixed block hash.
+  uint64 time = 3;          // Unix timestamp (seconds).
 }

--- a/protobuf/worker_grpc.pb.go
+++ b/protobuf/worker_grpc.pb.go
@@ -31,6 +31,7 @@ const (
 	ChainWorker_GetBalance_FullMethodName            = "/aggregator.ChainWorker/GetBalance"
 	ChainWorker_GetTokenBalance_FullMethodName       = "/aggregator.ChainWorker/GetTokenBalance"
 	ChainWorker_CallContract_FullMethodName          = "/aggregator.ChainWorker/CallContract"
+	ChainWorker_GetBlockHeader_FullMethodName        = "/aggregator.ChainWorker/GetBlockHeader"
 )
 
 // ChainWorkerClient is the client API for ChainWorker service.
@@ -81,6 +82,10 @@ type ChainWorkerClient interface {
 	// ethclient.CallContract. Used by the contractRead node so the gateway
 	// issues no direct eth_call against execution chains.
 	CallContract(ctx context.Context, in *WorkerCallContractReq, opts ...grpc.CallOption) (*WorkerCallContractResp, error)
+	// Read a block header's number, hash, and timestamp. Wraps
+	// ethclient.HeaderByNumber. Used to stamp simulation receipts and
+	// enrich event timestamps without a gateway-side chain dial.
+	GetBlockHeader(ctx context.Context, in *WorkerGetBlockHeaderReq, opts ...grpc.CallOption) (*WorkerGetBlockHeaderResp, error)
 }
 
 type chainWorkerClient struct {
@@ -211,6 +216,16 @@ func (c *chainWorkerClient) CallContract(ctx context.Context, in *WorkerCallCont
 	return out, nil
 }
 
+func (c *chainWorkerClient) GetBlockHeader(ctx context.Context, in *WorkerGetBlockHeaderReq, opts ...grpc.CallOption) (*WorkerGetBlockHeaderResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerGetBlockHeaderResp)
+	err := c.cc.Invoke(ctx, ChainWorker_GetBlockHeader_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ChainWorkerServer is the server API for ChainWorker service.
 // All implementations must embed UnimplementedChainWorkerServer
 // for forward compatibility.
@@ -259,6 +274,10 @@ type ChainWorkerServer interface {
 	// ethclient.CallContract. Used by the contractRead node so the gateway
 	// issues no direct eth_call against execution chains.
 	CallContract(context.Context, *WorkerCallContractReq) (*WorkerCallContractResp, error)
+	// Read a block header's number, hash, and timestamp. Wraps
+	// ethclient.HeaderByNumber. Used to stamp simulation receipts and
+	// enrich event timestamps without a gateway-side chain dial.
+	GetBlockHeader(context.Context, *WorkerGetBlockHeaderReq) (*WorkerGetBlockHeaderResp, error)
 	mustEmbedUnimplementedChainWorkerServer()
 }
 
@@ -304,6 +323,9 @@ func (UnimplementedChainWorkerServer) GetTokenBalance(context.Context, *WorkerGe
 }
 func (UnimplementedChainWorkerServer) CallContract(context.Context, *WorkerCallContractReq) (*WorkerCallContractResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CallContract not implemented")
+}
+func (UnimplementedChainWorkerServer) GetBlockHeader(context.Context, *WorkerGetBlockHeaderReq) (*WorkerGetBlockHeaderResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetBlockHeader not implemented")
 }
 func (UnimplementedChainWorkerServer) mustEmbedUnimplementedChainWorkerServer() {}
 func (UnimplementedChainWorkerServer) testEmbeddedByValue()                     {}
@@ -542,6 +564,24 @@ func _ChainWorker_CallContract_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ChainWorker_GetBlockHeader_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerGetBlockHeaderReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).GetBlockHeader(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_GetBlockHeader_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).GetBlockHeader(ctx, req.(*WorkerGetBlockHeaderReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ChainWorker_ServiceDesc is the grpc.ServiceDesc for ChainWorker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -596,6 +636,10 @@ var ChainWorker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CallContract",
 			Handler:    _ChainWorker_CallContract_Handler,
+		},
+		{
+			MethodName: "GetBlockHeader",
+			Handler:    _ChainWorker_GetBlockHeader_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/worker/server.go
+++ b/worker/server.go
@@ -397,11 +397,17 @@ func (s *Server) GetBlockHeader(ctx context.Context, req *avsproto.WorkerGetBloc
 		if b.Sign() < 0 {
 			return nil, fmt.Errorf("invalid block_number %q: must be non-negative", req.BlockNumber)
 		}
+		if !b.IsUint64() {
+			return nil, fmt.Errorf("invalid block_number %q: exceeds uint64", req.BlockNumber)
+		}
 		number = b
 	}
 	header, err := s.worker.rpcClient.HeaderByNumber(ctx, number)
 	if err != nil {
 		return nil, fmt.Errorf("HeaderByNumber: %w", err)
+	}
+	if header == nil {
+		return nil, fmt.Errorf("HeaderByNumber returned nil header")
 	}
 	return &avsproto.WorkerGetBlockHeaderResp{
 		Number: header.Number.Uint64(),

--- a/worker/server.go
+++ b/worker/server.go
@@ -384,6 +384,32 @@ func (s *Server) CallContract(ctx context.Context, req *avsproto.WorkerCallContr
 	}, nil
 }
 
+// GetBlockHeader wraps ethclient.HeaderByNumber, returning the number,
+// hash, and timestamp the gateway reads (a full header can't be carried
+// over gRPC faithfully). block_number empty = latest.
+func (s *Server) GetBlockHeader(ctx context.Context, req *avsproto.WorkerGetBlockHeaderReq) (*avsproto.WorkerGetBlockHeaderResp, error) {
+	var number *big.Int
+	if req.BlockNumber != "" {
+		b, ok := new(big.Int).SetString(req.BlockNumber, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid block_number %q (expected base-10 big.Int string)", req.BlockNumber)
+		}
+		if b.Sign() < 0 {
+			return nil, fmt.Errorf("invalid block_number %q: must be non-negative", req.BlockNumber)
+		}
+		number = b
+	}
+	header, err := s.worker.rpcClient.HeaderByNumber(ctx, number)
+	if err != nil {
+		return nil, fmt.Errorf("HeaderByNumber: %w", err)
+	}
+	return &avsproto.WorkerGetBlockHeaderResp{
+		Number: header.Number.Uint64(),
+		Hash:   header.Hash().Hex(),
+		Time:   header.Time,
+	}, nil
+}
+
 // GetBalance wraps ethclient.BalanceAt(addr, latest). Used by the gateway's
 // withdraw preflight to validate / size native-coin withdrawals.
 func (s *Server) GetBalance(ctx context.Context, req *avsproto.WorkerGetBalanceReq) (*avsproto.WorkerGetBalanceResp, error) {


### PR DESCRIPTION
## What

PR 3 of [`docs/changes/20260614-route-vm-execution-through-workers.md`](docs/changes/20260614-route-vm-execution-through-workers.md). The contractWrite node stamped its simulation receipt with the latest block number/hash via a direct per-chain `ethclient.HeaderByNumber`. This routes that block read through the chain worker.

## Changes

- **`worker.proto` / `worker/server.go`**: new `GetBlockHeader` RPC returning `number`/`hash`/`time` (a full `types.Header` can't be carried over gRPC — its hash depends on every field), with a non-negative `block_number` guard.
- **`ChainStateReader`**: add `HeaderByNumber` returning a lightweight `BlockHeader{Number, Hash, Time}` (direct wraps `ethclient.HeaderByNumber`; worker-routed guards a nil response).
- **`ContractWriteProcessor`**: field changed from `*ethclient.Client` to `ChainStateReader`; the receipt block-stamp now reads through it. `runContractWrite` resolves the per-chain reader (worker-routed in gateway mode), falling back to a direct dial only when no reader is registered.

## Deferred (with reasoning)

- The `rpcConn`-based block reads (`run_node_immediately.go`, `engine.go`, `utils.go`) use the gateway's **AVS-chain** client with no chainID parameter — chain-ambiguous, so they move as a unit with the `run_node_immediately` chain-threading work (alongside the `callContractMethod` decimals read deferred in PR 2).
- The contractWrite processor's two **log-only / best-effort** dials (`:715` salt-0 sender validation, `:784` balance logging) → PR 4.

## Testing

- `go build ./...`, `go vet ./core/taskengine/ ./worker/` clean.
- New `HeaderByNumber` tests: block-number base-10 propagation, nil→latest (empty string).
- Existing `ContractWrite*` / `ContractRead*` processor tests pass.

## Next

PR 4 — contractWrite/ethTransfer residual dials (fold gas estimation into `ExecuteUserOp`; migrate the `:715`/`:784` log-only reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
