### PR TITLE
fix: retire invalid tasks correctly + clearer config errors and diagnostics

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -446,7 +446,15 @@ func NewConfig(configFilePath string) (*Config, error) {
 
 	controllerPrivateKey, err := crypto.HexToECDSA(configRaw.SmartWallet.ControllerPrivateKey)
 	if err != nil {
-		panic(err)
+		// Name the field + the likely cause. The bare crypto error
+		// ("invalid length, need 256 bits") gives no hint which key is at
+		// fault. In practice this is almost always a missing/empty env var or
+		// an unresolved ${{shared.*}} Railway reference, which decodes to the
+		// wrong length. (Production incident: gateway crash-loop after a
+		// per-tier controller key var was unset on the service.)
+		panic(fmt.Errorf("smart_wallet.controller_private_key is not a valid 64-hex-char "+
+			"private key — check the controller key env var for this service; an empty value or an "+
+			"unresolved ${...}/${{shared.*}} reference produces this: %w", err))
 	}
 
 	// Enforce sane default for max wallets per owner (no unlimited allowed)
@@ -712,7 +720,11 @@ func ReadYamlConfig(path string, o interface{}) error {
 	})
 
 	if err := yaml.Unmarshal([]byte(expanded), o); err != nil {
-		return fmt.Errorf("unable to parse file with error %#v", err)
+		// A common cause is an env var that resolved to a value containing
+		// YAML-special characters — e.g. an unresolved ${{shared.*}} Railway
+		// reference left as literal "${{...}}" text after expansion.
+		return fmt.Errorf("unable to parse YAML config %q (a substituted env var may "+
+			"contain an unresolved ${{...}} reference or YAML-special characters): %w", path, err)
 	}
 
 	return nil

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -6165,6 +6165,13 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 
 	invalidTasks := []string{}
 	updates := make(map[string][]byte)
+	// Status-keyed storage uses status in the key (t:<chain>:<status>:<id>),
+	// so flipping a task to Failed means writing the new Failed key AND
+	// deleting the old (Enabled) one. Without the delete, the stale Enabled
+	// key survives, MustStart reloads it from the Enabled prefix on the next
+	// boot, and this scan re-fails it — an invisible every-boot loop. Collect
+	// the stale keys here and delete them after the batch write succeeds.
+	staleStatusKeys := [][]byte{}
 
 	// Acquire lock once for the entire operation to reduce lock contention
 	n.lock.Lock()
@@ -6176,6 +6183,9 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 			n.logger.Warn("🚨 Found invalid task configuration",
 				"task_id", taskID,
 				"error", err.Error())
+
+			// Capture the pre-failure status key before SetFailed mutates it.
+			oldStatus := task.Status
 
 			// Mark task as failed and prepare storage updates
 			task.SetFailed()
@@ -6191,6 +6201,18 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 			// Prepare the task status update in storage
 			updates[string(ChainWorkflowStorageKey(task.ChainId, task.Id, task.Status))] = taskJSON
 			updates[string(ChainTaskUserKey(task.ChainId, task))] = []byte(fmt.Sprintf("%d", avsproto.TaskStatus_Failed))
+
+			// Queue the old status-keyed row for deletion (skip when the
+			// status didn't actually change, to avoid deleting what we just
+			// wrote).
+			if oldStatus != task.Status {
+				staleStatusKeys = append(staleStatusKeys, ChainWorkflowStorageKey(task.ChainId, task.Id, oldStatus))
+			}
+
+			// Drop from the in-memory active set so it isn't treated as active
+			// for the rest of this process run. Deleting the current key while
+			// ranging over a map is safe in Go.
+			delete(n.tasks, taskID)
 		}
 	}
 
@@ -6205,12 +6227,22 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 		"count", len(invalidTasks),
 		"task_ids", invalidTasks)
 
