### PR TITLE
feat: route wallet-derivation validation through chain workers (exec 1)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -80,6 +80,12 @@ type ChainStateReader interface {
 	// GetBlockNumber returns the latest block number. Mirrors
 	// ethclient.BlockNumber.
 	GetBlockNumber(ctx context.Context) (uint64, error)
+
+	// FindMatchingWalletSalt scans salts [0, maxSalts) for the one whose
+	// CREATE2 smart-wallet address (under factory) equals target. Returns
+	// found=false when none matches. The worker-routed implementation runs
+	// the scan server-side so a wide range is a single round-trip.
+	FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (found bool, salt int64, err error)
 }
 
 // BlockHeader is the subset of block-header fields the gateway reads:
@@ -224,6 +230,22 @@ func (d *directChainStateReader) HeaderByNumber(ctx context.Context, number *big
 
 func (d *directChainStateReader) GetBlockNumber(ctx context.Context) (uint64, error) {
 	return d.client.BlockNumber(ctx)
+}
+
+func (d *directChainStateReader) FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (bool, int64, error) {
+	for salt := int64(0); salt < maxSalts; salt++ {
+		if err := ctx.Err(); err != nil {
+			return false, 0, err
+		}
+		addr, err := aa.GetSenderAddressForFactory(d.client, owner, factory, big.NewInt(salt))
+		if err != nil {
+			continue
+		}
+		if addr != nil && *addr == target {
+			return true, salt, nil
+		}
+	}
+	return false, 0, nil
 }
 
 // ---------------------------------------------------------------------
@@ -472,6 +494,24 @@ func (w *workerChainStateReader) GetBlockNumber(ctx context.Context) (uint64, er
 		return 0, fmt.Errorf("worker returned nil response for GetBlockNumber on chain %d", w.chainID)
 	}
 	return resp.Number, nil
+}
+
+func (w *workerChainStateReader) FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (bool, int64, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	resp, err := w.client.FindMatchingWalletSalt(ctx, &avsproto.WorkerFindMatchingWalletSaltReq{
+		Owner:          owner.Hex(),
+		FactoryAddress: factory.Hex(),
+		TargetAddress:  target.Hex(),
+		MaxSalts:       maxSalts,
+	})
+	if err != nil {
+		return false, 0, fmt.Errorf("worker FindMatchingWalletSalt (chain %d): %w", w.chainID, err)
+	}
+	if resp == nil {
+		return false, 0, fmt.Errorf("worker returned nil response for FindMatchingWalletSalt on chain %d", w.chainID)
+	}
+	return resp.Found, resp.Salt, nil
 }
 
 // withTimeout caps the gRPC call's wall time. context.WithTimeout

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -67,6 +67,11 @@ type chainStateFakeClient struct {
 	// GetBlockNumber
 	getBlockNumberResp *avsproto.WorkerGetBlockNumberResp
 	getBlockNumberErr  error
+
+	// FindMatchingWalletSalt
+	findSaltReq  *avsproto.WorkerFindMatchingWalletSaltReq
+	findSaltResp *avsproto.WorkerFindMatchingWalletSaltResp
+	findSaltErr  error
 }
 
 func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
@@ -92,6 +97,10 @@ func (f *chainStateFakeClient) GetBlockHeader(_ context.Context, req *avsproto.W
 }
 func (f *chainStateFakeClient) GetBlockNumber(_ context.Context, _ *avsproto.WorkerGetBlockNumberReq, _ ...grpc.CallOption) (*avsproto.WorkerGetBlockNumberResp, error) {
 	return f.getBlockNumberResp, f.getBlockNumberErr
+}
+func (f *chainStateFakeClient) FindMatchingWalletSalt(_ context.Context, req *avsproto.WorkerFindMatchingWalletSaltReq, _ ...grpc.CallOption) (*avsproto.WorkerFindMatchingWalletSaltResp, error) {
+	f.findSaltReq = req
+	return f.findSaltResp, f.findSaltErr
 }
 func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
 	panic("unused")
