### PR TITLE
feat(operator): multi-chain operators per network tier + liveness hardening

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -24,8 +24,8 @@ config/
 ├── worker-<chain>-dev.example.yaml      — per-chain local-dev worker template
 ├── worker-<chain>-dev.yaml              — per-chain local-dev worker, real (gitignored)
 │
-├── operator-railway.yaml                — Railway operator template
-├── operator-<chain>-railway.yaml        — per-chain operator overrides
+├── operator-sepolia-railway.yaml        — Railway operator: all TESTNET chains
+├── operator-ethereum-railway.yaml       — Railway operator: all MAINNET chains
 └── operator-<chain>.yaml                — local operator configs (gitignored symlinks)
 ```
 
@@ -35,7 +35,8 @@ config/
 |---|---|
 | Production aggregator on Railway | `gateway-railway.yaml` |
 | Production worker for chain N on Railway | `worker-<chain>-railway.yaml` |
-| Production operator on Railway | `operator-railway.yaml` (+ optional per-chain override) |
+| Production testnet operator on Railway | `operator-sepolia-railway.yaml` (monitors all testnet chains) |
+| Production mainnet operator on Railway | `operator-ethereum-railway.yaml` (monitors all mainnet chains) |
 | Local dev gateway | `gateway-dev.yaml` (copy from `gateway-dev.example.yaml`, fill in secrets) |
 | Local dev worker for chain N | `worker-<chain>-dev.yaml` (same copy pattern) |
 | Operating drill / rehearsal | `gateway-dev-rehearsal.yaml` |

--- a/config/archived/README.md
+++ b/config/archived/README.md
@@ -21,7 +21,8 @@ to per-chain **workers**. The new templates live one level up:
   [`../gateway-railway.yaml`](../gateway-railway.yaml)
 - Workers → [`../worker-<chain>-dev.example.yaml`](..) +
   [`../worker-<chain>-railway.yaml`](..)
-- Operator → [`../operator-railway.yaml`](../operator-railway.yaml)
+- Operator → [`../operator-sepolia-railway.yaml`](../operator-sepolia-railway.yaml) (testnets),
+  [`../operator-ethereum-railway.yaml`](../operator-ethereum-railway.yaml) (mainnets)
 
 If you're reading the codebase trying to understand how the pre-Railway
 shape looked — what fields the old aggregator config had, how a

--- a/config/operator-ethereum-railway.yaml
+++ b/config/operator-ethereum-railway.yaml
@@ -16,7 +16,9 @@ operator_address: 0xc6B87cc9e85b07365b6aBEfff061F237F7cf7Dc3
 avs_registry_coordinator_address: 0x8DE3Ee0dE880161Aa0CD8Bf9F8F6a7AfEeB9A44B
 operator_state_retriever_address: 0xb3af70D5f72C04D1f490ff49e5aB189fA7122713
 
-# EigenLayer chain RPC (Ethereum mainnet)
+# EigenLayer / AVS registration chain RPC (Ethereum mainnet). This is the
+# chain the operator registers against — distinct from the destination chains
+# it monitors (see `chains:` below).
 eth_rpc_url: ${CHAIN_ENDPOINT}
 
 # Key files — written at startup by scripts/operator-entrypoint.sh
@@ -43,9 +45,24 @@ enable_node_api: true
 sentry_dsn: https://d304c8708d5097f7787eeb664e4098c6@o1156669.ingest.us.sentry.io/4509386759733248
 server_name: "operator-ethereum-railway"
 
-# Destination chain — Ethereum mainnet
-target_chain:
-  eth_rpc_url: ${CHAIN_ENDPOINT}
+# Destination chains — all MAINNETS. This single operator monitors every
+# mainnet the gateway routes (Ethereum, Base, BNB). Each chain's WS URL is
+# derived from its HTTPS RPC in code (config.DeriveWsURL); set an explicit
+# eth_ws_url here only if a provider serves WS on a different host/path.
+# chain_id is validated against the RPC at startup — a mismatched RPC is
+# soft-skipped (chain dropped from the advertised set) rather than crashing
+# the operator. Set the per-chain RPC env vars on the operator-ethereum
+# service: ETHEREUM_RPC, BASE_RPC, BNB_RPC.
+chains:
+  - chain_id: 1
+    name: ethereum
+    eth_rpc_url: ${ETHEREUM_RPC}
+  - chain_id: 8453
+    name: base
+    eth_rpc_url: ${BASE_RPC}
+  - chain_id: 56
+    name: bnb-mainnet
+    eth_rpc_url: ${BNB_RPC}
 
 enabled_features:
   event_trigger: true

--- a/config/operator-sepolia-railway.yaml
+++ b/config/operator-sepolia-railway.yaml
@@ -1,5 +1,7 @@
-# Operator configuration for Railway deployment (testnet)
-# Connects to gateway over Railway private networking
+# Operator configuration for Railway deployment (testnet — Sepolia AVS).
+# This single operator monitors all TESTNET destination chains.
+# Connects to gateway over Railway private networking.
+# Railway service: operator-sepolia
 environment: production
 
 operator_address: 0x997E5D40a32c44a3D93E59fC55C4Fd20b7d2d49D
@@ -8,8 +10,10 @@ operator_address: 0x997E5D40a32c44a3D93E59fC55C4Fd20b7d2d49D
 avs_registry_coordinator_address: 0xcA95381802FD1398d5BF2D01243210cFb3a2b3BD
 operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
 
-# EigenLayer chain RPC (Sepolia) — driven by env var so the key can
-# be rotated without redeploying. Set on the operator service:
+# EigenLayer / AVS registration chain RPC (Sepolia) — driven by env var so
+# the key can be rotated without redeploying. This is the chain the operator
+# registers against, distinct from the destination chains it monitors (see
+# `chains:` below). Set on the operator-sepolia service:
 #   CHAIN_ENDPOINT (HTTPS; WS derived in code)
 eth_rpc_url: ${CHAIN_ENDPOINT}
 
@@ -36,11 +40,23 @@ sentry_dsn: https://d304c8708d5097f7787eeb664e4098c6@o1156669.ingest.us.sentry.i
 # board. operator-ethereum-railway (mainnet) stays unset → defaults to
 # production.
 sentry_environment: staging
-server_name: "operator-railway"
+server_name: "operator-sepolia-railway"
 
-# Destination chain - Sepolia
-target_chain:
-  eth_rpc_url: ${CHAIN_ENDPOINT}
+# Destination chains — all TESTNETS. This single operator monitors every
+# testnet the gateway routes (Sepolia, Base-Sepolia). Each chain's WS URL is
+# derived from its HTTPS RPC in code (config.DeriveWsURL); set an explicit
+# eth_ws_url here only if a provider serves WS on a different host/path.
+# chain_id is validated against the RPC at startup — a mismatched RPC is
+# soft-skipped (chain dropped from the advertised set) rather than crashing
+# the operator. Set the per-chain RPC env vars on the operator-sepolia
+# service: SEPOLIA_RPC, BASE_SEPOLIA_RPC.
+chains:
+  - chain_id: 11155111
+    name: sepolia
+    eth_rpc_url: ${SEPOLIA_RPC}
+  - chain_id: 84532
+    name: base-sepolia
+    eth_rpc_url: ${BASE_SEPOLIA_RPC}
 
 enabled_features:
   event_trigger: true

--- a/core/taskengine/trigger/block.go
+++ b/core/taskengine/trigger/block.go
@@ -156,6 +156,15 @@ func (b *BlockTrigger) calculateMinInterval() int64 {
 	return minInterval
 }
 
+// HasBlockTasks reports whether this trigger currently has any block-interval
+// tasks. When false, the head subscription is intentionally stopped (no work
+// to do), so the absence of fresh heads is expected and must NOT be read as a
+// stalled subscription — the operator's chain-capability watermark uses this
+// to avoid un-advertising an idle-but-healthy chain.
+func (b *BlockTrigger) HasBlockTasks() bool {
+	return b.registry.GetBlockTaskCount() > 0
+}
+
 // shouldCheckAtBlock determines if we should perform checks at the given block number
 // Using checkpoint system starting from block 0: check at minInterval, 2*minInterval, 3*minInterval, etc.
 func (b *BlockTrigger) shouldCheckAtBlock(blockNumber int64) bool {

--- a/core/taskengine/trigger/common.go
+++ b/core/taskengine/trigger/common.go
@@ -55,6 +55,20 @@ func (b *CommonTrigger) Shutdown() {
 	b.done <- true
 }
 
+// Close releases the trigger's RPC/WS clients without going through the
+// Run/Shutdown lifecycle. Unlike Shutdown it does NOT signal the done
+// channel, so it's safe to call on a trigger that was constructed but never
+// Run — e.g. when multi-chain operator setup soft-skips a sibling chain after
+// this trigger's constructor already dialed its clients.
+func (b *CommonTrigger) Close() {
+	if b.ethClient != nil {
+		b.ethClient.Close()
+	}
+	if b.wsEthClient != nil {
+		b.wsEthClient.Close()
+	}
+}
+
 func (b *CommonTrigger) GetProgress() int64 {
 	return b.progress
 }

--- a/dockerfiles/aggregator.Dockerfile
+++ b/dockerfiles/aggregator.Dockerfile
@@ -36,8 +36,9 @@ COPY --from=builder /app/config /app/config
 # services (which need ECDSA/BLS keystores materialized from env vars
 # at startup) can pin to this image. The script auto-detects the
 # binary path so it works equally for /ava (this image) and ./ap (the
-# root Dockerfile). Railway Start Command for an operator service:
-#   /app/scripts/operator-entrypoint.sh operator --config=/app/config/operator-railway.yaml
+# root Dockerfile). Railway Start Command per operator service:
+#   operator-sepolia:  /app/scripts/operator-entrypoint.sh operator --config=/app/config/operator-sepolia-railway.yaml
+#   operator-ethereum: /app/scripts/operator-entrypoint.sh operator --config=/app/config/operator-ethereum-railway.yaml
 COPY --from=builder /app/scripts/operator-entrypoint.sh /app/scripts/operator-entrypoint.sh
 
 ENTRYPOINT ["/ava"]

--- a/dockerfiles/operator.Dockerfile
+++ b/dockerfiles/operator.Dockerfile
@@ -36,8 +36,9 @@ COPY --from=builder /app/config /app/config
 # services (which need ECDSA/BLS keystores materialized from env vars
 # at startup) can pin to this image. The script auto-detects the
 # binary path so it works equally for /ava (this image) and ./ap (the
-# root Dockerfile). Railway Start Command for an operator service:
-#   /app/scripts/operator-entrypoint.sh operator --config=/app/config/operator-railway.yaml
+# root Dockerfile). Railway Start Command per operator service:
+#   operator-sepolia:  /app/scripts/operator-entrypoint.sh operator --config=/app/config/operator-sepolia-railway.yaml
+#   operator-ethereum: /app/scripts/operator-entrypoint.sh operator --config=/app/config/operator-ethereum-railway.yaml
 COPY --from=builder /app/scripts/operator-entrypoint.sh /app/scripts/operator-entrypoint.sh
 
 ENTRYPOINT ["/ava"]

--- a/docs/changes/20260616-multichain-operators.md
+++ b/docs/changes/20260616-multichain-operators.md
@@ -1,0 +1,75 @@
+# Multi-chain operators: one operator per network tier + liveness hardening
+
+## Why
+
+Production ran two operators that each advertised **a single chain** —
+`operator-ethereum` → `[1]`, `operator` → `[11155111]` — so Base (8453),
+BNB (56) and Base-Sepolia (84532) tasks were **orphaned** (no operator
+advertised their chain, so the gateway never routed or fired them).
+
+The operator already had the machinery to monitor an **array** of chains
+(`OperatorConfig.Chains`, `EffectiveChains`, per-chain trigger sets, the
+liveness watermark from #581), but the Railway operator configs were never
+migrated off the legacy single-chain `eth_rpc_url: ${CHAIN_ENDPOINT}` /
+`target_chain` form. This finishes that migration and fixes two latent
+hardening gaps that the multi-chain setup exposes.
+
+## Intended topology
+
+- **operator-ethereum** (mainnet tier): monitors **all mainnets** —
+  Ethereum (1), Base (8453), BNB (56).
+- **operator-sepolia** (testnet tier, renamed from `operator`): monitors
+  **all testnets** — Sepolia (11155111), Base-Sepolia (84532).
+
+Each operator still *registers* against one AVS chain (`eth_rpc_url`:
+Ethereum mainnet / Sepolia respectively) — that's separate from the
+destination `chains:` it monitors.
+
+## Changes
+
+### Part A — config (this repo)
+- `config/operator-ethereum-railway.yaml`: replaced the single
+  `target_chain` with a `chains:` array (ethereum/base/bnb), each pointing at
+  its per-chain RPC env var (`ETHEREUM_RPC`, `BASE_RPC`, `BNB_RPC`).
+- `config/operator-railway.yaml` → **renamed** to
+  `config/operator-sepolia-railway.yaml`; `chains:` array
+  (sepolia/base-sepolia → `SEPOLIA_RPC`, `BASE_SEPOLIA_RPC`).
+- Updated Dockerfile/README references to the new filenames.
+- Railway side (env vars + service rename + start commands) handled
+  out-of-band.
+
+### Fix 1 — a bad per-chain WS no longer crashes the whole operator
+`NewBlockTrigger`/`NewEventTrigger` dial the chain's WS endpoint in their
+constructors and **panic** on failure. With one operator monitoring several
+chains, a single unreachable WS would take down *every* chain. The per-chain
+setup now constructs the triggers under panic-recovery and **soft-skips** the
+bad chain (added to the `Skipped` set, dropped from the advertised
+capabilities) — the same treatment a failed HTTP dial already gets. WS URLs
+are still derived from each chain's HTTPS RPC (`config.DeriveWsURL`); an
+explicit per-chain `eth_ws_url` can override when a provider serves WS on a
+different host/path.
+
+### Fix 2 — an idle chain no longer un-advertises itself
+The block subscription stops when a chain has no block tasks
+("No more block monitoring tasks"). With it stopped, no heads arrive, the
+liveness watermark goes stale, and `supportedChainIDs()` dropped the chain —
+even though it was healthy and could still serve event tasks. Worse, this
+**deadlocks coverage**: the gateway only routes tasks (including the first
+block task) to advertised chains, so a dropped idle chain never gets tasks,
+never restarts its subscription, and never re-advertises.
+
+`supportedChainIDs()` now treats a stale watermark as a stall **only when the
+chain has block work** (`BlockTrigger.HasBlockTasks()`). An idle chain stays
+advertised. Adding a block task also resets the watermark so a freshly
+(re)started subscription gets its full staleness window before it can be
+considered stalled. (The block-work probe is injected onto `ChainTriggerSet`
+so the liveness logic is unit-testable without a real WS-dialing trigger.)
+
+## Risk / follow-up
+
+- WS derivation is relied on for Base/BNB; if a provider needs a different WS
+  host the new soft-skip surfaces it as a dropped chain (visible in
+  `Skipped`/`SetChainAdvertised`) instead of a crash — set an explicit
+  `eth_ws_url` for that entry.
+- The watermark still only tracks *block* heads; an event-only chain with a
+  dead event WS isn't caught by it (pre-existing; out of scope here).

--- a/operator/chain_liveness_test.go
+++ b/operator/chain_liveness_test.go
@@ -35,8 +35,15 @@ func TestChainTriggerSet_LivenessWatermark(t *testing.T) {
 	}
 }
 
-// TestSupportedChainIDs_FiltersStalled confirms a stalled chain (head
-// older than the staleness threshold) drops out of the advertised set
+// hasBlockWork / noBlockWork are injectable stubs for ChainTriggerSet's
+// block-task probe, so liveness tests don't need a real (WS-dialing)
+// BlockTrigger.
+func hasBlockWork() bool { return true }
+func noBlockWork() bool  { return false }
+
+// TestSupportedChainIDs_FiltersStalled confirms a chain that is stalled
+// *while it has block work* (head older than the staleness threshold but the
+// subscription should be producing heads) drops out of the advertised set,
 // even though it's still in chainOrder.
 func TestSupportedChainIDs_FiltersStalled(t *testing.T) {
 	o := &Operator{
@@ -44,10 +51,12 @@ func TestSupportedChainIDs_FiltersStalled(t *testing.T) {
 			1: {
 				ChainID:        1,
 				lastHeadSeenAt: time.Now(), // fresh
+				hasBlockTasks:  hasBlockWork,
 			},
 			8453: {
 				ChainID:        8453,
 				lastHeadSeenAt: time.Now().Add(-10 * time.Minute), // stale
+				hasBlockTasks:  hasBlockWork,                      // has block work → stall counts
 			},
 		},
 		chainOrder: []int64{1, 8453},
@@ -65,6 +74,35 @@ func TestSupportedChainIDs_FiltersStalled(t *testing.T) {
 	wantAll := []int64{1, 8453}
 	if !reflect.DeepEqual(all, wantAll) {
 		t.Fatalf("allConfiguredChainIDs: got %v, want %v", all, wantAll)
+	}
+}
+
+// TestSupportedChainIDs_IdleChainStaysAdvertised is the core fix: a chain with
+// NO block tasks has its head subscription intentionally stopped, so a stale
+// watermark is expected — it must STAY advertised (it can still serve event
+// tasks, and the gateway only routes the first block task to advertised
+// chains; dropping it would deadlock coverage).
+func TestSupportedChainIDs_IdleChainStaysAdvertised(t *testing.T) {
+	o := &Operator{
+		chainTriggers: map[int64]*ChainTriggerSet{
+			1: {
+				ChainID:        1,
+				lastHeadSeenAt: time.Now().Add(-10 * time.Minute), // stale...
+				hasBlockTasks:  noBlockWork,                       // ...but idle → not a stall
+			},
+			8453: {
+				ChainID:        8453,
+				lastHeadSeenAt: time.Now().Add(-10 * time.Minute), // stale + has work → dropped
+				hasBlockTasks:  hasBlockWork,
+			},
+		},
+		chainOrder: []int64{1, 8453},
+	}
+
+	got := o.supportedChainIDs()
+	want := []int64{1} // idle chain 1 advertised; stalled-with-work chain 8453 dropped
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("idle chain advertisement: got %v, want %v", got, want)
 	}
 }
 

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -183,12 +183,18 @@ func (o *Operator) triggersForChain(chainID int64) (*ChainTriggerSet, bool) {
 const chainCapabilityStaleThreshold = 90 * time.Second
 
 // supportedChainIDs returns the chain_ids the operator currently
-// advertises to the aggregator/gateway. A chain is included only when
-// its block subscription has produced a head within the staleness
-// window — see ChainTriggerSet.isHeadFresh. Chains that have stalled
-// (subscription dead, RPC unreachable) drop out of the advertised set
-// on the next Ping so the gateway can re-route their tasks to a
-// healthier operator without waiting for a SyncMessages reconnect.
+// advertises to the aggregator/gateway. A chain is advertised unless its
+// block subscription is genuinely STALLED — i.e. it has block tasks (so the
+// subscription should be producing heads) but no head has arrived within the
+// staleness window. See ChainTriggerSet.isHeadFresh.
+//
+// A chain with no block tasks has its head subscription intentionally
+// stopped, so it produces no heads by design. Such an idle chain must STILL
+// be advertised: it can serve event tasks, and — critically — the gateway
+// only routes tasks (including the first block task) to chains an operator
+// advertises. Dropping an idle chain creates a deadlock: no tasks → no
+// subscription → stale watermark → un-advertised → never gets tasks. So
+// liveness is gated on the watermark only while block work is present.
 //
 // Order matches chainOrder for deterministic output.
 func (o *Operator) supportedChainIDs() []int64 {
@@ -201,7 +207,10 @@ func (o *Operator) supportedChainIDs() []int64 {
 		if !ok || set == nil {
 			continue
 		}
-		if !set.isHeadFresh(chainCapabilityStaleThreshold) {
+		// Only a chain with active block work can be "stalled": no block
+		// tasks means no head subscription is expected to be running, so a
+		// stale watermark is normal, not a failure.
+		if set.blockWorkPresent() && !set.isHeadFresh(chainCapabilityStaleThreshold) {
 			continue
 		}
 		out = append(out, id)
@@ -355,6 +364,14 @@ type ChainTriggerSet struct {
 	EventTrigger *triggerengine.EventTrigger
 	EthClient    *ethclient.Client
 
+	// hasBlockTasks reports whether the block subscription currently has
+	// work (and so should be producing heads). supportedChainIDs uses it to
+	// distinguish a genuinely stalled chain from an idle one — only a chain
+	// with block work can be "stalled". Wired to BlockTrigger.HasBlockTasks
+	// in real setup; injectable so liveness logic is unit-testable without
+	// constructing a real (WS-dialing) BlockTrigger.
+	hasBlockTasks func() bool
+
 	// lastHeadSeenAt is updated every time the per-chain block-subscription
 	// fans an event into sharedBlockCh. It's the freshness watermark
 	// liveSupportedChainIDs() uses to decide whether to keep advertising
@@ -374,6 +391,13 @@ func (s *ChainTriggerSet) markHeadSeen() {
 	s.lastHeadMu.Lock()
 	s.lastHeadSeenAt = time.Now()
 	s.lastHeadMu.Unlock()
+}
+
+// blockWorkPresent reports whether this chain currently has block tasks (so
+// its head subscription should be running). When false the chain is idle —
+// stale heads are expected, not a stall — and it stays advertised.
+func (s *ChainTriggerSet) blockWorkPresent() bool {
+	return s.hasBlockTasks != nil && s.hasBlockTasks()
 }
 
 // isHeadFresh reports whether the most recent observed head is within

--- a/operator/worker_loop.go
+++ b/operator/worker_loop.go
@@ -252,11 +252,33 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 		}
 
 		perChainBlockCh := make(chan triggerengine.TriggerMetadata[int64], 1000)
-		bt := triggerengine.NewBlockTrigger(&rpcOpt, perChainBlockCh, o.logger)
-
 		perChainEventCh := make(chan triggerengine.TriggerMetadata[triggerengine.EventMark], 1000)
-		et := triggerengine.NewEventTrigger(&rpcOpt, perChainEventCh, o.logger,
-			o.config.GetMaxEventsPerQueryPerBlock(), o.config.GetMaxTotalEventsPerBlock(), o.config.OperatorAddress)
+
+		// NewBlockTrigger / NewEventTrigger dial the chain's WS endpoint in
+		// their constructors and panic on failure. In a multi-chain operator
+		// one unreachable per-chain WS must not crash the whole process and
+		// take down every other chain — construct under recovery and soft-skip
+		// the chain, the same treatment a failed HTTP dial gets above.
+		var bt *triggerengine.BlockTrigger
+		var et *triggerengine.EventTrigger
+		constructErr := func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("%v", r)
+				}
+			}()
+			bt = triggerengine.NewBlockTrigger(&rpcOpt, perChainBlockCh, o.logger)
+			et = triggerengine.NewEventTrigger(&rpcOpt, perChainEventCh, o.logger,
+				o.config.GetMaxEventsPerQueryPerBlock(), o.config.GetMaxTotalEventsPerBlock(), o.config.OperatorAddress)
+			return nil
+		}()
+		if constructErr != nil {
+			perChainEthClient.Close()
+			o.logger.Warn("chain WS unreachable — skipping chain (will not advertise capability)",
+				"chain_index", i, "chain_name", chainCfg.Name, "ws", chainCfg.EthWsUrl, "error", constructErr)
+			skipped = append(skipped, skippedChain{name: chainCfg.Name, reason: "ws dial failed"})
+			continue
+		}
 		et.SetSubscriptionMetrics(
 			func(active, desired int) {
 				o.metrics.SetEventSubscriptions(detectedID, active, desired)
@@ -291,11 +313,12 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 		// usable; but the write still needs to happen before goroutine
 		// spawn to satisfy the Go memory model under -race.
 		triggerSet := &ChainTriggerSet{
-			ChainID:      detectedID,
-			Name:         chainCfg.Name,
-			BlockTrigger: bt,
-			EventTrigger: et,
-			EthClient:    perChainEthClient,
+			ChainID:       detectedID,
+			Name:          chainCfg.Name,
+			BlockTrigger:  bt,
+			EventTrigger:  et,
+			EthClient:     perChainEthClient,
+			hasBlockTasks: bt.HasBlockTasks,
 			// Seed the watermark to "now" so the chain is advertised
 			// immediately at boot. The fan-in goroutine refreshes it
 			// on every block; an unhealthy chain will fall out of the
@@ -1064,6 +1087,12 @@ func (o *Operator) StreamMessages() {
 							o.logger.Info("❌ Failed to add block trigger to monitoring", "error", err, "task_id", resp.Id, "solution", "Task may not be monitored for blocks")
 						}
 					}()
+					// Adding a block task (re)starts the head subscription if it
+					// was idle. Reset the liveness watermark so the freshly
+					// started subscription gets a full staleness window to
+					// produce its first head before supportedChainIDs() could
+					// consider the chain stalled.
+					set.markHeadSeen()
 				} else if trigger := triggerObj.GetCron(); trigger != nil {
 					scheduleInfo := "unknown"
 					if trigger.Config != nil && trigger.Config.Schedules != nil {

--- a/operator/worker_loop.go
+++ b/operator/worker_loop.go
@@ -157,9 +157,22 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 		o.logger.Error("Failed to create ping job", "error", err)
 	}
 
-	macros.SetRpc(o.config.TargetChain.EthWsUrl)
-	taskengine.SetRpc(o.config.TargetChain.EthRpcUrl)
-	taskengine.SetWsRpc(o.config.TargetChain.EthWsUrl)
+	// Resolve the chains this operator monitors. EffectiveChains returns the
+	// chains[] array (multi-chain config) or a single chain derived from
+	// TargetChain/EthRpcUrl (legacy config).
+	chains := o.config.EffectiveChains()
+	if len(chains) == 0 {
+		return fmt.Errorf("operator has no chains configured")
+	}
+
+	// The package-global RPC setters are single-valued; point them at the
+	// primary (first) chain. With a multi-chain config TargetChain is empty,
+	// so deriving from TargetChain here would set these to "" and silently
+	// break macro / task-engine code that reads them — use the primary chain.
+	primaryChain := chains[0]
+	macros.SetRpc(primaryChain.EthWsUrl)
+	taskengine.SetRpc(primaryChain.EthRpcUrl)
+	taskengine.SetWsRpc(primaryChain.EthWsUrl)
 	taskengine.SetLogger(o.logger)
 
 	var metricsErrChan <-chan error
@@ -173,17 +186,13 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 		}
 	}
 
-	// Build per-chain trigger engines from the resolved chains list. Each
-	// chain gets its own BlockTrigger and EventTrigger speaking to that
+	// Build per-chain trigger engines from the resolved chains list (above).
+	// Each chain gets its own BlockTrigger and EventTrigger speaking to that
 	// chain's RPC + WS; their output channels are fanned-in (tagged with
-	// chain_id) to a shared consumer loop below.
-	chains := o.config.EffectiveChains()
-	if len(chains) == 0 {
-		return fmt.Errorf("operator has no chains configured")
-	}
-
-	sharedBlockCh := make(chan chainTaggedBlockEvent, 1000)
-	sharedEventCh := make(chan chainTaggedEventEvent, 1000)
+	// chain_id) to a shared consumer loop below. Scale the shared buffers by
+	// chain count so a single busy chain can't starve the others' headroom.
+	sharedBlockCh := make(chan chainTaggedBlockEvent, len(chains)*1000)
+	sharedEventCh := make(chan chainTaggedEventEvent, len(chains)*1000)
 
 	o.chainTriggers = make(map[int64]*ChainTriggerSet, len(chains))
 	o.chainOrder = make([]int64, 0, len(chains))
@@ -274,6 +283,11 @@ func (o *Operator) runWorkLoop(ctx context.Context) error {
 		}()
 		if constructErr != nil {
 			perChainEthClient.Close()
+			// NewBlockTrigger may have succeeded before NewEventTrigger
+			// panicked; close its already-dialed clients so they don't leak.
+			if bt != nil {
+				bt.Close()
+			}
 			o.logger.Warn("chain WS unreachable — skipping chain (will not advertise capability)",
 				"chain_index", i, "chain_name", chainCfg.Name, "ws", chainCfg.EthWsUrl, "error", constructErr)
 			skipped = append(skipped, skippedChain{name: chainCfg.Name, reason: "ws dial failed"})


### PR DESCRIPTION
## Summary

Finishes the multi-chain operator migration and fixes two liveness gaps it exposes. Production ran two operators each advertising **a single chain** (`operator-ethereum`→`[1]`, `operator`→`[11155111]`), so **Base (8453), BNB (56), and Base-Sepolia (84532) tasks were orphaned** — no operator advertised their chain, so the gateway never routed or fired them.

The operator already had multi-chain machinery (`OperatorConfig.Chains`, `EffectiveChains`, per-chain trigger sets, the #581 liveness watermark), but the Railway operator configs were never moved off the legacy single-chain `eth_rpc_url: ${CHAIN_ENDPOINT}` / `target_chain` form. This wires it up.

## Intended topology
- **operator-ethereum** (mainnet tier) → monitors **all mainnets**: ethereum (1), base (8453), bnb (56).
- **operator-sepolia** (testnet tier, renamed from `operator`) → monitors **all testnets**: sepolia (11155111), base-sepolia (84532).

Each operator still *registers* against one AVS chain (`eth_rpc_url`); that's separate from the destination `chains:` it monitors.

## Part A — config
- `config/operator-ethereum-railway.yaml`: `target_chain` → `chains:` array (ethereum/base/bnb → `ETHEREUM_RPC`/`BASE_RPC`/`BNB_RPC`).
- `config/operator-railway.yaml` → **renamed** `config/operator-sepolia-railway.yaml`; `chains:` array (sepolia/base-sepolia → `SEPOLIA_RPC`/`BASE_SEPOLIA_RPC`).
- Updated Dockerfile/README references. **Railway env vars + service rename + start commands were applied out-of-band by the operator.**

## Fix 1 — a bad per-chain WS no longer crashes the whole operator
`NewBlockTrigger`/`NewEventTrigger` dial the chain's WS in their constructors and **panic** on failure. With one operator monitoring several chains, a single unreachable WS would take down *every* chain. The per-chain setup now constructs under panic-recovery and **soft-skips** the bad chain (added to `Skipped`, dropped from advertised capabilities) — same as a failed HTTP dial. WS URLs are still derived from each chain's HTTPS RPC; an explicit per-chain `eth_ws_url` can override.

## Fix 2 — an idle chain no longer un-advertises itself
The block subscription stops when a chain has no block tasks. With it stopped, no heads arrive → watermark goes stale → `supportedChainIDs()` dropped the chain, even though it was healthy and could serve event tasks. This **deadlocks coverage**: the gateway only routes tasks (incl. the first block task) to advertised chains, so a dropped idle chain never gets tasks, never restarts its subscription, never re-advertises.

Now a stale watermark counts as a stall **only when the chain has block work** (`BlockTrigger.HasBlockTasks()`); idle chains stay advertised. Adding a block task resets the watermark so a freshly (re)started subscription gets its full staleness window. The block-work probe is injected onto `ChainTriggerSet` so the liveness logic is unit-testable without a real (WS-dialing) trigger — see `TestSupportedChainIDs_IdleChainStaysAdvertised`.

## Testing
- `go build ./...`, `go vet`, and the operator + trigger suites pass.
- New/updated liveness tests cover: stalled-with-block-work → dropped; stalled-but-idle → advertised.

## Follow-up / risk
- WS derivation is relied on for Base/BNB; a provider needing a different WS host now surfaces as a *soft-skipped* chain (visible in `Skipped` / `SetChainAdvertised`) rather than a crash — set an explicit `eth_ws_url` for it.
- The watermark still only tracks block heads; an event-only chain with a dead event WS isn't caught (pre-existing, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
