### PR TITLE
fix: delete stale Enabled key when auto-failing invalid tasks

### DIFF
--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -6165,6 +6165,13 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 
 	invalidTasks := []string{}
 	updates := make(map[string][]byte)
+	// Status-keyed storage uses status in the key (t:<chain>:<status>:<id>),
+	// so flipping a task to Failed means writing the new Failed key AND
+	// deleting the old (Enabled) one. Without the delete, the stale Enabled
+	// key survives, MustStart reloads it from the Enabled prefix on the next
+	// boot, and this scan re-fails it — an invisible every-boot loop. Collect
+	// the stale keys here and delete them after the batch write succeeds.
+	staleStatusKeys := [][]byte{}
 
 	// Acquire lock once for the entire operation to reduce lock contention
 	n.lock.Lock()
@@ -6176,6 +6183,9 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 			n.logger.Warn("🚨 Found invalid task configuration",
 				"task_id", taskID,
 				"error", err.Error())
+
+			// Capture the pre-failure status key before SetFailed mutates it.
+			oldStatus := task.Status
 
 			// Mark task as failed and prepare storage updates
 			task.SetFailed()
@@ -6191,6 +6201,18 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 			// Prepare the task status update in storage
 			updates[string(ChainWorkflowStorageKey(task.ChainId, task.Id, task.Status))] = taskJSON
 			updates[string(ChainTaskUserKey(task.ChainId, task))] = []byte(fmt.Sprintf("%d", avsproto.TaskStatus_Failed))
+
+			// Queue the old status-keyed row for deletion (skip when the
+			// status didn't actually change, to avoid deleting what we just
+			// wrote).
+			if oldStatus != task.Status {
+				staleStatusKeys = append(staleStatusKeys, ChainWorkflowStorageKey(task.ChainId, task.Id, oldStatus))
+			}
+
+			// Drop from the in-memory active set so it isn't treated as active
+			// for the rest of this process run. Deleting the current key while
+			// ranging over a map is safe in Go.
+			delete(n.tasks, taskID)
 		}
 	}
 
@@ -6205,12 +6227,22 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 		"count", len(invalidTasks),
 		"task_ids", invalidTasks)
 
-	// Batch write the updates
+	// Write the Failed records first so we never lose a task record, ...
 	if len(updates) > 0 {
 		if err := n.db.BatchWrite(updates); err != nil {
 			n.logger.Error("Failed to update invalid tasks in storage",
 				"error", err)
 			return err
+		}
+	}
+
+	// ... then delete the stale old-status rows so the next boot's
+	// Enabled-prefix scan doesn't reload and re-fail them.
+	for _, key := range staleStatusKeys {
+		if err := n.db.Delete(key); err != nil {
+			n.logger.Error("Failed to delete stale task status key",
+				"key", string(key),
+				"error", err)
 		}
 	}
 

