### PR TITLE
chore: clearer errors for invalid controller key / unparseable config

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -446,7 +446,15 @@ func NewConfig(configFilePath string) (*Config, error) {
 
 	controllerPrivateKey, err := crypto.HexToECDSA(configRaw.SmartWallet.ControllerPrivateKey)
 	if err != nil {
-		panic(err)
+		// Name the field + the likely cause. The bare crypto error
+		// ("invalid length, need 256 bits") gives no hint which key is at
+		// fault. In practice this is almost always a missing/empty env var or
+		// an unresolved ${{shared.*}} Railway reference, which decodes to the
+		// wrong length. (Production incident: gateway crash-loop after a
+		// per-tier controller key var was unset on the service.)
+		panic(fmt.Errorf("smart_wallet.controller_private_key is not a valid 64-hex-char "+
+			"private key — check the controller key env var for this service; an empty value or an "+
+			"unresolved ${...}/${{shared.*}} reference produces this: %w", err))
 	}
 
 	// Enforce sane default for max wallets per owner (no unlimited allowed)
@@ -712,7 +720,11 @@ func ReadYamlConfig(path string, o interface{}) error {
 	})
 
 	if err := yaml.Unmarshal([]byte(expanded), o); err != nil {
-		return fmt.Errorf("unable to parse file with error %#v", err)
+		// A common cause is an env var that resolved to a value containing
+		// YAML-special characters — e.g. an unresolved ${{shared.*}} Railway
+		// reference left as literal "${{...}}" text after expansion.
+		return fmt.Errorf("unable to parse YAML config %q (a substituted env var may "+
+			"contain an unresolved ${{...}} reference or YAML-special characters): %w", path, err)
 	}
 
 	return nil


### PR DESCRIPTION
## What

Make two config-load failures self-explanatory instead of opaque. Both were exposed by a gateway crash-loop after a controller-key env var was missing/misconfigured on the service.

- **`config.NewConfig`** — when the controller private key fails to parse, the error now names the field and the likely cause (a missing/empty env var, or an unresolved `${{shared.*}}` reference that decodes to the wrong length). Previously it panicked with a bare `invalid length, need 256 bits` that named no field.
- **`ReadYamlConfig`** — the YAML parse error is now wrapped with the file path and a hint that a substituted env var may contain an unresolved `${{...}}` reference (literal reference text left after expansion contains YAML-special characters, which breaks parsing).

## Why

During the v3.10 release the gateway crash-looped twice with unhelpful messages — first `invalid length, need 256 bits` (empty controller key var), then `Failed to parse config file` (an unresolved reference left as literal `${{...}}` text). Neither pointed at the actual misconfigured variable. This makes the next misconfig diagnosable from the logs alone.

## Scope

Diagnostics only — no behavior change on the happy path. Not required to resolve any active incident.

## Testing
- `go build ./...` ✅
- `go vet ./core/config/` ✅
- `go test ./core/config/` ✅
