### PR TITLE
chore: migration to delete legacy invalid Failed tasks

### DIFF
--- a/migrations/delete_invalid_failed_tasks.go
+++ b/migrations/delete_invalid_failed_tasks.go
@@ -1,0 +1,85 @@
+package migrations
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// DeleteInvalidFailedTasks removes workflow records that are BOTH in Failed
+// status AND still fail config validation — the legacy cohort that the
+// boot-time invalid-task scan (DetectAndHandleInvalidTasks) retired: invalid
+// node names like "send eth", or trigger configs orphaned by an older proto
+// field migration. They can never become valid and persist only as dead rows.
+//
+// Safety properties:
+//   - Only Failed rows (t:<chain>:f:<id>) are considered; Enabled/Completed/
+//     Disabled/Running tasks are never touched.
+//   - A Failed row is deleted ONLY if ValidateWithError still reports it
+//     invalid. A task that is Failed for a legitimate runtime reason (valid
+//     config) is preserved.
+//   - Rows whose JSON can't be decoded are left in place — we never delete
+//     data we can't interpret.
+//   - The migrator takes a full DB backup before this runs, and records the
+//     migration so it executes exactly once.
+//
+// For each deleted task we remove every key it owns: the Failed status row,
+// the user index (u:<chain>:<owner>:<wallet>:<id>), and — defensively — any
+// lingering Enabled orphan (t:<chain>:a:<id>) left by the pre-fix scan.
+func DeleteInvalidFailedTasks(db storage.Storage) (int, error) {
+	failedToken := storageschema.WorkflowStatusToStorageKey(avsproto.TaskStatus_Failed)
+
+	items, err := db.GetByPrefix([]byte("t:"))
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, it := range items {
+		// Match Failed workflow rows: t:<chain>:f:<id>. Task IDs are ULIDs
+		// (no colons), so a 4-way split is exact.
+		parts := strings.SplitN(string(it.Key), ":", 4)
+		if len(parts) != 4 || parts[0] != "t" || parts[2] != failedToken {
+			continue
+		}
+		chainID, perr := strconv.ParseInt(parts[1], 10, 64)
+		if perr != nil {
+			continue
+		}
+
+		task := &model.Workflow{Task: &avsproto.Task{}}
+		if uerr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(it.Value, task); uerr != nil {
+			// Undecodable record — leave it alone rather than risk deleting
+			// something we can't interpret.
+			continue
+		}
+
+		// Only delete genuinely-invalid tasks (the orphaned cohort). A Failed
+		// task with a valid config is a legitimate runtime failure — keep it.
+		if task.ValidateWithError() == nil {
+			continue
+		}
+
+		// Delete the Failed status row (fail loudly — this key definitely
+		// exists, so an error here is real).
+		if derr := db.Delete(it.Key); derr != nil {
+			return deleted, fmt.Errorf("delete failed-status key %q: %w", string(it.Key), derr)
+		}
+		// Delete the user index and any Enabled orphan. These may be absent
+		// (Delete on a missing key is a no-op), so best-effort is fine.
+		userKey := fmt.Sprintf("u:%d:%s:%s:%s", chainID,
+			strings.ToLower(task.GetOwner()), strings.ToLower(task.GetSmartWalletAddress()), task.GetId())
+		_ = db.Delete([]byte(userKey))
+		_ = db.Delete(storageschema.ChainWorkflowStorageKey(chainID, task.GetId(), avsproto.TaskStatus_Enabled))
+
+		deleted++
+	}
+
+	return deleted, nil
+}

