### PR TITLE
feat: route userop receipt waiting through chain workers (exec 2)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -2,6 +2,7 @@ package taskengine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
@@ -86,6 +88,12 @@ type ChainStateReader interface {
 	// found=false when none matches. The worker-routed implementation runs
 	// the scan server-side so a wide range is a single round-trip.
 	FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (found bool, salt int64, err error)
+
+	// GetTransactionReceipt reads a tx receipt by hash. Returns (nil, nil)
+	// when the receipt isn't available yet (pending). Only the gas / status /
+	// block fields are populated — not logs. Mirrors
+	// ethclient.TransactionReceipt with NotFound mapped to a nil receipt.
+	GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 }
 
 // BlockHeader is the subset of block-header fields the gateway reads:
@@ -230,6 +238,14 @@ func (d *directChainStateReader) HeaderByNumber(ctx context.Context, number *big
 
 func (d *directChainStateReader) GetBlockNumber(ctx context.Context) (uint64, error) {
 	return d.client.BlockNumber(ctx)
+}
+
+func (d *directChainStateReader) GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	receipt, err := d.client.TransactionReceipt(ctx, txHash)
+	if errors.Is(err, ethereum.NotFound) {
+		return nil, nil
+	}
+	return receipt, err
 }
 
 func (d *directChainStateReader) FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (bool, int64, error) {
@@ -494,6 +510,31 @@ func (w *workerChainStateReader) GetBlockNumber(ctx context.Context) (uint64, er
 		return 0, fmt.Errorf("worker returned nil response for GetBlockNumber on chain %d", w.chainID)
 	}
 	return resp.Number, nil
+}
+
+func (w *workerChainStateReader) GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	resp, err := w.client.GetTransactionReceipt(ctx, &avsproto.WorkerGetTransactionReceiptReq{TxHash: txHash.Hex()})
+	if err != nil {
+		return nil, fmt.Errorf("worker GetTransactionReceipt (chain %d): %w", w.chainID, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("worker returned nil response for GetTransactionReceipt on chain %d", w.chainID)
+	}
+	if !resp.Found {
+		return nil, nil
+	}
+	receipt := &types.Receipt{
+		Status:      resp.Status,
+		GasUsed:     resp.GasUsed,
+		TxHash:      common.HexToHash(resp.TxHash),
+		BlockNumber: new(big.Int).SetUint64(resp.BlockNumber),
+	}
+	if egp, ok := new(big.Int).SetString(resp.EffectiveGasPrice, 10); ok {
+		receipt.EffectiveGasPrice = egp
+	}
+	return receipt, nil
 }
 
 func (w *workerChainStateReader) FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (bool, int64, error) {

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -72,6 +72,11 @@ type chainStateFakeClient struct {
 	findSaltReq  *avsproto.WorkerFindMatchingWalletSaltReq
 	findSaltResp *avsproto.WorkerFindMatchingWalletSaltResp
 	findSaltErr  error
+
+	// GetTransactionReceipt
+	getReceiptReq  *avsproto.WorkerGetTransactionReceiptReq
+	getReceiptResp *avsproto.WorkerGetTransactionReceiptResp
+	getReceiptErr  error
 }
 
 func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
@@ -101,6 +106,10 @@ func (f *chainStateFakeClient) GetBlockNumber(_ context.Context, _ *avsproto.Wor
 func (f *chainStateFakeClient) FindMatchingWalletSalt(_ context.Context, req *avsproto.WorkerFindMatchingWalletSaltReq, _ ...grpc.CallOption) (*avsproto.WorkerFindMatchingWalletSaltResp, error) {
 	f.findSaltReq = req
 	return f.findSaltResp, f.findSaltErr
+}
+func (f *chainStateFakeClient) GetTransactionReceipt(_ context.Context, req *avsproto.WorkerGetTransactionReceiptReq, _ ...grpc.CallOption) (*avsproto.WorkerGetTransactionReceiptResp, error) {
+	f.getReceiptReq = req
+	return f.getReceiptResp, f.getReceiptErr
 }
 func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
 	panic("unused")
@@ -762,5 +771,45 @@ func TestWorkerChainStateReader_FindMatchingWalletSalt_NotFound(t *testing.T) {
 	found, _, err := r.FindMatchingWalletSalt(context.Background(), common.HexToAddress("0xaa"), common.HexToAddress("0xbb"), common.HexToAddress("0xcc"), 5)
 	if err != nil || found {
 		t.Fatalf("expected not-found, no error; got found=%v err=%v", found, err)
+	}
+}
+
+// TestWorkerChainStateReader_GetTransactionReceipt: a found receipt maps its
+// gas/status/block fields; tx hash propagates.
+func TestWorkerChainStateReader_GetTransactionReceipt(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getReceiptResp: &avsproto.WorkerGetTransactionReceiptResp{
+			Found: true, Status: 1, GasUsed: 21000,
+			EffectiveGasPrice: "1500000000", BlockNumber: 19000000,
+			TxHash: "0xabc",
+		},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	txHash := common.HexToHash("0xdeadbeef")
+	receipt, err := r.GetTransactionReceipt(context.Background(), txHash)
+	if err != nil {
+		t.Fatalf("GetTransactionReceipt: %v", err)
+	}
+	if receipt == nil || receipt.Status != 1 || receipt.GasUsed != 21000 {
+		t.Fatalf("unexpected receipt %+v", receipt)
+	}
+	if receipt.EffectiveGasPrice == nil || receipt.EffectiveGasPrice.Cmp(big.NewInt(1500000000)) != 0 {
+		t.Fatalf("effective gas price not mapped: %v", receipt.EffectiveGasPrice)
+	}
+	if fake.getReceiptReq.TxHash != txHash.Hex() {
+		t.Fatalf("tx hash not propagated: %q", fake.getReceiptReq.TxHash)
+	}
+}
+
+// TestWorkerChainStateReader_GetTransactionReceipt_Pending: found=false maps
+// to (nil, nil) so the caller's polling loop keeps waiting.
+func TestWorkerChainStateReader_GetTransactionReceipt_Pending(t *testing.T) {
+	fake := &chainStateFakeClient{
+		getReceiptResp: &avsproto.WorkerGetTransactionReceiptResp{Found: false},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	receipt, err := r.GetTransactionReceipt(context.Background(), common.HexToHash("0xaa"))
+	if err != nil || receipt != nil {
+		t.Fatalf("pending should be (nil, nil); got receipt=%v err=%v", receipt, err)
 	}
 }

--- a/core/taskengine/vm_contract_write_waiting.go
+++ b/core/taskengine/vm_contract_write_waiting.go
@@ -2,16 +2,41 @@ package taskengine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/bundler"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
+
+// receiptForTx fetches a transaction receipt for the VM's chain via the
+// per-chain worker (gateway mode) when a reader is registered, falling back
+// to a direct dial otherwise. Returns (nil, nil) when the receipt isn't
+// available yet (pending).
+func (v *VM) receiptForTx(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	if v.smartWalletConfig == nil {
+		return nil, fmt.Errorf("smart wallet config not available")
+	}
+	if reader := GetChainStateReaderForChain(uint64(v.smartWalletConfig.ChainID)); reader != nil {
+		return reader.GetTransactionReceipt(ctx, txHash)
+	}
+	client, err := ethclient.Dial(v.smartWalletConfig.EthRpcUrl)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+	receipt, err := client.TransactionReceipt(ctx, txHash)
+	if errors.Is(err, ethereum.NotFound) {
+		return nil, nil
+	}
+	return receipt, err
+}
 
 // shouldWaitForContractWriteConfirmation checks if a contract_write execution step requires waiting for on-chain confirmation
 // This is true when:
@@ -86,13 +111,6 @@ func (v *VM) waitForUserOpConfirmation(userOpHash string) (*waitForUserOpConfirm
 		return nil, fmt.Errorf("smart wallet config not available for UserOp confirmation")
 	}
 
-	// Create eth client
-	client, err := ethclient.Dial(v.smartWalletConfig.EthRpcUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to RPC: %w", err)
-	}
-	defer client.Close()
-
 	// Create bundler client
 	bundlerClient, err := bundler.NewBundlerClient(v.smartWalletConfig.BundlerURL)
 	if err != nil {
@@ -143,7 +161,7 @@ func (v *VM) waitForUserOpConfirmation(userOpHash string) (*waitForUserOpConfirm
 			result := &waitForUserOpConfirmationResult{TxHash: txHash}
 			if txHash != "" {
 				receiptCtx, receiptCancel := context.WithTimeout(context.Background(), 30*time.Second)
-				onChainReceipt, receiptErr := client.TransactionReceipt(receiptCtx, common.HexToHash(txHash))
+				onChainReceipt, receiptErr := v.receiptForTx(receiptCtx, common.HexToHash(txHash))
 				receiptCancel()
 				if receiptErr == nil && onChainReceipt != nil {
 					result.Receipt = onChainReceipt
@@ -173,37 +191,6 @@ func (v *VM) waitForUserOpConfirmation(userOpHash string) (*waitForUserOpConfirm
 		// Wait before next retry
 		time.Sleep(currentInterval)
 	}
-}
-
-// getReceiptByUserOpHash queries the EntryPoint contract for UserOperation events to find the transaction receipt
-// This is a fallback method when the bundler doesn't provide the receipt directly
-func (v *VM) getReceiptByUserOpHash(userOpHash string) (*types.Receipt, error) {
-	if v.smartWalletConfig == nil {
-		return nil, fmt.Errorf("smart wallet config not available")
-	}
-
-	client, err := ethclient.Dial(v.smartWalletConfig.EthRpcUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to RPC: %w", err)
-	}
-	defer client.Close()
-
-	// This method is currently unused - we rely on bundler.GetUserOperationReceipt instead
-	// Keeping this as a placeholder for future implementation if needed
-
-	// In a real implementation, you would query eth_getLogs with UserOperationEvent signature
-	// and search for the matching userOpHash in recent blocks
-
-	// In a real implementation, you would:
-	// 1. Query eth_getLogs with UserOperationEvent signature
-	// 2. Parse the logs to find the matching userOpHash
-	// 3. Extract the transaction hash from the log
-	// 4. Get the receipt using eth_getTransactionReceipt
-
-	// For now, we rely on the bundler's GetUserOperationReceipt method
-	// which is called in waitForUserOpConfirmation
-
-	return nil, fmt.Errorf("receipt not found (use bundler.GetUserOperationReceipt instead)")
 }
 
 // waitForOnChainConfirmationIfNeeded is the single entry point for receipt-waiting logic.

--- a/core/taskengine/worker_token_fetcher_test.go
+++ b/core/taskengine/worker_token_fetcher_test.go
@@ -75,6 +75,9 @@ func (f *fakeChainWorkerClient) GetBlockNumber(context.Context, *avsproto.Worker
 func (f *fakeChainWorkerClient) FindMatchingWalletSalt(context.Context, *avsproto.WorkerFindMatchingWalletSaltReq, ...grpc.CallOption) (*avsproto.WorkerFindMatchingWalletSaltResp, error) {
 	panic("unused")
 }
+func (f *fakeChainWorkerClient) GetTransactionReceipt(context.Context, *avsproto.WorkerGetTransactionReceiptReq, ...grpc.CallOption) (*avsproto.WorkerGetTransactionReceiptResp, error) {
+	panic("unused")
+}
 
 // TestWorkerRoutedFetcher_HappyPath confirms a successful worker response
 // gets mapped to a TokenMetadata correctly — name, symbol, decimals, source

--- a/docs/changes/20260615-route-execution-layer-through-workers.md
+++ b/docs/changes/20260615-route-execution-layer-through-workers.md
@@ -65,11 +65,17 @@ dials follow the same model, reusing existing worker RPCs where possible:
    path sets `user.SmartAccountAddress` from the worker-derived address
    (using the task's per-chain factory, fixing the latent global-factory
    inconsistency).
-2. **PR 2 — userop receipt waiting.** Migrate `waitForUserOpConfirmation`.
-   First check whether gateway-mode sends (via `ExecuteUserOp`) already
-   return a confirmed receipt, making the separate wait redundant; if not,
-   add a `GetTransactionReceipt` worker RPC. Removes 2 live dials + the
-   per-chain bundler dependency in this path.
+2. **PR 2 — userop receipt waiting (delivered).** `waitForUserOpConfirmation`
+   is a real pending-receipt poll (reachable when a send returns "pending"),
+   so it was migrated rather than dropped: added a `GetTransactionReceipt`
+   worker RPC (gas/status/block fields; `found=false` → pending) + a
+   `ChainStateReader.GetTransactionReceipt` (NotFound → `(nil, nil)`). The
+   single `client.TransactionReceipt` call now goes through `v.receiptForTx`
+   (per-chain reader, direct-dial fallback), removing the function's
+   top-level chain dial. Deleted the dead `getReceiptByUserOpHash`
+   placeholder (it dialed then returned an error without using the client).
+   The bundler poll (`bundler.GetUserOperationReceipt`) stays — bundler
+   routing is a separate concern from chain RPC.
 3. **PR 3 — simulation state overrides.** Resolve `InjectERC20BalanceChange`
    — either supply the balance override through Tenderly's `state_objects`
    directly (no chain read), or add a worker `GetStorageAt` RPC. Removes

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -1587,6 +1587,135 @@ func (x *WorkerFindMatchingWalletSaltResp) GetSalt() int64 {
 	return 0
 }
 
+// Transaction receipt (the subset of fields the gateway reads)
+type WorkerGetTransactionReceiptReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TxHash        string                 `protobuf:"bytes,1,opt,name=tx_hash,json=txHash,proto3" json:"tx_hash,omitempty"` // 0x-prefixed transaction hash.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetTransactionReceiptReq) Reset() {
+	*x = WorkerGetTransactionReceiptReq{}
+	mi := &file_worker_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetTransactionReceiptReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetTransactionReceiptReq) ProtoMessage() {}
+
+func (x *WorkerGetTransactionReceiptReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetTransactionReceiptReq.ProtoReflect.Descriptor instead.
+func (*WorkerGetTransactionReceiptReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *WorkerGetTransactionReceiptReq) GetTxHash() string {
+	if x != nil {
+		return x.TxHash
+	}
+	return ""
+}
+
+type WorkerGetTransactionReceiptResp struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Found             bool                   `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`   // false when not yet available (pending).
+	Status            uint64                 `protobuf:"varint,2,opt,name=status,proto3" json:"status,omitempty"` // 1 = success, 0 = reverted.
+	GasUsed           uint64                 `protobuf:"varint,3,opt,name=gas_used,json=gasUsed,proto3" json:"gas_used,omitempty"`
+	EffectiveGasPrice string                 `protobuf:"bytes,4,opt,name=effective_gas_price,json=effectiveGasPrice,proto3" json:"effective_gas_price,omitempty"` // wei (big.Int as string).
+	BlockNumber       uint64                 `protobuf:"varint,5,opt,name=block_number,json=blockNumber,proto3" json:"block_number,omitempty"`
+	TxHash            string                 `protobuf:"bytes,6,opt,name=tx_hash,json=txHash,proto3" json:"tx_hash,omitempty"` // 0x-prefixed.
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *WorkerGetTransactionReceiptResp) Reset() {
+	*x = WorkerGetTransactionReceiptResp{}
+	mi := &file_worker_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetTransactionReceiptResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetTransactionReceiptResp) ProtoMessage() {}
+
+func (x *WorkerGetTransactionReceiptResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetTransactionReceiptResp.ProtoReflect.Descriptor instead.
+func (*WorkerGetTransactionReceiptResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *WorkerGetTransactionReceiptResp) GetFound() bool {
+	if x != nil {
+		return x.Found
+	}
+	return false
+}
+
+func (x *WorkerGetTransactionReceiptResp) GetStatus() uint64 {
+	if x != nil {
+		return x.Status
+	}
+	return 0
+}
+
+func (x *WorkerGetTransactionReceiptResp) GetGasUsed() uint64 {
+	if x != nil {
+		return x.GasUsed
+	}
+	return 0
+}
+
+func (x *WorkerGetTransactionReceiptResp) GetEffectiveGasPrice() string {
+	if x != nil {
+		return x.EffectiveGasPrice
+	}
+	return ""
+}
+
+func (x *WorkerGetTransactionReceiptResp) GetBlockNumber() uint64 {
+	if x != nil {
+		return x.BlockNumber
+	}
+	return 0
+}
+
+func (x *WorkerGetTransactionReceiptResp) GetTxHash() string {
+	if x != nil {
+		return x.TxHash
+	}
+	return ""
+}
+
 var File_worker_proto protoreflect.FileDescriptor
 
 const file_worker_proto_rawDesc = "" +
@@ -1691,8 +1820,16 @@ const file_worker_proto_rawDesc = "" +
 	"\tmax_salts\x18\x04 \x01(\x03R\bmaxSalts\"L\n" +
 	" WorkerFindMatchingWalletSaltResp\x12\x14\n" +
 	"\x05found\x18\x01 \x01(\bR\x05found\x12\x12\n" +
-	"\x04salt\x18\x02 \x01(\x03R\x04salt2\xe5\n" +
-	"\n" +
+	"\x04salt\x18\x02 \x01(\x03R\x04salt\"9\n" +
+	"\x1eWorkerGetTransactionReceiptReq\x12\x17\n" +
+	"\atx_hash\x18\x01 \x01(\tR\x06txHash\"\xd6\x01\n" +
+	"\x1fWorkerGetTransactionReceiptResp\x12\x14\n" +
+	"\x05found\x18\x01 \x01(\bR\x05found\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\x04R\x06status\x12\x19\n" +
+	"\bgas_used\x18\x03 \x01(\x04R\agasUsed\x12.\n" +
+	"\x13effective_gas_price\x18\x04 \x01(\tR\x11effectiveGasPrice\x12!\n" +
+	"\fblock_number\x18\x05 \x01(\x04R\vblockNumber\x12\x17\n" +
+	"\atx_hash\x18\x06 \x01(\tR\x06txHash2\xd7\v\n" +
 	"\vChainWorker\x12X\n" +
 	"\x11WorkerHealthCheck\x12 .aggregator.WorkerHealthCheckReq\x1a!.aggregator.WorkerHealthCheckResp\x12L\n" +
 	"\rExecuteUserOp\x12\x1c.aggregator.ExecuteUserOpReq\x1a\x1d.aggregator.ExecuteUserOpResp\x12I\n" +
@@ -1709,7 +1846,8 @@ const file_worker_proto_rawDesc = "" +
 	"\fCallContract\x12!.aggregator.WorkerCallContractReq\x1a\".aggregator.WorkerCallContractResp\x12[\n" +
 	"\x0eGetBlockHeader\x12#.aggregator.WorkerGetBlockHeaderReq\x1a$.aggregator.WorkerGetBlockHeaderResp\x12[\n" +
 	"\x0eGetBlockNumber\x12#.aggregator.WorkerGetBlockNumberReq\x1a$.aggregator.WorkerGetBlockNumberResp\x12s\n" +
-	"\x16FindMatchingWalletSalt\x12+.aggregator.WorkerFindMatchingWalletSaltReq\x1a,.aggregator.WorkerFindMatchingWalletSaltRespB\fZ\n" +
+	"\x16FindMatchingWalletSalt\x12+.aggregator.WorkerFindMatchingWalletSaltReq\x1a,.aggregator.WorkerFindMatchingWalletSaltResp\x12p\n" +
+	"\x15GetTransactionReceipt\x12*.aggregator.WorkerGetTransactionReceiptReq\x1a+.aggregator.WorkerGetTransactionReceiptRespB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (
@@ -1724,7 +1862,7 @@ func file_worker_proto_rawDescGZIP() []byte {
 	return file_worker_proto_rawDescData
 }
 
-var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_worker_proto_goTypes = []any{
 	(*WorkerHealthCheckReq)(nil),             // 0: aggregator.WorkerHealthCheckReq
 	(*WorkerHealthCheckResp)(nil),            // 1: aggregator.WorkerHealthCheckResp
@@ -1755,6 +1893,8 @@ var file_worker_proto_goTypes = []any{
 	(*WorkerGetBlockNumberResp)(nil),         // 26: aggregator.WorkerGetBlockNumberResp
 	(*WorkerFindMatchingWalletSaltReq)(nil),  // 27: aggregator.WorkerFindMatchingWalletSaltReq
 	(*WorkerFindMatchingWalletSaltResp)(nil), // 28: aggregator.WorkerFindMatchingWalletSaltResp
+	(*WorkerGetTransactionReceiptReq)(nil),   // 29: aggregator.WorkerGetTransactionReceiptReq
+	(*WorkerGetTransactionReceiptResp)(nil),  // 30: aggregator.WorkerGetTransactionReceiptResp
 }
 var file_worker_proto_depIdxs = []int32{
 	0,  // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
@@ -1772,23 +1912,25 @@ var file_worker_proto_depIdxs = []int32{
 	23, // 12: aggregator.ChainWorker.GetBlockHeader:input_type -> aggregator.WorkerGetBlockHeaderReq
 	25, // 13: aggregator.ChainWorker.GetBlockNumber:input_type -> aggregator.WorkerGetBlockNumberReq
 	27, // 14: aggregator.ChainWorker.FindMatchingWalletSalt:input_type -> aggregator.WorkerFindMatchingWalletSaltReq
-	1,  // 15: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
-	3,  // 16: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
-	5,  // 17: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
-	7,  // 18: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
-	9,  // 19: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
-	5,  // 20: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
-	12, // 21: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
-	14, // 22: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
-	16, // 23: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
-	18, // 24: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
-	20, // 25: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
-	22, // 26: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
-	24, // 27: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
-	26, // 28: aggregator.ChainWorker.GetBlockNumber:output_type -> aggregator.WorkerGetBlockNumberResp
-	28, // 29: aggregator.ChainWorker.FindMatchingWalletSalt:output_type -> aggregator.WorkerFindMatchingWalletSaltResp
-	15, // [15:30] is the sub-list for method output_type
-	0,  // [0:15] is the sub-list for method input_type
+	29, // 15: aggregator.ChainWorker.GetTransactionReceipt:input_type -> aggregator.WorkerGetTransactionReceiptReq
+	1,  // 16: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
+	3,  // 17: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
+	5,  // 18: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
+	7,  // 19: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
+	9,  // 20: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
+	5,  // 21: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
+	12, // 22: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
+	14, // 23: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
+	16, // 24: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
+	18, // 25: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
+	20, // 26: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
+	22, // 27: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
+	24, // 28: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
+	26, // 29: aggregator.ChainWorker.GetBlockNumber:output_type -> aggregator.WorkerGetBlockNumberResp
+	28, // 30: aggregator.ChainWorker.FindMatchingWalletSalt:output_type -> aggregator.WorkerFindMatchingWalletSaltResp
+	30, // 31: aggregator.ChainWorker.GetTransactionReceipt:output_type -> aggregator.WorkerGetTransactionReceiptResp
+	16, // [16:32] is the sub-list for method output_type
+	0,  // [0:16] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -1805,7 +1947,7 @@ func file_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -73,6 +73,11 @@ service ChainWorker {
   // comparison locally so a wide range is a single round-trip. Used by the
   // gateway's wallet-ownership validation (factory-upgrade fallback).
   rpc FindMatchingWalletSalt(WorkerFindMatchingWalletSaltReq) returns (WorkerFindMatchingWalletSaltResp);
+
+  // Read a transaction receipt by hash. Wraps ethclient.TransactionReceipt.
+  // found=false when the receipt isn't available yet (pending). Used by the
+  // gateway's userop confirmation-waiting to backfill gas data.
+  rpc GetTransactionReceipt(WorkerGetTransactionReceiptReq) returns (WorkerGetTransactionReceiptResp);
 }
 
 // Health check
@@ -242,4 +247,18 @@ message WorkerFindMatchingWalletSaltReq {
 message WorkerFindMatchingWalletSaltResp {
   bool found = 1;
   int64 salt = 2;              // The matching salt; valid only when found.
+}
+
+// Transaction receipt (the subset of fields the gateway reads)
+message WorkerGetTransactionReceiptReq {
+  string tx_hash = 1;          // 0x-prefixed transaction hash.
+}
+
+message WorkerGetTransactionReceiptResp {
+  bool found = 1;                 // false when not yet available (pending).
+  uint64 status = 2;             // 1 = success, 0 = reverted.
+  uint64 gas_used = 3;
+  string effective_gas_price = 4; // wei (big.Int as string).
+  uint64 block_number = 5;
+  string tx_hash = 6;            // 0x-prefixed.
 }

--- a/protobuf/worker_grpc.pb.go
+++ b/protobuf/worker_grpc.pb.go
@@ -34,6 +34,7 @@ const (
 	ChainWorker_GetBlockHeader_FullMethodName         = "/aggregator.ChainWorker/GetBlockHeader"
 	ChainWorker_GetBlockNumber_FullMethodName         = "/aggregator.ChainWorker/GetBlockNumber"
 	ChainWorker_FindMatchingWalletSalt_FullMethodName = "/aggregator.ChainWorker/FindMatchingWalletSalt"
+	ChainWorker_GetTransactionReceipt_FullMethodName  = "/aggregator.ChainWorker/GetTransactionReceipt"
 )
 
 // ChainWorkerClient is the client API for ChainWorker service.
@@ -96,6 +97,10 @@ type ChainWorkerClient interface {
 	// comparison locally so a wide range is a single round-trip. Used by the
 	// gateway's wallet-ownership validation (factory-upgrade fallback).
 	FindMatchingWalletSalt(ctx context.Context, in *WorkerFindMatchingWalletSaltReq, opts ...grpc.CallOption) (*WorkerFindMatchingWalletSaltResp, error)
+	// Read a transaction receipt by hash. Wraps ethclient.TransactionReceipt.
+	// found=false when the receipt isn't available yet (pending). Used by the
+	// gateway's userop confirmation-waiting to backfill gas data.
+	GetTransactionReceipt(ctx context.Context, in *WorkerGetTransactionReceiptReq, opts ...grpc.CallOption) (*WorkerGetTransactionReceiptResp, error)
 }
 
 type chainWorkerClient struct {
@@ -256,6 +261,16 @@ func (c *chainWorkerClient) FindMatchingWalletSalt(ctx context.Context, in *Work
 	return out, nil
 }
 
+func (c *chainWorkerClient) GetTransactionReceipt(ctx context.Context, in *WorkerGetTransactionReceiptReq, opts ...grpc.CallOption) (*WorkerGetTransactionReceiptResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerGetTransactionReceiptResp)
+	err := c.cc.Invoke(ctx, ChainWorker_GetTransactionReceipt_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ChainWorkerServer is the server API for ChainWorker service.
 // All implementations must embed UnimplementedChainWorkerServer
 // for forward compatibility.
@@ -316,6 +331,10 @@ type ChainWorkerServer interface {
 	// comparison locally so a wide range is a single round-trip. Used by the
 	// gateway's wallet-ownership validation (factory-upgrade fallback).
 	FindMatchingWalletSalt(context.Context, *WorkerFindMatchingWalletSaltReq) (*WorkerFindMatchingWalletSaltResp, error)
+	// Read a transaction receipt by hash. Wraps ethclient.TransactionReceipt.
+	// found=false when the receipt isn't available yet (pending). Used by the
+	// gateway's userop confirmation-waiting to backfill gas data.
+	GetTransactionReceipt(context.Context, *WorkerGetTransactionReceiptReq) (*WorkerGetTransactionReceiptResp, error)
 	mustEmbedUnimplementedChainWorkerServer()
 }
 
@@ -370,6 +389,9 @@ func (UnimplementedChainWorkerServer) GetBlockNumber(context.Context, *WorkerGet
 }
 func (UnimplementedChainWorkerServer) FindMatchingWalletSalt(context.Context, *WorkerFindMatchingWalletSaltReq) (*WorkerFindMatchingWalletSaltResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FindMatchingWalletSalt not implemented")
+}
+func (UnimplementedChainWorkerServer) GetTransactionReceipt(context.Context, *WorkerGetTransactionReceiptReq) (*WorkerGetTransactionReceiptResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetTransactionReceipt not implemented")
 }
 func (UnimplementedChainWorkerServer) mustEmbedUnimplementedChainWorkerServer() {}
 func (UnimplementedChainWorkerServer) testEmbeddedByValue()                     {}
@@ -662,6 +684,24 @@ func _ChainWorker_FindMatchingWalletSalt_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ChainWorker_GetTransactionReceipt_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerGetTransactionReceiptReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).GetTransactionReceipt(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_GetTransactionReceipt_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).GetTransactionReceipt(ctx, req.(*WorkerGetTransactionReceiptReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ChainWorker_ServiceDesc is the grpc.ServiceDesc for ChainWorker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -728,6 +768,10 @@ var ChainWorker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "FindMatchingWalletSalt",
 			Handler:    _ChainWorker_FindMatchingWalletSalt_Handler,
+		},
+		{
+			MethodName: "GetTransactionReceipt",
+			Handler:    _ChainWorker_GetTransactionReceipt_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/worker/server.go
+++ b/worker/server.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -483,6 +484,32 @@ func (s *Server) FindMatchingWalletSalt(ctx context.Context, req *avsproto.Worke
 		}
 	}
 	return &avsproto.WorkerFindMatchingWalletSaltResp{Found: false}, nil
+}
+
+// GetTransactionReceipt wraps ethclient.TransactionReceipt. found=false (not
+// an error) when the receipt isn't available yet (pending / unknown hash),
+// so the gateway's confirmation-waiting loop can keep polling.
+func (s *Server) GetTransactionReceipt(ctx context.Context, req *avsproto.WorkerGetTransactionReceiptReq) (*avsproto.WorkerGetTransactionReceiptResp, error) {
+	receipt, err := s.worker.rpcClient.TransactionReceipt(ctx, common.HexToHash(req.TxHash))
+	if errors.Is(err, ethereum.NotFound) {
+		return &avsproto.WorkerGetTransactionReceiptResp{Found: false}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("TransactionReceipt for %s: %w", req.TxHash, err)
+	}
+	resp := &avsproto.WorkerGetTransactionReceiptResp{
+		Found:   true,
+		Status:  receipt.Status,
+		GasUsed: receipt.GasUsed,
+		TxHash:  receipt.TxHash.Hex(),
+	}
+	if receipt.EffectiveGasPrice != nil {
+		resp.EffectiveGasPrice = receipt.EffectiveGasPrice.String()
+	}
+	if receipt.BlockNumber != nil {
+		resp.BlockNumber = receipt.BlockNumber.Uint64()
+	}
+	return resp, nil
 }
 
 // GetBalance wraps ethclient.BalanceAt(addr, latest). Used by the gateway's


### PR DESCRIPTION
## What

PR 2 of [`docs/changes/20260615-route-execution-layer-through-workers.md`](docs/changes/20260615-route-execution-layer-through-workers.md). Routes the userop **receipt-waiting** poll off a direct per-chain dial onto the chain worker.

`waitForUserOpConfirmation` is a real fallback (it polls for the on-chain receipt when a send returns "pending"), so it's migrated, not dropped.

## Changes

- **`worker.proto` / `worker/server.go`**: `GetTransactionReceipt(tx_hash) → (found, status, gas_used, effective_gas_price, block_number, tx_hash)`. `found=false` (not an error) when the receipt isn't available yet, so the gateway's polling loop keeps waiting.
- **`ChainStateReader`**: `GetTransactionReceipt` — `ethereum.NotFound` → `(nil, nil)`; only gas/status/block fields populated (no logs). Direct + worker-routed impls.
- **`vm_contract_write_waiting.go`**: new `VM.receiptForTx` resolves the per-chain reader (worker-routed in gateway mode) with a direct-dial fallback; `waitForUserOpConfirmation` uses it, dropping its top-level chain dial. The bundler poll (`bundler.GetUserOperationReceipt`) is unchanged — bundler routing is a separate concern.
- **Deleted** the dead `getReceiptByUserOpHash` placeholder (it dialed then returned an error without using the client).

## Testing

- `go build ./...`, `go vet`, gofmt clean.
- New `GetTransactionReceipt` reader tests (found field-mapping + pending→nil); contractWrite / wallet tests pass.

## Next

exec PR 3 — `InjectERC20BalanceChange` (Tenderly state-override storage probe), then PR 4 (env-var strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
