### PR TITLE
feat: route immediate-trigger block read through chain workers (rpcConn A)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -76,6 +76,10 @@ type ChainStateReader interface {
 	// the gateway reads — a full types.Header can't be carried over gRPC
 	// faithfully (its hash depends on every field).
 	HeaderByNumber(ctx context.Context, number *big.Int) (*BlockHeader, error)
+
+	// GetBlockNumber returns the latest block number. Mirrors
+	// ethclient.BlockNumber.
+	GetBlockNumber(ctx context.Context) (uint64, error)
 }
 
 // BlockHeader is the subset of block-header fields the gateway reads:
@@ -201,6 +205,10 @@ func (d *directChainStateReader) HeaderByNumber(ctx context.Context, number *big
 		return nil, fmt.Errorf("HeaderByNumber returned nil header")
 	}
 	return &BlockHeader{Number: h.Number.Uint64(), Hash: h.Hash(), Time: h.Time}, nil
+}
+
+func (d *directChainStateReader) GetBlockNumber(ctx context.Context) (uint64, error) {
+	return d.client.BlockNumber(ctx)
 }
 
 // ---------------------------------------------------------------------
@@ -418,6 +426,19 @@ func (w *workerChainStateReader) HeaderByNumber(ctx context.Context, number *big
 		Hash:   common.HexToHash(resp.Hash),
 		Time:   resp.Time,
 	}, nil
+}
+
+func (w *workerChainStateReader) GetBlockNumber(ctx context.Context) (uint64, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	resp, err := w.client.GetBlockNumber(ctx, &avsproto.WorkerGetBlockNumberReq{})
+	if err != nil {
+		return 0, fmt.Errorf("worker GetBlockNumber (chain %d): %w", w.chainID, err)
+	}
+	if resp == nil {
+		return 0, fmt.Errorf("worker returned nil response for GetBlockNumber on chain %d", w.chainID)
+	}
+	return resp.Number, nil
 }
 
 // withTimeout caps the gRPC call's wall time. context.WithTimeout

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -63,6 +63,10 @@ type chainStateFakeClient struct {
 	getBlockHeaderReq  *avsproto.WorkerGetBlockHeaderReq
 	getBlockHeaderResp *avsproto.WorkerGetBlockHeaderResp
 	getBlockHeaderErr  error
+
+	// GetBlockNumber
+	getBlockNumberResp *avsproto.WorkerGetBlockNumberResp
+	getBlockNumberErr  error
 }
 
 func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
@@ -85,6 +89,9 @@ func (f *chainStateFakeClient) CallContract(_ context.Context, req *avsproto.Wor
 func (f *chainStateFakeClient) GetBlockHeader(_ context.Context, req *avsproto.WorkerGetBlockHeaderReq, _ ...grpc.CallOption) (*avsproto.WorkerGetBlockHeaderResp, error) {
 	f.getBlockHeaderReq = req
 	return f.getBlockHeaderResp, f.getBlockHeaderErr
+}
+func (f *chainStateFakeClient) GetBlockNumber(_ context.Context, _ *avsproto.WorkerGetBlockNumberReq, _ ...grpc.CallOption) (*avsproto.WorkerGetBlockNumberResp, error) {
+	return f.getBlockNumberResp, f.getBlockNumberErr
 }
 func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
 	panic("unused")
@@ -614,5 +621,31 @@ func TestWorkerChainStateReader_HeaderByNumber_Latest(t *testing.T) {
 	}
 	if fake.getBlockHeaderReq.BlockNumber != "" {
 		t.Fatalf("nil number should send empty block_number: got %q", fake.getBlockHeaderReq.BlockNumber)
+	}
+}
+
+// TestWorkerChainStateReader_GetBlockNumber: the worker's latest block
+// number is returned verbatim.
+func TestWorkerChainStateReader_GetBlockNumber(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getBlockNumberResp: &avsproto.WorkerGetBlockNumberResp{Number: 21000000},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	n, err := r.GetBlockNumber(context.Background())
+	if err != nil {
+		t.Fatalf("GetBlockNumber: %v", err)
+	}
+	if n != 21000000 {
+		t.Fatalf("block number: got %d want 21000000", n)
+	}
+}
+
+// TestWorkerChainStateReader_GetBlockNumber_Err: a transport error wraps
+// the chain ID for triage.
+func TestWorkerChainStateReader_GetBlockNumber_Err(t *testing.T) {
+	fake := &chainStateFakeClient{getBlockNumberErr: errors.New("transport closed")}
+	r := NewWorkerChainStateReader(fake, 99, time.Second)
+	if _, err := r.GetBlockNumber(context.Background()); err == nil || !strings.Contains(err.Error(), "chain 99") {
+		t.Fatalf("expected chain-id-wrapped error, got %v", err)
 	}
 }

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -3088,11 +3088,21 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 		return fmt.Errorf("failed to get task for immediate trigger: %w", err)
 	}
 
