### PR TITLE
feat: thread request context to gateway worker-routed chain calls

### DIFF
--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -1,15 +1,10 @@
 name: Publish Dev Docker Image
 
 on:
-  # Auto-build on PR merge to staging when protobuf changes — SDK CI pulls :latest to test against.
-  # Non-proto changes don't affect the wire format, so no need to rebuild the image.
-  push:
-    branches:
-      - staging
-    paths:
-      - 'protobuf/avs.proto'
-
-  # Manual dispatch for ad-hoc builds (specific tag, commit, or branch)
+  # Dev image publishing is driven entirely through the release flow
+  # (scripts/release.sh dispatches this workflow). The auto-build-on-proto-change
+  # push trigger was removed so a push to staging (e.g. a release merge or a
+  # sync-main force-push) no longer kicks off a duplicate dev image build.
   workflow_dispatch:
     inputs:
       branch_name:

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -55,7 +55,7 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		req.InputVariables = converted
 	}
 
-	resp, err := s.engine.RunNodeImmediatelyRPC(user, req)
+	resp, err := s.engine.RunNodeImmediatelyRPCWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_triggers.go
+++ b/aggregator/rest/handlers_triggers.go
@@ -44,7 +44,7 @@ func (s *Server) RunTrigger(ctx echo.Context) error {
 		req.TriggerInput = converted
 	}
 
-	resp, err := s.engine.RunTriggerRPC(user, req)
+	resp, err := s.engine.RunTriggerRPCWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_wallets.go
+++ b/aggregator/rest/handlers_wallets.go
@@ -86,7 +86,7 @@ func (s *Server) CreateWallet(ctx echo.Context) error {
 		req.FactoryAddress = string(*body.FactoryAddress)
 	}
 
-	resp, err := s.engine.GetWallet(user, req)
+	resp, err := s.engine.GetWalletWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -256,7 +256,7 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 		}
 	}
 
-	resp, err := s.engine.TriggerWorkflow(user, req)
+	resp, err := s.engine.TriggerWorkflowWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return notFoundOrError(err)
 	}

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -333,7 +333,7 @@ func (s *Server) SimulateWorkflow(ctx echo.Context) error {
 		chainIDs = append(chainIDs, authed.ChainID)
 	}
 
