### PR TITLE
feat: thread explicit chain through block-trigger reads (rpcConn B)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -436,6 +436,14 @@ func (w *workerChainStateReader) HeaderByNumber(ctx context.Context, number *big
 	if resp == nil {
 		return nil, fmt.Errorf("worker returned nil response for GetBlockHeader on chain %d", w.chainID)
 	}
+	// A blank hash means the worker didn't populate it (version skew) —
+	// HexToHash would silently coerce "" to the zero hash and propagate an
+	// incorrect block-trigger output. Hard-fail instead. (ParentHash is
+	// genuinely zero only for genesis, but the worker always serializes it
+	// via .Hex(), so an empty string is still skew.)
+	if resp.Hash == "" || resp.ParentHash == "" {
+		return nil, fmt.Errorf("worker returned incomplete block header (hash=%q parentHash=%q) on chain %d", resp.Hash, resp.ParentHash, w.chainID)
+	}
 	difficulty, ok := new(big.Int).SetString(resp.Difficulty, 10)
 	if !ok {
 		// Difficulty is informational (post-merge it's 0); tolerate a

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -83,11 +83,18 @@ type ChainStateReader interface {
 }
 
 // BlockHeader is the subset of block-header fields the gateway reads:
-// number + hash (receipt stamping) and time (event-timestamp enrichment).
+// number + hash (receipt stamping), time (event-timestamp enrichment), and
+// parentHash/difficulty/gasLimit/gasUsed (block-trigger output). A full
+// types.Header can't be carried over gRPC faithfully (its hash depends on
+// every field), so these are the explicit fields callers consume.
 type BlockHeader struct {
-	Number uint64
-	Hash   common.Hash
-	Time   uint64
+	Number     uint64
+	Hash       common.Hash
+	Time       uint64
+	ParentHash common.Hash
+	Difficulty *big.Int
+	GasLimit   uint64
+	GasUsed    uint64
 }
 
 // ---------------------------------------------------------------------
@@ -204,7 +211,15 @@ func (d *directChainStateReader) HeaderByNumber(ctx context.Context, number *big
 	if h == nil {
 		return nil, fmt.Errorf("HeaderByNumber returned nil header")
 	}
-	return &BlockHeader{Number: h.Number.Uint64(), Hash: h.Hash(), Time: h.Time}, nil
+	return &BlockHeader{
+		Number:     h.Number.Uint64(),
+		Hash:       h.Hash(),
+		Time:       h.Time,
+		ParentHash: h.ParentHash,
+		Difficulty: h.Difficulty,
+		GasLimit:   h.GasLimit,
+		GasUsed:    h.GasUsed,
+	}, nil
 }
 
 func (d *directChainStateReader) GetBlockNumber(ctx context.Context) (uint64, error) {
@@ -421,10 +436,20 @@ func (w *workerChainStateReader) HeaderByNumber(ctx context.Context, number *big
 	if resp == nil {
 		return nil, fmt.Errorf("worker returned nil response for GetBlockHeader on chain %d", w.chainID)
 	}
+	difficulty, ok := new(big.Int).SetString(resp.Difficulty, 10)
+	if !ok {
+		// Difficulty is informational (post-merge it's 0); tolerate a
+		// missing/blank value rather than failing the whole header read.
+		difficulty = big.NewInt(0)
+	}
 	return &BlockHeader{
-		Number: resp.Number,
-		Hash:   common.HexToHash(resp.Hash),
-		Time:   resp.Time,
+		Number:     resp.Number,
+		Hash:       common.HexToHash(resp.Hash),
+		Time:       resp.Time,
+		ParentHash: common.HexToHash(resp.ParentHash),
+		Difficulty: difficulty,
+		GasLimit:   resp.GasLimit,
+		GasUsed:    resp.GasUsed,
 	}, nil
 }
 

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -589,11 +589,16 @@ func TestWorkerChainStateReader_CallContract_NilToRejected(t *testing.T) {
 // serializes as base-10; the worker's number/hash/time map into BlockHeader.
 func TestWorkerChainStateReader_HeaderByNumber(t *testing.T) {
 	hash := common.HexToHash("0xabc123")
+	parent := common.HexToHash("0xdef456")
 	fake := &chainStateFakeClient{
 		getBlockHeaderResp: &avsproto.WorkerGetBlockHeaderResp{
-			Number: 19000000,
-			Hash:   hash.Hex(),
-			Time:   1700000000,
+			Number:     19000000,
+			Hash:       hash.Hex(),
+			Time:       1700000000,
+			ParentHash: parent.Hex(),
+			Difficulty: "12345",
+			GasLimit:   30000000,
+			GasUsed:    15000000,
 		},
 	}
 	r := NewWorkerChainStateReader(fake, 1, time.Second)
@@ -604,8 +609,34 @@ func TestWorkerChainStateReader_HeaderByNumber(t *testing.T) {
 	if h.Number != 19000000 || h.Hash != hash || h.Time != 1700000000 {
 		t.Fatalf("unexpected header %+v", h)
 	}
+	if h.ParentHash != parent || h.Difficulty.Cmp(big.NewInt(12345)) != 0 || h.GasLimit != 30000000 || h.GasUsed != 15000000 {
+		t.Fatalf("extended header fields not mapped: %+v", h)
+	}
 	if fake.getBlockHeaderReq.BlockNumber != "19000000" {
 		t.Fatalf("block number not propagated: %q", fake.getBlockHeaderReq.BlockNumber)
+	}
+}
+
+// TestRequireChainIDFromConfig: chain_id is mandatory with no engine-default
+// fallback — absent, zero, or wrong-typed values are hard errors; valid
+// numeric types (int64 / float64 from a structpb round-trip) parse.
+func TestRequireChainIDFromConfig(t *testing.T) {
+	if _, err := requireChainIDFromConfig(map[string]interface{}{}); err == nil {
+		t.Fatalf("absent chain_id should error")
+	}
+	if _, err := requireChainIDFromConfig(map[string]interface{}{"chain_id": int64(0)}); err == nil {
+		t.Fatalf("zero chain_id should error")
+	}
+	if _, err := requireChainIDFromConfig(map[string]interface{}{"chain_id": "11155111"}); err == nil {
+		t.Fatalf("string chain_id should error (unexpected type)")
+	}
+	got, err := requireChainIDFromConfig(map[string]interface{}{"chain_id": int64(11155111)})
+	if err != nil || got != 11155111 {
+		t.Fatalf("int64 chain_id: got %d err %v", got, err)
+	}
+	got, err = requireChainIDFromConfig(map[string]interface{}{"chain_id": float64(8453)})
+	if err != nil || got != 8453 {
+		t.Fatalf("float64 chain_id: got %d err %v", got, err)
 	}
 }
 

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -644,7 +644,9 @@ func TestRequireChainIDFromConfig(t *testing.T) {
 // empty block_number string (worker treats empty as "latest").
 func TestWorkerChainStateReader_HeaderByNumber_Latest(t *testing.T) {
 	fake := &chainStateFakeClient{
-		getBlockHeaderResp: &avsproto.WorkerGetBlockHeaderResp{Number: 1, Hash: "0x00", Time: 1},
+		getBlockHeaderResp: &avsproto.WorkerGetBlockHeaderResp{
+			Number: 1, Hash: "0x01", Time: 1, ParentHash: "0x00", Difficulty: "0",
+		},
 	}
 	r := NewWorkerChainStateReader(fake, 1, time.Second)
 	if _, err := r.HeaderByNumber(context.Background(), nil); err != nil {
@@ -652,6 +654,19 @@ func TestWorkerChainStateReader_HeaderByNumber_Latest(t *testing.T) {
 	}
 	if fake.getBlockHeaderReq.BlockNumber != "" {
 		t.Fatalf("nil number should send empty block_number: got %q", fake.getBlockHeaderReq.BlockNumber)
+	}
+}
+
+// TestWorkerChainStateReader_HeaderByNumber_IncompleteRejected: an empty
+// hash (worker/gateway version skew) must hard-fail, not coerce to the
+// zero hash and propagate an incorrect block-trigger output.
+func TestWorkerChainStateReader_HeaderByNumber_IncompleteRejected(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getBlockHeaderResp: &avsproto.WorkerGetBlockHeaderResp{Number: 1, Hash: "", ParentHash: "0x00"},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	if _, err := r.HeaderByNumber(context.Background(), nil); err == nil {
+		t.Fatalf("expected error for empty hash")
 	}
 }
 

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -3088,18 +3088,13 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 		return fmt.Errorf("failed to get task for immediate trigger: %w", err)
 	}
 
-	// Resolve the chain for the current-block read. task.ChainId can be 0
-	// in single-chain mode or for legacy tasks created before chain_id was
-	// always persisted; fall back to the engine's default chain — the same
-	// key the reader registry uses in single-chain mode — so we don't
-	// regress the path that previously worked via the single global RPC.
+	// The current-block read must target the task's chain. Required — there
+	// is no engine-default chain; a zero/unset chain_id is a hard error so
+	// the read never silently targets the wrong chain.
 	chainID := task.ChainId
-	if chainID == 0 && n.tokenEnrichmentService != nil {
-		chainID = int64(n.tokenEnrichmentService.GetChainID())
+	if chainID == 0 {
+		return fmt.Errorf("task %s has no chain_id; cannot resolve chain for immediate block trigger", taskID)
 	}
-
-	// Current block for the resolved chain, routed through the chain worker
-	// in gateway mode (no gateway-side chain dial).
 	reader := GetChainStateReaderForChain(uint64(chainID))
 	if reader == nil {
 		return fmt.Errorf("no chain-state reader available for chain %d (immediate block trigger)", chainID)

--- a/core/taskengine/node_types.go
+++ b/core/taskengine/node_types.go
@@ -230,8 +230,10 @@ func TaskTriggerToConfig(trigger *avsproto.TaskTrigger) map[string]interface{} {
 	case *avsproto.TaskTrigger_Block:
 		blockTrigger := trigger.GetBlock()
 		if blockTrigger != nil && blockTrigger.Config != nil {
-			// Direct field access - BlockTrigger.Config only has interval field
 			triggerConfig["interval"] = blockTrigger.Config.Interval
+			// Surface the trigger's chain so the immediate block read
+			// resolves the right per-chain worker.
+			triggerConfig["chain_id"] = blockTrigger.Config.GetChainId()
 		}
 	case *avsproto.TaskTrigger_Cron:
 		cronTrigger := trigger.GetCron()

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -100,14 +100,21 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 		}
 	}
 
-	// Ensure RPC connection is available
-	if rpcConn == nil {
-		return nil, fmt.Errorf("RPC connection not available for BlockTrigger execution")
+	// Resolve the trigger's chain. Required — there is no engine-default
+	// chain; a missing/zero chain_id is a hard error so the block read
+	// never silently targets the wrong chain.
+	chainID, err := requireChainIDFromConfig(triggerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("BlockTrigger: %w", err)
+	}
+	reader := GetChainStateReaderForChain(uint64(chainID))
+	if reader == nil {
+		return nil, fmt.Errorf("BlockTrigger: no chain-state reader available for chain %d", chainID)
 	}
 
 	// If no specific block number, get the latest block
 	if blockNumber == 0 {
-		currentBlock, err := rpcConn.BlockNumber(context.Background())
+		currentBlock, err := reader.GetBlockNumber(context.Background())
 		if err != nil {
 			// For simulations, use a mock block number to avoid RPC rate limiting
 			if strings.Contains(err.Error(), "rate limit") || strings.Contains(err.Error(), "429") {
@@ -121,13 +128,13 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 		} else {
 			blockNumber = currentBlock
 			if n.logger != nil {
-				n.logger.Info("BlockTrigger: Using latest block for immediate execution", "blockNumber", blockNumber)
+				n.logger.Info("BlockTrigger: Using latest block for immediate execution", "blockNumber", blockNumber, "chainID", chainID)
 			}
 		}
 	}
 
-	// Get real block data from RPC
-	header, err := rpcConn.HeaderByNumber(context.Background(), big.NewInt(int64(blockNumber)))
+	// Get real block data via the chain's worker
+	header, err := reader.HeaderByNumber(context.Background(), big.NewInt(int64(blockNumber)))
 	if err != nil {
 		// For simulations, use mock block data to avoid RPC rate limiting
 		if strings.Contains(err.Error(), "rate limit") || strings.Contains(err.Error(), "429") {
@@ -151,7 +158,7 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 
 	result := map[string]interface{}{
 		"blockNumber": blockNumber,
-		"blockHash":   header.Hash().Hex(),
+		"blockHash":   header.Hash.Hex(),
 		"timestamp":   header.Time,
 		"parentHash":  header.ParentHash.Hex(),
 		"difficulty":  header.Difficulty.String(),
@@ -160,9 +167,38 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 	}
 
 	if n.logger != nil {
-		n.logger.Info("BlockTrigger executed immediately", "blockNumber", blockNumber, "blockHash", header.Hash().Hex())
+		n.logger.Info("BlockTrigger executed immediately", "blockNumber", blockNumber, "blockHash", header.Hash.Hex())
 	}
 	return result, nil
+}
+
+// requireChainIDFromConfig extracts the required chain_id from a trigger /
+// node config map. There is NO engine-default fallback: a missing or zero
+// chain_id is a hard error, so chain-scoped reads never silently target
+// the wrong chain. Accepts the numeric types config maps carry (int64 from
+// direct proto extraction, float64 after a structpb round-trip).
+func requireChainIDFromConfig(config map[string]interface{}) (int64, error) {
+	raw, ok := config["chain_id"]
+	if !ok {
+		return 0, fmt.Errorf("chain_id not specified in trigger config")
+	}
+	var chainID int64
+	switch v := raw.(type) {
+	case int64:
+		chainID = v
+	case int:
+		chainID = int64(v)
+	case uint64:
+		chainID = int64(v)
+	case float64:
+		chainID = int64(v)
+	default:
+		return 0, fmt.Errorf("chain_id has unexpected type %T", raw)
+	}
+	if chainID == 0 {
+		return 0, fmt.Errorf("chain_id must be non-zero")
+	}
+	return chainID, nil
 }
 
 // runFixedTimeTriggerImmediately returns the current timestamp immediately

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -123,7 +123,7 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 					n.logger.Warn("BlockTrigger: Using mock block number due to RPC rate limiting", "mockBlockNumber", blockNumber, "rpcError", err.Error())
 				}
 			} else {
-				return nil, fmt.Errorf("failed to get current block number from RPC: %w", err)
+				return nil, fmt.Errorf("failed to get current block number for chain %d: %w", chainID, err)
 			}
 		} else {
 			blockNumber = currentBlock
@@ -153,7 +153,7 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 				"parentHash":  common.HexToHash(fmt.Sprintf("0x%016x%016x%016x%016x", blockNumber-1, blockNumber, blockNumber+1, blockNumber+2)).Hex(),
 			}, nil
 		}
-		return nil, fmt.Errorf("failed to get block header for block %d from RPC: %w", blockNumber, err)
+		return nil, fmt.Errorf("failed to get block header for block %d on chain %d: %w", blockNumber, chainID, err)
 	}
 
 	result := map[string]interface{}{
@@ -189,14 +189,25 @@ func requireChainIDFromConfig(config map[string]interface{}) (int64, error) {
 	case int:
 		chainID = int64(v)
 	case uint64:
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("chain_id %d exceeds int64 range", v)
+		}
 		chainID = int64(v)
 	case float64:
+		// structpb round-trips numbers as float64; require an exact,
+		// in-range integer rather than silently truncating.
+		if v != math.Trunc(v) {
+			return 0, fmt.Errorf("chain_id %v is not an integer", v)
+		}
+		if v < math.MinInt64 || v > math.MaxInt64 {
+			return 0, fmt.Errorf("chain_id %v out of int64 range", v)
+		}
 		chainID = int64(v)
 	default:
 		return 0, fmt.Errorf("chain_id has unexpected type %T", raw)
 	}
-	if chainID == 0 {
-		return 0, fmt.Errorf("chain_id must be non-zero")
+	if chainID <= 0 {
+		return 0, fmt.Errorf("chain_id must be a positive integer, got %d", chainID)
 	}
 	return chainID, nil
 }

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -1295,9 +1295,13 @@ func (x *WorkerGetBlockHeaderReq) GetBlockNumber() string {
 
 type WorkerGetBlockHeaderResp struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Number        uint64                 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"` // Block number.
-	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`      // 0x-prefixed block hash.
-	Time          uint64                 `protobuf:"varint,3,opt,name=time,proto3" json:"time,omitempty"`     // Unix timestamp (seconds).
+	Number        uint64                 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`                          // Block number.
+	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`                               // 0x-prefixed block hash.
+	Time          uint64                 `protobuf:"varint,3,opt,name=time,proto3" json:"time,omitempty"`                              // Unix timestamp (seconds).
+	ParentHash    string                 `protobuf:"bytes,4,opt,name=parent_hash,json=parentHash,proto3" json:"parent_hash,omitempty"` // 0x-prefixed parent block hash.
+	Difficulty    string                 `protobuf:"bytes,5,opt,name=difficulty,proto3" json:"difficulty,omitempty"`                   // big.Int as base-10 string.
+	GasLimit      uint64                 `protobuf:"varint,6,opt,name=gas_limit,json=gasLimit,proto3" json:"gas_limit,omitempty"`      // Block gas limit.
+	GasUsed       uint64                 `protobuf:"varint,7,opt,name=gas_used,json=gasUsed,proto3" json:"gas_used,omitempty"`         // Block gas used.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1349,6 +1353,34 @@ func (x *WorkerGetBlockHeaderResp) GetHash() string {
 func (x *WorkerGetBlockHeaderResp) GetTime() uint64 {
 	if x != nil {
 		return x.Time
+	}
+	return 0
+}
+
+func (x *WorkerGetBlockHeaderResp) GetParentHash() string {
+	if x != nil {
+		return x.ParentHash
+	}
+	return ""
+}
+
+func (x *WorkerGetBlockHeaderResp) GetDifficulty() string {
+	if x != nil {
+		return x.Difficulty
+	}
+	return ""
+}
+
+func (x *WorkerGetBlockHeaderResp) GetGasLimit() uint64 {
+	if x != nil {
+		return x.GasLimit
+	}
+	return 0
+}
+
+func (x *WorkerGetBlockHeaderResp) GetGasUsed() uint64 {
+	if x != nil {
+		return x.GasUsed
 	}
 	return 0
 }
@@ -1516,11 +1548,18 @@ const file_worker_proto_rawDesc = "" +
 	"\x16WorkerCallContractResp\x12\x16\n" +
 	"\x06result\x18\x01 \x01(\fR\x06result\"<\n" +
 	"\x17WorkerGetBlockHeaderReq\x12!\n" +
-	"\fblock_number\x18\x01 \x01(\tR\vblockNumber\"Z\n" +
+	"\fblock_number\x18\x01 \x01(\tR\vblockNumber\"\xd3\x01\n" +
 	"\x18WorkerGetBlockHeaderResp\x12\x16\n" +
 	"\x06number\x18\x01 \x01(\x04R\x06number\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x12\n" +
-	"\x04time\x18\x03 \x01(\x04R\x04time\"\x19\n" +
+	"\x04time\x18\x03 \x01(\x04R\x04time\x12\x1f\n" +
+	"\vparent_hash\x18\x04 \x01(\tR\n" +
+	"parentHash\x12\x1e\n" +
+	"\n" +
+	"difficulty\x18\x05 \x01(\tR\n" +
+	"difficulty\x12\x1b\n" +
+	"\tgas_limit\x18\x06 \x01(\x04R\bgasLimit\x12\x19\n" +
+	"\bgas_used\x18\a \x01(\x04R\agasUsed\"\x19\n" +
 	"\x17WorkerGetBlockNumberReq\"2\n" +
 	"\x18WorkerGetBlockNumberResp\x12\x16\n" +
 	"\x06number\x18\x01 \x01(\x04R\x06number2\xf0\t\n" +

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -212,6 +212,10 @@ message WorkerGetBlockHeaderResp {
   uint64 number = 1;        // Block number.
   string hash = 2;          // 0x-prefixed block hash.
   uint64 time = 3;          // Unix timestamp (seconds).
+  string parent_hash = 4;   // 0x-prefixed parent block hash.
+  string difficulty = 5;    // big.Int as base-10 string.
+  uint64 gas_limit = 6;     // Block gas limit.
+  uint64 gas_used = 7;      // Block gas used.
 }
 
 // Latest block number

--- a/worker/server.go
+++ b/worker/server.go
@@ -409,10 +409,18 @@ func (s *Server) GetBlockHeader(ctx context.Context, req *avsproto.WorkerGetBloc
 	if header == nil {
 		return nil, fmt.Errorf("HeaderByNumber returned nil header")
 	}
+	difficulty := "0"
+	if header.Difficulty != nil {
+		difficulty = header.Difficulty.String()
+	}
 	return &avsproto.WorkerGetBlockHeaderResp{
-		Number: header.Number.Uint64(),
-		Hash:   header.Hash().Hex(),
-		Time:   header.Time,
+		Number:     header.Number.Uint64(),
+		Hash:       header.Hash().Hex(),
+		Time:       header.Time,
+		ParentHash: header.ParentHash.Hex(),
+		Difficulty: difficulty,
+		GasLimit:   header.GasLimit,
+		GasUsed:    header.GasUsed,
 	}, nil
 }
 


### PR DESCRIPTION
## What

Second PR of [`docs/changes/20260614-rpcconn-chain-threading.md`](docs/changes/20260614-rpcconn-chain-threading.md). Routes the block-trigger reads off the package-level `rpcConn` (the gateway's AVS chain) onto the **trigger's own** per-chain worker — with the chain sourced **explicitly, no engine-default fallback**.

## Changes

- **`node_types.go`**: `TaskTriggerToConfig` now emits `chain_id` for block triggers (from `BlockTrigger_Config.GetChainId`), so the immediate block read can resolve the trigger's chain.
- **`run_node_immediately.go`**: `runBlockTriggerImmediately` **requires** `chain_id` from the trigger config (new `requireChainIDFromConfig` helper — absent / zero / wrong-typed is a **hard error**, no default), resolves the per-chain `ChainStateReader`, and routes `GetBlockNumber` + `HeaderByNumber` through it.
- **`engine.go`**: `instructOperatorImmediateTrigger` **drops the `tokenEnrichmentService` default-chain fallback added in #590** — a zero `task.ChainId` is now a hard error. There is no engine-default chain; chain-scoped reads target an explicit chain or fail.
- **`worker.proto` / `chain_state_reader.go`**: extend `GetBlockHeader` + `BlockHeader` with `parent_hash`/`difficulty`/`gas_limit`/`gas_used` (the fields the block-trigger output exposes).

## Design note

Per maintainer direction: **there is no engine-default chain.** Every chain-scoped read must derive its chain explicitly from the task/trigger; a missing or zero `chain_id` hard-fails rather than silently targeting a default (which could be the wrong chain in multi-chain mode). This PR also corrects the #590 fallback to that rule.

## Testing

- `go build ./...`, `go vet ./core/taskengine/ ./worker/` clean.
- New: `requireChainIDFromConfig` hard-fail matrix; extended `HeaderByNumber` field mapping.
- Full short-mode taskengine suite passes. (One failing test, `TestSimulateTask_StopLossWorkflow_Sepolia`, hard-fails at its first line on a missing `OWNER_EOA` env var — an env-gated Sepolia integration test, unrelated to this change.)

## Next

Event-enrichment reads (`parseEventWithParsedABI` timestamp, `callContractMethod` decimals) — thread the event trigger's chain (its `chain_id` emission is deferred to that PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