--- a/core/taskengine/engine_invalid_tasks_test.go
+++ b/core/taskengine/engine_invalid_tasks_test.go
@@ -1,0 +1,110 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedInvalidEnabledTask stores an invalid task (block trigger with no config)
+// under the Enabled status key, mirroring a task created before validation
+// existed, and returns it.
+func seedInvalidEnabledTask(t *testing.T, db interface {
+	Set(key, value []byte) error
+}, chainID int64, id string) *model.Workflow {
+	t.Helper()
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id:      id,
+		ChainId: chainID,
+		Status:  avsproto.TaskStatus_Enabled,
+		Trigger: &avsproto.TaskTrigger{
+			Name: "trigger1",
+			// Block trigger with a nil Config → fails ValidateWithError with
+			// "block trigger config is required but missing".
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{}},
+		},
+	}}
+	require.Error(t, task.ValidateWithError(), "fixture must be invalid")
+
+	taskJSON, err := task.ToJSON()
+	require.NoError(t, err)
+	require.NoError(t, db.Set(ChainWorkflowStorageKey(chainID, id, avsproto.TaskStatus_Enabled), taskJSON))
+	return task
+}
+
+// TestDetectAndHandleInvalidTasks_DeletesStaleEnabledKey is the regression test
+// for the every-boot re-fail loop: marking a task Failed must also remove its
+// stale Enabled-status key, so a subsequent boot's Enabled-prefix scan does not
+// reload and re-fail it.
+func TestDetectAndHandleInvalidTasks_DeletesStaleEnabledKey(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	const chainID = int64(11155111)
+	task := seedInvalidEnabledTask(t, db, chainID, "invalid-task-1")
+	n.AddWorkflowForTesting(task)
+
+	// First scan: marks it failed.
+	require.NoError(t, n.DetectAndHandleInvalidTasks())
+
+	// The stale Enabled key must be gone...
+	enabledItems, err := db.GetByPrefix(ChainWorkflowByStatusStoragePrefix(chainID, avsproto.TaskStatus_Enabled))
+	require.NoError(t, err)
+	assert.Empty(t, enabledItems, "stale Enabled-status key must be deleted so the next boot can't reload it")
+
+	// ...and the task must now live under the Failed key.
+	failedExists, err := db.Exist(ChainWorkflowStorageKey(chainID, task.Id, avsproto.TaskStatus_Failed))
+	require.NoError(t, err)
+	assert.True(t, failedExists, "task should now be stored under the Failed status key")
+
+	// It must be dropped from the in-memory active set.
+	n.lock.Lock()
+	_, stillActive := n.tasks[task.Id]
+	n.lock.Unlock()
+	assert.False(t, stillActive, "failed task should be dropped from the active set")
+
+	// Simulate the next boot: reloading from the Enabled prefix must NOT bring
+	// it back. This is the assertion that would have caught the loop.
+	reloaded, err := db.GetByPrefix(ChainWorkflowByStatusStoragePrefix(chainID, avsproto.TaskStatus_Enabled))
+	require.NoError(t, err)
+	assert.Empty(t, reloaded, "invalid task must not reappear under Enabled on the next boot")
+}
+
+// TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone ensures the scan is a
+// no-op for valid tasks (no spurious failures, no key churn).
+func TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	const chainID = int64(11155111)
+	valid := &model.Workflow{Task: &avsproto.Task{
+		Id:      "valid-task-1",
+		ChainId: chainID,
+		Status:  avsproto.TaskStatus_Enabled,
+		Trigger: &avsproto.TaskTrigger{
+			Name: "trigger1",
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{
+				Config: &avsproto.BlockTrigger_Config{Interval: 1},
+			}},
+		},
+	}}
+	require.NoError(t, valid.ValidateWithError(), "fixture must be valid")
+	n.AddWorkflowForTesting(valid)
+
+	require.NoError(t, n.DetectAndHandleInvalidTasks())
+
+	n.lock.Lock()
+	_, stillActive := n.tasks[valid.Id]
+	n.lock.Unlock()
+	assert.True(t, stillActive, "valid task must remain active")
+
+	failedExists, err := db.Exist(ChainWorkflowStorageKey(chainID, valid.Id, avsproto.TaskStatus_Failed))
+	require.NoError(t, err)
+	assert.False(t, failedExists, "valid task must not be written under the Failed key")
+}


### PR DESCRIPTION
## What

`DetectAndHandleInvalidTasks` (the boot-time scan that fails tasks with invalid configs) wrote the new `Failed` status row but **never deleted the task's original `Enabled`-status key**. Storage keys embed status (`t:<chain>:<status>:<id>`), and `MustStart` loads active tasks from the `Enabled` prefix — so the orphaned `Enabled` key was reloaded and re-failed **on every boot**. The status flip never stuck: an invisible loop that re-emitted the same WARNs indefinitely and never actually retired the tasks.

This is why a year-old cohort of 33 invalid tasks kept resurfacing every restart (and why it went unnoticed — the scan only logs at `WARN`, never to Sentry/metrics).

## Fix

In the scan: capture the pre-failure status, **delete the old status-keyed row** after the `Failed` write succeeds, and drop the task from the in-memory active set. Mirrors the existing correct transition pattern at `engine.go:4513`.

## Test

`engine_invalid_tasks_test.go`:
- **Regression:** after one scan, the `Enabled` key is gone, the task is under the `Failed` key, it's removed from the active set, and a simulated next-boot `Enabled`-prefix reload returns nothing — the assertion that would have caught the loop.
- **No-op on valid tasks:** valid task stays active, never written under `Failed`.

## Notes
- Bug-fix only; does not delete or repair the existing 33 records (that's a separate data decision, pending owner identification).
- A follow-up should also surface auto-failures via a metric / owner notification so the next cohort isn't invisible.

## Testing
- `go build ./...`, `go vet ./core/taskengine/` ✅
- new tests + CRUD/status tests pass ✅