--- a/migrations/delete_invalid_failed_tasks_test.go
+++ b/migrations/delete_invalid_failed_tasks_test.go
@@ -1,0 +1,96 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func userIndexKey(w *model.Workflow) []byte {
+	return []byte(fmt.Sprintf("u:%d:%s:%s:%s", w.ChainId,
+		strings.ToLower(w.Owner), strings.ToLower(w.SmartWalletAddress), w.Id))
+}
+
+// seed writes a task under its status key plus the matching user index.
+func seed(t *testing.T, db storage.Storage, status avsproto.TaskStatus, w *model.Workflow) {
+	t.Helper()
+	w.Status = status
+	b, err := w.ToJSON()
+	require.NoError(t, err)
+	require.NoError(t, db.Set(storageschema.ChainWorkflowStorageKey(w.ChainId, w.Id, status), b))
+	require.NoError(t, db.Set(userIndexKey(w), []byte("ref")))
+}
+
+func blockTaskWorkflow(id, owner, wallet string, chainID int64, withConfig bool) *model.Workflow {
+	block := &avsproto.BlockTrigger{}
+	if withConfig {
+		block.Config = &avsproto.BlockTrigger_Config{Interval: 1}
+	}
+	return &model.Workflow{Task: &avsproto.Task{
+		Id: id, ChainId: chainID, Owner: owner, SmartWalletAddress: wallet,
+		Trigger: &avsproto.TaskTrigger{
+			Name:        "trigger1",
+			TriggerType: &avsproto.TaskTrigger_Block{Block: block},
+		},
+	}}
+}
+
+func TestDeleteInvalidFailedTasks(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	const chainID = int64(11155111)
+
+	// 1) Invalid + Failed → must be deleted (block trigger with nil config).
+	invalid := blockTaskWorkflow("invalid-failed", "0xOwnerA", "0xWalletA", chainID, false)
+	require.Error(t, invalid.ValidateWithError(), "fixture 1 must be invalid")
+	seed(t, db, avsproto.TaskStatus_Failed, invalid)
+	// Also leave a stale Enabled orphan to prove it gets cleaned up too.
+	orphanBytes, _ := invalid.ToJSON()
+	require.NoError(t, db.Set(storageschema.ChainWorkflowStorageKey(chainID, invalid.Id, avsproto.TaskStatus_Enabled), orphanBytes))
+
+	// 2) Valid + Failed → must be preserved (legitimate runtime failure).
+	validFailed := blockTaskWorkflow("valid-failed", "0xOwnerB", "0xWalletB", chainID, true)
+	require.NoError(t, validFailed.ValidateWithError(), "fixture 2 must be valid")
+	seed(t, db, avsproto.TaskStatus_Failed, validFailed)
+
+	// 3) Valid + Enabled → must be untouched.
+	enabled := blockTaskWorkflow("valid-enabled", "0xOwnerC", "0xWalletC", chainID, true)
+	seed(t, db, avsproto.TaskStatus_Enabled, enabled)
+
+	n, err := DeleteInvalidFailedTasks(db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only the invalid Failed task should be deleted")
+
+	// Invalid task: every key gone.
+	for _, k := range [][]byte{
+		storageschema.ChainWorkflowStorageKey(chainID, invalid.Id, avsproto.TaskStatus_Failed),
+		storageschema.ChainWorkflowStorageKey(chainID, invalid.Id, avsproto.TaskStatus_Enabled),
+		userIndexKey(invalid),
+	} {
+		ex, _ := db.Exist(k)
+		assert.False(t, ex, "invalid task key must be deleted: %s", string(k))
+	}
+
+	// Valid Failed task: preserved (status row + index).
+	vex, _ := db.Exist(storageschema.ChainWorkflowStorageKey(chainID, validFailed.Id, avsproto.TaskStatus_Failed))
+	assert.True(t, vex, "valid Failed task must be preserved")
+	vuex, _ := db.Exist(userIndexKey(validFailed))
+	assert.True(t, vuex, "valid Failed task user index must be preserved")
+
+	// Enabled task: untouched.
+	eex, _ := db.Exist(storageschema.ChainWorkflowStorageKey(chainID, enabled.Id, avsproto.TaskStatus_Enabled))
+	assert.True(t, eex, "enabled task must be untouched")
+
+	// Idempotent: a second run deletes nothing.
+	n2, err := DeleteInvalidFailedTasks(db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n2, "second run must be a no-op")
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -32,4 +32,12 @@ var Migrations = []migrator.Migration{
 	// ACTIVE MIGRATIONS
 	// ========================================
 	// Add new migrations here that need to be applied
+	{
+		// One-time cleanup of the legacy invalid-task cohort: workflow rows
+		// that are Failed AND still fail config validation (invalid node
+		// names / configs orphaned by an old proto migration). See
+		// delete_invalid_failed_tasks.go. Idempotent: re-running finds none.
+		Name:     "20260618-delete-invalid-failed-tasks",
+		Function: DeleteInvalidFailedTasks,
+	},
 }


### PR DESCRIPTION
## What

A one-time migration that deletes the legacy invalid-task cohort — workflow rows that are **`Failed` AND still fail config validation** (the `"send eth"` node-name tasks + the trigger-config-orphaned tasks). They can never become valid and persist only as dead rows after the boot scan retires them.

`DeleteInvalidFailedTasks` scans `Failed` workflow rows and, for each that still fails `ValidateWithError`, deletes **every key it owns**:
- the `Failed` status row (`t:<chain>:f:<id>`)
- the user index (`u:<chain>:<owner>:<wallet>:<id>`)
- any lingering `Enabled` orphan (`t:<chain>:a:<id>`)

Runs at gateway boot via the existing migrator (auto-backup first, recorded so it executes once). Registered as `20260618-delete-invalid-failed-tasks`.

## Why a migration (not a standalone script)

The live gateway holds an exclusive BadgerDB lock, so an external delete script can't open the DB without downtime/a copy. A migration runs **in-process** where the DB is already open, takes a full backup first, and is tracked/idempotent.

## Safety
- Only `Failed` rows are considered — `Enabled`/`Completed`/`Disabled`/`Running` are never touched.
- A `Failed` row is deleted **only if it still fails validation**. A task `Failed` for a legitimate runtime reason (valid config) is preserved.
- Undecodable rows are left in place (never delete data we can't interpret).
- Idempotent — a second run deletes nothing.

## Test
`TestDeleteInvalidFailedTasks`: deletes an invalid `Failed` task (all its keys, incl. a seeded `Enabled` orphan), preserves a valid `Failed` task and a valid `Enabled` task, and verifies the second run is a no-op.

- `go build ./...`, `go vet ./migrations/`, `go test ./migrations/` ✅
