### PR TITLE
test: guard that CreateWorkflow rejects invalid node names

### DIFF
--- a/core/taskengine/engine_invalid_tasks_test.go
+++ b/core/taskengine/engine_invalid_tasks_test.go
@@ -108,3 +108,29 @@ func TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, failedExists, "valid task must not be written under the Failed key")
 }
+
+// TestCreateWorkflow_RejectsInvalidNodeName guards the dominant legacy-cohort
+// failure mode at the create boundary: a node name with a space ("send eth")
+// is not a valid JavaScript identifier. The create path validates this via
+// model.NewWorkflowFromProtobuf → ValidateWithError, so such a task can no
+// longer be persisted. (Block/cron/event missing-config is already covered by
+// TestCreateTaskReturnErrorWhenNilBlockTriggerConfig and the same
+// ValidateWithError path; the 7 missing-config legacy tasks were valid at
+// creation and only became invalid after a proto schema migration moved
+// trigger-config fields — a data artifact, not a create-time gap.)
+func TestCreateWorkflow_RejectsInvalidNodeName(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	// Sanity: a valid task creates fine.
+	if _, err := n.CreateWorkflow(testutil.TestUser1(), testutil.RestTask()); err != nil {
+		t.Fatalf("valid task should create: %v", err)
+	}
+
+	bad := testutil.RestTask()
+	bad.Nodes[0].Name = "send eth" // space → not a valid JS identifier
+	_, err := n.CreateWorkflow(testutil.TestUser1(), bad)
+	require.Error(t, err, "CreateWorkflow must reject a spaced node name")
+	assert.Contains(t, err.Error(), "JavaScript identifier")
+}


### PR DESCRIPTION
## Outcome of the root-cause investigation: current code already prevents both classes — no production change needed.

I verified (empirically + by tracing the code) that `CreateWorkflow` already rejects both legacy failure modes at creation, because it builds the task via `model.NewWorkflowFromProtobuf`, which calls `ValidateWithError()` (node/trigger names **and** all trigger configs) before persisting. Confirmed by stashing a change and seeing `TestCreateTaskReturnErrorWhenNilBlockTriggerConfig` still pass.

This PR adds the **one missing regression test** and nothing else.

### Root cause (for the record)
- **`"send eth"` node name (26 tasks):** created **before** node-name validation existed in `ValidateWithError` (added in the v3 gateway cutover). Today the create path rejects it — but there was **no create-time test** for it. This PR adds it.
- **Missing trigger config (7 tasks):** these were **valid at creation** and only became invalid later, when a proto schema migration moved trigger-config fields (`interval`/`epochs`/…) into `Config` sub-messages; the old fields are dropped on load (`DiscardUnknown`), so `GetConfig()` now reads `nil`. This is a **stored-data artifact, not a create-time gap** — already covered by `TestCreateTaskReturnErrorWhenNilBlockTriggerConfig`, and guarded against recurrence by `make storage-check` (which flags breaking proto/storage field changes).

### Change
- `TestCreateWorkflow_RejectsInvalidNodeName`: asserts a spaced node name (`"send eth"`) is rejected at create. No source change.

### Testing
- `go test ./core/taskengine/ -run TestCreateWorkflow_RejectsInvalidNodeName` ✅
- `go vet ./core/taskengine/` ✅