-	// Batch write the updates
+	// Write the Failed records first so we never lose a task record, ...
 	if len(updates) > 0 {
 		if err := n.db.BatchWrite(updates); err != nil {
 			n.logger.Error("Failed to update invalid tasks in storage",
 				"error", err)
 			return err
+		}
+	}
+
+	// ... then delete the stale old-status rows so the next boot's
+	// Enabled-prefix scan doesn't reload and re-fail them.
+	for _, key := range staleStatusKeys {
+		if err := n.db.Delete(key); err != nil {
+			n.logger.Error("Failed to delete stale task status key",
+				"key", string(key),
+				"error", err)
 		}
 	}
 

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -6180,8 +6180,22 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 	for taskID, task := range n.tasks {
 		if err := task.ValidateWithError(); err != nil {
 			invalidTasks = append(invalidTasks, taskID)
+
+			// Log owner/smart-wallet/created-at so an auto-failed task can be
+			// traced to its user straight from the logs, without a DB query —
+			// the observability gap that let a cohort of invalid tasks fail
+			// silently for ~a year. created_at is derived from the ULID task
+			// ID since Task has no created_at field.
+			createdAt := "unknown"
+			if parsed, perr := ulid.Parse(strings.ToUpper(taskID)); perr == nil {
+				createdAt = time.UnixMilli(int64(parsed.Time())).UTC().Format(time.RFC3339)
+			}
 			n.logger.Warn("🚨 Found invalid task configuration",
 				"task_id", taskID,
+				"owner", task.GetOwner(),
+				"smart_wallet", task.GetSmartWalletAddress(),
+				"chain_id", task.GetChainId(),
+				"created_at", createdAt,
 				"error", err.Error())
 
 			// Capture the pre-failure status key before SetFailed mutates it.

--- a/core/taskengine/engine_invalid_tasks_test.go
+++ b/core/taskengine/engine_invalid_tasks_test.go
@@ -1,0 +1,110 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedInvalidEnabledTask stores an invalid task (block trigger with no config)
+// under the Enabled status key, mirroring a task created before validation
+// existed, and returns it.
+func seedInvalidEnabledTask(t *testing.T, db interface {
+	Set(key, value []byte) error
+}, chainID int64, id string) *model.Workflow {
+	t.Helper()
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id:      id,
+		ChainId: chainID,
+		Status:  avsproto.TaskStatus_Enabled,
+		Trigger: &avsproto.TaskTrigger{
+			Name: "trigger1",
+			// Block trigger with a nil Config → fails ValidateWithError with
+			// "block trigger config is required but missing".
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{}},
+		},
+	}}
+	require.Error(t, task.ValidateWithError(), "fixture must be invalid")
+
+	taskJSON, err := task.ToJSON()
+	require.NoError(t, err)
+	require.NoError(t, db.Set(ChainWorkflowStorageKey(chainID, id, avsproto.TaskStatus_Enabled), taskJSON))
+	return task
+}
+
+// TestDetectAndHandleInvalidTasks_DeletesStaleEnabledKey is the regression test
+// for the every-boot re-fail loop: marking a task Failed must also remove its
+// stale Enabled-status key, so a subsequent boot's Enabled-prefix scan does not
+// reload and re-fail it.
+func TestDetectAndHandleInvalidTasks_DeletesStaleEnabledKey(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	const chainID = int64(11155111)
+	task := seedInvalidEnabledTask(t, db, chainID, "invalid-task-1")
+	n.AddWorkflowForTesting(task)
+
+	// First scan: marks it failed.
+	require.NoError(t, n.DetectAndHandleInvalidTasks())
+
+	// The stale Enabled key must be gone...
+	enabledItems, err := db.GetByPrefix(ChainWorkflowByStatusStoragePrefix(chainID, avsproto.TaskStatus_Enabled))
+	require.NoError(t, err)
+	assert.Empty(t, enabledItems, "stale Enabled-status key must be deleted so the next boot can't reload it")
+
+	// ...and the task must now live under the Failed key.
+	failedExists, err := db.Exist(ChainWorkflowStorageKey(chainID, task.Id, avsproto.TaskStatus_Failed))
+	require.NoError(t, err)
+	assert.True(t, failedExists, "task should now be stored under the Failed status key")
+
+	// It must be dropped from the in-memory active set.
+	n.lock.Lock()
+	_, stillActive := n.tasks[task.Id]
+	n.lock.Unlock()
+	assert.False(t, stillActive, "failed task should be dropped from the active set")
+
+	// Simulate the next boot: reloading from the Enabled prefix must NOT bring
+	// it back. This is the assertion that would have caught the loop.
+	reloaded, err := db.GetByPrefix(ChainWorkflowByStatusStoragePrefix(chainID, avsproto.TaskStatus_Enabled))
+	require.NoError(t, err)
+	assert.Empty(t, reloaded, "invalid task must not reappear under Enabled on the next boot")
+}
+
+// TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone ensures the scan is a
+// no-op for valid tasks (no spurious failures, no key churn).
+func TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	const chainID = int64(11155111)
+	valid := &model.Workflow{Task: &avsproto.Task{
+		Id:      "valid-task-1",
+		ChainId: chainID,
+		Status:  avsproto.TaskStatus_Enabled,
+		Trigger: &avsproto.TaskTrigger{
+			Name: "trigger1",
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{
+				Config: &avsproto.BlockTrigger_Config{Interval: 1},
+			}},
+		},
+	}}
+	require.NoError(t, valid.ValidateWithError(), "fixture must be valid")
+	n.AddWorkflowForTesting(valid)
+
+	require.NoError(t, n.DetectAndHandleInvalidTasks())
+
+	n.lock.Lock()
+	_, stillActive := n.tasks[valid.Id]
+	n.lock.Unlock()
+	assert.True(t, stillActive, "valid task must remain active")
+
+	failedExists, err := db.Exist(ChainWorkflowStorageKey(chainID, valid.Id, avsproto.TaskStatus_Failed))
+	require.NoError(t, err)
+	assert.False(t, failedExists, "valid task must not be written under the Failed key")
+}

