### PR TITLE
fix: EventCondition.value is a string, not an object

### DIFF
--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -550,7 +550,13 @@ type EventCondition struct {
 	FieldName string                 `json:"fieldName"`
 	FieldType *string                `json:"fieldType,omitempty"`
 	Operator  EventConditionOperator `json:"operator"`
-	Value     map[string]interface{} `json:"value"`
+
+	// Value Value to compare against, encoded as a string. The operator
+	// parses it according to `fieldType` (e.g. `int256` / `uint256`
+	// → big.Int, `address` → checksummed hex, `bool` →
+	// "true"/"false"). Matches the proto `EventCondition.value`,
+	// which is also a string.
+	Value string `json:"value"`
 }
 
 // EventConditionOperator defines model for EventCondition.Operator.

--- a/aggregator/rest/mapping/event_query.go
+++ b/aggregator/rest/mapping/event_query.go
@@ -1,8 +1,6 @@
 package mapping
 
 import (
-	"encoding/json"
-
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
@@ -57,13 +55,11 @@ func openAPIEventQueriesToProto(in []generated.EventTriggerQuery) []*avsproto.Ev
 				if c.FieldType != nil {
 					pc.FieldType = *c.FieldType
 				}
-				// OpenAPI carries Value as an object so SDKs can pass
-				// typed payloads (e.g. {"address":"0x…"}). The proto
-				// stores it as a JSON-encoded string and parses it on
-				// the operator side via FieldType.
-				if raw, err := json.Marshal(c.Value); err == nil {
-					pc.Value = string(raw)
-				}
+				// Value is a plain string on the wire, matching the proto
+				// EventCondition.value. The operator parses it according
+				// to FieldType (e.g. "200000000000" → big.Int for a
+				// uint256/int256 field).
+				pc.Value = c.Value
 				pq.Conditions = append(pq.Conditions, pc)
 			}
 		}
@@ -92,9 +88,7 @@ func openAPIEventQueriesToProto(in []generated.EventTriggerQuery) []*avsproto.Ev
 	return out
 }
 
-// protoEventQueriesToOpenAPI inverts openAPIEventQueriesToProto. The
-// condition Value is round-tripped through JSON so the polymorphic
-// SDK shape survives.
+// protoEventQueriesToOpenAPI inverts openAPIEventQueriesToProto.
 func protoEventQueriesToOpenAPI(in []*avsproto.EventTrigger_Query) []generated.EventTriggerQuery {
 	if len(in) == 0 {
 		return nil
@@ -143,11 +137,7 @@ func protoEventQueriesToOpenAPI(in []*avsproto.EventTrigger_Query) []generated.E
 				if ft := c.GetFieldType(); ft != "" {
 					ec.FieldType = &ft
 				}
-				var v map[string]interface{}
-				if c.GetValue() != "" {
-					_ = json.Unmarshal([]byte(c.GetValue()), &v)
-				}
-				ec.Value = v
+				ec.Value = c.GetValue()
 				conds = append(conds, ec)
 			}
 			oq.Conditions = &conds

--- a/aggregator/rest/mapping/trigger_test.go
+++ b/aggregator/rest/mapping/trigger_test.go
@@ -94,6 +94,12 @@ func TestTriggerRoundTrip(t *testing.T) {
 						Queries: []generated.EventTriggerQuery{{
 							Addresses: &[]generated.EthereumAddress{addr},
 							Topics:    &[]string{sig, ""},
+							Conditions: &[]generated.EventCondition{{
+								FieldName: "AnswerUpdated.current",
+								Operator:  generated.Gt,
+								Value:     "200000000000",
+								FieldType: func() *string { s := "int256"; return &s }(),
+							}},
 						}},
 					},
 				}
@@ -111,6 +117,14 @@ func TestTriggerRoundTrip(t *testing.T) {
 				require.Len(t, topics, 2)
 				assert.Equal(t, "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", topics[0])
 				assert.Equal(t, "", topics[1], "wildcard topic round-trips as empty string in the []string shape")
+				require.NotNil(t, v.Config.Queries[0].Conditions)
+				conds := *v.Config.Queries[0].Conditions
+				require.Len(t, conds, 1)
+				assert.Equal(t, "AnswerUpdated.current", conds[0].FieldName)
+				assert.Equal(t, generated.Gt, conds[0].Operator)
+				assert.Equal(t, "200000000000", conds[0].Value, "condition value is a plain string, matching the proto")
+				require.NotNil(t, conds[0].FieldType)
+				assert.Equal(t, "int256", *conds[0].FieldType)
 			},
 		},
 	}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -448,8 +448,13 @@ components:
           type: string
           enum: [eq, ne, gt, gte, lt, lte, contains]
         value:
