### PR TITLE
chore: log owner/smart-wallet/factory/created-at on task auto-disable

### DIFF
--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"github.com/oklog/ulid/v2"
 )
 
 // reconstructTriggerOutputData is a helper function to reconstruct trigger output data
@@ -1104,16 +1105,43 @@ func (x *WorkflowExecutor) persistFailedExecution(task *model.Workflow, executio
 // scoped to the task ID so each broken workflow gets its own Sentry issue
 // rather than rolling into a single noisy one. The event is logged at Warn
 // in addition; SentryLogger.Warn does not double-capture.
+//
+// The Warn log and the Sentry scope both carry owner, smart_wallet,
+// created_at (derived from the ULID task id since Task has no created_at
+// field) and the factory_address resolved at validation time. Without those,
+// an operator triaging a burst of these alerts (e.g. EIGENLAYER-AVS-1Y..28)
+// can't tell at a glance whether it's one customer's wallet-migration
+// mistake, a cohort from a SDK regression, or a chain-config drift — the
+// same observability gap 460292b closed for the startup invalid-task log.
 func (x *WorkflowExecutor) reportTaskAutoDisabled(task *model.Workflow, reason string) {
+	createdAt := "unknown"
+	if parsed, perr := ulid.Parse(strings.ToUpper(task.Id)); perr == nil {
+		createdAt = time.UnixMilli(int64(parsed.Time())).UTC().Format(time.RFC3339)
+	}
+	factoryAddress := ""
+	if swCfg := x.resolveSmartWalletConfig(task.ChainId); swCfg != nil {
+		factoryAddress = swCfg.FactoryAddress.Hex()
+	}
+
 	x.logger.Warn("task auto-disabled after consecutive validation failures",
 		"task_id", task.Id,
 		"chain_id", task.ChainId,
+		"owner", task.Owner,
+		"smart_wallet", task.SmartWalletAddress,
+		"factory_address", factoryAddress,
+		"created_at", createdAt,
 		"consecutive_failures", task.ConsecutiveValidationFailures,
 		"reason", reason)
 	sentry.WithScope(func(scope *sentry.Scope) {
 		scope.SetTag("event", "task_auto_disabled")
 		scope.SetTag("task_id", task.Id)
 		scope.SetTag("chain_id", strconv.FormatInt(task.ChainId, 10))
+		scope.SetTag("owner", task.Owner)
+		scope.SetTag("smart_wallet", task.SmartWalletAddress)
+		if factoryAddress != "" {
+			scope.SetTag("factory_address", factoryAddress)
+		}
+		scope.SetExtra("created_at", createdAt)
 		scope.SetExtra("consecutive_failures", task.ConsecutiveValidationFailures)
 		scope.SetExtra("reason", reason)
 		scope.SetFingerprint([]string{"task-auto-disabled", task.Id})

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -1108,11 +1108,14 @@ func (x *WorkflowExecutor) persistFailedExecution(task *model.Workflow, executio
 //
 // The Warn log and the Sentry scope both carry owner, smart_wallet,
 // created_at (derived from the ULID task id since Task has no created_at
-// field) and the factory_address resolved at validation time. Without those,
-// an operator triaging a burst of these alerts (e.g. EIGENLAYER-AVS-1Y..28)
-// can't tell at a glance whether it's one customer's wallet-migration
-// mistake, a cohort from a SDK regression, or a chain-config drift — the
-// same observability gap 460292b closed for the startup invalid-task log.
+// field) and factory_address (resolved here via resolveSmartWalletConfig
+// for the task's chain — the same lookup the validation path used moments
+// earlier; config doesn't drift mid-process, so the values match). Without
+// those, an operator triaging a burst of these alerts (e.g.
+// EIGENLAYER-AVS-1Y..28) can't tell at a glance whether it's one
+// customer's wallet-migration mistake, a cohort from a SDK regression, or
+// a chain-config drift — the same observability gap 460292b closed for
+// the startup invalid-task log.
 func (x *WorkflowExecutor) reportTaskAutoDisabled(task *model.Workflow, reason string) {
 	createdAt := "unknown"
 	if parsed, perr := ulid.Parse(strings.ToUpper(task.Id)); perr == nil {

--- a/core/taskengine/executor_validation_log_level_test.go
+++ b/core/taskengine/executor_validation_log_level_test.go
@@ -11,14 +11,17 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/oklog/ulid/v2"
 )
 
-// captureLogger spies on which level a message was logged at. We only need
-// Error vs Warn for this fix — everything else delegates to no-op.
+// captureLogger spies on which level a message was logged at and (for Warn)
+// also retains the key/value pairs so tests can assert on structured fields.
+// Other levels delegate to no-op.
 type captureLogger struct {
 	mu       sync.Mutex
 	errorMsg []string
 	warnMsg  []string
+	warnKVs  [][]interface{}
 }
 
 func (l *captureLogger) record(bucket *[]string, msg string) {
@@ -27,11 +30,18 @@ func (l *captureLogger) record(bucket *[]string, msg string) {
 	*bucket = append(*bucket, msg)
 }
 
-func (l *captureLogger) Debug(msg string, _ ...interface{})    {}
-func (l *captureLogger) Debugf(string, ...interface{})         {}
-func (l *captureLogger) Info(msg string, _ ...interface{})     {}
-func (l *captureLogger) Infof(string, ...interface{})          {}
-func (l *captureLogger) Warn(msg string, _ ...interface{})     { l.record(&l.warnMsg, msg) }
+func (l *captureLogger) Debug(msg string, _ ...interface{}) {}
+func (l *captureLogger) Debugf(string, ...interface{})      {}
+func (l *captureLogger) Info(msg string, _ ...interface{})  {}
+func (l *captureLogger) Infof(string, ...interface{})       {}
+func (l *captureLogger) Warn(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnMsg = append(l.warnMsg, msg)
+	captured := make([]interface{}, len(kvs))
+	copy(captured, kvs)
+	l.warnKVs = append(l.warnKVs, captured)
+}
 func (l *captureLogger) Warnf(string, ...interface{})          {}
 func (l *captureLogger) Error(msg string, _ ...interface{})    { l.record(&l.errorMsg, msg) }
 func (l *captureLogger) Errorf(string, ...interface{})         {}
@@ -80,5 +90,99 @@ func TestPersistFailedExecutionLogsAtWarnNotError(t *testing.T) {
 		if strings.Contains(m, wantMsg) {
 			t.Fatalf("validation-failure message must not log at Error (would trigger Sentry capture every tick); got: %q", m)
 		}
+	}
+}
+
+// findWarnKVs locates the first warnKVs entry whose paired Warn message
+// contains substr, returning the key/value slice and ok=true.
+func (l *captureLogger) findWarnKVs(substr string) ([]interface{}, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, m := range l.warnMsg {
+		if strings.Contains(m, substr) && i < len(l.warnKVs) {
+			return l.warnKVs[i], true
+		}
+	}
+	return nil, false
+}
+
+func kvLookup(kvs []interface{}, key string) (interface{}, bool) {
+	for i := 0; i+1 < len(kvs); i += 2 {
+		k, ok := kvs[i].(string)
+		if ok && k == key {
+			return kvs[i+1], true
+		}
+	}
+	return nil, false
+}
+
+// TestReportTaskAutoDisabledIncludesOwnerContext is the regression for the
+// EIGENLAYER-AVS-1Y..28 burst: the auto-disable Warn log (and the matching
+// Sentry scope, which is populated from the same data) must carry owner,
+// smart_wallet, factory_address and created_at so an operator can triage
+// without dropping into BadgerDB.
+func TestReportTaskAutoDisabledIncludesOwnerContext(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	spy := &captureLogger{}
+	executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, spy)
+
+	taskID := ulid.Make().String()
+	task := &model.Workflow{
+		Task: &avsproto.Task{
+			Id:                 taskID,
+			Owner:              "0x000000000000000000000000000000000000beef",
+			SmartWalletAddress: "0x000000000000000000000000000000000000dead",
+			ChainId:            11155111,
+			Status:             avsproto.TaskStatus_Enabled,
+		},
+	}
+
+	const errMsg = "task smart wallet address does not belong to owner"
+	for i := uint32(1); i <= validationFailureDisableThreshold; i++ {
+		executor.persistFailedExecution(task, &avsproto.Execution{
+			Id:     "e",
+			Error:  errMsg,
+			Status: avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED,
+		}, avsproto.TaskStatus_Enabled)
+	}
+	if task.Status != avsproto.TaskStatus_Disabled {
+		t.Fatalf("precondition: task must be Disabled after threshold, got %v", task.Status)
+	}
+
+	kvs, ok := spy.findWarnKVs("task auto-disabled after consecutive validation failures")
+	if !ok {
+		t.Fatalf("expected the auto-disable Warn line to be logged; got warn=%v", spy.warnMsg)
+	}
+	wantFields := map[string]interface{}{
+		"task_id":      taskID,
+		"owner":        task.Owner,
+		"smart_wallet": task.SmartWalletAddress,
+		"chain_id":     task.ChainId,
+		"reason":       errMsg,
+	}
+	for k, want := range wantFields {
+		got, found := kvLookup(kvs, k)
+		if !found {
+			t.Fatalf("auto-disable Warn missing %q; got kvs=%v", k, kvs)
+		}
+		if got != want {
+			t.Fatalf("auto-disable Warn %q = %v, want %v", k, got, want)
+		}
+	}
+	createdAt, found := kvLookup(kvs, "created_at")
+	if !found {
+		t.Fatalf("auto-disable Warn missing created_at; got kvs=%v", kvs)
+	}
+	if s, _ := createdAt.(string); s == "" || s == "unknown" {
+		t.Fatalf("created_at should derive from the ULID id, got %v", createdAt)
+	}
+	factoryAddress, found := kvLookup(kvs, "factory_address")
+	if !found {
+		t.Fatalf("auto-disable Warn missing factory_address; got kvs=%v", kvs)
+	}
+	if s, _ := factoryAddress.(string); s == "" {
+		t.Fatalf("factory_address should resolve from smartWalletConfig in test env, got empty string")
 	}
 }


### PR DESCRIPTION
## Summary
- The EIGENLAYER-AVS-1Y..28 burst on 2026-06-15 fired 12 separate Sentry issues (one per `task_id` fingerprint), each with only `task_id`, `chain_id`, `consecutive_failures`, `reason`. Looking at the burst, an operator can't tell whether it's one customer's wallet-migration mistake, a cohort from an SDK regression, or a chain-config drift — without manually grepping BadgerDB per task.
- `reportTaskAutoDisabled` now attaches `owner`, `smart_wallet`, `factory_address` (resolved per-chain at validation time — exposes factory-mismatch regressions directly), and `created_at` (derived from the ULID task id, since `Task` has no created_at field) to both the Warn log and the Sentry scope. Same shape as the diagnostics 460292b added for the startup invalid-task log.
- Test upgrades `captureLogger` to retain Warn key/value pairs and asserts every diagnostic field lands in the auto-disable Warn line.

## Test plan
- [x] `go test ./core/taskengine/ -run 'TestPersistFailedExecutionLogsAtWarnNotError|TestReportTaskAutoDisabledIncludesOwnerContext|TestAutoDisableOnThreshold|TestPermanentValidationErrorIncrementsCounter|TestTransientValidationErrorDoesNotIncrementCounter|TestIsPermanentValidationErrorClassification|TestCounterResetOnValidationPassThrough' -count=1` passes locally
- [ ] On the next real auto-disable event, confirm the Sentry issue's tags now include `owner`, `smart_wallet`, `factory_address` and the extras include `created_at`