--- a/scripts/dev/dump-invalid-tasks/main.go
+++ b/scripts/dev/dump-invalid-tasks/main.go
@@ -1,0 +1,98 @@
+// dump-invalid-tasks — read-only diagnostic that scans a gateway BadgerDB for
+// Enabled workflows failing validation, printing task id / chain / created-at /
+// owner / error so operators can decide whether to repair or delete them
+// (e.g. the legacy "send eth" node-name and missing-trigger-config cohorts).
+//
+// READ-ONLY in intent, but BadgerDB takes an exclusive directory lock, so run
+// this against a COPY/backup of the gateway DB (e.g. /data/gateway-backup),
+// NOT the live directory while the gateway is running.
+//
+// Usage:
+//
+//	go run ./scripts/dev/dump-invalid-tasks --gateway-path /path/to/gateway-db-copy
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// ulidTime decodes the millisecond timestamp embedded in a ULID's first 10
+// Crockford-base32 characters (task IDs are ULIDs).
+func ulidTime(id string) string {
+	const enc = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+	u := strings.ToUpper(id)
+	if len(u) < 10 {
+		return "?"
+	}
+	var ms int64
+	for _, c := range u[:10] {
+		i := strings.IndexRune(enc, c)
+		if i < 0 {
+			return "?"
+		}
+		ms = ms*32 + int64(i)
+	}
+	return time.UnixMilli(ms).UTC().Format("2006-01-02 15:04")
+}
+
+func main() {
+	gatewayPath := flag.String("gateway-path", "", "Path to a COPY of the gateway BadgerDB directory (not the live DB)")
+	flag.Parse()
+	if *gatewayPath == "" {
+		log.Fatalf("--gateway-path is required (point it at a backup/copy, not the live DB)")
+	}
+
+	db, err := storage.NewWithPath(*gatewayPath)
+	if err != nil {
+		log.Fatalf("open BadgerDB at %s: %v", *gatewayPath, err)
+	}
+	defer db.Close()
+
+	items, err := db.GetByPrefix([]byte("t:"))
+	if err != nil {
+		log.Fatalf("scan workflows: %v", err)
+	}
+
+	fmt.Printf("%-28s %-9s %-16s %-44s %s\n", "TaskID", "Chain", "CreatedUTC", "Owner", "Error")
+	fmt.Println(strings.Repeat("-", 150))
+
+	scanned, invalid := 0, 0
+	for _, it := range items {
+		// Only Enabled workflow rows: t:<chain>:a:<id>. ULIDs contain no
+		// colons, so a 4-way split is exact.
+		parts := strings.SplitN(string(it.Key), ":", 4)
+		if len(parts) != 4 || parts[0] != "t" || parts[1] == "" || parts[2] != "a" {
+			continue
+		}
+		scanned++
+
+		task := &model.Workflow{Task: &avsproto.Task{}}
+		if derr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(it.Value, task); derr != nil {
+			invalid++
+			fmt.Printf("%-28s %-9s %-16s %-44s %s\n", parts[3], parts[1], "?", "?", "DECODE ERROR: "+derr.Error())
+			continue
+		}
+
+		if verr := task.ValidateWithError(); verr != nil {
+			invalid++
+			owner := task.GetOwner()
+			if owner == "" {
+				owner = task.GetSmartWalletAddress()
+			}
+			fmt.Printf("%-28s %-9s %-16s %-44s %s\n",
+				task.GetId(), parts[1], ulidTime(task.GetId()), owner, verr.Error())
+		}
+	}
+
+	fmt.Println(strings.Repeat("-", 150))
+	fmt.Printf("Scanned %d Enabled workflows; %d invalid.\n", scanned, invalid)
+}


### PR DESCRIPTION
## Release: staging → main

Highest-impact change is a `fix:`, so this cuts a **patch** release.

### Included
- **fix:** delete stale `Enabled` key when auto-failing invalid tasks (`41c84bd`) — `DetectAndHandleInvalidTasks` wrote the `Failed` row but never removed the original `Enabled`-status key, so invalid tasks were reloaded and re-failed on **every boot** (an invisible loop). Now deletes the stale key and drops the task from the active set; regression test asserts it isn't re-detected on a simulated next boot.
- **chore:** log `owner` / `smart_wallet` / `chain_id` / `created_at` for auto-failed tasks (`460292b`) — closes the observability gap that hid the loop; an auto-failed task is now traceable to its user straight from the logs.
- **chore:** read-only `dump-invalid-tasks` diagnostic (`aaf7be0`) — scans a gateway DB copy and reports invalid tasks with owner/created-at.
- **chore:** clearer errors for invalid controller key / unparseable config (`8efffe1`) — names the field + likely cause (missing env var / unresolved `${{shared.*}}` reference) instead of an opaque crypto/YAML panic.

### Storage check
`make storage-check` vs `origin/main`: ✅ no breaking storage changes (key templates + persisted model structs unchanged).

### Deploy note
On the first gateway boot after this release, the boot scan logs each invalid task **once** with full owner attribution, then retires the cohort to `Failed` (loop fixed). Capture owners with:
`railway logs --service gateway | grep "Found invalid task configuration"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