@@ -715,5 +724,43 @@ func TestChainReaderForEnrichment(t *testing.T) {
 	RegisterChainStateReader(8453, NewWorkerChainStateReader(&chainStateFakeClient{}, 8453, 0))
 	if chainReaderForEnrichment(8453) == nil {
 		t.Fatalf("registered chain should resolve a reader")
+	}
+}
+
+// TestWorkerChainStateReader_FindMatchingWalletSalt: owner/factory/target
+// are hex-encoded, max_salts propagates, and (found, salt) round-trips.
+func TestWorkerChainStateReader_FindMatchingWalletSalt(t *testing.T) {
+	fake := &chainStateFakeClient{
+		findSaltResp: &avsproto.WorkerFindMatchingWalletSaltResp{Found: true, Salt: 3},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	factory := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	target := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	found, salt, err := r.FindMatchingWalletSalt(context.Background(), owner, factory, target, 2000)
+	if err != nil {
+		t.Fatalf("FindMatchingWalletSalt: %v", err)
+	}
+	if !found || salt != 3 {
+		t.Fatalf("got found=%v salt=%d, want true/3", found, salt)
+	}
+	if fake.findSaltReq.Owner != owner.Hex() || fake.findSaltReq.FactoryAddress != factory.Hex() || fake.findSaltReq.TargetAddress != target.Hex() {
+		t.Fatalf("address args not propagated: %+v", fake.findSaltReq)
+	}
+	if fake.findSaltReq.MaxSalts != 2000 {
+		t.Fatalf("max_salts not propagated: %d", fake.findSaltReq.MaxSalts)
+	}
+}
+
+// TestWorkerChainStateReader_FindMatchingWalletSalt_NotFound: a no-match
+// scan returns found=false without error.
+func TestWorkerChainStateReader_FindMatchingWalletSalt_NotFound(t *testing.T) {
+	fake := &chainStateFakeClient{
+		findSaltResp: &avsproto.WorkerFindMatchingWalletSaltResp{Found: false},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	found, _, err := r.FindMatchingWalletSalt(context.Background(), common.HexToAddress("0xaa"), common.HexToAddress("0xbb"), common.HexToAddress("0xcc"), 5)
+	if err != nil || found {
+		t.Fatalf("expected not-found, no error; got found=%v err=%v", found, err)
 	}
 }

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -892,14 +893,23 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 	// Must use the task's chain config — deriving against the gateway's default
 	// chain factory produces a different wallet than the task's chain factory
 	// and the comparison will spuriously miss.
-	if swCfg != nil && swCfg.EthRpcUrl != "" {
-		if rpcClient, err := ethclient.Dial(swCfg.EthRpcUrl); err == nil {
-			// Load the default smart wallet address (salt:0)
-			if err := user.LoadDefaultSmartWallet(rpcClient); err != nil {
+	if swCfg != nil {
+		if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
+			// Gateway mode: derive salt:0 via the chain worker (no gateway dial).
+			if addr, derr := reader.GetSmartWalletAddress(context.Background(), user.Address, swCfg.FactoryAddress, big.NewInt(0)); derr == nil {
+				user.SmartAccountAddress = &addr
+			} else {
 				x.logger.Warn("Failed to load default smart wallet for validation",
-					"owner", user.Address.Hex(), "chain_id", chainID, "error", err)
+					"owner", user.Address.Hex(), "chain_id", chainID, "error", derr)
 			}
-			rpcClient.Close()
+		} else if swCfg.EthRpcUrl != "" {
+			if rpcClient, err := ethclient.Dial(swCfg.EthRpcUrl); err == nil {
+				if err := user.LoadDefaultSmartWallet(rpcClient); err != nil {
+					x.logger.Warn("Failed to load default smart wallet for validation",
+						"owner", user.Address.Hex(), "chain_id", chainID, "error", err)
+				}
+				rpcClient.Close()
+			}
 		}
 	}
 
@@ -915,8 +925,8 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 	// Handles factory-upgrade scenarios where the original wallet record was
 	// never written for the post-upgrade derived address. MUST use the task's
 	// per-chain config — see resolveSmartWalletConfig above.
-	if swCfg != nil && swCfg.EthRpcUrl != "" {
-		if isValid, err := x.validateDerivedWallet(swCfg, user.Address, smartWalletAddr); err == nil && isValid {
+	if swCfg != nil {
+		if isValid, err := x.validateDerivedWallet(chainID, swCfg, user.Address, smartWalletAddr); err == nil && isValid {
 			x.logger.Info("Wallet validated as legitimate derived wallet",
 				"owner", user.Address.Hex(), "wallet", smartWalletAddr.Hex(), "chain_id", chainID)
 			return true, nil
@@ -934,25 +944,42 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 // The swCfg argument is the per-chain config resolved by the caller —
 // passing it in (rather than reading x.smartWalletConfig) is what makes
 // this work in gateway mode where the executor is shared across chains.
-func (x *WorkflowExecutor) validateDerivedWallet(swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
-	rpcClient, err := ethclient.Dial(swCfg.EthRpcUrl)
-	if err != nil {
-		return false, fmt.Errorf("failed to connect to RPC: %w", err)
-	}
-	defer rpcClient.Close()
-
+func (x *WorkflowExecutor) validateDerivedWallet(chainID int64, swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
 	factoryAddr := swCfg.FactoryAddress
 
 	// Try salt values from 0 to max_wallets_per_owner to see if any produce the target wallet address
 	// This uses the configured limit from aggregator.yaml
 	maxWallets := int64(swCfg.MaxWalletsPerOwner)
 
-	for salt := int64(0); salt < maxWallets; salt++ {
-		derivedAddr, err := aa.GetSenderAddressForFactory(rpcClient, owner, factoryAddr, big.NewInt(salt))
+	// Prefer the per-chain reader: in gateway mode the worker runs the whole
+	// salt scan server-side (one round-trip). Fall back to a direct dial +
+	// local loop only when no reader is registered (single-chain mode / tests).
+	if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
+		found, salt, err := reader.FindMatchingWalletSalt(context.Background(), owner, factoryAddr, smartWalletAddr, maxWallets)
 		if err != nil {
-			// Log error for debugging but continue with next salt
+			return false, err
+		}
+		if found {
+			x.logger.Debug("Found matching derived wallet",
+				"owner", owner.Hex(), "wallet", smartWalletAddr.Hex(), "factory", factoryAddr.Hex(), "salt", salt)
+			return true, nil
+		}
+		x.logger.Debug("No matching derived wallet found",
+			"owner", owner.Hex(), "wallet", smartWalletAddr.Hex(), "factory", factoryAddr.Hex(), "salts_checked", maxWallets)
+		return false, fmt.Errorf("wallet address cannot be derived from owner with factory %s (checked %d salts)", factoryAddr.Hex(), maxWallets)
+	}
+
+	rpcClient, err := ethclient.Dial(swCfg.EthRpcUrl)
+	if err != nil {
+		return false, fmt.Errorf("failed to connect to RPC: %w", err)
+	}
+	defer rpcClient.Close()
+
+	for salt := int64(0); salt < maxWallets; salt++ {
+		derivedAddr, derr := aa.GetSenderAddressForFactory(rpcClient, owner, factoryAddr, big.NewInt(salt))
+		if derr != nil {
 			x.logger.Debug("Failed to derive wallet address",
-				"owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt, "error", err)
+				"owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt, "error", derr)
 			continue
 		}
 

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2564,29 +2564,43 @@ func (n *Engine) runProcessingNodeWithInputs(user *model.User, nodeType string, 
 							"owner", vm.TaskOwner.Hex())
 					}
 
-					// Connect to RPC to derive addresses
-					client, err := ethclient.Dial(n.smartWalletConfig.EthRpcUrl)
-					if err != nil {
-						return nil, fmt.Errorf("failed to connect to RPC for address derivation: %w", err)
-					}
-
-					// Check salts 0-4 (we allow up to 5 smart wallets per EOA)
-					for salt := int64(0); salt < 5; salt++ {
-						derivedAddr, err := aa.GetSenderAddress(client, vm.TaskOwner, big.NewInt(salt))
-						if err != nil {
-							if n.logger != nil {
-								n.logger.Debug("Failed to derive address for salt", "salt", salt, "error", err)
-							}
-							continue
+					// Check salts 0-4 (we allow up to 5 smart wallets per EOA).
+					// Prefer the per-chain reader: in gateway mode the worker
+					// runs the scan server-side. Fall back to a direct dial +
+					// local loop when no reader is registered.
+					const runnerSaltScan = int64(5)
+					factoryAddr := n.smartWalletConfig.FactoryAddress
+					runnerAddr := common.HexToAddress(runnerStr)
+					if reader := GetChainStateReaderForChain(uint64(n.smartWalletConfig.ChainID)); reader != nil {
+						found, salt, derr := reader.FindMatchingWalletSalt(context.Background(), vm.TaskOwner, factoryAddr, runnerAddr, runnerSaltScan)
+						if derr != nil {
+							return nil, fmt.Errorf("failed to derive addresses for runner validation: %w", derr)
 						}
-
-						if strings.EqualFold(derivedAddr.Hex(), runnerStr) {
+						if found {
 							matchedSalt = big.NewInt(salt)
-							chosenSender = *derivedAddr
-							break
+							chosenSender = runnerAddr
 						}
+					} else {
+						client, err := ethclient.Dial(n.smartWalletConfig.EthRpcUrl)
+						if err != nil {
+							return nil, fmt.Errorf("failed to connect to RPC for address derivation: %w", err)
+						}
+						for salt := int64(0); salt < runnerSaltScan; salt++ {
+							derivedAddr, derr := aa.GetSenderAddress(client, vm.TaskOwner, big.NewInt(salt))
+							if derr != nil {
+								if n.logger != nil {
+									n.logger.Debug("Failed to derive address for salt", "salt", salt, "error", derr)
+								}
+								continue
+							}
+							if strings.EqualFold(derivedAddr.Hex(), runnerStr) {
+								matchedSalt = big.NewInt(salt)
+								chosenSender = *derivedAddr
+								break
+							}
+						}
+						client.Close()
 					}
-					client.Close()
 
 					// If no match found in salts 0-4, reject the runner
 					if matchedSalt == nil {

--- a/core/taskengine/worker_token_fetcher_test.go
+++ b/core/taskengine/worker_token_fetcher_test.go
@@ -72,6 +72,9 @@ func (f *fakeChainWorkerClient) GetBlockHeader(context.Context, *avsproto.Worker
 func (f *fakeChainWorkerClient) GetBlockNumber(context.Context, *avsproto.WorkerGetBlockNumberReq, ...grpc.CallOption) (*avsproto.WorkerGetBlockNumberResp, error) {
 	panic("unused")
 }
+func (f *fakeChainWorkerClient) FindMatchingWalletSalt(context.Context, *avsproto.WorkerFindMatchingWalletSaltReq, ...grpc.CallOption) (*avsproto.WorkerFindMatchingWalletSaltResp, error) {
+	panic("unused")
+}
 
 // TestWorkerRoutedFetcher_HappyPath confirms a successful worker response
 // gets mapped to a TokenMetadata correctly — name, symbol, decimals, source

--- a/docs/changes/20260615-route-execution-layer-through-workers.md
+++ b/docs/changes/20260615-route-execution-layer-through-workers.md
@@ -52,12 +52,19 @@ dials follow the same model, reusing existing worker RPCs where possible:
 
 ## PR breakdown
 
-1. **PR 1 — wallet-derivation dials.** Route `validateWalletOwnership`,
-   `validateDerivedWallet`, and the `run_node` salt-scan through the
-   per-chain `ChainStateReader.GetSmartWalletAddress`. Refactor
-   `user.LoadDefaultSmartWallet` to take a derived address (or a reader)
-   instead of a raw `*ethclient.Client`. Lowest-risk; no new proto. Removes
-   3 live dials.
+1. **PR 1 — wallet-derivation dials (delivered).** The `validateDerivedWallet`
+   salt-scan (up to `MaxWalletsPerOwner` = 2000) made per-salt routing a
+   non-starter, so a **server-side scan RPC** `FindMatchingWalletSalt(owner,
+   factory, target, max_salts) → (found, salt)` was added (capped at 2000):
+   the worker runs the loop + comparison locally, one round-trip. Added it
+   to the `ChainStateReader` interface + both impls. Migrated:
+   `validateWalletOwnership` Step 1 (default wallet) → `GetSmartWalletAddress`;
+   `validateDerivedWallet` and the `run_node` salt-scan → `FindMatchingWalletSalt`.
+   Each keeps a direct-dial + local-loop fallback for single-chain mode /
+   no-reader. `LoadDefaultSmartWallet` stays for the fallback; the reader
+   path sets `user.SmartAccountAddress` from the worker-derived address
+   (using the task's per-chain factory, fixing the latent global-factory
+   inconsistency).
 2. **PR 2 — userop receipt waiting.** Migrate `waitForUserOpConfirmation`.
    First check whether gateway-mode sends (via `ExecuteUserOp`) already
    return a confirmed receipt, making the separate wait redundant; if not,

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -1466,6 +1466,127 @@ func (x *WorkerGetBlockNumberResp) GetNumber() uint64 {
 	return 0
 }
 
+// Salt-scan wallet match
+type WorkerFindMatchingWalletSaltReq struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Owner          string                 `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`                                         // Owner EOA address (hex).
+	FactoryAddress string                 `protobuf:"bytes,2,opt,name=factory_address,json=factoryAddress,proto3" json:"factory_address,omitempty"` // Factory override (hex). Empty = worker's configured factory.
+	TargetAddress  string                 `protobuf:"bytes,3,opt,name=target_address,json=targetAddress,proto3" json:"target_address,omitempty"`    // Smart-wallet address to match (hex).
+	MaxSalts       int64                  `protobuf:"varint,4,opt,name=max_salts,json=maxSalts,proto3" json:"max_salts,omitempty"`                  // Scan salts in [0, max_salts).
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *WorkerFindMatchingWalletSaltReq) Reset() {
+	*x = WorkerFindMatchingWalletSaltReq{}
+	mi := &file_worker_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerFindMatchingWalletSaltReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerFindMatchingWalletSaltReq) ProtoMessage() {}
+
+func (x *WorkerFindMatchingWalletSaltReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerFindMatchingWalletSaltReq.ProtoReflect.Descriptor instead.
+func (*WorkerFindMatchingWalletSaltReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *WorkerFindMatchingWalletSaltReq) GetOwner() string {
+	if x != nil {
+		return x.Owner
+	}
+	return ""
+}
+
+func (x *WorkerFindMatchingWalletSaltReq) GetFactoryAddress() string {
+	if x != nil {
+		return x.FactoryAddress
+	}
+	return ""
+}
+
+func (x *WorkerFindMatchingWalletSaltReq) GetTargetAddress() string {
+	if x != nil {
+		return x.TargetAddress
+	}
+	return ""
+}
+
+func (x *WorkerFindMatchingWalletSaltReq) GetMaxSalts() int64 {
+	if x != nil {
+		return x.MaxSalts
+	}
+	return 0
+}
+
+type WorkerFindMatchingWalletSaltResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Found         bool                   `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`
+	Salt          int64                  `protobuf:"varint,2,opt,name=salt,proto3" json:"salt,omitempty"` // The matching salt; valid only when found.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerFindMatchingWalletSaltResp) Reset() {
+	*x = WorkerFindMatchingWalletSaltResp{}
+	mi := &file_worker_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerFindMatchingWalletSaltResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerFindMatchingWalletSaltResp) ProtoMessage() {}
+
+func (x *WorkerFindMatchingWalletSaltResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerFindMatchingWalletSaltResp.ProtoReflect.Descriptor instead.
+func (*WorkerFindMatchingWalletSaltResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *WorkerFindMatchingWalletSaltResp) GetFound() bool {
+	if x != nil {
+		return x.Found
+	}
+	return false
+}
+
+func (x *WorkerFindMatchingWalletSaltResp) GetSalt() int64 {
+	if x != nil {
+		return x.Salt
+	}
+	return 0
+}
+
 var File_worker_proto protoreflect.FileDescriptor
 
 const file_worker_proto_rawDesc = "" +
@@ -1562,7 +1683,16 @@ const file_worker_proto_rawDesc = "" +
 	"\bgas_used\x18\a \x01(\x04R\agasUsed\"\x19\n" +
 	"\x17WorkerGetBlockNumberReq\"2\n" +
 	"\x18WorkerGetBlockNumberResp\x12\x16\n" +
-	"\x06number\x18\x01 \x01(\x04R\x06number2\xf0\t\n" +
+	"\x06number\x18\x01 \x01(\x04R\x06number\"\xa4\x01\n" +
+	"\x1fWorkerFindMatchingWalletSaltReq\x12\x14\n" +
+	"\x05owner\x18\x01 \x01(\tR\x05owner\x12'\n" +
+	"\x0ffactory_address\x18\x02 \x01(\tR\x0efactoryAddress\x12%\n" +
+	"\x0etarget_address\x18\x03 \x01(\tR\rtargetAddress\x12\x1b\n" +
+	"\tmax_salts\x18\x04 \x01(\x03R\bmaxSalts\"L\n" +
+	" WorkerFindMatchingWalletSaltResp\x12\x14\n" +
+	"\x05found\x18\x01 \x01(\bR\x05found\x12\x12\n" +
+	"\x04salt\x18\x02 \x01(\x03R\x04salt2\xe5\n" +
+	"\n" +
 	"\vChainWorker\x12X\n" +
 	"\x11WorkerHealthCheck\x12 .aggregator.WorkerHealthCheckReq\x1a!.aggregator.WorkerHealthCheckResp\x12L\n" +
 	"\rExecuteUserOp\x12\x1c.aggregator.ExecuteUserOpReq\x1a\x1d.aggregator.ExecuteUserOpResp\x12I\n" +
@@ -1578,7 +1708,8 @@ const file_worker_proto_rawDesc = "" +
 	"\x0fGetTokenBalance\x12$.aggregator.WorkerGetTokenBalanceReq\x1a%.aggregator.WorkerGetTokenBalanceResp\x12U\n" +
 	"\fCallContract\x12!.aggregator.WorkerCallContractReq\x1a\".aggregator.WorkerCallContractResp\x12[\n" +
 	"\x0eGetBlockHeader\x12#.aggregator.WorkerGetBlockHeaderReq\x1a$.aggregator.WorkerGetBlockHeaderResp\x12[\n" +
-	"\x0eGetBlockNumber\x12#.aggregator.WorkerGetBlockNumberReq\x1a$.aggregator.WorkerGetBlockNumberRespB\fZ\n" +
+	"\x0eGetBlockNumber\x12#.aggregator.WorkerGetBlockNumberReq\x1a$.aggregator.WorkerGetBlockNumberResp\x12s\n" +
+	"\x16FindMatchingWalletSalt\x12+.aggregator.WorkerFindMatchingWalletSaltReq\x1a,.aggregator.WorkerFindMatchingWalletSaltRespB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (
@@ -1593,35 +1724,37 @@ func file_worker_proto_rawDescGZIP() []byte {
 	return file_worker_proto_rawDescData
 }
 
-var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_worker_proto_goTypes = []any{
-	(*WorkerHealthCheckReq)(nil),            // 0: aggregator.WorkerHealthCheckReq
-	(*WorkerHealthCheckResp)(nil),           // 1: aggregator.WorkerHealthCheckResp
-	(*ExecuteUserOpReq)(nil),                // 2: aggregator.ExecuteUserOpReq
-	(*ExecuteUserOpResp)(nil),               // 3: aggregator.ExecuteUserOpResp
-	(*WorkerGetNonceReq)(nil),               // 4: aggregator.WorkerGetNonceReq
-	(*WorkerGetNonceResp)(nil),              // 5: aggregator.WorkerGetNonceResp
-	(*WorkerGetSmartWalletAddressReq)(nil),  // 6: aggregator.WorkerGetSmartWalletAddressReq
-	(*WorkerGetSmartWalletAddressResp)(nil), // 7: aggregator.WorkerGetSmartWalletAddressResp
-	(*WorkerGetTokenMetadataReq)(nil),       // 8: aggregator.WorkerGetTokenMetadataReq
-	(*WorkerGetTokenMetadataResp)(nil),      // 9: aggregator.WorkerGetTokenMetadataResp
-	(*WorkerGetNonceByAddressReq)(nil),      // 10: aggregator.WorkerGetNonceByAddressReq
-	(*WorkerSuggestGasPriceReq)(nil),        // 11: aggregator.WorkerSuggestGasPriceReq
-	(*WorkerSuggestGasPriceResp)(nil),       // 12: aggregator.WorkerSuggestGasPriceResp
-	(*WorkerEstimateGasReq)(nil),            // 13: aggregator.WorkerEstimateGasReq
-	(*WorkerEstimateGasResp)(nil),           // 14: aggregator.WorkerEstimateGasResp
-	(*WorkerGetCodeReq)(nil),                // 15: aggregator.WorkerGetCodeReq
-	(*WorkerGetCodeResp)(nil),               // 16: aggregator.WorkerGetCodeResp
-	(*WorkerGetBalanceReq)(nil),             // 17: aggregator.WorkerGetBalanceReq
-	(*WorkerGetBalanceResp)(nil),            // 18: aggregator.WorkerGetBalanceResp
-	(*WorkerGetTokenBalanceReq)(nil),        // 19: aggregator.WorkerGetTokenBalanceReq
-	(*WorkerGetTokenBalanceResp)(nil),       // 20: aggregator.WorkerGetTokenBalanceResp
-	(*WorkerCallContractReq)(nil),           // 21: aggregator.WorkerCallContractReq
-	(*WorkerCallContractResp)(nil),          // 22: aggregator.WorkerCallContractResp
-	(*WorkerGetBlockHeaderReq)(nil),         // 23: aggregator.WorkerGetBlockHeaderReq
-	(*WorkerGetBlockHeaderResp)(nil),        // 24: aggregator.WorkerGetBlockHeaderResp
-	(*WorkerGetBlockNumberReq)(nil),         // 25: aggregator.WorkerGetBlockNumberReq
-	(*WorkerGetBlockNumberResp)(nil),        // 26: aggregator.WorkerGetBlockNumberResp
+	(*WorkerHealthCheckReq)(nil),             // 0: aggregator.WorkerHealthCheckReq
+	(*WorkerHealthCheckResp)(nil),            // 1: aggregator.WorkerHealthCheckResp
+	(*ExecuteUserOpReq)(nil),                 // 2: aggregator.ExecuteUserOpReq
+	(*ExecuteUserOpResp)(nil),                // 3: aggregator.ExecuteUserOpResp
+	(*WorkerGetNonceReq)(nil),                // 4: aggregator.WorkerGetNonceReq
+	(*WorkerGetNonceResp)(nil),               // 5: aggregator.WorkerGetNonceResp
+	(*WorkerGetSmartWalletAddressReq)(nil),   // 6: aggregator.WorkerGetSmartWalletAddressReq
+	(*WorkerGetSmartWalletAddressResp)(nil),  // 7: aggregator.WorkerGetSmartWalletAddressResp
+	(*WorkerGetTokenMetadataReq)(nil),        // 8: aggregator.WorkerGetTokenMetadataReq
+	(*WorkerGetTokenMetadataResp)(nil),       // 9: aggregator.WorkerGetTokenMetadataResp
+	(*WorkerGetNonceByAddressReq)(nil),       // 10: aggregator.WorkerGetNonceByAddressReq
+	(*WorkerSuggestGasPriceReq)(nil),         // 11: aggregator.WorkerSuggestGasPriceReq
+	(*WorkerSuggestGasPriceResp)(nil),        // 12: aggregator.WorkerSuggestGasPriceResp
+	(*WorkerEstimateGasReq)(nil),             // 13: aggregator.WorkerEstimateGasReq
+	(*WorkerEstimateGasResp)(nil),            // 14: aggregator.WorkerEstimateGasResp
+	(*WorkerGetCodeReq)(nil),                 // 15: aggregator.WorkerGetCodeReq
+	(*WorkerGetCodeResp)(nil),                // 16: aggregator.WorkerGetCodeResp
+	(*WorkerGetBalanceReq)(nil),              // 17: aggregator.WorkerGetBalanceReq
+	(*WorkerGetBalanceResp)(nil),             // 18: aggregator.WorkerGetBalanceResp
+	(*WorkerGetTokenBalanceReq)(nil),         // 19: aggregator.WorkerGetTokenBalanceReq
+	(*WorkerGetTokenBalanceResp)(nil),        // 20: aggregator.WorkerGetTokenBalanceResp
+	(*WorkerCallContractReq)(nil),            // 21: aggregator.WorkerCallContractReq
+	(*WorkerCallContractResp)(nil),           // 22: aggregator.WorkerCallContractResp
+	(*WorkerGetBlockHeaderReq)(nil),          // 23: aggregator.WorkerGetBlockHeaderReq
+	(*WorkerGetBlockHeaderResp)(nil),         // 24: aggregator.WorkerGetBlockHeaderResp
+	(*WorkerGetBlockNumberReq)(nil),          // 25: aggregator.WorkerGetBlockNumberReq
+	(*WorkerGetBlockNumberResp)(nil),         // 26: aggregator.WorkerGetBlockNumberResp
+	(*WorkerFindMatchingWalletSaltReq)(nil),  // 27: aggregator.WorkerFindMatchingWalletSaltReq
+	(*WorkerFindMatchingWalletSaltResp)(nil), // 28: aggregator.WorkerFindMatchingWalletSaltResp
 }
 var file_worker_proto_depIdxs = []int32{
 	0,  // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
@@ -1638,22 +1771,24 @@ var file_worker_proto_depIdxs = []int32{
 	21, // 11: aggregator.ChainWorker.CallContract:input_type -> aggregator.WorkerCallContractReq
 	23, // 12: aggregator.ChainWorker.GetBlockHeader:input_type -> aggregator.WorkerGetBlockHeaderReq
 	25, // 13: aggregator.ChainWorker.GetBlockNumber:input_type -> aggregator.WorkerGetBlockNumberReq
-	1,  // 14: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
-	3,  // 15: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
-	5,  // 16: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
-	7,  // 17: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
-	9,  // 18: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
-	5,  // 19: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
-	12, // 20: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
-	14, // 21: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
-	16, // 22: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
-	18, // 23: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
-	20, // 24: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
-	22, // 25: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
-	24, // 26: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
-	26, // 27: aggregator.ChainWorker.GetBlockNumber:output_type -> aggregator.WorkerGetBlockNumberResp
-	14, // [14:28] is the sub-list for method output_type
-	0,  // [0:14] is the sub-list for method input_type
+	27, // 14: aggregator.ChainWorker.FindMatchingWalletSalt:input_type -> aggregator.WorkerFindMatchingWalletSaltReq
+	1,  // 15: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
+	3,  // 16: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
+	5,  // 17: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
+	7,  // 18: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
+	9,  // 19: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
+	5,  // 20: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
+	12, // 21: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
+	14, // 22: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
+	16, // 23: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
+	18, // 24: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
+	20, // 25: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
+	22, // 26: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
+	24, // 27: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
+	26, // 28: aggregator.ChainWorker.GetBlockNumber:output_type -> aggregator.WorkerGetBlockNumberResp
+	28, // 29: aggregator.ChainWorker.FindMatchingWalletSalt:output_type -> aggregator.WorkerFindMatchingWalletSaltResp
+	15, // [15:30] is the sub-list for method output_type
+	0,  // [0:15] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -1670,7 +1805,7 @@ func file_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   27,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -67,6 +67,12 @@ service ChainWorker {
   // Read the latest block number. Wraps ethclient.BlockNumber. Used by the
   // immediate-trigger path to stamp the current block for the operator.
   rpc GetBlockNumber(WorkerGetBlockNumberReq) returns (WorkerGetBlockNumberResp);
+
+  // Find the salt in [0, max_salts) whose CREATE2 smart-wallet address
+  // (under the given factory) matches target. The worker runs the scan +
+  // comparison locally so a wide range is a single round-trip. Used by the
+  // gateway's wallet-ownership validation (factory-upgrade fallback).
+  rpc FindMatchingWalletSalt(WorkerFindMatchingWalletSaltReq) returns (WorkerFindMatchingWalletSaltResp);
 }
 
 // Health check
@@ -223,4 +229,17 @@ message WorkerGetBlockNumberReq {}
 
 message WorkerGetBlockNumberResp {
   uint64 number = 1;        // Latest block number.
+}
+
+// Salt-scan wallet match
+message WorkerFindMatchingWalletSaltReq {
+  string owner = 1;            // Owner EOA address (hex).
+  string factory_address = 2;  // Factory override (hex). Empty = worker's configured factory.
+  string target_address = 3;   // Smart-wallet address to match (hex).
+  int64 max_salts = 4;         // Scan salts in [0, max_salts).
+}
+
+message WorkerFindMatchingWalletSaltResp {
+  bool found = 1;
+  int64 salt = 2;              // The matching salt; valid only when found.
 }

--- a/protobuf/worker_grpc.pb.go
+++ b/protobuf/worker_grpc.pb.go
@@ -19,20 +19,21 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ChainWorker_WorkerHealthCheck_FullMethodName     = "/aggregator.ChainWorker/WorkerHealthCheck"
-	ChainWorker_ExecuteUserOp_FullMethodName         = "/aggregator.ChainWorker/ExecuteUserOp"
-	ChainWorker_GetNonce_FullMethodName              = "/aggregator.ChainWorker/GetNonce"
-	ChainWorker_GetSmartWalletAddress_FullMethodName = "/aggregator.ChainWorker/GetSmartWalletAddress"
-	ChainWorker_GetTokenMetadata_FullMethodName      = "/aggregator.ChainWorker/GetTokenMetadata"
-	ChainWorker_GetNonceByAddress_FullMethodName     = "/aggregator.ChainWorker/GetNonceByAddress"
-	ChainWorker_SuggestGasPrice_FullMethodName       = "/aggregator.ChainWorker/SuggestGasPrice"
-	ChainWorker_EstimateGas_FullMethodName           = "/aggregator.ChainWorker/EstimateGas"
-	ChainWorker_GetCode_FullMethodName               = "/aggregator.ChainWorker/GetCode"
-	ChainWorker_GetBalance_FullMethodName            = "/aggregator.ChainWorker/GetBalance"
-	ChainWorker_GetTokenBalance_FullMethodName       = "/aggregator.ChainWorker/GetTokenBalance"
-	ChainWorker_CallContract_FullMethodName          = "/aggregator.ChainWorker/CallContract"
-	ChainWorker_GetBlockHeader_FullMethodName        = "/aggregator.ChainWorker/GetBlockHeader"
-	ChainWorker_GetBlockNumber_FullMethodName        = "/aggregator.ChainWorker/GetBlockNumber"
+	ChainWorker_WorkerHealthCheck_FullMethodName      = "/aggregator.ChainWorker/WorkerHealthCheck"
+	ChainWorker_ExecuteUserOp_FullMethodName          = "/aggregator.ChainWorker/ExecuteUserOp"
+	ChainWorker_GetNonce_FullMethodName               = "/aggregator.ChainWorker/GetNonce"
+	ChainWorker_GetSmartWalletAddress_FullMethodName  = "/aggregator.ChainWorker/GetSmartWalletAddress"
+	ChainWorker_GetTokenMetadata_FullMethodName       = "/aggregator.ChainWorker/GetTokenMetadata"
+	ChainWorker_GetNonceByAddress_FullMethodName      = "/aggregator.ChainWorker/GetNonceByAddress"
+	ChainWorker_SuggestGasPrice_FullMethodName        = "/aggregator.ChainWorker/SuggestGasPrice"
+	ChainWorker_EstimateGas_FullMethodName            = "/aggregator.ChainWorker/EstimateGas"
+	ChainWorker_GetCode_FullMethodName                = "/aggregator.ChainWorker/GetCode"
+	ChainWorker_GetBalance_FullMethodName             = "/aggregator.ChainWorker/GetBalance"
+	ChainWorker_GetTokenBalance_FullMethodName        = "/aggregator.ChainWorker/GetTokenBalance"
+	ChainWorker_CallContract_FullMethodName           = "/aggregator.ChainWorker/CallContract"
+	ChainWorker_GetBlockHeader_FullMethodName         = "/aggregator.ChainWorker/GetBlockHeader"
+	ChainWorker_GetBlockNumber_FullMethodName         = "/aggregator.ChainWorker/GetBlockNumber"
+	ChainWorker_FindMatchingWalletSalt_FullMethodName = "/aggregator.ChainWorker/FindMatchingWalletSalt"
 )
 
 // ChainWorkerClient is the client API for ChainWorker service.
@@ -90,6 +91,11 @@ type ChainWorkerClient interface {
 	// Read the latest block number. Wraps ethclient.BlockNumber. Used by the
 	// immediate-trigger path to stamp the current block for the operator.
 	GetBlockNumber(ctx context.Context, in *WorkerGetBlockNumberReq, opts ...grpc.CallOption) (*WorkerGetBlockNumberResp, error)
+	// Find the salt in [0, max_salts) whose CREATE2 smart-wallet address
+	// (under the given factory) matches target. The worker runs the scan +
+	// comparison locally so a wide range is a single round-trip. Used by the
+	// gateway's wallet-ownership validation (factory-upgrade fallback).
+	FindMatchingWalletSalt(ctx context.Context, in *WorkerFindMatchingWalletSaltReq, opts ...grpc.CallOption) (*WorkerFindMatchingWalletSaltResp, error)
 }
 
 type chainWorkerClient struct {
@@ -240,6 +246,16 @@ func (c *chainWorkerClient) GetBlockNumber(ctx context.Context, in *WorkerGetBlo
 	return out, nil
 }
 
+func (c *chainWorkerClient) FindMatchingWalletSalt(ctx context.Context, in *WorkerFindMatchingWalletSaltReq, opts ...grpc.CallOption) (*WorkerFindMatchingWalletSaltResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerFindMatchingWalletSaltResp)
+	err := c.cc.Invoke(ctx, ChainWorker_FindMatchingWalletSalt_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ChainWorkerServer is the server API for ChainWorker service.
 // All implementations must embed UnimplementedChainWorkerServer
 // for forward compatibility.
@@ -295,6 +311,11 @@ type ChainWorkerServer interface {
 	// Read the latest block number. Wraps ethclient.BlockNumber. Used by the
 	// immediate-trigger path to stamp the current block for the operator.
 	GetBlockNumber(context.Context, *WorkerGetBlockNumberReq) (*WorkerGetBlockNumberResp, error)
+	// Find the salt in [0, max_salts) whose CREATE2 smart-wallet address
+	// (under the given factory) matches target. The worker runs the scan +
+	// comparison locally so a wide range is a single round-trip. Used by the
+	// gateway's wallet-ownership validation (factory-upgrade fallback).
+	FindMatchingWalletSalt(context.Context, *WorkerFindMatchingWalletSaltReq) (*WorkerFindMatchingWalletSaltResp, error)
 	mustEmbedUnimplementedChainWorkerServer()
 }
 
@@ -346,6 +367,9 @@ func (UnimplementedChainWorkerServer) GetBlockHeader(context.Context, *WorkerGet
 }
 func (UnimplementedChainWorkerServer) GetBlockNumber(context.Context, *WorkerGetBlockNumberReq) (*WorkerGetBlockNumberResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetBlockNumber not implemented")
+}
+func (UnimplementedChainWorkerServer) FindMatchingWalletSalt(context.Context, *WorkerFindMatchingWalletSaltReq) (*WorkerFindMatchingWalletSaltResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FindMatchingWalletSalt not implemented")
 }
 func (UnimplementedChainWorkerServer) mustEmbedUnimplementedChainWorkerServer() {}
 func (UnimplementedChainWorkerServer) testEmbeddedByValue()                     {}
@@ -620,6 +644,24 @@ func _ChainWorker_GetBlockNumber_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ChainWorker_FindMatchingWalletSalt_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerFindMatchingWalletSaltReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).FindMatchingWalletSalt(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_FindMatchingWalletSalt_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).FindMatchingWalletSalt(ctx, req.(*WorkerFindMatchingWalletSaltReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ChainWorker_ServiceDesc is the grpc.ServiceDesc for ChainWorker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -682,6 +724,10 @@ var ChainWorker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetBlockNumber",
 			Handler:    _ChainWorker_GetBlockNumber_Handler,
+		},
+		{
+			MethodName: "FindMatchingWalletSalt",
+			Handler:    _ChainWorker_FindMatchingWalletSalt_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/worker/server.go
+++ b/worker/server.go
@@ -433,6 +433,58 @@ func (s *Server) GetBlockNumber(ctx context.Context, req *avsproto.WorkerGetBloc
 	return &avsproto.WorkerGetBlockNumberResp{Number: number}, nil
 }
 
+// maxWalletSaltScan caps the salt range FindMatchingWalletSalt will scan, so a
+// caller can't make the worker issue an unbounded number of factory calls.
+const maxWalletSaltScan = 2000
+
+// FindMatchingWalletSalt scans salts [0, max_salts) for the one whose CREATE2
+// smart-wallet address (under factory_address, or the worker's configured
+// factory) matches target_address. The loop + comparison run worker-side so a
+// wide range is a single round-trip. Returns found=false when no salt matches.
+func (s *Server) FindMatchingWalletSalt(ctx context.Context, req *avsproto.WorkerFindMatchingWalletSaltReq) (*avsproto.WorkerFindMatchingWalletSaltResp, error) {
+	if s.worker.smartWalletCfg == nil {
+		return nil, fmt.Errorf("smart wallet config not initialized")
+	}
+	if !common.IsHexAddress(req.Owner) {
+		return nil, fmt.Errorf("invalid owner address %q", req.Owner)
+	}
+	if !common.IsHexAddress(req.TargetAddress) {
+		return nil, fmt.Errorf("invalid target address %q", req.TargetAddress)
+	}
+	if req.MaxSalts <= 0 {
+		return nil, fmt.Errorf("max_salts must be positive, got %d", req.MaxSalts)
+	}
+	if req.MaxSalts > maxWalletSaltScan {
+		return nil, fmt.Errorf("max_salts %d exceeds cap %d", req.MaxSalts, maxWalletSaltScan)
+	}
+
+	factory := s.worker.smartWalletCfg.FactoryAddress
+	if req.FactoryAddress != "" {
+		if !common.IsHexAddress(req.FactoryAddress) {
+			return nil, fmt.Errorf("invalid factory address %q", req.FactoryAddress)
+		}
+		factory = common.HexToAddress(req.FactoryAddress)
+	}
+
+	owner := common.HexToAddress(req.Owner)
+	target := common.HexToAddress(req.TargetAddress)
+
+	for salt := int64(0); salt < req.MaxSalts; salt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		addr, err := aa.GetSenderAddressForFactory(s.worker.rpcClient, owner, factory, big.NewInt(salt))
+		if err != nil {
+			// A single failed derivation shouldn't abort the whole scan.
+			continue
+		}
+		if addr != nil && *addr == target {
+			return &avsproto.WorkerFindMatchingWalletSaltResp{Found: true, Salt: salt}, nil
+		}
+	}
+	return &avsproto.WorkerFindMatchingWalletSaltResp{Found: false}, nil
+}
+
 // GetBalance wraps ethclient.BalanceAt(addr, latest). Used by the gateway's
 // withdraw preflight to validate / size native-coin withdrawals.
 func (s *Server) GetBalance(ctx context.Context, req *avsproto.WorkerGetBalanceReq) (*avsproto.WorkerGetBalanceResp, error) {


### PR DESCRIPTION
## What

PR 1 of [`docs/changes/20260615-route-execution-layer-through-workers.md`](docs/changes/20260615-route-execution-layer-through-workers.md). Routes the gateway's **wallet-ownership validation** (CREATE2 derivation) off per-chain `ethclient.Dial` onto the chain worker.

## The salt-scan → server-side RPC

`validateDerivedWallet` brute-forces salts `0 … MaxWalletsPerOwner` (up to **2000**) comparing each derived address to a target. Per-salt gRPC routing would be 2000 round-trips, so this adds a **server-side scan RPC** (per the agreed approach):

- **`FindMatchingWalletSalt(owner, factory, target, max_salts) → (found, salt)`** — the worker runs the loop + comparison locally (capped at 2000); one round-trip regardless of range.

## Changes

- **`worker.proto` / `worker/server.go`**: `FindMatchingWalletSalt` handler.
- **`ChainStateReader`**: add `FindMatchingWalletSalt` (direct impl loops locally; worker-routed calls the RPC).
- **`executor.go`**: `validateWalletOwnership` Step 1 (default wallet) → `GetSmartWalletAddress` via the per-chain reader (using the **task's** chain factory, which also fixes a latent global-factory inconsistency in `LoadDefaultSmartWallet`); Step 3 `validateDerivedWallet` takes `chainID` and uses `FindMatchingWalletSalt`.
- **`run_node_immediately.go`**: the salts-0..4 runner check uses `FindMatchingWalletSalt(maxSalts=5)`.
- Each site keeps a **direct-dial + local-loop fallback** for single-chain mode / no reader.

## Testing

- `go build ./...`, `go vet`, gofmt clean.
- New `FindMatchingWalletSalt` reader tests (found + arg propagation, not-found); wallet-validation / run_node tests pass.

## Next

exec PR 2 — userop receipt waiting (`waitForUserOpConfirmation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
