### PR TITLE
feat: remove contractWrite residual chain dials (VM Phase 4)

### DIFF
--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -16,13 +16,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/bigint"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/byte4"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/eip1559"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/bundler"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
@@ -713,18 +711,15 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 	// Optional runner validation: if task.SmartWalletAddress is set, ensure it matches
 	// one of the owner EOA's known smart wallets (authoritative). If wallet list cannot be checked,
 	// fall back to checking the derived salt:0 address as a best-effort sanity check.
-	if r.vm.task != nil && r.vm.task.Task != nil && r.vm.task.SmartWalletAddress != "" {
+	if r.vm.task != nil && r.vm.task.Task != nil && r.vm.task.SmartWalletAddress != "" && r.client != nil {
 		runnerStr := r.vm.task.SmartWalletAddress
-		client, err := ethclient.Dial(r.smartWalletConfig.EthRpcUrl)
-		if err == nil {
-			// derive sender at salt:0
-			sender, derr := aa.GetSenderAddress(client, r.owner, big.NewInt(0))
-			client.Close()
-			if derr == nil && sender != nil {
-				if !strings.EqualFold(sender.Hex(), runnerStr) {
-					// Do not fail solely on derived salt:0 mismatch; authoritative check is the wallet list in run_node path
-					r.vm.logger.Warn("runner does not match derived salt:0; proceeding (wallet list validation applies in run_node)", "expected", sender.Hex(), "runner", runnerStr)
-				}
+		// Derive sender at salt:0 via the per-chain reader (worker-routed in
+		// gateway mode) instead of a direct dial. Best-effort sanity check;
+		// the authoritative wallet-list validation runs in the run_node path.
+		sender, derr := r.client.GetSmartWalletAddress(ctx, r.owner, r.smartWalletConfig.FactoryAddress, big.NewInt(0))
+		if derr == nil && (sender != common.Address{}) {
+			if !strings.EqualFold(sender.Hex(), runnerStr) {
+				r.vm.logger.Warn("runner does not match derived salt:0; proceeding (wallet list validation applies in run_node)", "expected", sender.Hex(), "runner", runnerStr)
 			}
 		}
 	}
@@ -780,37 +775,25 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 		executionLogBuilder.WriteString("No paymaster (self-funded transaction)\n")
 	}
 
-	// Pre-send gas estimation to capture in logs
-	executionLogBuilder.WriteString("Performing gas estimation...\n")
-
-	// Create a temporary UserOp for gas estimation
-	rpcClient, rpcErr := ethclient.Dial(r.smartWalletConfig.EthRpcUrl)
-	if rpcErr != nil {
-		executionLogBuilder.WriteString(fmt.Sprintf("Failed to connect to RPC: %v\n", rpcErr))
-	} else {
-		defer rpcClient.Close()
-
-		_, bundlerErr := bundler.NewBundlerClient(r.smartWalletConfig.BundlerURL)
-		if bundlerErr != nil {
+	// Pre-send diagnostics (logged only). Read via the per-chain reader
+	// (worker-routed in gateway mode) so there's no gateway-side dial; the
+	// bundler does the authoritative gas pricing at send time.
+	executionLogBuilder.WriteString("Collecting pre-send diagnostics...\n")
+	if r.client != nil {
+		if _, bundlerErr := bundler.NewBundlerClient(r.smartWalletConfig.BundlerURL); bundlerErr != nil {
 			executionLogBuilder.WriteString(fmt.Sprintf("Failed to create bundler client: %v\n", bundlerErr))
 		} else {
-			// Check smart wallet balance
-			smartWalletAddr := senderOverride
-			if smartWalletAddr != nil {
-				if balance, balErr := rpcClient.BalanceAt(ctx, *smartWalletAddr, nil); balErr == nil {
+			if senderOverride != nil {
+				if balance, balErr := r.client.GetBalance(ctx, *senderOverride); balErr == nil {
 					executionLogBuilder.WriteString(fmt.Sprintf("Smart wallet balance: %s wei\n", balance.String()))
 				} else {
 					executionLogBuilder.WriteString(fmt.Sprintf("Failed to check balance: %v\n", balErr))
 				}
 			}
-
-			// Try to get current gas prices
-			if maxFee, maxPriority, feeErr := eip1559.SuggestFee(rpcClient); feeErr == nil {
-				executionLogBuilder.WriteString(fmt.Sprintf("Current gas prices:\n"))
-				executionLogBuilder.WriteString(fmt.Sprintf("  MaxFeePerGas: %s wei\n", maxFee.String()))
-				executionLogBuilder.WriteString(fmt.Sprintf("  MaxPriorityFeePerGas: %s wei\n", maxPriority.String()))
+			if gasPrice, feeErr := r.client.SuggestGasPrice(ctx); feeErr == nil {
+				executionLogBuilder.WriteString(fmt.Sprintf("Suggested gas price: %s wei\n", gasPrice.String()))
 			} else {
-				executionLogBuilder.WriteString(fmt.Sprintf("Failed to get gas prices: %v\n", feeErr))
+				executionLogBuilder.WriteString(fmt.Sprintf("Failed to get gas price: %v\n", feeErr))
 			}
 		}
 	}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -780,9 +780,10 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 	// bundler does the authoritative gas pricing at send time.
 	executionLogBuilder.WriteString("Collecting pre-send diagnostics...\n")
 	if r.client != nil {
-		if _, bundlerErr := bundler.NewBundlerClient(r.smartWalletConfig.BundlerURL); bundlerErr != nil {
+		if bundlerClient, bundlerErr := bundler.NewBundlerClient(r.smartWalletConfig.BundlerURL); bundlerErr != nil {
 			executionLogBuilder.WriteString(fmt.Sprintf("Failed to create bundler client: %v\n", bundlerErr))
 		} else {
+			bundlerClient.Close()
 			if senderOverride != nil {
 				if balance, balErr := r.client.GetBalance(ctx, *senderOverride); balErr == nil {
 					executionLogBuilder.WriteString(fmt.Sprintf("Smart wallet balance: %s wei\n", balance.String()))

--- a/docs/changes/20260614-route-vm-execution-through-workers.md
+++ b/docs/changes/20260614-route-vm-execution-through-workers.md
@@ -183,9 +183,15 @@ next — same migrate-then-verify discipline as Phases 2→4a.
    chain-threading work alongside the deferred `callContractMethod`. The
    contractWrite processor's two log-only/best-effort dials (`:715` sender
    validation, `:784` balance logging) are deferred to PR 4.
-4. **PR 4 — contractWrite / ethTransfer residual dials.** Fold gas
-   estimation into `ExecuteUserOp`'s response; drop log-only dials; add
-   `GetTransactionReceipt` if a polling path needs it.
+4. **PR 4 — contractWrite residual dials (delivered).** Migrated the
+   contractWrite processor's last two direct dials onto its existing
+   `ChainStateReader` (no new worker RPC): the salt-0 sender-validation
+   read now uses `GetSmartWalletAddress`, and the pre-send diagnostic block
+   uses `GetBalance` + `SuggestGasPrice` (replacing the raw-client
+   `eip1559.SuggestFee` log). The contractWrite node now issues **zero**
+   direct chain dials. ethTransfer was already dial-free (it sends via the
+   userop path). `GetTransactionReceipt` proved unnecessary — no gateway
+   path polls receipts directly.
 5. **PR 5 — event log queries (`FilterLogs`).** Worker-side chunking +
    pagination. Gate behind a design review on whether the gateway should
    replay events at all (operator overlap).


### PR DESCRIPTION
## What

PR 4 of [`docs/changes/20260614-route-vm-execution-through-workers.md`](docs/changes/20260614-route-vm-execution-through-workers.md). The contractWrite processor had two remaining direct `ethclient.Dial` calls for best-effort / log-only reads. This migrates both onto its existing `ChainStateReader` (worker-routed in gateway mode), so the contractWrite node issues **zero** direct chain dials.

## Changes

- **salt-0 sender validation**: `aa.GetSenderAddress(dial, ...)` → `r.client.GetSmartWalletAddress(ctx, owner, factory, 0)` (best-effort sanity check; authoritative wallet-list validation still runs in the run_node path).
- **pre-send diagnostics** (log-only): `rpcClient.BalanceAt` → `r.client.GetBalance`; `eip1559.SuggestFee(rpcClient)` → `r.client.SuggestGasPrice`. The bundler does authoritative gas pricing at send time, so the single suggested price is sufficient for the diagnostic log. Dropped the now-unused `ethclient` + `eip1559` imports.

No new worker RPC or `ChainStateReader` method — this reuses `GetSmartWalletAddress` (Phase 1), `GetBalance` (Phase 4a), and `SuggestGasPrice` (#580).

`ethTransfer` was already dial-free (it sends via the userop path). `GetTransactionReceipt` proved unnecessary — no gateway path polls receipts directly.

## Testing

- `go build ./...`, `go vet ./core/taskengine/` clean; `grep ethclient.Dial` in contractWrite now returns nothing.
- Existing `ContractWrite*` processor tests pass.

## Next

PR 5 — event log queries (`FilterLogs`), gated on the operator-overlap design question; and the grouped `run_node_immediately` AVS-chain `rpcConn` chain-threading (block/call/filterlogs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
