### PR TITLE
feat: route simulation balance-slot probing through chain workers (exec 3)

### DIFF
--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -94,6 +94,10 @@ type ChainStateReader interface {
 	// block fields are populated — not logs. Mirrors
 	// ethclient.TransactionReceipt with NotFound mapped to a nil receipt.
 	GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+
+	// GetStorageAt reads a contract storage slot (latest block). Mirrors
+	// ethclient.StorageAt.
+	GetStorageAt(ctx context.Context, account common.Address, slot common.Hash) ([]byte, error)
 }
 
 // BlockHeader is the subset of block-header fields the gateway reads:
@@ -246,6 +250,10 @@ func (d *directChainStateReader) GetTransactionReceipt(ctx context.Context, txHa
 		return nil, nil
 	}
 	return receipt, err
+}
+
+func (d *directChainStateReader) GetStorageAt(ctx context.Context, account common.Address, slot common.Hash) ([]byte, error) {
+	return d.client.StorageAt(ctx, account, slot, nil)
 }
 
 func (d *directChainStateReader) FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (bool, int64, error) {
@@ -535,6 +543,22 @@ func (w *workerChainStateReader) GetTransactionReceipt(ctx context.Context, txHa
 		receipt.EffectiveGasPrice = egp
 	}
 	return receipt, nil
+}
+
+func (w *workerChainStateReader) GetStorageAt(ctx context.Context, account common.Address, slot common.Hash) ([]byte, error) {
+	ctx, cancel := w.withTimeout(ctx)
+	defer cancel()
+	resp, err := w.client.GetStorageAt(ctx, &avsproto.WorkerGetStorageAtReq{
+		Address: account.Hex(),
+		Slot:    slot.Hex(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("worker GetStorageAt (chain %d): %w", w.chainID, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("worker returned nil response for GetStorageAt on chain %d", w.chainID)
+	}
+	return resp.Value, nil
 }
 
 func (w *workerChainStateReader) FindMatchingWalletSalt(ctx context.Context, owner, factory, target common.Address, maxSalts int64) (bool, int64, error) {

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -77,6 +77,11 @@ type chainStateFakeClient struct {
 	getReceiptReq  *avsproto.WorkerGetTransactionReceiptReq
 	getReceiptResp *avsproto.WorkerGetTransactionReceiptResp
 	getReceiptErr  error
+
+	// GetStorageAt
+	getStorageReq  *avsproto.WorkerGetStorageAtReq
+	getStorageResp *avsproto.WorkerGetStorageAtResp
+	getStorageErr  error
 }
 
 func (f *chainStateFakeClient) WorkerHealthCheck(context.Context, *avsproto.WorkerHealthCheckReq, ...grpc.CallOption) (*avsproto.WorkerHealthCheckResp, error) {
@@ -110,6 +115,10 @@ func (f *chainStateFakeClient) FindMatchingWalletSalt(_ context.Context, req *av
 func (f *chainStateFakeClient) GetTransactionReceipt(_ context.Context, req *avsproto.WorkerGetTransactionReceiptReq, _ ...grpc.CallOption) (*avsproto.WorkerGetTransactionReceiptResp, error) {
 	f.getReceiptReq = req
 	return f.getReceiptResp, f.getReceiptErr
+}
+func (f *chainStateFakeClient) GetStorageAt(_ context.Context, req *avsproto.WorkerGetStorageAtReq, _ ...grpc.CallOption) (*avsproto.WorkerGetStorageAtResp, error) {
+	f.getStorageReq = req
+	return f.getStorageResp, f.getStorageErr
 }
 func (f *chainStateFakeClient) GetTokenMetadata(context.Context, *avsproto.WorkerGetTokenMetadataReq, ...grpc.CallOption) (*avsproto.WorkerGetTokenMetadataResp, error) {
 	panic("unused")
@@ -811,5 +820,27 @@ func TestWorkerChainStateReader_GetTransactionReceipt_Pending(t *testing.T) {
 	receipt, err := r.GetTransactionReceipt(context.Background(), common.HexToHash("0xaa"))
 	if err != nil || receipt != nil {
 		t.Fatalf("pending should be (nil, nil); got receipt=%v err=%v", receipt, err)
+	}
+}
+
+// TestWorkerChainStateReader_GetStorageAt: address/slot are hex-encoded;
+// the raw 32-byte value round-trips.
+func TestWorkerChainStateReader_GetStorageAt(t *testing.T) {
+	want := []byte{0xde, 0xad, 0xbe, 0xef}
+	fake := &chainStateFakeClient{
+		getStorageResp: &avsproto.WorkerGetStorageAtResp{Value: want},
+	}
+	r := NewWorkerChainStateReader(fake, 1, time.Second)
+	addr := common.HexToAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238")
+	slot := common.HexToHash("0x09")
+	got, err := r.GetStorageAt(context.Background(), addr, slot)
+	if err != nil {
+		t.Fatalf("GetStorageAt: %v", err)
+	}
+	if len(got) != 4 || got[0] != 0xde {
+		t.Fatalf("unexpected value %x", got)
+	}
+	if fake.getStorageReq.Address != addr.Hex() || fake.getStorageReq.Slot != slot.Hex() {
+		t.Fatalf("args not propagated: %+v", fake.getStorageReq)
 	}
 }

--- a/core/taskengine/simulation_state.go
+++ b/core/taskengine/simulation_state.go
@@ -181,7 +181,7 @@ var commonAllowanceSlots = []int64{1, 2, 3, 10}
 // Returns the slot index, or an error if no match is found.
 func (s *SimulationStateMap) ProbeERC20BalanceSlot(
 	ctx context.Context,
-	rpcURL string,
+	reader ChainStateReader,
 	tokenContract common.Address,
 	holder common.Address,
 ) (int64, error) {
@@ -198,17 +198,11 @@ func (s *SimulationStateMap) ProbeERC20BalanceSlot(
 		return *cached, nil
 	}
 
-	client, err := ethclient.DialContext(ctx, rpcURL)
-	if err != nil {
-		return -1, fmt.Errorf("failed to connect to RPC for slot probing: %w", err)
-	}
-	defer client.Close()
-
 	// Call balanceOf(holder) to get the expected value
 	balanceOfSig := crypto.Keccak256([]byte("balanceOf(address)"))[:4]
 	callData := append(balanceOfSig, common.LeftPadBytes(holder.Bytes(), 32)...)
 
-	result, err := client.CallContract(ctx, ethereum.CallMsg{
+	result, err := reader.CallContract(ctx, ethereum.CallMsg{
 		To:   &tokenContract,
 		Data: callData,
 	}, nil)
@@ -225,7 +219,7 @@ func (s *SimulationStateMap) ProbeERC20BalanceSlot(
 	if expectedBalance.Sign() > 0 {
 		for _, candidateSlot := range commonBalanceSlots {
 			slotHash := erc20BalanceSlot(holder, candidateSlot)
-			storageValue, err := client.StorageAt(ctx, tokenContract, slotHash, nil)
+			storageValue, err := reader.GetStorageAt(ctx, tokenContract, slotHash)
 			if err != nil {
 				continue
 			}
@@ -264,7 +258,7 @@ func (s *SimulationStateMap) ProbeERC20BalanceSlot(
 
 		for _, refAddr := range referenceAddresses {
 			refCallData := append(crypto.Keccak256([]byte("balanceOf(address)"))[:4], common.LeftPadBytes(refAddr.Bytes(), 32)...)
-			refResult, err := client.CallContract(ctx, ethereum.CallMsg{To: &tokenContract, Data: refCallData}, nil)
+			refResult, err := reader.CallContract(ctx, ethereum.CallMsg{To: &tokenContract, Data: refCallData}, nil)
 			if err != nil {
 				continue
 			}
@@ -276,7 +270,7 @@ func (s *SimulationStateMap) ProbeERC20BalanceSlot(
 			// Found a reference holder with balance — probe slots against it
 			for _, candidateSlot := range commonBalanceSlots {
 				slotHash := erc20BalanceSlot(refAddr, candidateSlot)
-				storageValue, err := client.StorageAt(ctx, tokenContract, slotHash, nil)
+				storageValue, err := reader.GetStorageAt(ctx, tokenContract, slotHash)
 				if err != nil {
 					continue
 				}
@@ -328,29 +322,36 @@ func (s *SimulationStateMap) InjectERC20BalanceChange(
 	holder common.Address,
 	delta *big.Int,
 ) error {
-	if smartWalletConfig == nil || smartWalletConfig.EthRpcUrl == "" {
-		return fmt.Errorf("no RPC URL available for ERC20 balance probing")
+	if smartWalletConfig == nil {
+		return fmt.Errorf("no smart wallet config available for ERC20 balance probing")
 	}
 
-	rpcURL := smartWalletConfig.EthRpcUrl
+	// Resolve the per-chain reader (worker-routed in gateway mode); fall back
+	// to a direct dial only when no reader is registered.
+	reader := GetChainStateReaderForChain(uint64(smartWalletConfig.ChainID))
+	if reader == nil {
+		if smartWalletConfig.EthRpcUrl == "" {
+			return fmt.Errorf("no chain-state reader or RPC URL available for ERC20 balance probing")
+		}
+		client, dialErr := ethclient.DialContext(ctx, smartWalletConfig.EthRpcUrl)
+		if dialErr != nil {
+			return fmt.Errorf("failed to connect to RPC: %w", dialErr)
+		}
+		defer client.Close()
+		reader = NewDirectChainStateReader(client, smartWalletConfig.ChainID)
+	}
 
 	// Discover the balance mapping slot
-	mappingSlot, err := s.ProbeERC20BalanceSlot(ctx, rpcURL, tokenContract, holder)
+	mappingSlot, err := s.ProbeERC20BalanceSlot(ctx, reader, tokenContract, holder)
 	if err != nil {
 		return fmt.Errorf("failed to probe balance slot: %w", err)
 	}
 
 	// Get current on-chain balance
-	client, err := ethclient.DialContext(ctx, rpcURL)
-	if err != nil {
-		return fmt.Errorf("failed to connect to RPC: %w", err)
-	}
-	defer client.Close()
-
 	balanceOfSig := crypto.Keccak256([]byte("balanceOf(address)"))[:4]
 	callData := append(balanceOfSig, common.LeftPadBytes(holder.Bytes(), 32)...)
 
-	result, err := client.CallContract(ctx, ethereum.CallMsg{
+	result, err := reader.CallContract(ctx, ethereum.CallMsg{
 		To:   &tokenContract,
 		Data: callData,
 	}, nil)

--- a/core/taskengine/worker_token_fetcher_test.go
+++ b/core/taskengine/worker_token_fetcher_test.go
@@ -78,6 +78,9 @@ func (f *fakeChainWorkerClient) FindMatchingWalletSalt(context.Context, *avsprot
 func (f *fakeChainWorkerClient) GetTransactionReceipt(context.Context, *avsproto.WorkerGetTransactionReceiptReq, ...grpc.CallOption) (*avsproto.WorkerGetTransactionReceiptResp, error) {
 	panic("unused")
 }
+func (f *fakeChainWorkerClient) GetStorageAt(context.Context, *avsproto.WorkerGetStorageAtReq, ...grpc.CallOption) (*avsproto.WorkerGetStorageAtResp, error) {
+	panic("unused")
+}
 
 // TestWorkerRoutedFetcher_HappyPath confirms a successful worker response
 // gets mapped to a TokenMetadata correctly — name, symbol, decimals, source

--- a/docs/changes/20260615-route-execution-layer-through-workers.md
+++ b/docs/changes/20260615-route-execution-layer-through-workers.md
@@ -76,10 +76,18 @@ dials follow the same model, reusing existing worker RPCs where possible:
    placeholder (it dialed then returned an error without using the client).
    The bundler poll (`bundler.GetUserOperationReceipt`) stays — bundler
    routing is a separate concern from chain RPC.
-3. **PR 3 — simulation state overrides.** Resolve `InjectERC20BalanceChange`
-   — either supply the balance override through Tenderly's `state_objects`
-   directly (no chain read), or add a worker `GetStorageAt` RPC. Removes
-   the last live dial.
+3. **PR 3 — simulation state overrides (delivered).** Tenderly's
+   `state_objects` can't supply an ERC-20 balance override without the
+   discovered storage slot, so the probe stays — routed through a new worker
+   `GetStorageAt` RPC. Added it to `ChainStateReader`; changed
+   `ProbeERC20BalanceSlot` to take a `ChainStateReader` (its `balanceOf`
+   `eth_call` reuses `CallContract`; its slot probing uses `GetStorageAt`)
+   and `InjectERC20BalanceChange` to resolve the per-chain reader (direct
+   dial fallback). The probe result is cached per token, so the worker
+   round-trips are one-time. **With this, every live per-chain read / write
+   / derivation in gateway mode is worker-routed** — the remaining
+   `ethclient.Dial` sites in `core/taskengine` are all fallback-only
+   (reached only in single-chain mode / when no reader is registered).
 4. **PR 4 — remove fallback dials + env-var strip.** Once no live path
    dials per-chain RPC: delete the `vm.go`/`engine.go` fallback dials,
    `smartWalletRpcByChain` + `ChainEntry.GetRPC` + the REST/withdraw

--- a/protobuf/worker.pb.go
+++ b/protobuf/worker.pb.go
@@ -1716,6 +1716,103 @@ func (x *WorkerGetTransactionReceiptResp) GetTxHash() string {
 	return ""
 }
 
+// Storage slot read
+type WorkerGetStorageAtReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Address       string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"` // Contract address (hex).
+	Slot          string                 `protobuf:"bytes,2,opt,name=slot,proto3" json:"slot,omitempty"`       // 0x-prefixed 32-byte storage slot key.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetStorageAtReq) Reset() {
+	*x = WorkerGetStorageAtReq{}
+	mi := &file_worker_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetStorageAtReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetStorageAtReq) ProtoMessage() {}
+
+func (x *WorkerGetStorageAtReq) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetStorageAtReq.ProtoReflect.Descriptor instead.
+func (*WorkerGetStorageAtReq) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *WorkerGetStorageAtReq) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *WorkerGetStorageAtReq) GetSlot() string {
+	if x != nil {
+		return x.Slot
+	}
+	return ""
+}
+
+type WorkerGetStorageAtResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Value         []byte                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"` // Raw 32-byte storage word.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerGetStorageAtResp) Reset() {
+	*x = WorkerGetStorageAtResp{}
+	mi := &file_worker_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerGetStorageAtResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerGetStorageAtResp) ProtoMessage() {}
+
+func (x *WorkerGetStorageAtResp) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerGetStorageAtResp.ProtoReflect.Descriptor instead.
+func (*WorkerGetStorageAtResp) Descriptor() ([]byte, []int) {
+	return file_worker_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *WorkerGetStorageAtResp) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
 var File_worker_proto protoreflect.FileDescriptor
 
 const file_worker_proto_rawDesc = "" +
@@ -1829,7 +1926,12 @@ const file_worker_proto_rawDesc = "" +
 	"\bgas_used\x18\x03 \x01(\x04R\agasUsed\x12.\n" +
 	"\x13effective_gas_price\x18\x04 \x01(\tR\x11effectiveGasPrice\x12!\n" +
 	"\fblock_number\x18\x05 \x01(\x04R\vblockNumber\x12\x17\n" +
-	"\atx_hash\x18\x06 \x01(\tR\x06txHash2\xd7\v\n" +
+	"\atx_hash\x18\x06 \x01(\tR\x06txHash\"E\n" +
+	"\x15WorkerGetStorageAtReq\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x12\n" +
+	"\x04slot\x18\x02 \x01(\tR\x04slot\".\n" +
+	"\x16WorkerGetStorageAtResp\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\fR\x05value2\xae\f\n" +
 	"\vChainWorker\x12X\n" +
 	"\x11WorkerHealthCheck\x12 .aggregator.WorkerHealthCheckReq\x1a!.aggregator.WorkerHealthCheckResp\x12L\n" +
 	"\rExecuteUserOp\x12\x1c.aggregator.ExecuteUserOpReq\x1a\x1d.aggregator.ExecuteUserOpResp\x12I\n" +
@@ -1847,7 +1949,8 @@ const file_worker_proto_rawDesc = "" +
 	"\x0eGetBlockHeader\x12#.aggregator.WorkerGetBlockHeaderReq\x1a$.aggregator.WorkerGetBlockHeaderResp\x12[\n" +
 	"\x0eGetBlockNumber\x12#.aggregator.WorkerGetBlockNumberReq\x1a$.aggregator.WorkerGetBlockNumberResp\x12s\n" +
 	"\x16FindMatchingWalletSalt\x12+.aggregator.WorkerFindMatchingWalletSaltReq\x1a,.aggregator.WorkerFindMatchingWalletSaltResp\x12p\n" +
-	"\x15GetTransactionReceipt\x12*.aggregator.WorkerGetTransactionReceiptReq\x1a+.aggregator.WorkerGetTransactionReceiptRespB\fZ\n" +
+	"\x15GetTransactionReceipt\x12*.aggregator.WorkerGetTransactionReceiptReq\x1a+.aggregator.WorkerGetTransactionReceiptResp\x12U\n" +
+	"\fGetStorageAt\x12!.aggregator.WorkerGetStorageAtReq\x1a\".aggregator.WorkerGetStorageAtRespB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (
@@ -1862,7 +1965,7 @@ func file_worker_proto_rawDescGZIP() []byte {
 	return file_worker_proto_rawDescData
 }
 
-var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_worker_proto_goTypes = []any{
 	(*WorkerHealthCheckReq)(nil),             // 0: aggregator.WorkerHealthCheckReq
 	(*WorkerHealthCheckResp)(nil),            // 1: aggregator.WorkerHealthCheckResp
@@ -1895,6 +1998,8 @@ var file_worker_proto_goTypes = []any{
 	(*WorkerFindMatchingWalletSaltResp)(nil), // 28: aggregator.WorkerFindMatchingWalletSaltResp
 	(*WorkerGetTransactionReceiptReq)(nil),   // 29: aggregator.WorkerGetTransactionReceiptReq
 	(*WorkerGetTransactionReceiptResp)(nil),  // 30: aggregator.WorkerGetTransactionReceiptResp
+	(*WorkerGetStorageAtReq)(nil),            // 31: aggregator.WorkerGetStorageAtReq
+	(*WorkerGetStorageAtResp)(nil),           // 32: aggregator.WorkerGetStorageAtResp
 }
 var file_worker_proto_depIdxs = []int32{
 	0,  // 0: aggregator.ChainWorker.WorkerHealthCheck:input_type -> aggregator.WorkerHealthCheckReq
@@ -1913,24 +2018,26 @@ var file_worker_proto_depIdxs = []int32{
 	25, // 13: aggregator.ChainWorker.GetBlockNumber:input_type -> aggregator.WorkerGetBlockNumberReq
 	27, // 14: aggregator.ChainWorker.FindMatchingWalletSalt:input_type -> aggregator.WorkerFindMatchingWalletSaltReq
 	29, // 15: aggregator.ChainWorker.GetTransactionReceipt:input_type -> aggregator.WorkerGetTransactionReceiptReq
-	1,  // 16: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
-	3,  // 17: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
-	5,  // 18: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
-	7,  // 19: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
-	9,  // 20: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
-	5,  // 21: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
-	12, // 22: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
-	14, // 23: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
-	16, // 24: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
-	18, // 25: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
-	20, // 26: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
-	22, // 27: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
-	24, // 28: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
-	26, // 29: aggregator.ChainWorker.GetBlockNumber:output_type -> aggregator.WorkerGetBlockNumberResp
-	28, // 30: aggregator.ChainWorker.FindMatchingWalletSalt:output_type -> aggregator.WorkerFindMatchingWalletSaltResp
-	30, // 31: aggregator.ChainWorker.GetTransactionReceipt:output_type -> aggregator.WorkerGetTransactionReceiptResp
-	16, // [16:32] is the sub-list for method output_type
-	0,  // [0:16] is the sub-list for method input_type
+	31, // 16: aggregator.ChainWorker.GetStorageAt:input_type -> aggregator.WorkerGetStorageAtReq
+	1,  // 17: aggregator.ChainWorker.WorkerHealthCheck:output_type -> aggregator.WorkerHealthCheckResp
+	3,  // 18: aggregator.ChainWorker.ExecuteUserOp:output_type -> aggregator.ExecuteUserOpResp
+	5,  // 19: aggregator.ChainWorker.GetNonce:output_type -> aggregator.WorkerGetNonceResp
+	7,  // 20: aggregator.ChainWorker.GetSmartWalletAddress:output_type -> aggregator.WorkerGetSmartWalletAddressResp
+	9,  // 21: aggregator.ChainWorker.GetTokenMetadata:output_type -> aggregator.WorkerGetTokenMetadataResp
+	5,  // 22: aggregator.ChainWorker.GetNonceByAddress:output_type -> aggregator.WorkerGetNonceResp
+	12, // 23: aggregator.ChainWorker.SuggestGasPrice:output_type -> aggregator.WorkerSuggestGasPriceResp
+	14, // 24: aggregator.ChainWorker.EstimateGas:output_type -> aggregator.WorkerEstimateGasResp
+	16, // 25: aggregator.ChainWorker.GetCode:output_type -> aggregator.WorkerGetCodeResp
+	18, // 26: aggregator.ChainWorker.GetBalance:output_type -> aggregator.WorkerGetBalanceResp
+	20, // 27: aggregator.ChainWorker.GetTokenBalance:output_type -> aggregator.WorkerGetTokenBalanceResp
+	22, // 28: aggregator.ChainWorker.CallContract:output_type -> aggregator.WorkerCallContractResp
+	24, // 29: aggregator.ChainWorker.GetBlockHeader:output_type -> aggregator.WorkerGetBlockHeaderResp
+	26, // 30: aggregator.ChainWorker.GetBlockNumber:output_type -> aggregator.WorkerGetBlockNumberResp
+	28, // 31: aggregator.ChainWorker.FindMatchingWalletSalt:output_type -> aggregator.WorkerFindMatchingWalletSaltResp
+	30, // 32: aggregator.ChainWorker.GetTransactionReceipt:output_type -> aggregator.WorkerGetTransactionReceiptResp
+	32, // 33: aggregator.ChainWorker.GetStorageAt:output_type -> aggregator.WorkerGetStorageAtResp
+	17, // [17:34] is the sub-list for method output_type
+	0,  // [0:17] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -1947,7 +2054,7 @@ func file_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   31,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protobuf/worker.proto
+++ b/protobuf/worker.proto
@@ -78,6 +78,11 @@ service ChainWorker {
   // found=false when the receipt isn't available yet (pending). Used by the
   // gateway's userop confirmation-waiting to backfill gas data.
   rpc GetTransactionReceipt(WorkerGetTransactionReceiptReq) returns (WorkerGetTransactionReceiptResp);
+
+  // Read a contract storage slot (latest). Wraps ethclient.StorageAt. Used
+  // by the gateway's Tenderly simulation to probe an ERC-20's balance slot
+  // for state overrides.
+  rpc GetStorageAt(WorkerGetStorageAtReq) returns (WorkerGetStorageAtResp);
 }
 
 // Health check
@@ -261,4 +266,14 @@ message WorkerGetTransactionReceiptResp {
   string effective_gas_price = 4; // wei (big.Int as string).
   uint64 block_number = 5;
   string tx_hash = 6;            // 0x-prefixed.
+}
+
+// Storage slot read
+message WorkerGetStorageAtReq {
+  string address = 1;  // Contract address (hex).
+  string slot = 2;     // 0x-prefixed 32-byte storage slot key.
+}
+
+message WorkerGetStorageAtResp {
+  bytes value = 1;     // Raw 32-byte storage word.
 }

--- a/protobuf/worker_grpc.pb.go
+++ b/protobuf/worker_grpc.pb.go
@@ -35,6 +35,7 @@ const (
 	ChainWorker_GetBlockNumber_FullMethodName         = "/aggregator.ChainWorker/GetBlockNumber"
 	ChainWorker_FindMatchingWalletSalt_FullMethodName = "/aggregator.ChainWorker/FindMatchingWalletSalt"
 	ChainWorker_GetTransactionReceipt_FullMethodName  = "/aggregator.ChainWorker/GetTransactionReceipt"
+	ChainWorker_GetStorageAt_FullMethodName           = "/aggregator.ChainWorker/GetStorageAt"
 )
 
 // ChainWorkerClient is the client API for ChainWorker service.
@@ -101,6 +102,10 @@ type ChainWorkerClient interface {
 	// found=false when the receipt isn't available yet (pending). Used by the
 	// gateway's userop confirmation-waiting to backfill gas data.
 	GetTransactionReceipt(ctx context.Context, in *WorkerGetTransactionReceiptReq, opts ...grpc.CallOption) (*WorkerGetTransactionReceiptResp, error)
+	// Read a contract storage slot (latest). Wraps ethclient.StorageAt. Used
+	// by the gateway's Tenderly simulation to probe an ERC-20's balance slot
+	// for state overrides.
+	GetStorageAt(ctx context.Context, in *WorkerGetStorageAtReq, opts ...grpc.CallOption) (*WorkerGetStorageAtResp, error)
 }
 
 type chainWorkerClient struct {
@@ -271,6 +276,16 @@ func (c *chainWorkerClient) GetTransactionReceipt(ctx context.Context, in *Worke
 	return out, nil
 }
 
+func (c *chainWorkerClient) GetStorageAt(ctx context.Context, in *WorkerGetStorageAtReq, opts ...grpc.CallOption) (*WorkerGetStorageAtResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkerGetStorageAtResp)
+	err := c.cc.Invoke(ctx, ChainWorker_GetStorageAt_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ChainWorkerServer is the server API for ChainWorker service.
 // All implementations must embed UnimplementedChainWorkerServer
 // for forward compatibility.
@@ -335,6 +350,10 @@ type ChainWorkerServer interface {
 	// found=false when the receipt isn't available yet (pending). Used by the
 	// gateway's userop confirmation-waiting to backfill gas data.
 	GetTransactionReceipt(context.Context, *WorkerGetTransactionReceiptReq) (*WorkerGetTransactionReceiptResp, error)
+	// Read a contract storage slot (latest). Wraps ethclient.StorageAt. Used
+	// by the gateway's Tenderly simulation to probe an ERC-20's balance slot
+	// for state overrides.
+	GetStorageAt(context.Context, *WorkerGetStorageAtReq) (*WorkerGetStorageAtResp, error)
 	mustEmbedUnimplementedChainWorkerServer()
 }
 
@@ -392,6 +411,9 @@ func (UnimplementedChainWorkerServer) FindMatchingWalletSalt(context.Context, *W
 }
 func (UnimplementedChainWorkerServer) GetTransactionReceipt(context.Context, *WorkerGetTransactionReceiptReq) (*WorkerGetTransactionReceiptResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTransactionReceipt not implemented")
+}
+func (UnimplementedChainWorkerServer) GetStorageAt(context.Context, *WorkerGetStorageAtReq) (*WorkerGetStorageAtResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStorageAt not implemented")
 }
 func (UnimplementedChainWorkerServer) mustEmbedUnimplementedChainWorkerServer() {}
 func (UnimplementedChainWorkerServer) testEmbeddedByValue()                     {}
@@ -702,6 +724,24 @@ func _ChainWorker_GetTransactionReceipt_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ChainWorker_GetStorageAt_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WorkerGetStorageAtReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ChainWorkerServer).GetStorageAt(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ChainWorker_GetStorageAt_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ChainWorkerServer).GetStorageAt(ctx, req.(*WorkerGetStorageAtReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ChainWorker_ServiceDesc is the grpc.ServiceDesc for ChainWorker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -772,6 +812,10 @@ var ChainWorker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetTransactionReceipt",
 			Handler:    _ChainWorker_GetTransactionReceipt_Handler,
+		},
+		{
+			MethodName: "GetStorageAt",
+			Handler:    _ChainWorker_GetStorageAt_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/worker/server.go
+++ b/worker/server.go
@@ -512,6 +512,19 @@ func (s *Server) GetTransactionReceipt(ctx context.Context, req *avsproto.Worker
 	return resp, nil
 }
 
+// GetStorageAt wraps ethclient.StorageAt (latest block). Used by the
+// gateway's simulation balance-slot probing.
+func (s *Server) GetStorageAt(ctx context.Context, req *avsproto.WorkerGetStorageAtReq) (*avsproto.WorkerGetStorageAtResp, error) {
+	if !common.IsHexAddress(req.Address) {
+		return nil, fmt.Errorf("invalid address %q", req.Address)
+	}
+	value, err := s.worker.rpcClient.StorageAt(ctx, common.HexToAddress(req.Address), common.HexToHash(req.Slot), nil)
+	if err != nil {
+		return nil, fmt.Errorf("StorageAt %s slot %s: %w", req.Address, req.Slot, err)
+	}
+	return &avsproto.WorkerGetStorageAtResp{Value: value}, nil
+}
+
 // GetBalance wraps ethclient.BalanceAt(addr, latest). Used by the gateway's
 // withdraw preflight to validate / size native-coin withdrawals.
 func (s *Server) GetBalance(ctx context.Context, req *avsproto.WorkerGetBalanceReq) (*avsproto.WorkerGetBalanceResp, error) {


### PR DESCRIPTION
## What

PR 3 of [`docs/changes/20260615-route-execution-layer-through-workers.md`](docs/changes/20260615-route-execution-layer-through-workers.md). Routes the Tenderly **simulation state-override** chain reads off per-chain `ethclient.Dial` onto the worker.

`InjectERC20BalanceChange` probes an ERC-20's balance storage slot (`eth_getStorageAt`) + reads the holder's balance to build a Tenderly `state_objects` override. Tenderly can't supply the override without the discovered slot, so the probe is **routed**, not removed.

## Changes

- **`worker.proto` / `worker/server.go`**: `GetStorageAt(address, slot) → value`, wrapping `ethclient.StorageAt`.
- **`ChainStateReader`**: add `GetStorageAt` (direct + worker-routed).
- **`simulation_state.go`**: `ProbeERC20BalanceSlot` now takes a `ChainStateReader` — its `balanceOf` `eth_call` reuses `CallContract`, its slot probing uses `GetStorageAt`. `InjectERC20BalanceChange` resolves the per-chain reader (direct-dial fallback) and passes it down. The slot is cached per token, so the worker round-trips are one-time.

## Milestone

**With this, every live per-chain read / write / derivation in gateway mode is worker-routed.** The remaining `ethclient.Dial` sites in `core/taskengine` are all **fallback-only** (single-chain mode / no reader registered).

## Testing

- `go build ./...`, `go vet`, gofmt clean.
- New `GetStorageAt` reader test; simulation / contractWrite / probe tests pass.

## Next (gated)

PR 4 — the env-var strip — removes the aggregator's per-chain RPC pool (`smartWalletRpcByChain` / `ChainEntry.GetRPC`), the now-unreachable fallbacks, and the `<CHAIN>_RPC` env vars. **It's the irreversible step and should land only after PRs 1–3 soak in prod a release cycle.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