-          # JSON Value; type depends on field
-          additionalProperties: true
+          type: string
+          description: |
+            Value to compare against, encoded as a string. The operator
+            parses it according to `fieldType` (e.g. `int256` / `uint256`
+            → big.Int, `address` → checksummed hex, `bool` →
+            "true"/"false"). Matches the proto `EventCondition.value`,
+            which is also a string.
         fieldType: { type: string }
 
     EventMethodCall:

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -1443,7 +1443,11 @@ message EstimateFeesResp {
   repeated string warnings = 11;
 }
 
-// EventCondition represents a condition to evaluate on decoded event data
+// EventCondition represents a condition to evaluate on decoded event data.
+// MIRRORED in api/openapi.yaml (components.schemas.EventCondition). The two
+// schemas must agree on every field's type — `value` in particular MUST stay
+// `string` in both. Past schema drift here (OpenAPI authored as an object,
+// proto as a string) broke production simulate requests; see PR #601.
 message EventCondition {
   string field_name = 1;        // Event field name (e.g., "answer", "roundId")
   string operator = 2;          // Comparison operator: "gt", "gte", "lt", "lte", "eq", "ne"


### PR DESCRIPTION
## Problem

Applying the stop-loss Uniswap template in production fails with a 400 from the aggregator's REST layer:

```
trigger: decode EventTrigger: json: cannot unmarshal string into Go struct
field EventCondition.config.queries.conditions.value of type map[string]interface {}
```

Studio sends the condition value as a plain string (e.g. `"200000000000"` — Chainlink's 8-decimal scaled price), which matches the proto. The REST decoder rejected it because the generated Go struct typed `value` as `map[string]interface{}`.

## Root cause — schema drift

`EventCondition.value` was modeled three different ways:

| Layer | Type |
|---|---|
| `protobuf/avs.proto:1450` | `string value = 3` (source of truth) |
| `api/openapi.yaml` | `additionalProperties: true` → **object** (wrong) |
| `aggregator/rest/generated/types.gen.go` | `map[string]interface{}` → rejected the request |

The OpenAPI author wrote `additionalProperties: true` intending "any JSON value", but in OpenAPI 3.x that means "object with arbitrary properties". oapi-codegen faithfully generated a map, and the JSON decoder then rejected the string the proto, operator-side decoder, and existing test fixtures all expect.

## Fix

- `api/openapi.yaml` — `value` changed from `additionalProperties: true` → `type: string`, with a description of the `fieldType`-based decode semantics.
- `aggregator/rest/generated/types.gen.go` — regenerated via `make rest-gen`; `Value` is now `string`. Diff is limited to that one field (no toolchain drift).
- `aggregator/rest/mapping/event_query.go` — dropped the now-unnecessary `json.Marshal`/`Unmarshal` round-trip in both mapping directions; removed the unused `encoding/json` import.
- `aggregator/rest/mapping/trigger_test.go` — added a condition (`value: "200000000000"`, `fieldType: int256`) to the round-trip test so a string value is asserted end-to-end.
- `protobuf/avs.proto` — doc-only comment on `message EventCondition` declaring the OpenAPI mirror invariant, so the next person who touches either spec sees the cross-reference and can't drift again.

`go build ./aggregator/...` and `go test ./aggregator/rest/...` pass.

## Compatibility

This looks like a breaking change in the OpenAPI surface but isn't one in practice:

- The studio template was already sending a string (broke at REST today, works after).
- A hypothetical client following the old TS SDK type and sending an object would have gotten past REST, but the marshal step would have stored `'{"raw":"…"}'` as the proto value — the operator-side decoder would then silently fail to parse against `fieldType: int256`. No live client is happy today; all are happy after.

## ⚠️ Release coordination — this is a release gate

**Do not ship the aggregator side without the matching `ava-sdk-js` PR.** Either land them together, or SDK-first.

- The matching SDK PR regenerates the TS SDK types so `value` is typed as `string` instead of an object.
- If aggregator ships alone, TS callers using the typed SDK will pass an object (their type still claims that's correct), the request will round-trip but populate `pc.Value = c.Value` with an empty string (since the new REST type expects `string` not `map`), and the operator-side decoder will then silently fail on `fieldType: int256`. Worse than the current failure mode — it would simulate "successfully" but never fire.
- After the SDK regen, `value` is typed `string` end-to-end; the studio template (already correct) passes through unchanged.

https://claude.ai/code/session_01GfVUGE3vFviWEbXqAvKNkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfVUGE3vFviWEbXqAvKNkn)_