-	// Current block for the task's chain, routed through the chain worker
+	// Resolve the chain for the current-block read. task.ChainId can be 0
+	// in single-chain mode or for legacy tasks created before chain_id was
+	// always persisted; fall back to the engine's default chain — the same
+	// key the reader registry uses in single-chain mode — so we don't
+	// regress the path that previously worked via the single global RPC.
+	chainID := task.ChainId
+	if chainID == 0 && n.tokenEnrichmentService != nil {
+		chainID = int64(n.tokenEnrichmentService.GetChainID())
+	}
+
+	// Current block for the resolved chain, routed through the chain worker
 	// in gateway mode (no gateway-side chain dial).
-	reader := GetChainStateReaderForChain(uint64(task.ChainId))
+	reader := GetChainStateReaderForChain(uint64(chainID))
 	if reader == nil {
-		return fmt.Errorf("no chain-state reader available for chain %d (immediate block trigger)", task.ChainId)
+		return fmt.Errorf("no chain-state reader available for chain %d (immediate block trigger)", chainID)
 	}
 	currentBlock, err := reader.GetBlockNumber(context.Background())
 	if err != nil {
@@ -3102,7 +3112,7 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 	if n.logger != nil {
 		n.logger.Info("Instructing operator to trigger immediately",
 			"task_id", taskID,
-			"chain_id", task.ChainId,
+			"chain_id", chainID,
 			"current_block", currentBlock)
 	}
 

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -3081,12 +3081,20 @@ func (n *Engine) GetWorkflow(user *model.User, taskID string) (*model.Workflow, 
 // instructOperatorImmediateTrigger instructs the connected operator to trigger the task immediately
 // with the current block number, bypassing the normal interval waiting
 func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
-	// Get the current block number to pass to the operator
-	if rpcConn == nil {
-		return fmt.Errorf("RPC connection not available for immediate block trigger")
+	// Load the task first so the current-block read targets the task's
+	// chain (via its per-chain worker), not a single gateway RPC.
+	task, err := n.GetWorkflowByID(taskID)
+	if err != nil {
+		return fmt.Errorf("failed to get task for immediate trigger: %w", err)
 	}
 
-	currentBlock, err := rpcConn.BlockNumber(context.Background())
+	// Current block for the task's chain, routed through the chain worker
+	// in gateway mode (no gateway-side chain dial).
+	reader := GetChainStateReaderForChain(uint64(task.ChainId))
+	if reader == nil {
+		return fmt.Errorf("no chain-state reader available for chain %d (immediate block trigger)", task.ChainId)
+	}
+	currentBlock, err := reader.GetBlockNumber(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get current block number: %w", err)
 	}
@@ -3094,13 +3102,8 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 	if n.logger != nil {
 		n.logger.Info("Instructing operator to trigger immediately",
 			"task_id", taskID,
+			"chain_id", task.ChainId,
 			"current_block", currentBlock)
-	}
-
-	// Get the task to include proper metadata
-	task, err := n.GetWorkflowByID(taskID)
-	if err != nil {
-		return fmt.Errorf("failed to get task for immediate trigger: %w", err)
 	}
 
 	// Send immediate trigger instruction directly to operators with task metadata

--- a/core/taskengine/worker_token_fetcher_test.go
+++ b/core/taskengine/worker_token_fetcher_test.go
@@ -69,6 +69,9 @@ func (f *fakeChainWorkerClient) CallContract(context.Context, *avsproto.WorkerCa
 func (f *fakeChainWorkerClient) GetBlockHeader(context.Context, *avsproto.WorkerGetBlockHeaderReq, ...grpc.CallOption) (*avsproto.WorkerGetBlockHeaderResp, error) {
 	panic("unused")
 }
+func (f *fakeChainWorkerClient) GetBlockNumber(context.Context, *avsproto.WorkerGetBlockNumberReq, ...grpc.CallOption) (*avsproto.WorkerGetBlockNumberResp, error) {
+	panic("unused")
+}
 
 // TestWorkerRoutedFetcher_HappyPath confirms a successful worker response
 // gets mapped to a TokenMetadata correctly — name, symbol, decimals, source

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -1353,6 +1353,87 @@ func (x *WorkerGetBlockHeaderResp) GetTime() uint64 {
 	return 0
 }
 
+// Latest block number
+type WorkerGetBlockNumberReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetBlockNumberReq) Reset() {
+	*x = WorkerGetBlockNumberReq{}
+	mi := &file_worker_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetBlockNumberReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetBlockNumberReq) ProtoMessage() {}
+
+func (x *WorkerGetBlockNumberReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetBlockNumberReq.ProtoReflect.Descriptor instead.
+func (*WorkerGetBlockNumberReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{25}
+}
+
+type WorkerGetBlockNumberResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Number        uint64                 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"` // Latest block number.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetBlockNumberResp) Reset() {
+	*x = WorkerGetBlockNumberResp{}
+	mi := &file_worker_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetBlockNumberResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetBlockNumberResp) ProtoMessage() {}
+
+func (x *WorkerGetBlockNumberResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetBlockNumberResp.ProtoReflect.Descriptor instead.
+func (*WorkerGetBlockNumberResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *WorkerGetBlockNumberResp) GetNumber() uint64 {
+	if x != nil {
+		return x.Number
+	}
+	return 0
+}
+
 var File_worker_proto protoreflect.FileDescriptor
 
 const file_worker_proto_rawDesc = "" +
@@ -1439,7 +1520,10 @@ const file_worker_proto_rawDesc = "" +
 	"\x18WorkerGetBlockHeaderResp\x12\x16\n" +
 	"\x06number\x18\x01 \x01(\x04R\x06number\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x12\n" +
-	"\x04time\x18\x03 \x01(\x04R\x04time2\x93\t\n" +
+	"\x04time\x18\x03 \x01(\x04R\x04time\"\x19\n" +
+	"\x17WorkerGetBlockNumberReq\"2\n" +
+	"\x18WorkerGetBlockNumberResp\x12\x16\n" +
+	"\x06number\x18\x01 \x01(\x04R\x06number2\xf0\t\n" +
 	"\vChainWorker\x12X\n" +
 	"\x11WorkerHealthCheck\x12 .aggregator.WorkerHealthCheckReq\x1a!.aggregator.WorkerHealthCheckResp\x12L\n" +
 	"\rExecuteUserOp\x12\x1c.aggregator.ExecuteUserOpReq\x1a\x1d.aggregator.ExecuteUserOpResp\x12I\n" +
@@ -1454,7 +1538,8 @@ const file_worker_proto_rawDesc = "" +
 	"GetBalance\x12\x1f.aggregator.WorkerGetBalanceReq\x1a .aggregator.WorkerGetBalanceResp\x12^\n" +
 	"\x0fGetTokenBalance\x12$.aggregator.WorkerGetTokenBalanceReq\x1a%.aggregator.WorkerGetTokenBalanceResp\x12U\n" +
 	"\fCallContract\x12!.aggregator.WorkerCallContractReq\x1a\".aggregator.WorkerCallContractResp\x12[\n" +
-	"\x0eGetBlockHeader\x12#.aggregator.WorkerGetBlockHeaderReq\x1a$.aggregator.WorkerGetBlockHeaderRespB\fZ\n" +
+	"\x0eGetBlockHeader\x12#.aggregator.WorkerGetBlockHeaderReq\x1a$.aggregator.WorkerGetBlockHeaderResp\x12[\n" +
+	"\x0eGetBlockNumber\x12#.aggregator.WorkerGetBlockNumberReq\x1a$.aggregator.WorkerGetBlockNumberRespB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (
@@ -1469,7 +1554,7 @@ func file_worker_proto_rawDescGZIP() []byte {
 	return file_worker_proto_rawDescData
 }
 
-var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_worker_proto_goTypes = []any{
 	(*WorkerHealthCheckReq)(nil),            // 0: aggregator.WorkerHealthCheckReq
 	(*WorkerHealthCheckResp)(nil),           // 1: aggregator.WorkerHealthCheckResp
@@ -1496,6 +1581,8 @@ var file_worker_proto_goTypes = []any{
 	(*WorkerCallContractResp)(nil),          // 22: aggregator.WorkerCallContractResp
 	(*WorkerGetBlockHeaderReq)(nil),         // 23: aggregator.WorkerGetBlockHeaderReq
 	(*WorkerGetBlockHeaderResp)(nil),        // 24: aggregator.WorkerGetBlockHeaderResp
+	(*WorkerGetBlockNumberReq)(nil),         // 25: aggregator.WorkerGetBlockNumberReq
+	(*WorkerGetBlockNumberResp)(nil),        // 26: aggregator.WorkerGetBlockNumberResp
 }
 var file_worker_proto_depIdxs = []int32{
 	0,  // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
@@ -1511,21 +1598,23 @@ var file_worker_proto_depIdxs = []int32{
 	19, // 10: aggregator.ChainWorker.GetTokenBalance:input_type -> aggregator.WorkerGetTokenBalanceReq
 	21, // 11: aggregator.ChainWorker.CallContract:input_type -> aggregator.WorkerCallContractReq
 	23, // 12: aggregator.ChainWorker.GetBlockHeader:input_type -> aggregator.WorkerGetBlockHeaderReq
-	1,  // 13: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
-	3,  // 14: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
-	5,  // 15: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
-	7,  // 16: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
-	9,  // 17: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
-	5,  // 18: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
-	12, // 19: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
-	14, // 20: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
-	16, // 21: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
-	18, // 22: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
-	20, // 23: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
-	22, // 24: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
-	24, // 25: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
-	13, // [13:26] is the sub-list for method output_type
-	0,  // [0:13] is the sub-list for method input_type
+	25, // 13: aggregator.ChainWorker.GetBlockNumber:input_type -> aggregator.WorkerGetBlockNumberReq
+	1,  // 14: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
+	3,  // 15: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
+	5,  // 16: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
+	7,  // 17: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
+	9,  // 18: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
+	5,  // 19: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
+	12, // 20: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
+	14, // 21: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
+	16, // 22: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
+	18, // 23: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
+	20, // 24: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
+	22, // 25: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
+	24, // 26: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
+	26, // 27: aggregator.ChainWorker.GetBlockNumber:output_type -> aggregator.WorkerGetBlockNumberResp
+	14, // [14:28] is the sub-list for method output_type
+	0,  // [0:14] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -1542,7 +1631,7 @@ func file_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   25,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -63,6 +63,10 @@ service ChainWorker {
   // ethclient.HeaderByNumber. Used to stamp simulation receipts and
   // enrich event timestamps without a gateway-side chain dial.
   rpc GetBlockHeader(WorkerGetBlockHeaderReq) returns (WorkerGetBlockHeaderResp);
+
+  // Read the latest block number. Wraps ethclient.BlockNumber. Used by the
+  // immediate-trigger path to stamp the current block for the operator.
+  rpc GetBlockNumber(WorkerGetBlockNumberReq) returns (WorkerGetBlockNumberResp);
 }
 
 // Health check
@@ -208,4 +212,11 @@ message WorkerGetBlockHeaderResp {
   uint64 number = 1;        // Block number.
   string hash = 2;          // 0x-prefixed block hash.
   uint64 time = 3;          // Unix timestamp (seconds).
+}
+
+// Latest block number
+message WorkerGetBlockNumberReq {}
+
+message WorkerGetBlockNumberResp {
+  uint64 number = 1;        // Latest block number.
 }

--- a/protobuf/worker_grpc.pb.go
+++ b/protobuf/worker_grpc.pb.go
@@ -32,6 +32,7 @@ const (
 	ChainWorker_GetTokenBalance_FullMethodName       = "/aggregator.ChainWorker/GetTokenBalance"
 	ChainWorker_CallContract_FullMethodName          = "/aggregator.ChainWorker/CallContract"
 	ChainWorker_GetBlockHeader_FullMethodName        = "/aggregator.ChainWorker/GetBlockHeader"
+	ChainWorker_GetBlockNumber_FullMethodName        = "/aggregator.ChainWorker/GetBlockNumber"
 )
 
 // ChainWorkerClient is the client API for ChainWorker service.
@@ -86,6 +87,9 @@ type ChainWorkerClient interface {
 	// ethclient.HeaderByNumber. Used to stamp simulation receipts and
 	// enrich event timestamps without a gateway-side chain dial.
 	GetBlockHeader(ctx context.Context, in *WorkerGetBlockHeaderReq, opts ...grpc.CallOption) (*WorkerGetBlockHeaderResp, error)
+	// Read the latest block number. Wraps ethclient.BlockNumber. Used by the
+	// immediate-trigger path to stamp the current block for the operator.
+	GetBlockNumber(ctx context.Context, in *WorkerGetBlockNumberReq, opts ...grpc.CallOption) (*WorkerGetBlockNumberResp, error)
 }
 
 type chainWorkerClient struct {
@@ -226,6 +230,16 @@ func (c *chainWorkerClient) GetBlockHeader(ctx context.Context, in *WorkerGetBlo
 	return out, nil
 }
 
+func (c *chainWorkerClient) GetBlockNumber(ctx context.Context, in *WorkerGetBlockNumberReq, opts ...grpc.CallOption) (*WorkerGetBlockNumberResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerGetBlockNumberResp)
+	err := c.cc.Invoke(ctx, ChainWorker_GetBlockNumber_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ChainWorkerServer is the server API for ChainWorker service.
 // All implementations must embed UnimplementedChainWorkerServer
 // for forward compatibility.
@@ -278,6 +292,9 @@ type ChainWorkerServer interface {
 	// ethclient.HeaderByNumber. Used to stamp simulation receipts and
 	// enrich event timestamps without a gateway-side chain dial.
 	GetBlockHeader(context.Context, *WorkerGetBlockHeaderReq) (*WorkerGetBlockHeaderResp, error)
+	// Read the latest block number. Wraps ethclient.BlockNumber. Used by the
+	// immediate-trigger path to stamp the current block for the operator.
+	GetBlockNumber(context.Context, *WorkerGetBlockNumberReq) (*WorkerGetBlockNumberResp, error)
 	mustEmbedUnimplementedChainWorkerServer()
 }
 
@@ -326,6 +343,9 @@ func (UnimplementedChainWorkerServer) CallContract(context.Context, *WorkerCallC
 }
 func (UnimplementedChainWorkerServer) GetBlockHeader(context.Context, *WorkerGetBlockHeaderReq) (*WorkerGetBlockHeaderResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetBlockHeader not implemented")
+}
+func (UnimplementedChainWorkerServer) GetBlockNumber(context.Context, *WorkerGetBlockNumberReq) (*WorkerGetBlockNumberResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetBlockNumber not implemented")
 }
 func (UnimplementedChainWorkerServer) mustEmbedUnimplementedChainWorkerServer() {}
 func (UnimplementedChainWorkerServer) testEmbeddedByValue()                     {}
@@ -582,6 +602,24 @@ func _ChainWorker_GetBlockHeader_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ChainWorker_GetBlockNumber_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerGetBlockNumberReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).GetBlockNumber(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_GetBlockNumber_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).GetBlockNumber(ctx, req.(*WorkerGetBlockNumberReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ChainWorker_ServiceDesc is the grpc.ServiceDesc for ChainWorker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -640,6 +678,10 @@ var ChainWorker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetBlockHeader",
 			Handler:    _ChainWorker_GetBlockHeader_Handler,
+		},
+		{
+			MethodName: "GetBlockNumber",
+			Handler:    _ChainWorker_GetBlockNumber_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/worker/server.go
+++ b/worker/server.go
@@ -416,6 +416,15 @@ func (s *Server) GetBlockHeader(ctx context.Context, req *avsproto.WorkerGetBloc
 	}, nil
 }
 
+// GetBlockNumber wraps ethclient.BlockNumber (latest block).
+func (s *Server) GetBlockNumber(ctx context.Context, req *avsproto.WorkerGetBlockNumberReq) (*avsproto.WorkerGetBlockNumberResp, error) {
+	number, err := s.worker.rpcClient.BlockNumber(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("BlockNumber: %w", err)
+	}
+	return &avsproto.WorkerGetBlockNumberResp{Number: number}, nil
+}
+
 // GetBalance wraps ethclient.BalanceAt(addr, latest). Used by the gateway's
 // withdraw preflight to validate / size native-coin withdrawals.
 func (s *Server) GetBalance(ctx context.Context, req *avsproto.WorkerGetBalanceReq) (*avsproto.WorkerGetBalanceResp, error) {


### PR DESCRIPTION
## What

First PR of [`docs/changes/20260614-rpcconn-chain-threading.md`](docs/changes/20260614-rpcconn-chain-threading.md) — retiring the package-level `rpcConn` (the gateway's AVS-chain client) in favor of per-chain workers.

`instructOperatorImmediateTrigger` read the current block via `rpcConn` to stamp the immediate trigger for the operator. This routes it through the **task's** per-chain worker.

## Changes

- **`worker.proto` / `worker/server.go`**: new `GetBlockNumber` RPC (wraps `ethclient.BlockNumber`).
- **`ChainStateReader`**: add `GetBlockNumber` (direct + worker-routed, with nil-response guard + chain-id-wrapped error).
- **`engine.go` `instructOperatorImmediateTrigger`**: load the task first, resolve the `ChainStateReader` for `task.ChainId`, and read the current block through it. A missing reader is now an explicit error (replaces the `rpcConn == nil` guard). The block targets the **task's chain**, not a single gateway RPC.

## Scope notes

- **`runBlockTriggerImmediately`** (the other block-trigger reader) also uses `rpcConn`, but its chain source is the simulate/runTrigger trigger config — non-trivial to thread cleanly, and the existing run_node path uses the global token-service chain (which differs from `rpcConn`'s AVS chain). It moves to the next PR (rpcConn B) alongside the event-enrichment reads, where the run_node chain context is threaded properly — rather than guessing the chain here and risking a behavior change in which chain a simulate returns.
- **`utils.GetBlock`** is dead code (no callers); it'll be removed in the `rpcConn`-retirement PR.

## Testing

- `go build ./...`, `go vet ./core/taskengine/ ./worker/` clean.
- New `GetBlockNumber` reader tests: happy path + chain-id-wrapped transport error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