-	exec, err := s.engine.SimulateWorkflow(user, trigger, nodes, edges, inputVars, chainIDs...)
+	exec, err := s.engine.SimulateWorkflowWithContext(ctx.Request().Context(), user, trigger, nodes, edges, inputVars, chainIDs...)
 	if err != nil {
 		return err
 	}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -3419,6 +3419,15 @@ func (n *Engine) TriggerWorkflowWithContext(ctx context.Context, user *model.Use
 // default. Per-node / per-trigger chain_id (set on the node configs) takes
 // precedence over this value.
 func (n *Engine) SimulateWorkflow(user *model.User, trigger *avsproto.TaskTrigger, nodes []*avsproto.TaskNode, edges []*avsproto.TaskEdge, inputVariables map[string]interface{}, chainIDs ...int64) (*avsproto.Execution, error) {
+	return n.SimulateWorkflowWithContext(context.Background(), user, trigger, nodes, edges, inputVariables, chainIDs...)
+}
+
+// SimulateWorkflowWithContext is SimulateWorkflow with a caller-supplied
+// context. The REST simulate handler passes the request context so a client
+// disconnect / timeout cancels the worker-routed trigger reads (e.g. a
+// BlockTrigger's GetBlockNumber / HeaderByNumber) reached via
+// runTriggerImmediately.
+func (n *Engine) SimulateWorkflowWithContext(ctx context.Context, user *model.User, trigger *avsproto.TaskTrigger, nodes []*avsproto.TaskNode, edges []*avsproto.TaskEdge, inputVariables map[string]interface{}, chainIDs ...int64) (*avsproto.Execution, error) {
 	var chainID int64
 	if len(chainIDs) > 0 {
 		chainID = chainIDs[0]
@@ -3533,7 +3542,7 @@ func (n *Engine) SimulateWorkflow(user *model.User, trigger *avsproto.TaskTrigge
 	// Step 1: Start timing BEFORE trigger execution (consistent with node timing)
 	triggerStartTime := time.Now()
 
-	triggerOutput, err := n.runTriggerImmediately(context.Background(), triggerTypeStr, triggerConfig, inputVariables)
+	triggerOutput, err := n.runTriggerImmediately(ctx, triggerTypeStr, triggerConfig, inputVariables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to simulate trigger: %w", err)
 	}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1194,6 +1194,14 @@ func (n *Engine) resolveUserChainID(user *model.User) int64 {
 // resolveUserChainID — REST callers route by their JWT `aud` chain,
 // gRPC callers fall back to the gateway's default chain.
 func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*avsproto.GetWalletResp, error) {
+	return n.GetWalletWithContext(context.Background(), user, payload)
+}
+
+// GetWalletWithContext is GetWallet with a caller-supplied context. REST
+// handlers pass the request context so a client disconnect / timeout cancels
+// the worker-routed CREATE2 derivation; the worker reader's withTimeout still
+// bounds the call when ctx carries no deadline.
+func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, payload *avsproto.GetWalletReq) (*avsproto.GetWalletResp, error) {
 	chainID := n.resolveUserChainID(user)
 	// Resolve the per-chain smart wallet config. In single-chain mode
 	// this returns n.smartWalletConfig (the gateway default); in
@@ -1270,7 +1278,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 		// gateway mode this is worker-routed, so the gateway issues no
 		// direct chain RPC for wallet derivation; in single-chain mode it's
 		// a direct reader that reuses the existing client (no per-call dial).
-		addr, deriveErr := reader.GetSmartWalletAddress(context.Background(), user.Address, factoryAddr, saltBig)
+		addr, deriveErr := reader.GetSmartWalletAddress(ctx, user.Address, factoryAddr, saltBig)
 		if deriveErr != nil {
 			n.logger.Error("GetWallet: factory.getAddress() failed (worker-routed)",
 				"chain_id", chainID, "owner", user.Address.Hex(), "factory", factoryAddr.Hex(),
@@ -3080,7 +3088,7 @@ func (n *Engine) GetWorkflow(user *model.User, taskID string) (*model.Workflow, 
 
 // instructOperatorImmediateTrigger instructs the connected operator to trigger the task immediately
 // with the current block number, bypassing the normal interval waiting
-func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
+func (n *Engine) instructOperatorImmediateTrigger(ctx context.Context, taskID string) error {
 	// Load the task first so the current-block read targets the task's
 	// chain (via its per-chain worker), not a single gateway RPC.
 	task, err := n.GetWorkflowByID(taskID)
@@ -3099,7 +3107,7 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 	if reader == nil {
 		return fmt.Errorf("no chain-state reader available for chain %d (immediate block trigger)", chainID)
 	}
-	currentBlock, err := reader.GetBlockNumber(context.Background())
+	currentBlock, err := reader.GetBlockNumber(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current block number: %w", err)
 	}
@@ -3197,6 +3205,14 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 }
 
 func (n *Engine) TriggerWorkflow(user *model.User, payload *avsproto.TriggerTaskReq) (*avsproto.TriggerTaskResp, error) {
+	return n.TriggerWorkflowWithContext(context.Background(), user, payload)
+}
+
+// TriggerWorkflowWithContext is TriggerWorkflow with a caller-supplied context.
+// REST handlers pass the request context so a client disconnect / timeout
+// cancels the worker-routed current-block read (immediate trigger) and the
+// blocking execution's wallet-ownership validation.
+func (n *Engine) TriggerWorkflowWithContext(ctx context.Context, user *model.User, payload *avsproto.TriggerTaskReq) (*avsproto.TriggerTaskResp, error) {
 	// Validate task ID format first
 	if !ValidateTaskId(payload.TaskId) {
 		return nil, status.Errorf(codes.InvalidArgument, InvalidTaskIdFormat)
@@ -3265,7 +3281,7 @@ func (n *Engine) TriggerWorkflow(user *model.User, payload *avsproto.TriggerTask
 			n.logger.Debug("💾 Persisted pending execution ID with index", "task_id", task.Id, "execution_id", preExecID, "index", preAssignedIndex, "key", string(pendingKey))
 
 			// Best-effort operator instruction (ignore errors; operator may connect later)
-			_ = n.instructOperatorImmediateTrigger(task.Id)
+			_ = n.instructOperatorImmediateTrigger(ctx, task.Id)
 
 			startTime := time.Now().UnixMilli()
 			resp := &avsproto.TriggerTaskResp{
@@ -3326,7 +3342,7 @@ func (n *Engine) TriggerWorkflow(user *model.User, payload *avsproto.TriggerTask
 
 	if payload.IsBlocking {
 		executor := NewExecutor(n.ResolveSmartWalletConfig(task.ChainId), n.db, n.logger, n, n.priceService)
-		execution, runErr := executor.RunTask(task, &queueTaskData)
+		execution, runErr := executor.RunTaskWithContext(ctx, task, &queueTaskData)
 		if runErr != nil {
 			n.logger.Error("failed to run blocking task", runErr)
 			// For blocking execution, return the error to the caller
@@ -3517,7 +3533,7 @@ func (n *Engine) SimulateWorkflow(user *model.User, trigger *avsproto.TaskTrigge
 	// Step 1: Start timing BEFORE trigger execution (consistent with node timing)
 	triggerStartTime := time.Now()
 
-	triggerOutput, err := n.runTriggerImmediately(triggerTypeStr, triggerConfig, inputVariables)
+	triggerOutput, err := n.runTriggerImmediately(context.Background(), triggerTypeStr, triggerConfig, inputVariables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to simulate trigger: %w", err)
 	}

--- a/core/taskengine/event_trigger_oracle_test.go
+++ b/core/taskengine/event_trigger_oracle_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"context"
 	"testing"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
@@ -181,7 +182,7 @@ func TestEventTriggerOraclePriceConditions(t *testing.T) {
 			}
 
 			// Execute the trigger
-			result, err := engine.runTriggerImmediately("eventTrigger", triggerConfig, map[string]interface{}{})
+			result, err := engine.runTriggerImmediately(context.Background(), "eventTrigger", triggerConfig, map[string]interface{}{})
 			require.NoError(t, err, "runTriggerImmediately should not return an error")
 
 			// Debug: Print actual response for analysis

--- a/core/taskengine/event_trigger_test.go
+++ b/core/taskengine/event_trigger_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -344,7 +345,7 @@ func TestEventTriggerQueriesBasedConfiguration(t *testing.T) {
 			}
 			inputVariables := map[string]interface{}{}
 
-			result, err := engine.runTriggerImmediately("eventTrigger", triggerConfig, inputVariables)
+			result, err := engine.runTriggerImmediately(context.Background(), "eventTrigger", triggerConfig, inputVariables)
 
 			if tc.expectError {
 				if err == nil || !strings.Contains(err.Error(), tc.errorMsg) {
@@ -436,7 +437,7 @@ func TestEventTriggerQueriesBasedUserScenario(t *testing.T) {
 	}
 	inputVariables := map[string]interface{}{}
 
-	result, err := engine.runTriggerImmediately("eventTrigger", triggerConfig, inputVariables)
+	result, err := engine.runTriggerImmediately(context.Background(), "eventTrigger", triggerConfig, inputVariables)
 	if err != nil {
 		t.Errorf("runTriggerImmediately failed: %v", err)
 		return

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -206,7 +206,16 @@ func (x *WorkflowExecutor) Perform(job *apqueue.Job) error {
 	return runErr // Propagate the error from task execution
 }
 
+// RunTask executes a task using a background context. It is retained for the
+// async queue path (Perform) and tests, which have no request-scoped context.
 func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecutionData) (*avsproto.Execution, error) {
+	return x.RunTaskWithContext(context.Background(), task, queueData)
+}
+
+// RunTaskWithContext is RunTask with a caller-supplied context. The ctx is
+// propagated to wallet-ownership validation so a cancelled request interrupts
+// in-flight chain-worker derivations.
+func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.Workflow, queueData *QueueExecutionData) (*avsproto.Execution, error) {
 	// Load secrets for the task
 	secrets, err := LoadSecretForTask(x.db, task)
 	if err != nil {
@@ -450,7 +459,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 		smartWalletAddr := common.HexToAddress(task.SmartWalletAddress)
 
 		// Enhanced wallet validation that handles any legitimately derived wallet
-		isValid, err := x.validateWalletOwnership(task.ChainId, user, smartWalletAddr)
+		isValid, err := x.validateWalletOwnership(ctx, task.ChainId, user, smartWalletAddr)
 		if err != nil {
 			execution.EndAt = time.Now().UnixMilli()
 			execution.Error = fmt.Sprintf("failed to validate wallet ownership for owner %s: %v", owner.Hex(), err)
@@ -885,8 +894,11 @@ func (x *WorkflowExecutor) resolveSmartWalletConfig(chainID int64) *config.Smart
 }
 
 // validateWalletOwnership performs comprehensive wallet ownership validation
-// This handles default wallets (salt:0), stored wallets, and legitimately derived wallets
-func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.User, smartWalletAddr common.Address) (bool, error) {
+// This handles default wallets (salt:0), stored wallets, and legitimately derived wallets.
+// ctx is propagated to the chain-worker calls so a cancelled request (client
+// disconnect / timeout) interrupts an in-flight derivation; the worker reader's
+// own withTimeout still bounds the call when ctx carries no deadline.
+func (x *WorkflowExecutor) validateWalletOwnership(ctx context.Context, chainID int64, user *model.User, smartWalletAddr common.Address) (bool, error) {
 	swCfg := x.resolveSmartWalletConfig(chainID)
 
 	// Step 1: Load the user's default smart wallet address (salt:0) for comparison.
@@ -896,7 +908,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 	if swCfg != nil {
 		if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
 			// Gateway mode: derive salt:0 via the chain worker (no gateway dial).
-			if addr, derr := reader.GetSmartWalletAddress(context.Background(), user.Address, swCfg.FactoryAddress, big.NewInt(0)); derr == nil {
+			if addr, derr := reader.GetSmartWalletAddress(ctx, user.Address, swCfg.FactoryAddress, big.NewInt(0)); derr == nil {
 				user.SmartAccountAddress = &addr
 			} else {
 				x.logger.Warn("Failed to load default smart wallet for validation",
@@ -926,7 +938,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 	// never written for the post-upgrade derived address. MUST use the task's
 	// per-chain config — see resolveSmartWalletConfig above.
 	if swCfg != nil {
-		if isValid, err := x.validateDerivedWallet(chainID, swCfg, user.Address, smartWalletAddr); err == nil && isValid {
+		if isValid, err := x.validateDerivedWallet(ctx, chainID, swCfg, user.Address, smartWalletAddr); err == nil && isValid {
 			x.logger.Info("Wallet validated as legitimate derived wallet",
 				"owner", user.Address.Hex(), "wallet", smartWalletAddr.Hex(), "chain_id", chainID)
 			return true, nil
@@ -944,7 +956,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 // The swCfg argument is the per-chain config resolved by the caller —
 // passing it in (rather than reading x.smartWalletConfig) is what makes
 // this work in gateway mode where the executor is shared across chains.
-func (x *WorkflowExecutor) validateDerivedWallet(chainID int64, swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
+func (x *WorkflowExecutor) validateDerivedWallet(ctx context.Context, chainID int64, swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
 	factoryAddr := swCfg.FactoryAddress
 
 	// Try salt values from 0 to max_wallets_per_owner to see if any produce the target wallet address
@@ -955,7 +967,7 @@ func (x *WorkflowExecutor) validateDerivedWallet(chainID int64, swCfg *config.Sm
 	// salt scan server-side (one round-trip). Fall back to a direct dial +
 	// local loop only when no reader is registered (single-chain mode / tests).
 	if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
-		found, salt, err := reader.FindMatchingWalletSalt(context.Background(), owner, factoryAddr, smartWalletAddr, maxWallets)
+		found, salt, err := reader.FindMatchingWalletSalt(ctx, owner, factoryAddr, smartWalletAddr, maxWallets)
 		if err != nil {
 			return false, err
 		}

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -45,6 +45,15 @@ func getRealisticBlockNumberForChain(chainID int64) uint64 {
 // RunNodeImmediately executes a node immediately with optional simulation mode
 // useSimulation parameter (bool): true = simulation (default), false = real execution
 func (n *Engine) RunNodeImmediately(nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, user *model.User, useSimulation ...interface{}) (map[string]interface{}, error) {
+	return n.RunNodeImmediatelyWithContext(context.Background(), nodeType, nodeConfig, inputVariables, user, useSimulation...)
+}
+
+// RunNodeImmediatelyWithContext is RunNodeImmediately with a caller-supplied
+// context. RPC handlers pass the request context so a client disconnect /
+// timeout cancels the worker-routed block reads and wallet-salt scan reached
+// from here; the worker reader's withTimeout still bounds each call when ctx
+// carries no deadline.
+func (n *Engine) RunNodeImmediatelyWithContext(ctx context.Context, nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, user *model.User, useSimulation ...interface{}) (map[string]interface{}, error) {
 	// Default to simulation mode
 	simulationMode := true
 
@@ -56,17 +65,17 @@ func (n *Engine) RunNodeImmediately(nodeType string, nodeConfig map[string]inter
 	}
 
 	if IsTriggerNodeType(nodeType) {
-		return n.runTriggerImmediately(nodeType, nodeConfig, inputVariables)
+		return n.runTriggerImmediately(ctx, nodeType, nodeConfig, inputVariables)
 	} else {
-		return n.runProcessingNodeWithInputs(user, nodeType, nodeConfig, inputVariables, simulationMode)
+		return n.runProcessingNodeWithInputs(ctx, user, nodeType, nodeConfig, inputVariables, simulationMode)
 	}
 }
 
 // runTriggerImmediately executes trigger nodes immediately, ignoring any scheduling configuration
-func (n *Engine) runTriggerImmediately(triggerType string, triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
+func (n *Engine) runTriggerImmediately(ctx context.Context, triggerType string, triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
 	switch triggerType {
 	case NodeTypeBlockTrigger:
-		return n.runBlockTriggerImmediately(triggerConfig, inputVariables)
+		return n.runBlockTriggerImmediately(ctx, triggerConfig, inputVariables)
 	case NodeTypeFixedTimeTrigger:
 		return n.runFixedTimeTriggerImmediately(triggerConfig, inputVariables)
 	case NodeTypeCronTrigger:
@@ -81,7 +90,7 @@ func (n *Engine) runTriggerImmediately(triggerType string, triggerConfig map[str
 }
 
 // runBlockTriggerImmediately gets the latest block data immediately, ignoring any interval configuration
-func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
+func (n *Engine) runBlockTriggerImmediately(ctx context.Context, triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
 	// For immediate execution, we ignore interval and always get the latest block
 	// unless a specific blockNumber is provided
 	var blockNumber uint64
@@ -114,7 +123,7 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 
 	// If no specific block number, get the latest block
 	if blockNumber == 0 {
-		currentBlock, err := reader.GetBlockNumber(context.Background())
+		currentBlock, err := reader.GetBlockNumber(ctx)
 		if err != nil {
 			// For simulations, use a mock block number to avoid RPC rate limiting
 			if strings.Contains(err.Error(), "rate limit") || strings.Contains(err.Error(), "429") {
@@ -134,7 +143,7 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 	}
 
 	// Get real block data via the chain's worker
-	header, err := reader.HeaderByNumber(context.Background(), big.NewInt(int64(blockNumber)))
+	header, err := reader.HeaderByNumber(ctx, big.NewInt(int64(blockNumber)))
 	if err != nil {
 		// For simulations, use mock block data to avoid RPC rate limiting
 		if strings.Contains(err.Error(), "rate limit") || strings.Contains(err.Error(), "429") {
@@ -2445,10 +2454,10 @@ func (n *Engine) runManualTriggerImmediately(triggerConfig map[string]interface{
 }
 
 // runProcessingNodeWithInputs handles execution of processing node types
-func (n *Engine) runProcessingNodeWithInputs(user *model.User, nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, useSimulation bool) (map[string]interface{}, error) {
+func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.User, nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, useSimulation bool) (map[string]interface{}, error) {
 	// Check if this is actually a trigger type that was misrouted
 	if IsTriggerNodeType(nodeType) {
-		return n.runTriggerImmediately(nodeType, nodeConfig, inputVariables)
+		return n.runTriggerImmediately(ctx, nodeType, nodeConfig, inputVariables)
 	}
 
 	// Load secrets for immediate execution (global macroSecrets + user-level secrets)
@@ -2572,7 +2581,7 @@ func (n *Engine) runProcessingNodeWithInputs(user *model.User, nodeType string, 
 					factoryAddr := n.smartWalletConfig.FactoryAddress
 					runnerAddr := common.HexToAddress(runnerStr)
 					if reader := GetChainStateReaderForChain(uint64(n.smartWalletConfig.ChainID)); reader != nil {
-						found, salt, derr := reader.FindMatchingWalletSalt(context.Background(), vm.TaskOwner, factoryAddr, runnerAddr, runnerSaltScan)
+						found, salt, derr := reader.FindMatchingWalletSalt(ctx, vm.TaskOwner, factoryAddr, runnerAddr, runnerSaltScan)
 						if derr != nil {
 							return nil, fmt.Errorf("failed to derive addresses for runner validation: %w", derr)
 						}
@@ -2870,6 +2879,13 @@ func (n *Engine) detectNodeTypeFromStep(step *avsproto.Execution_Step) string {
 
 // RunNodeImmediatelyRPC handles the RPC interface for immediate node execution
 func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWithInputsReq) (*avsproto.RunNodeWithInputsResp, error) {
+	return n.RunNodeImmediatelyRPCWithContext(context.Background(), user, req)
+}
+
+// RunNodeImmediatelyRPCWithContext is RunNodeImmediatelyRPC with a
+// caller-supplied context, propagated to the worker-routed block reads and
+// wallet-salt scan so a cancelled request interrupts them.
+func (n *Engine) RunNodeImmediatelyRPCWithContext(ctx context.Context, user *model.User, req *avsproto.RunNodeWithInputsReq) (*avsproto.RunNodeWithInputsResp, error) {
 	// The request now contains a complete TaskNode, consistent with SimulateTask
 	node := req.Node
 	if node == nil {
@@ -2948,7 +2964,7 @@ func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWi
 	// Execute the node immediately with authenticated user
 	// NOTE: lang field conversion for CustomCode is handled by ParseLanguageFromConfig
 	// Pass the isSimulated flag from node config to control simulation/real execution
-	result, err := n.RunNodeImmediately(nodeTypeStr, nodeConfig, inputVariables, user, useSimulation)
+	result, err := n.RunNodeImmediatelyWithContext(ctx, nodeTypeStr, nodeConfig, inputVariables, user, useSimulation)
 	if err != nil {
 		if n.logger != nil {
 			if isExpectedValidationError(err) {
@@ -3109,6 +3125,13 @@ func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWi
 
 // RunTriggerRPC handles the RPC interface for immediate trigger execution
 func (n *Engine) RunTriggerRPC(user *model.User, req *avsproto.RunTriggerReq) (*avsproto.RunTriggerResp, error) {
+	return n.RunTriggerRPCWithContext(context.Background(), user, req)
+}
+
+// RunTriggerRPCWithContext is RunTriggerRPC with a caller-supplied context,
+// propagated to the worker-routed block reads reached from runTriggerImmediately
+// so a cancelled request interrupts them.
+func (n *Engine) RunTriggerRPCWithContext(ctx context.Context, user *model.User, req *avsproto.RunTriggerReq) (*avsproto.RunTriggerResp, error) {
 	// Validate that trigger is provided
 	if req.Trigger == nil {
 		resp := &avsproto.RunTriggerResp{
@@ -3157,7 +3180,7 @@ func (n *Engine) RunTriggerRPC(user *model.User, req *avsproto.RunTriggerReq) (*
 
 	// Execute the trigger immediately with trigger input data
 	// NOTE: lang field conversion for ManualTrigger is handled by ParseLanguageFromConfig
-	result, err := n.runTriggerImmediately(triggerTypeStr, triggerConfig, triggerInput)
+	result, err := n.runTriggerImmediately(ctx, triggerTypeStr, triggerConfig, triggerInput)
 	if err != nil {
 		if n.logger != nil {
 			// Categorize errors to avoid unnecessary stack traces for expected validation errors

--- a/core/taskengine/worker_ctx_cancellation_test.go
+++ b/core/taskengine/worker_ctx_cancellation_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 // blockingChainStateReader embeds the ChainStateReader interface so it
-// satisfies the full method set, but overrides only GetBlockNumber. The
-// override signals when the worker call has started, then blocks until the
-// caller's context is cancelled — mirroring an in-flight worker round-trip
-// that a request cancellation should be able to interrupt.
+// satisfies the full method set, overriding the two block-read methods the
+// test exercises (GetBlockNumber and HeaderByNumber). GetBlockNumber signals
+// when the worker call has started, then both block until the caller's context
+// is cancelled — mirroring an in-flight worker round-trip that a request
+// cancellation should be able to interrupt.
 type blockingChainStateReader struct {
 	ChainStateReader
 	started chan struct{}
@@ -29,17 +30,22 @@ func (b *blockingChainStateReader) HeaderByNumber(ctx context.Context, _ *big.In
 	return nil, ctx.Err()
 }
 
-
 func TestRunBlockTriggerImmediately_ContextCancellationInterruptsWorkerCall(t *testing.T) {
 	// runBlockTriggerImmediately only reads n.logger (nil-guarded) and the
 	// global chain-state reader registry, so a zero-value Engine is enough —
 	// this keeps the test independent of the gateway config fixture.
 	engine := &Engine{}
 
+	// Start from a clean registry and clear it on exit. A nil-reader
+	// "unregister" is a no-op (RegisterChainStateReader early-returns on nil),
+	// so ClearChainStateReaderRegistry is the real cleanup — matches the
+	// pattern in chain_state_reader_test.go.
+	ClearChainStateReaderRegistry()
+	defer ClearChainStateReaderRegistry()
+
 	const testChainID int64 = 987654321
 	reader := &blockingChainStateReader{started: make(chan struct{})}
 	RegisterChainStateReader(uint64(testChainID), reader)
-	defer RegisterChainStateReader(uint64(testChainID), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/core/taskengine/worker_ctx_cancellation_test.go
+++ b/core/taskengine/worker_ctx_cancellation_test.go
@@ -1,0 +1,83 @@
+package taskengine
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// blockingChainStateReader embeds the ChainStateReader interface so it
+// satisfies the full method set, but overrides only GetBlockNumber. The
+// override signals when the worker call has started, then blocks until the
+// caller's context is cancelled — mirroring an in-flight worker round-trip
+// that a request cancellation should be able to interrupt.
+type blockingChainStateReader struct {
+	ChainStateReader
+	started chan struct{}
+}
+
+func (b *blockingChainStateReader) GetBlockNumber(ctx context.Context) (uint64, error) {
+	close(b.started)
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func (b *blockingChainStateReader) HeaderByNumber(ctx context.Context, _ *big.Int) (*BlockHeader, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+
+func TestRunBlockTriggerImmediately_ContextCancellationInterruptsWorkerCall(t *testing.T) {
+	// runBlockTriggerImmediately only reads n.logger (nil-guarded) and the
+	// global chain-state reader registry, so a zero-value Engine is enough —
+	// this keeps the test independent of the gateway config fixture.
+	engine := &Engine{}
+
+	const testChainID int64 = 987654321
+	reader := &blockingChainStateReader{started: make(chan struct{})}
+	RegisterChainStateReader(uint64(testChainID), reader)
+	defer RegisterChainStateReader(uint64(testChainID), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	triggerConfig := map[string]interface{}{
+		"chain_id": testChainID,
+	}
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, err := engine.runTriggerImmediately(ctx, NodeTypeBlockTrigger, triggerConfig, map[string]interface{}{})
+		done <- result{err: err}
+	}()
+
+	// Wait until the worker call is actually in flight before cancelling, so
+	// the test exercises interruption of an in-flight call rather than a
+	// pre-cancelled context shortcut.
+	select {
+	case <-reader.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker GetBlockNumber was never reached")
+	}
+
+	cancel()
+
+	select {
+	case res := <-done:
+		if res.err == nil {
+			t.Fatal("expected an error after context cancellation, got nil")
+		}
+		if !errors.Is(res.err, context.Canceled) {
+			t.Fatalf("expected error to wrap context.Canceled, got: %v", res.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runBlockTriggerImmediately did not return after context cancellation; " +
+			"cancellation was not propagated to the worker call")
+	}
+}


### PR DESCRIPTION
Fixes #599 

## Summary

Seven gateway → chain-worker calls passed `context.Background()`, so request cancellation (client disconnect, HTTP timeout) could not interrupt them. Each call was bounded only by the worker reader's own `withTimeout`.

This change threads the incoming request context down to all seven sites, making cancellation an additional, earlier signal. `withTimeout` remains the lower bound, so behaviour is unchanged when the context is never cancelled.

## Sites Updated

| Enclosing Function | Worker Call |
| --- | --- |
| `executor.go` → `validateWalletOwnership` | `GetSmartWalletAddress` |
| `executor.go` → `validateDerivedWallet` | `FindMatchingWalletSalt` |
| `engine.go` → `GetWallet` | `GetSmartWalletAddress` |
| `engine.go` → `instructOperatorImmediateTrigger` | `GetBlockNumber` |
| `run_node_immediately.go` → `runBlockTriggerImmediately` | `GetBlockNumber` |
| `run_node_immediately.go` → `runBlockTriggerImmediately` | `HeaderByNumber` |
| `run_node_immediately.go` → `runProcessingNodeWithInputs` | `FindMatchingWalletSalt` |

## Why the Implementation Differs from the Issue's Proposed Approach

The issue proposed:

> "Each enclosing function gains a leading `ctx context.Context` parameter; update callers up to the handler that already holds the request context."

Taken literally, this would require changing the signatures of several public methods:

- `GetWallet`
- `RunNodeImmediately`
- `RunNodeImmediatelyRPC`
- `RunTriggerRPC`
- `RunTask`
- `TriggerWorkflow`

Those methods have roughly 150 call sites, almost all in tests. The result would be a large, mostly mechanical diff and a breaking change to exported APIs for what the issue itself classifies as a robustness and latency improvement rather than a correctness fix.

Instead, this implementation takes a narrower approach:

- **Private internals accept `ctx` directly** (`validate*`, `runTriggerImmediately`, `runBlockTriggerImmediately`, `runProcessingNodeWithInputs`, `instructOperatorImmediateTrigger`, and the `GetWallet` implementation). Their callers are internal, so no API churn is required.
- **Public methods retain their existing signatures** as thin wrappers that delegate using `context.Background()`. The actual implementation is moved to new context-aware siblings:
  - `GetWalletWithContext`
  - `RunTaskWithContext`
  - `RunNodeImmediatelyWithContext`
  - `RunNodeImmediatelyRPCWithContext`
  - `RunTriggerRPCWithContext`
  - `TriggerWorkflowWithContext`
- **The four REST handlers** (wallets, triggers, nodes, and workflows)—the actual request-context entry points—call the `...WithContext` variants using `ctx.Request().Context()`.

This achieves the same result at the seven worker-call sites while:

- Preserving backward compatibility for exported APIs.
- Avoiding widespread test churn (only three internal callers required updates).
- Accurately modeling the async queue path (`Perform`), which has no request context and therefore continues to use `context.Background()`.

## Testing

`TestRunBlockTriggerImmediately_ContextCancellationInterruptsWorkerCall` registers a fake `ChainStateReader` whose `GetBlockNumber` method signals startup and then blocks on `ctx.Done()`.

The test:

1. Starts the worker call.
2. Cancels the request context while the call is in flight.
3. Verifies that the call returns an error wrapping `context.Canceled`.

Under the previous `context.Background()` implementation, the call would have remained blocked until the assertion timeout, demonstrating that cancellation now propagates correctly.

Additionally:

- `go build ./...` passes.
- `go vet` passes on all touched packages.

## Acceptance Criteria

- [x] All seven sites propagate a request-scoped `ctx` instead of `context.Background()`.
- [x] A canceled request context interrupts an in-flight worker call (test added).
- [x] No behavior changes when the context is not canceled (`withTimeout` still applies).