### PR TITLE
feat: thread chain through event-enrichment reads (rpcConn C)

### DIFF
--- a/core/taskengine/abi_typing_test.go
+++ b/core/taskengine/abi_typing_test.go
@@ -65,7 +65,7 @@ func TestABIFieldTyping(t *testing.T) {
 	}
 
 	// Test the parseEventWithABI function
-	parsedData, err := engine.parseEventWithABI(mockLog, testABI, nil)
+	parsedData, err := engine.parseEventWithABI(0, mockLog, testABI, nil)
 	if err != nil {
 		t.Fatalf("Failed to parse event with ABI: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestDecimalFormattingWithProperTypes(t *testing.T) {
 	// In a real scenario, this would be retrieved via RPC call
 
 	// Test without decimal formatting first
-	parsedData, err := engine.parseEventWithABI(mockLog, testABI, nil)
+	parsedData, err := engine.parseEventWithABI(0, mockLog, testABI, nil)
 	if err != nil {
 		t.Fatalf("Failed to parse event with ABI: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestValueRawPopulatedWhenDecimalsCallFails(t *testing.T) {
 	}
 
 	// Test the parseEventWithABI function with a query that will fail decimals() call
-	parsedData, err := engine.parseEventWithABI(mockLog, testABI, mockQuery)
+	parsedData, err := engine.parseEventWithABI(0, mockLog, testABI, mockQuery)
 	if err != nil {
 		t.Fatalf("Failed to parse event with ABI: %v", err)
 	}

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -695,3 +695,25 @@ func TestWorkerChainStateReader_GetBlockNumber_Err(t *testing.T) {
 		t.Fatalf("expected chain-id-wrapped error, got %v", err)
 	}
 }
+
+// TestChainReaderForEnrichment: best-effort enrichment resolves a reader
+// only for a registered, positive chain ID; an unspecified (<=0) or
+// unregistered chain returns nil ("skip enrichment", never a default).
+func TestChainReaderForEnrichment(t *testing.T) {
+	ClearChainStateReaderRegistry()
+	defer ClearChainStateReaderRegistry()
+
+	if chainReaderForEnrichment(0) != nil {
+		t.Fatalf("chainID 0 should skip (nil reader)")
+	}
+	if chainReaderForEnrichment(-1) != nil {
+		t.Fatalf("negative chainID should skip (nil reader)")
+	}
+	if chainReaderForEnrichment(8453) != nil {
+		t.Fatalf("unregistered chain should be nil")
+	}
+	RegisterChainStateReader(8453, NewWorkerChainStateReader(&chainStateFakeClient{}, 8453, 0))
+	if chainReaderForEnrichment(8453) == nil {
+		t.Fatalf("registered chain should resolve a reader")
+	}
+}

--- a/core/taskengine/node_output_handlers.go
+++ b/core/taskengine/node_output_handlers.go
@@ -24,7 +24,7 @@ type NodeOutputHandler interface {
 	// ConvertToProtobuf converts the extracted result map to the appropriate protobuf output type
 	// Returns the protobuf OutputData variant (which must implement isRunNodeWithInputsResp_OutputData),
 	// optional metadata, and any error encountered
-	ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error)
+	ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error)
 
 	// CreateEmptyOutput creates an empty output structure for error cases
 	// This ensures we never return OUTPUT_DATA_NOT_SET
@@ -48,7 +48,7 @@ func (h *RestAPIOutputHandler) ExtractFromExecutionStep(step *avsproto.Execution
 	return result, nil
 }
 
-func (h *RestAPIOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *RestAPIOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	var cleanData interface{}
 
 	if result != nil {
@@ -135,7 +135,7 @@ func (h *CustomCodeOutputHandler) ExtractFromExecutionStep(step *avsproto.Execut
 	return result, nil
 }
 
-func (h *CustomCodeOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *CustomCodeOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	var rawData interface{}
 
 	if result != nil {
@@ -188,7 +188,7 @@ func (h *BalanceOutputHandler) ExtractFromExecutionStep(step *avsproto.Execution
 	return result, nil
 }
 
-func (h *BalanceOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *BalanceOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	var dataValue *structpb.Value
 	var err error
 
@@ -244,7 +244,7 @@ func (h *ContractReadOutputHandler) ExtractFromExecutionStep(step *avsproto.Exec
 	return result, nil
 }
 
-func (h *ContractReadOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *ContractReadOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	contractReadOutput := &avsproto.ContractReadNode_Output{}
 	var metadata *structpb.Value
 
@@ -334,7 +334,7 @@ func (h *ContractWriteOutputHandler) ExtractFromExecutionStep(step *avsproto.Exe
 	return result, nil
 }
 
-func (h *ContractWriteOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *ContractWriteOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	contractWriteOutput := &avsproto.ContractWriteNode_Output{}
 	var resultsArray []interface{}
 	var decodedEventsData = make(map[string]interface{})
@@ -424,7 +424,7 @@ func (h *ContractWriteOutputHandler) ConvertToProtobuf(result map[string]interfa
 													}
 												}
 
-												if decodedEvent, err := h.engine.parseEventWithParsedABI(eventLog, contractABI, nil); err == nil {
+												if decodedEvent, err := h.engine.parseEventWithParsedABI(chainID, eventLog, contractABI, nil); err == nil {
 													// Flatten event data: if decoded map contains the concrete event name as a key,
 													// unwrap it so methodName maps directly to event fields
 													if nameVal, hasName := decodedEvent["eventName"]; hasName {
@@ -551,7 +551,7 @@ func (h *ETHTransferOutputHandler) ExtractFromExecutionStep(step *avsproto.Execu
 	return result, nil
 }
 
-func (h *ETHTransferOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *ETHTransferOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	// Only include transfer object in data to match ERC20 transfer format
 	ethData := map[string]interface{}{}
 	if result != nil {
@@ -600,7 +600,7 @@ func (h *GraphQLOutputHandler) ExtractFromExecutionStep(step *avsproto.Execution
 	return result, nil
 }
 
-func (h *GraphQLOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *GraphQLOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	var dataValue *structpb.Value
 	var err error
 
@@ -659,7 +659,7 @@ func (h *BranchOutputHandler) ExtractFromExecutionStep(step *avsproto.Execution_
 	return result, nil
 }
 
-func (h *BranchOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *BranchOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	branchData := map[string]interface{}{}
 	if result != nil && len(result) > 0 {
 		if conditionId, ok := result["conditionId"].(string); ok {
@@ -699,7 +699,7 @@ func (h *FilterOutputHandler) ExtractFromExecutionStep(step *avsproto.Execution_
 	return result, nil
 }
 
-func (h *FilterOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *FilterOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	var dataValue *structpb.Value
 	var err error
 
@@ -743,7 +743,7 @@ func (h *LoopOutputHandler) ExtractFromExecutionStep(step *avsproto.Execution_St
 	return result, nil
 }
 
-func (h *LoopOutputHandler) ConvertToProtobuf(result map[string]interface{}) (interface{}, *structpb.Value, error) {
+func (h *LoopOutputHandler) ConvertToProtobuf(chainID int64, result map[string]interface{}) (interface{}, *structpb.Value, error) {
 	if result != nil {
 		var loopData interface{}
 		if loopResult, exists := result["loopResult"]; exists {

--- a/core/taskengine/node_types.go
+++ b/core/taskengine/node_types.go
@@ -210,6 +210,9 @@ func TaskTriggerToConfig(trigger *avsproto.TaskTrigger) map[string]interface{} {
 	case *avsproto.TaskTrigger_Event:
 		eventTrigger := trigger.GetEvent()
 		if eventTrigger != nil && eventTrigger.Config != nil {
+			// Surface the trigger's chain so best-effort event enrichment
+			// (timestamp/decimals) resolves the right per-chain worker.
+			triggerConfig["chain_id"] = eventTrigger.Config.GetChainId()
 			// Access protobuf fields directly to avoid JSON roundtrip
 			if len(eventTrigger.Config.Queries) > 0 {
 				// Convert queries to interface{} for map storage

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -292,6 +292,11 @@ func (n *Engine) runEventTriggerImmediately(triggerConfig map[string]interface{}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
+	// Trigger chain for best-effort event enrichment. Soft-resolved: a
+	// missing chain_id yields 0, which skips enrichment rather than reading
+	// a default chain (there is no engine-default chain).
+	eventChainID, _ := requireChainIDFromConfig(triggerConfig)
+
 	// Create a temporary VM for template variable resolution
 	// This allows eventTrigger to use {{settings.uniswapv3_pool.token0.id}} syntax in addresses
 	tempVM := NewVM()
@@ -454,7 +459,7 @@ func (n *Engine) runEventTriggerImmediately(triggerConfig map[string]interface{}
 					historicalCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 					defer cancel()
 
-					historicalResult, histErr := n.runEventTriggerWithHistoricalSearch(historicalCtx, queriesArray, inputVariables)
+					historicalResult, histErr := n.runEventTriggerWithHistoricalSearch(historicalCtx, eventChainID, queriesArray, inputVariables)
 					if histErr != nil {
 						if n.logger != nil {
 							n.logger.Warn("⚠️ EventTrigger: Historical search failed after simulation failure",
@@ -482,7 +487,7 @@ func (n *Engine) runEventTriggerImmediately(triggerConfig map[string]interface{}
 	if rpcConn == nil {
 		return nil, fmt.Errorf("RPC connection not available for EventTrigger historical search")
 	}
-	return n.runEventTriggerWithHistoricalSearch(ctx, queriesArray, inputVariables)
+	return n.runEventTriggerWithHistoricalSearch(ctx, eventChainID, queriesArray, inputVariables)
 }
 
 // shouldUseDirectCalls determines if the query should use direct contract calls vs simulation
@@ -1917,7 +1922,7 @@ func (n *Engine) runEventTriggerWithTenderlySimulation(ctx context.Context, quer
 }
 
 // parseEventWithABI parses an event log using the provided contract ABI and applies method calls for enhanced formatting
-func (n *Engine) parseEventWithABI(eventLog *types.Log, contractABIString string, query *avsproto.EventTrigger_Query) (map[string]interface{}, error) {
+func (n *Engine) parseEventWithABI(chainID int64, eventLog *types.Log, contractABIString string, query *avsproto.EventTrigger_Query) (map[string]interface{}, error) {
 	// Parse the ABI
 	contractABI, err := abi.JSON(strings.NewReader(contractABIString))
 	if err != nil {
@@ -1925,11 +1930,11 @@ func (n *Engine) parseEventWithABI(eventLog *types.Log, contractABIString string
 	}
 
 	// Find the matching event in ABI using the first topic (event signature)
-	return n.parseEventWithParsedABI(eventLog, &contractABI, query)
+	return n.parseEventWithParsedABI(chainID, eventLog, &contractABI, query)
 }
 
 // parseEventWithParsedABI contains the shared logic for both optimized and legacy methods
-func (n *Engine) parseEventWithParsedABI(eventLog *types.Log, contractABI *abi.ABI, query *avsproto.EventTrigger_Query) (map[string]interface{}, error) {
+func (n *Engine) parseEventWithParsedABI(chainID int64, eventLog *types.Log, contractABI *abi.ABI, query *avsproto.EventTrigger_Query) (map[string]interface{}, error) {
 	// Find the matching event in ABI using the first topic (event signature)
 	if len(eventLog.Topics) == 0 {
 		return nil, fmt.Errorf("event log has no topics")
@@ -2002,7 +2007,7 @@ func (n *Engine) parseEventWithParsedABI(eventLog *types.Log, contractABI *abi.A
 				}
 
 				// Make the decimals() call to the contract
-				if decimals, err := n.callContractMethod(eventLog.Address, callData); err == nil {
+				if decimals, err := n.callContractMethod(chainID, eventLog.Address, callData); err == nil {
 					if decimalsInt, ok := decimals.(*big.Int); ok {
 						decimalsValue = decimalsInt
 
@@ -2291,12 +2296,14 @@ func (n *Engine) parseEventWithParsedABI(eventLog *types.Log, contractABI *abi.A
 			}
 		}
 
-		// Add proper blockTimestamp for real events (not simulated)
-		// For real events, we can get the actual block timestamp if needed
-		if eventLog.BlockNumber > 0 && rpcConn != nil {
+		// Add proper blockTimestamp for real events (not simulated). This is
+		// best-effort enrichment: route through the trigger's chain worker
+		// when the chain is known; if chain_id isn't specified we skip it
+		// (keep the default timestamp) rather than read a default chain.
+		if blockReader := chainReaderForEnrichment(chainID); eventLog.BlockNumber > 0 && blockReader != nil {
 			// Get actual block timestamp for real events
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			header, err := rpcConn.HeaderByNumber(ctx, big.NewInt(int64(eventLog.BlockNumber)))
+			header, err := blockReader.HeaderByNumber(ctx, big.NewInt(int64(eventLog.BlockNumber)))
 			cancel()
 
 			if err == nil {
@@ -2333,10 +2340,28 @@ func (n *Engine) parseEventWithParsedABI(eventLog *types.Log, contractABI *abi.A
 }
 
 // callContractMethod makes a contract method call to retrieve additional data
-func (n *Engine) callContractMethod(contractAddress common.Address, callData string) (interface{}, error) {
-	// Ensure RPC connection is available
-	if rpcConn == nil {
-		return nil, fmt.Errorf("RPC connection not available for contract method call")
+// chainReaderForEnrichment returns the per-chain reader for best-effort
+// event enrichment, or nil when the chain is unspecified (chainID <= 0) or
+// no reader is registered for it. A nil result means "skip enrichment" —
+// the caller keeps its defaults rather than reading a default/wrong chain.
+func chainReaderForEnrichment(chainID int64) ChainStateReader {
+	if chainID <= 0 {
+		return nil
+	}
+	return GetChainStateReaderForChain(uint64(chainID))
+}
+
+func (n *Engine) callContractMethod(chainID int64, contractAddress common.Address, callData string) (interface{}, error) {
+	// chain_id is required — there is no engine-default chain. Callers
+	// treat this as best-effort enrichment and skip on error, so an
+	// unresolvable chain simply means "no enrichment" (never a wrong
+	// chain), consistent with the no-default-chain rule.
+	if chainID <= 0 {
+		return nil, fmt.Errorf("callContractMethod: chain_id required for enrichment")
+	}
+	reader := GetChainStateReaderForChain(uint64(chainID))
+	if reader == nil {
+		return nil, fmt.Errorf("callContractMethod: no chain-state reader for chain %d", chainID)
 	}
 
 	// Remove 0x prefix if present
@@ -2351,11 +2376,11 @@ func (n *Engine) callContractMethod(contractAddress common.Address, callData str
 		Data: callDataBytes,
 	}
 
-	// Make the contract call
+	// Make the contract call via the chain's worker
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := rpcConn.CallContract(ctx, msg, nil)
+	result, err := reader.CallContract(ctx, msg, nil)
 	if err != nil {
 		return nil, fmt.Errorf("contract call failed: %w", err)
 	}
@@ -2372,7 +2397,11 @@ func (n *Engine) callContractMethod(contractAddress common.Address, callData str
 }
 
 // runEventTriggerWithHistoricalSearch executes event trigger using historical blockchain search
-func (n *Engine) runEventTriggerWithHistoricalSearch(ctx context.Context, queriesArray []interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
+// enrichChainID is the trigger's chain, used for best-effort event
+// enrichment (decimals/timestamp) via parseEventWithABI. The historical
+// search's own chain handling (search ranges / metadata / FilterLogs) is
+// migrated separately; see docs/changes/20260614-rpcconn-chain-threading.md.
+func (n *Engine) runEventTriggerWithHistoricalSearch(ctx context.Context, enrichChainID int64, queriesArray []interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
 	// Get the latest block number
 	currentBlock, err := rpcConn.BlockNumber(ctx)
 	if err != nil {
@@ -2610,7 +2639,7 @@ func (n *Engine) runEventTriggerWithHistoricalSearch(ctx context.Context, querie
 		}
 
 		// Parse using the provided ABI
-		parsedEventData, err := n.parseEventWithABI(mostRecentEvent, contractABI, protobufQuery)
+		parsedEventData, err := n.parseEventWithABI(enrichChainID, mostRecentEvent, contractABI, protobufQuery)
 		if err != nil {
 			n.logger.Warn("Failed to parse event with provided ABI, using raw data", "error", err)
 			// Fallback to raw data if ABI parsing fails
@@ -3547,6 +3576,14 @@ func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWi
 		ErrorCode: responseErrorCode,
 	}
 
+	// Chain for output handlers that decode event logs (contractWrite).
+	// Prefer the explicit request chain, then the node config; 0 means
+	// "skip enrichment" downstream — no engine-default chain.
+	outputChainID := req.GetChainId()
+	if outputChainID == 0 {
+		outputChainID, _ = requireChainIDFromConfig(nodeConfig)
+	}
+
 	// Use handler to convert result to protobuf output
 	factory := NewNodeOutputHandlerFactory(n)
 	handler, err := factory.GetHandler(nodeTypeStr)
@@ -3554,7 +3591,7 @@ func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWi
 		// Fallback to RestAPI for unknown node types
 		resp.OutputData = &avsproto.RunNodeWithInputsResp_RestApi{RestApi: &avsproto.RestAPINode_Output{}}
 	} else {
-		outputData, metadata, err := handler.ConvertToProtobuf(result)
+		outputData, metadata, err := handler.ConvertToProtobuf(outputChainID, result)
 		if err != nil {
 			return &avsproto.RunNodeWithInputsResp{
 				Success: false,

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2068,7 +2068,14 @@ func (n *Engine) parseEventWithParsedABI(chainID int64, eventLog *types.Log, con
 					}
 				} else {
 					if n.logger != nil {
-						n.logger.Warn("Failed to call decimals() method", "error", err)
+						if chainReaderForEnrichment(chainID) == nil {
+							// Chain unspecified / unregistered — best-effort
+							// decimals enrichment is skipped quietly (not a
+							// failure, and not warn-level noise per event).
+							n.logger.Debug("Skipping decimals enrichment: no chain-state reader", "chainID", chainID)
+						} else {
+							n.logger.Warn("Failed to call decimals() method", "error", err)
+						}
 					}
 				}
 				break

--- a/docs/changes/20260614-rpcconn-chain-threading.md
+++ b/docs/changes/20260614-rpcconn-chain-threading.md
@@ -88,11 +88,19 @@ small, independently-shippable slices, each verified before the next.
    `GetBlockNumber` worker RPC + reader method. Thread chainID through
    `instructOperatorImmediateTrigger`, `runBlockTriggerImmediately`,
    `GetBlock` (+ its callers). Lowest-risk, no payload concerns.
-2. **PR B — event-enrichment reads.** Thread chainID through
-   `parseEventWithParsedABI` + `callContractMethod`; route the
-   `HeaderByNumber` (event block timestamp) and `CallContract` (decimals)
-   through the per-chain reader. Subsumes the `callContractMethod`
-   deferral noted in parent PR 2.
+2. **PR B — event-enrichment reads (delivered).** Threaded chainID through
+   `callContractMethod`, `parseEventWithParsedABI`, `parseEventWithABI`,
+   `runEventTriggerWithHistoricalSearch` (enrichment only), the
+   `OutputHandler.ConvertToProtobuf` interface (+ all impls), and
+   `RunNodeImmediatelyRPC`; emitted `chain_id` into the event trigger
+   config. The `HeaderByNumber` (event block timestamp) and `CallContract`
+   (decimals) reads now route through the per-chain worker. These are
+   **best-effort, non-fatal** enrichment: an unspecified chain *skips*
+   enrichment (`chainReaderForEnrichment` → nil) rather than reading a
+   default chain — never hard-fails the event decode. Subsumes the
+   `callContractMethod` deferral from parent PR 2. The
+   `runEventTriggerWithHistoricalSearch` `BlockNumber`/`FilterLogs` reads
+   stay on `rpcConn` for PR C.
 3. **PR C — simulate historical search.** *Tenderly-first (see "Simulate
    fidelity" below).* First, prefer the existing Tenderly / direct-call
    simulate strategies and shrink the historical-`FilterLogs` path to the


### PR DESCRIPTION
## What

Third PR of [`docs/changes/20260614-rpcconn-chain-threading.md`](docs/changes/20260614-rpcconn-chain-threading.md). Routes the best-effort **event-enrichment** reads off the package-level `rpcConn` (the gateway's AVS chain) onto the trigger's own per-chain worker.

Two reads migrated:
- **token decimals** — `callContractMethod` (`CallContract`)
- **event block timestamp** — `parseEventWithParsedABI` (`HeaderByNumber`)

## Skip, never default (per maintainer direction)

These are **optional, non-fatal** adornments. The new `chainReaderForEnrichment(chainID)` helper returns `nil` for `chainID <= 0` or an unregistered chain, so enrichment is **skipped** (keeps the default timestamp/decimals) rather than reading a default/wrong chain. This honors *no engine-default chain* while not hard-failing the event decode (which the block-trigger path does, because there the read *is* the output).

## Threading

- `node_types.go`: `TaskTriggerToConfig` emits `chain_id` for event triggers.
- chainID threaded through `callContractMethod`, `parseEventWithParsedABI`, `parseEventWithABI`, `runEventTriggerWithHistoricalSearch` (enrichment path only), `runEventTriggerImmediately` (soft-resolves chain from the trigger config), and `RunNodeImmediatelyRPC` (sources chain from req / node config).
- `OutputHandler.ConvertToProtobuf` interface + all 10 implementations now take `chainID` (only `ContractWriteOutputHandler` uses it, for event-log decode) — the full interface threading you approved.

## Deferred

`runEventTriggerWithHistoricalSearch`'s own `BlockNumber` + `FilterLogs` reads stay on `rpcConn` — that's the **Tenderly-first** historical-search work (PR C in the plan), gated on the simulate-fidelity decision.

## Testing

- `go build ./...`, `go vet` clean (the 9 handlers that ignore `chainID` carry an expected unused-param info).
- New `chainReaderForEnrichment` skip matrix; existing ABI-decode tests pass with `chainID 0` (enrichment skipped). Full short-mode taskengine suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
