### PR TITLE
fix: clean up invalid & auto-disabled tasks with clearer diagnostics

### DIFF
--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -55,7 +55,7 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		req.InputVariables = converted
 	}
 
-	resp, err := s.engine.RunNodeImmediatelyRPC(user, req)
+	resp, err := s.engine.RunNodeImmediatelyRPCWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_triggers.go
+++ b/aggregator/rest/handlers_triggers.go
@@ -44,7 +44,7 @@ func (s *Server) RunTrigger(ctx echo.Context) error {
 		req.TriggerInput = converted
 	}
 
-	resp, err := s.engine.RunTriggerRPC(user, req)
+	resp, err := s.engine.RunTriggerRPCWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_wallets.go
+++ b/aggregator/rest/handlers_wallets.go
@@ -86,7 +86,7 @@ func (s *Server) CreateWallet(ctx echo.Context) error {
 		req.FactoryAddress = string(*body.FactoryAddress)
 	}
 
-	resp, err := s.engine.GetWallet(user, req)
+	resp, err := s.engine.GetWalletWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -256,7 +256,7 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 		}
 	}
 
-	resp, err := s.engine.TriggerWorkflow(user, req)
+	resp, err := s.engine.TriggerWorkflowWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return notFoundOrError(err)
 	}
@@ -333,7 +333,7 @@ func (s *Server) SimulateWorkflow(ctx echo.Context) error {
 		chainIDs = append(chainIDs, authed.ChainID)
 	}
 
-	exec, err := s.engine.SimulateWorkflow(user, trigger, nodes, edges, inputVars, chainIDs...)
+	exec, err := s.engine.SimulateWorkflowWithContext(ctx.Request().Context(), user, trigger, nodes, edges, inputVars, chainIDs...)
 	if err != nil {
 		return err
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -446,7 +446,15 @@ func NewConfig(configFilePath string) (*Config, error) {
 
 	controllerPrivateKey, err := crypto.HexToECDSA(configRaw.SmartWallet.ControllerPrivateKey)
 	if err != nil {
-		panic(err)
+		// Name the field + the likely cause. The bare crypto error
+		// ("invalid length, need 256 bits") gives no hint which key is at
+		// fault. In practice this is almost always a missing/empty env var or
+		// an unresolved ${{shared.*}} Railway reference, which decodes to the
+		// wrong length. (Production incident: gateway crash-loop after a
+		// per-tier controller key var was unset on the service.)
+		panic(fmt.Errorf("smart_wallet.controller_private_key is not a valid 64-hex-char "+
+			"private key — check the controller key env var for this service; an empty value or an "+
+			"unresolved ${...}/${{shared.*}} reference produces this: %w", err))
 	}
 
 	// Enforce sane default for max wallets per owner (no unlimited allowed)
@@ -712,7 +720,11 @@ func ReadYamlConfig(path string, o interface{}) error {
 	})
 
 	if err := yaml.Unmarshal([]byte(expanded), o); err != nil {
-		return fmt.Errorf("unable to parse file with error %#v", err)
+		// A common cause is an env var that resolved to a value containing
+		// YAML-special characters — e.g. an unresolved ${{shared.*}} Railway
+		// reference left as literal "${{...}}" text after expansion.
+		return fmt.Errorf("unable to parse YAML config %q (a substituted env var may "+
+			"contain an unresolved ${{...}} reference or YAML-special characters): %w", path, err)
 	}
 
 	return nil

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -6165,6 +6165,13 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 
 	invalidTasks := []string{}
 	updates := make(map[string][]byte)
+	// Status-keyed storage uses status in the key (t:<chain>:<status>:<id>),
+	// so flipping a task to Failed means writing the new Failed key AND
+	// deleting the old (Enabled) one. Without the delete, the stale Enabled
+	// key survives, MustStart reloads it from the Enabled prefix on the next
+	// boot, and this scan re-fails it — an invisible every-boot loop. Collect
+	// the stale keys here and delete them after the batch write succeeds.
+	staleStatusKeys := [][]byte{}
 
 	// Acquire lock once for the entire operation to reduce lock contention
 	n.lock.Lock()
@@ -6176,6 +6183,9 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 			n.logger.Warn("🚨 Found invalid task configuration",
 				"task_id", taskID,
 				"error", err.Error())
+
+			// Capture the pre-failure status key before SetFailed mutates it.
+			oldStatus := task.Status
 
 			// Mark task as failed and prepare storage updates
 			task.SetFailed()
@@ -6191,6 +6201,18 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 			// Prepare the task status update in storage
 			updates[string(ChainWorkflowStorageKey(task.ChainId, task.Id, task.Status))] = taskJSON
 			updates[string(ChainTaskUserKey(task.ChainId, task))] = []byte(fmt.Sprintf("%d", avsproto.TaskStatus_Failed))
+
+			// Queue the old status-keyed row for deletion (skip when the
+			// status didn't actually change, to avoid deleting what we just
+			// wrote).
+			if oldStatus != task.Status {
+				staleStatusKeys = append(staleStatusKeys, ChainWorkflowStorageKey(task.ChainId, task.Id, oldStatus))
+			}
+
+			// Drop from the in-memory active set so it isn't treated as active
+			// for the rest of this process run. Deleting the current key while
+			// ranging over a map is safe in Go.
+			delete(n.tasks, taskID)
 		}
 	}
 
@@ -6205,12 +6227,22 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 		"count", len(invalidTasks),
 		"task_ids", invalidTasks)
 
-	// Batch write the updates
+	// Write the Failed records first so we never lose a task record, ...
 	if len(updates) > 0 {
 		if err := n.db.BatchWrite(updates); err != nil {
 			n.logger.Error("Failed to update invalid tasks in storage",
 				"error", err)
 			return err
+		}
+	}
+
+	// ... then delete the stale old-status rows so the next boot's
+	// Enabled-prefix scan doesn't reload and re-fail them.
+	for _, key := range staleStatusKeys {
+		if err := n.db.Delete(key); err != nil {
+			n.logger.Error("Failed to delete stale task status key",
+				"key", string(key),
+				"error", err)
 		}
 	}
 

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -6180,8 +6180,22 @@ func (n *Engine) DetectAndHandleInvalidTasks() error {
 	for taskID, task := range n.tasks {
 		if err := task.ValidateWithError(); err != nil {
 			invalidTasks = append(invalidTasks, taskID)
+
+			// Log owner/smart-wallet/created-at so an auto-failed task can be
+			// traced to its user straight from the logs, without a DB query —
+			// the observability gap that let a cohort of invalid tasks fail
+			// silently for ~a year. created_at is derived from the ULID task
+			// ID since Task has no created_at field.
+			createdAt := "unknown"
+			if parsed, perr := ulid.Parse(strings.ToUpper(taskID)); perr == nil {
+				createdAt = time.UnixMilli(int64(parsed.Time())).UTC().Format(time.RFC3339)
+			}
 			n.logger.Warn("🚨 Found invalid task configuration",
 				"task_id", taskID,
+				"owner", task.GetOwner(),
+				"smart_wallet", task.GetSmartWalletAddress(),
+				"chain_id", task.GetChainId(),
+				"created_at", createdAt,
 				"error", err.Error())
 
 			// Capture the pre-failure status key before SetFailed mutates it.

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1194,6 +1194,14 @@ func (n *Engine) resolveUserChainID(user *model.User) int64 {
 // resolveUserChainID — REST callers route by their JWT `aud` chain,
 // gRPC callers fall back to the gateway's default chain.
 func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*avsproto.GetWalletResp, error) {
+	return n.GetWalletWithContext(context.Background(), user, payload)
+}
+
+// GetWalletWithContext is GetWallet with a caller-supplied context. REST
+// handlers pass the request context so a client disconnect / timeout cancels
+// the worker-routed CREATE2 derivation; the worker reader's withTimeout still
+// bounds the call when ctx carries no deadline.
+func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, payload *avsproto.GetWalletReq) (*avsproto.GetWalletResp, error) {
 	chainID := n.resolveUserChainID(user)
 	// Resolve the per-chain smart wallet config. In single-chain mode
 	// this returns n.smartWalletConfig (the gateway default); in
@@ -1270,7 +1278,7 @@ func (n *Engine) GetWallet(user *model.User, payload *avsproto.GetWalletReq) (*a
 		// gateway mode this is worker-routed, so the gateway issues no
 		// direct chain RPC for wallet derivation; in single-chain mode it's
 		// a direct reader that reuses the existing client (no per-call dial).
-		addr, deriveErr := reader.GetSmartWalletAddress(context.Background(), user.Address, factoryAddr, saltBig)
+		addr, deriveErr := reader.GetSmartWalletAddress(ctx, user.Address, factoryAddr, saltBig)
 		if deriveErr != nil {
 			n.logger.Error("GetWallet: factory.getAddress() failed (worker-routed)",
 				"chain_id", chainID, "owner", user.Address.Hex(), "factory", factoryAddr.Hex(),
@@ -3080,7 +3088,7 @@ func (n *Engine) GetWorkflow(user *model.User, taskID string) (*model.Workflow, 
 
 // instructOperatorImmediateTrigger instructs the connected operator to trigger the task immediately
 // with the current block number, bypassing the normal interval waiting
-func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
+func (n *Engine) instructOperatorImmediateTrigger(ctx context.Context, taskID string) error {
 	// Load the task first so the current-block read targets the task's
 	// chain (via its per-chain worker), not a single gateway RPC.
 	task, err := n.GetWorkflowByID(taskID)
@@ -3099,7 +3107,7 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 	if reader == nil {
 		return fmt.Errorf("no chain-state reader available for chain %d (immediate block trigger)", chainID)
 	}
-	currentBlock, err := reader.GetBlockNumber(context.Background())
+	currentBlock, err := reader.GetBlockNumber(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current block number: %w", err)
 	}
@@ -3197,6 +3205,14 @@ func (n *Engine) instructOperatorImmediateTrigger(taskID string) error {
 }
 
 func (n *Engine) TriggerWorkflow(user *model.User, payload *avsproto.TriggerTaskReq) (*avsproto.TriggerTaskResp, error) {
+	return n.TriggerWorkflowWithContext(context.Background(), user, payload)
+}
+
+// TriggerWorkflowWithContext is TriggerWorkflow with a caller-supplied context.
+// REST handlers pass the request context so a client disconnect / timeout
+// cancels the worker-routed current-block read (immediate trigger) and the
+// blocking execution's wallet-ownership validation.
+func (n *Engine) TriggerWorkflowWithContext(ctx context.Context, user *model.User, payload *avsproto.TriggerTaskReq) (*avsproto.TriggerTaskResp, error) {
 	// Validate task ID format first
 	if !ValidateTaskId(payload.TaskId) {
 		return nil, status.Errorf(codes.InvalidArgument, InvalidTaskIdFormat)
@@ -3265,7 +3281,7 @@ func (n *Engine) TriggerWorkflow(user *model.User, payload *avsproto.TriggerTask
 			n.logger.Debug("💾 Persisted pending execution ID with index", "task_id", task.Id, "execution_id", preExecID, "index", preAssignedIndex, "key", string(pendingKey))
 
 			// Best-effort operator instruction (ignore errors; operator may connect later)
-			_ = n.instructOperatorImmediateTrigger(task.Id)
+			_ = n.instructOperatorImmediateTrigger(ctx, task.Id)
 
 			startTime := time.Now().UnixMilli()
 			resp := &avsproto.TriggerTaskResp{
@@ -3326,7 +3342,7 @@ func (n *Engine) TriggerWorkflow(user *model.User, payload *avsproto.TriggerTask
 
 	if payload.IsBlocking {
 		executor := NewExecutor(n.ResolveSmartWalletConfig(task.ChainId), n.db, n.logger, n, n.priceService)
-		execution, runErr := executor.RunTask(task, &queueTaskData)
+		execution, runErr := executor.RunTaskWithContext(ctx, task, &queueTaskData)
 		if runErr != nil {
 			n.logger.Error("failed to run blocking task", runErr)
 			// For blocking execution, return the error to the caller
@@ -3403,6 +3419,15 @@ func (n *Engine) TriggerWorkflow(user *model.User, payload *avsproto.TriggerTask
 // default. Per-node / per-trigger chain_id (set on the node configs) takes
 // precedence over this value.
 func (n *Engine) SimulateWorkflow(user *model.User, trigger *avsproto.TaskTrigger, nodes []*avsproto.TaskNode, edges []*avsproto.TaskEdge, inputVariables map[string]interface{}, chainIDs ...int64) (*avsproto.Execution, error) {
+	return n.SimulateWorkflowWithContext(context.Background(), user, trigger, nodes, edges, inputVariables, chainIDs...)
+}
+
+// SimulateWorkflowWithContext is SimulateWorkflow with a caller-supplied
+// context. The REST simulate handler passes the request context so a client
+// disconnect / timeout cancels the worker-routed trigger reads (e.g. a
+// BlockTrigger's GetBlockNumber / HeaderByNumber) reached via
+// runTriggerImmediately.
+func (n *Engine) SimulateWorkflowWithContext(ctx context.Context, user *model.User, trigger *avsproto.TaskTrigger, nodes []*avsproto.TaskNode, edges []*avsproto.TaskEdge, inputVariables map[string]interface{}, chainIDs ...int64) (*avsproto.Execution, error) {
 	var chainID int64
 	if len(chainIDs) > 0 {
 		chainID = chainIDs[0]
@@ -3517,7 +3542,7 @@ func (n *Engine) SimulateWorkflow(user *model.User, trigger *avsproto.TaskTrigge
 	// Step 1: Start timing BEFORE trigger execution (consistent with node timing)
 	triggerStartTime := time.Now()
 
-	triggerOutput, err := n.runTriggerImmediately(triggerTypeStr, triggerConfig, inputVariables)
+	triggerOutput, err := n.runTriggerImmediately(ctx, triggerTypeStr, triggerConfig, inputVariables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to simulate trigger: %w", err)
 	}

--- a/core/taskengine/engine_invalid_tasks_test.go
+++ b/core/taskengine/engine_invalid_tasks_test.go
@@ -1,0 +1,110 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedInvalidEnabledTask stores an invalid task (block trigger with no config)
+// under the Enabled status key, mirroring a task created before validation
+// existed, and returns it.
+func seedInvalidEnabledTask(t *testing.T, db interface {
+	Set(key, value []byte) error
+}, chainID int64, id string) *model.Workflow {
+	t.Helper()
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id:      id,
+		ChainId: chainID,
+		Status:  avsproto.TaskStatus_Enabled,
+		Trigger: &avsproto.TaskTrigger{
+			Name: "trigger1",
+			// Block trigger with a nil Config → fails ValidateWithError with
+			// "block trigger config is required but missing".
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{}},
+		},
+	}}
+	require.Error(t, task.ValidateWithError(), "fixture must be invalid")
+
+	taskJSON, err := task.ToJSON()
+	require.NoError(t, err)
+	require.NoError(t, db.Set(ChainWorkflowStorageKey(chainID, id, avsproto.TaskStatus_Enabled), taskJSON))
+	return task
+}
+
+// TestDetectAndHandleInvalidTasks_DeletesStaleEnabledKey is the regression test
+// for the every-boot re-fail loop: marking a task Failed must also remove its
+// stale Enabled-status key, so a subsequent boot's Enabled-prefix scan does not
+// reload and re-fail it.
+func TestDetectAndHandleInvalidTasks_DeletesStaleEnabledKey(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	const chainID = int64(11155111)
+	task := seedInvalidEnabledTask(t, db, chainID, "invalid-task-1")
+	n.AddWorkflowForTesting(task)
+
+	// First scan: marks it failed.
+	require.NoError(t, n.DetectAndHandleInvalidTasks())
+
+	// The stale Enabled key must be gone...
+	enabledItems, err := db.GetByPrefix(ChainWorkflowByStatusStoragePrefix(chainID, avsproto.TaskStatus_Enabled))
+	require.NoError(t, err)
+	assert.Empty(t, enabledItems, "stale Enabled-status key must be deleted so the next boot can't reload it")
+
+	// ...and the task must now live under the Failed key.
+	failedExists, err := db.Exist(ChainWorkflowStorageKey(chainID, task.Id, avsproto.TaskStatus_Failed))
+	require.NoError(t, err)
+	assert.True(t, failedExists, "task should now be stored under the Failed status key")
+
+	// It must be dropped from the in-memory active set.
+	n.lock.Lock()
+	_, stillActive := n.tasks[task.Id]
+	n.lock.Unlock()
+	assert.False(t, stillActive, "failed task should be dropped from the active set")
+
+	// Simulate the next boot: reloading from the Enabled prefix must NOT bring
+	// it back. This is the assertion that would have caught the loop.
+	reloaded, err := db.GetByPrefix(ChainWorkflowByStatusStoragePrefix(chainID, avsproto.TaskStatus_Enabled))
+	require.NoError(t, err)
+	assert.Empty(t, reloaded, "invalid task must not reappear under Enabled on the next boot")
+}
+
+// TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone ensures the scan is a
+// no-op for valid tasks (no spurious failures, no key churn).
+func TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	const chainID = int64(11155111)
+	valid := &model.Workflow{Task: &avsproto.Task{
+		Id:      "valid-task-1",
+		ChainId: chainID,
+		Status:  avsproto.TaskStatus_Enabled,
+		Trigger: &avsproto.TaskTrigger{
+			Name: "trigger1",
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{
+				Config: &avsproto.BlockTrigger_Config{Interval: 1},
+			}},
+		},
+	}}
+	require.NoError(t, valid.ValidateWithError(), "fixture must be valid")
+	n.AddWorkflowForTesting(valid)
+
+	require.NoError(t, n.DetectAndHandleInvalidTasks())
+
+	n.lock.Lock()
+	_, stillActive := n.tasks[valid.Id]
+	n.lock.Unlock()
+	assert.True(t, stillActive, "valid task must remain active")
+
+	failedExists, err := db.Exist(ChainWorkflowStorageKey(chainID, valid.Id, avsproto.TaskStatus_Failed))
+	require.NoError(t, err)
+	assert.False(t, failedExists, "valid task must not be written under the Failed key")
+}

--- a/core/taskengine/engine_invalid_tasks_test.go
+++ b/core/taskengine/engine_invalid_tasks_test.go
@@ -108,3 +108,29 @@ func TestDetectAndHandleInvalidTasks_LeavesValidTasksAlone(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, failedExists, "valid task must not be written under the Failed key")
 }
+
+// TestCreateWorkflow_RejectsInvalidNodeName guards the dominant legacy-cohort
+// failure mode at the create boundary: a node name with a space ("send eth")
+// is not a valid JavaScript identifier. The create path validates this via
+// model.NewWorkflowFromProtobuf → ValidateWithError, so such a task can no
+// longer be persisted. (Block/cron/event missing-config is already covered by
+// TestCreateTaskReturnErrorWhenNilBlockTriggerConfig and the same
+// ValidateWithError path; the 7 missing-config legacy tasks were valid at
+// creation and only became invalid after a proto schema migration moved
+// trigger-config fields — a data artifact, not a create-time gap.)
+func TestCreateWorkflow_RejectsInvalidNodeName(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	// Sanity: a valid task creates fine.
+	if _, err := n.CreateWorkflow(testutil.TestUser1(), testutil.RestTask()); err != nil {
+		t.Fatalf("valid task should create: %v", err)
+	}
+
+	bad := testutil.RestTask()
+	bad.Nodes[0].Name = "send eth" // space → not a valid JS identifier
+	_, err := n.CreateWorkflow(testutil.TestUser1(), bad)
+	require.Error(t, err, "CreateWorkflow must reject a spaced node name")
+	assert.Contains(t, err.Error(), "JavaScript identifier")
+}

--- a/core/taskengine/event_trigger_oracle_test.go
+++ b/core/taskengine/event_trigger_oracle_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"context"
 	"testing"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
@@ -181,7 +182,7 @@ func TestEventTriggerOraclePriceConditions(t *testing.T) {
 			}
 
 			// Execute the trigger
-			result, err := engine.runTriggerImmediately("eventTrigger", triggerConfig, map[string]interface{}{})
+			result, err := engine.runTriggerImmediately(context.Background(), "eventTrigger", triggerConfig, map[string]interface{}{})
 			require.NoError(t, err, "runTriggerImmediately should not return an error")
 
 			// Debug: Print actual response for analysis

--- a/core/taskengine/event_trigger_test.go
+++ b/core/taskengine/event_trigger_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -344,7 +345,7 @@ func TestEventTriggerQueriesBasedConfiguration(t *testing.T) {
 			}
 			inputVariables := map[string]interface{}{}
 
-			result, err := engine.runTriggerImmediately("eventTrigger", triggerConfig, inputVariables)
+			result, err := engine.runTriggerImmediately(context.Background(), "eventTrigger", triggerConfig, inputVariables)
 
 			if tc.expectError {
 				if err == nil || !strings.Contains(err.Error(), tc.errorMsg) {
@@ -436,7 +437,7 @@ func TestEventTriggerQueriesBasedUserScenario(t *testing.T) {
 	}
 	inputVariables := map[string]interface{}{}
 
-	result, err := engine.runTriggerImmediately("eventTrigger", triggerConfig, inputVariables)
+	result, err := engine.runTriggerImmediately(context.Background(), "eventTrigger", triggerConfig, inputVariables)
 	if err != nil {
 		t.Errorf("runTriggerImmediately failed: %v", err)
 		return

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"github.com/oklog/ulid/v2"
 )
 
 // reconstructTriggerOutputData is a helper function to reconstruct trigger output data
@@ -1104,16 +1105,46 @@ func (x *WorkflowExecutor) persistFailedExecution(task *model.Workflow, executio
 // scoped to the task ID so each broken workflow gets its own Sentry issue
 // rather than rolling into a single noisy one. The event is logged at Warn
 // in addition; SentryLogger.Warn does not double-capture.
+//
+// The Warn log and the Sentry scope both carry owner, smart_wallet,
+// created_at (derived from the ULID task id since Task has no created_at
+// field) and factory_address (resolved here via resolveSmartWalletConfig
+// for the task's chain — the same lookup the validation path used moments
+// earlier; config doesn't drift mid-process, so the values match). Without
+// those, an operator triaging a burst of these alerts (e.g.
+// EIGENLAYER-AVS-1Y..28) can't tell at a glance whether it's one
+// customer's wallet-migration mistake, a cohort from a SDK regression, or
+// a chain-config drift — the same observability gap 460292b closed for
+// the startup invalid-task log.
 func (x *WorkflowExecutor) reportTaskAutoDisabled(task *model.Workflow, reason string) {
+	createdAt := "unknown"
+	if parsed, perr := ulid.Parse(strings.ToUpper(task.Id)); perr == nil {
+		createdAt = time.UnixMilli(int64(parsed.Time())).UTC().Format(time.RFC3339)
+	}
+	factoryAddress := ""
+	if swCfg := x.resolveSmartWalletConfig(task.ChainId); swCfg != nil {
+		factoryAddress = swCfg.FactoryAddress.Hex()
+	}
+
 	x.logger.Warn("task auto-disabled after consecutive validation failures",
 		"task_id", task.Id,
 		"chain_id", task.ChainId,
+		"owner", task.Owner,
+		"smart_wallet", task.SmartWalletAddress,
+		"factory_address", factoryAddress,
+		"created_at", createdAt,
 		"consecutive_failures", task.ConsecutiveValidationFailures,
 		"reason", reason)
 	sentry.WithScope(func(scope *sentry.Scope) {
 		scope.SetTag("event", "task_auto_disabled")
 		scope.SetTag("task_id", task.Id)
 		scope.SetTag("chain_id", strconv.FormatInt(task.ChainId, 10))
+		scope.SetTag("owner", task.Owner)
+		scope.SetTag("smart_wallet", task.SmartWalletAddress)
+		if factoryAddress != "" {
+			scope.SetTag("factory_address", factoryAddress)
+		}
+		scope.SetExtra("created_at", createdAt)
 		scope.SetExtra("consecutive_failures", task.ConsecutiveValidationFailures)
 		scope.SetExtra("reason", reason)
 		scope.SetFingerprint([]string{"task-auto-disabled", task.Id})

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -207,7 +207,16 @@ func (x *WorkflowExecutor) Perform(job *apqueue.Job) error {
 	return runErr // Propagate the error from task execution
 }
 
+// RunTask executes a task using a background context. It is retained for the
+// async queue path (Perform) and tests, which have no request-scoped context.
 func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecutionData) (*avsproto.Execution, error) {
+	return x.RunTaskWithContext(context.Background(), task, queueData)
+}
+
+// RunTaskWithContext is RunTask with a caller-supplied context. The ctx is
+// propagated to wallet-ownership validation so a cancelled request interrupts
+// in-flight chain-worker derivations.
+func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.Workflow, queueData *QueueExecutionData) (*avsproto.Execution, error) {
 	// Load secrets for the task
 	secrets, err := LoadSecretForTask(x.db, task)
 	if err != nil {
@@ -451,7 +460,7 @@ func (x *WorkflowExecutor) RunTask(task *model.Workflow, queueData *QueueExecuti
 		smartWalletAddr := common.HexToAddress(task.SmartWalletAddress)
 
 		// Enhanced wallet validation that handles any legitimately derived wallet
-		isValid, err := x.validateWalletOwnership(task.ChainId, user, smartWalletAddr)
+		isValid, err := x.validateWalletOwnership(ctx, task.ChainId, user, smartWalletAddr)
 		if err != nil {
 			execution.EndAt = time.Now().UnixMilli()
 			execution.Error = fmt.Sprintf("failed to validate wallet ownership for owner %s: %v", owner.Hex(), err)
@@ -886,8 +895,11 @@ func (x *WorkflowExecutor) resolveSmartWalletConfig(chainID int64) *config.Smart
 }
 
 // validateWalletOwnership performs comprehensive wallet ownership validation
-// This handles default wallets (salt:0), stored wallets, and legitimately derived wallets
-func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.User, smartWalletAddr common.Address) (bool, error) {
+// This handles default wallets (salt:0), stored wallets, and legitimately derived wallets.
+// ctx is propagated to the chain-worker calls so a cancelled request (client
+// disconnect / timeout) interrupts an in-flight derivation; the worker reader's
+// own withTimeout still bounds the call when ctx carries no deadline.
+func (x *WorkflowExecutor) validateWalletOwnership(ctx context.Context, chainID int64, user *model.User, smartWalletAddr common.Address) (bool, error) {
 	swCfg := x.resolveSmartWalletConfig(chainID)
 
 	// Step 1: Load the user's default smart wallet address (salt:0) for comparison.
@@ -897,7 +909,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 	if swCfg != nil {
 		if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
 			// Gateway mode: derive salt:0 via the chain worker (no gateway dial).
-			if addr, derr := reader.GetSmartWalletAddress(context.Background(), user.Address, swCfg.FactoryAddress, big.NewInt(0)); derr == nil {
+			if addr, derr := reader.GetSmartWalletAddress(ctx, user.Address, swCfg.FactoryAddress, big.NewInt(0)); derr == nil {
 				user.SmartAccountAddress = &addr
 			} else {
 				x.logger.Warn("Failed to load default smart wallet for validation",
@@ -927,7 +939,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 	// never written for the post-upgrade derived address. MUST use the task's
 	// per-chain config — see resolveSmartWalletConfig above.
 	if swCfg != nil {
-		if isValid, err := x.validateDerivedWallet(chainID, swCfg, user.Address, smartWalletAddr); err == nil && isValid {
+		if isValid, err := x.validateDerivedWallet(ctx, chainID, swCfg, user.Address, smartWalletAddr); err == nil && isValid {
 			x.logger.Info("Wallet validated as legitimate derived wallet",
 				"owner", user.Address.Hex(), "wallet", smartWalletAddr.Hex(), "chain_id", chainID)
 			return true, nil
@@ -945,7 +957,7 @@ func (x *WorkflowExecutor) validateWalletOwnership(chainID int64, user *model.Us
 // The swCfg argument is the per-chain config resolved by the caller —
 // passing it in (rather than reading x.smartWalletConfig) is what makes
 // this work in gateway mode where the executor is shared across chains.
-func (x *WorkflowExecutor) validateDerivedWallet(chainID int64, swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
+func (x *WorkflowExecutor) validateDerivedWallet(ctx context.Context, chainID int64, swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
 	factoryAddr := swCfg.FactoryAddress
 
 	// Try salt values from 0 to max_wallets_per_owner to see if any produce the target wallet address
@@ -956,7 +968,7 @@ func (x *WorkflowExecutor) validateDerivedWallet(chainID int64, swCfg *config.Sm
 	// salt scan server-side (one round-trip). Fall back to a direct dial +
 	// local loop only when no reader is registered (single-chain mode / tests).
 	if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
-		found, salt, err := reader.FindMatchingWalletSalt(context.Background(), owner, factoryAddr, smartWalletAddr, maxWallets)
+		found, salt, err := reader.FindMatchingWalletSalt(ctx, owner, factoryAddr, smartWalletAddr, maxWallets)
 		if err != nil {
 			return false, err
 		}

--- a/core/taskengine/executor_validation_log_level_test.go
+++ b/core/taskengine/executor_validation_log_level_test.go
@@ -11,14 +11,17 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/oklog/ulid/v2"
 )
 
-// captureLogger spies on which level a message was logged at. We only need
-// Error vs Warn for this fix — everything else delegates to no-op.
+// captureLogger spies on which level a message was logged at and (for Warn)
+// also retains the key/value pairs so tests can assert on structured fields.
+// Other levels delegate to no-op.
 type captureLogger struct {
 	mu       sync.Mutex
 	errorMsg []string
 	warnMsg  []string
+	warnKVs  [][]interface{}
 }
 
 func (l *captureLogger) record(bucket *[]string, msg string) {
@@ -27,11 +30,18 @@ func (l *captureLogger) record(bucket *[]string, msg string) {
 	*bucket = append(*bucket, msg)
 }
 
-func (l *captureLogger) Debug(msg string, _ ...interface{})    {}
-func (l *captureLogger) Debugf(string, ...interface{})         {}
-func (l *captureLogger) Info(msg string, _ ...interface{})     {}
-func (l *captureLogger) Infof(string, ...interface{})          {}
-func (l *captureLogger) Warn(msg string, _ ...interface{})     { l.record(&l.warnMsg, msg) }
+func (l *captureLogger) Debug(msg string, _ ...interface{}) {}
+func (l *captureLogger) Debugf(string, ...interface{})      {}
+func (l *captureLogger) Info(msg string, _ ...interface{})  {}
+func (l *captureLogger) Infof(string, ...interface{})       {}
+func (l *captureLogger) Warn(msg string, kvs ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnMsg = append(l.warnMsg, msg)
+	captured := make([]interface{}, len(kvs))
+	copy(captured, kvs)
+	l.warnKVs = append(l.warnKVs, captured)
+}
 func (l *captureLogger) Warnf(string, ...interface{})          {}
 func (l *captureLogger) Error(msg string, _ ...interface{})    { l.record(&l.errorMsg, msg) }
 func (l *captureLogger) Errorf(string, ...interface{})         {}
@@ -80,5 +90,99 @@ func TestPersistFailedExecutionLogsAtWarnNotError(t *testing.T) {
 		if strings.Contains(m, wantMsg) {
 			t.Fatalf("validation-failure message must not log at Error (would trigger Sentry capture every tick); got: %q", m)
 		}
+	}
+}
+
+// findWarnKVs locates the first warnKVs entry whose paired Warn message
+// contains substr, returning the key/value slice and ok=true.
+func (l *captureLogger) findWarnKVs(substr string) ([]interface{}, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, m := range l.warnMsg {
+		if strings.Contains(m, substr) && i < len(l.warnKVs) {
+			return l.warnKVs[i], true
+		}
+	}
+	return nil, false
+}
+
+func kvLookup(kvs []interface{}, key string) (interface{}, bool) {
+	for i := 0; i+1 < len(kvs); i += 2 {
+		k, ok := kvs[i].(string)
+		if ok && k == key {
+			return kvs[i+1], true
+		}
+	}
+	return nil, false
+}
+
+// TestReportTaskAutoDisabledIncludesOwnerContext is the regression for the
+// EIGENLAYER-AVS-1Y..28 burst: the auto-disable Warn log (and the matching
+// Sentry scope, which is populated from the same data) must carry owner,
+// smart_wallet, factory_address and created_at so an operator can triage
+// without dropping into BadgerDB.
+func TestReportTaskAutoDisabledIncludesOwnerContext(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	spy := &captureLogger{}
+	executor := NewExecutorForTesting(testutil.GetTestSmartWalletConfig(), db, spy)
+
+	taskID := ulid.Make().String()
+	task := &model.Workflow{
+		Task: &avsproto.Task{
+			Id:                 taskID,
+			Owner:              "0x000000000000000000000000000000000000beef",
+			SmartWalletAddress: "0x000000000000000000000000000000000000dead",
+			ChainId:            11155111,
+			Status:             avsproto.TaskStatus_Enabled,
+		},
+	}
+
+	const errMsg = "task smart wallet address does not belong to owner"
+	for i := uint32(1); i <= validationFailureDisableThreshold; i++ {
+		executor.persistFailedExecution(task, &avsproto.Execution{
+			Id:     "e",
+			Error:  errMsg,
+			Status: avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED,
+		}, avsproto.TaskStatus_Enabled)
+	}
+	if task.Status != avsproto.TaskStatus_Disabled {
+		t.Fatalf("precondition: task must be Disabled after threshold, got %v", task.Status)
+	}
+
+	kvs, ok := spy.findWarnKVs("task auto-disabled after consecutive validation failures")
+	if !ok {
+		t.Fatalf("expected the auto-disable Warn line to be logged; got warn=%v", spy.warnMsg)
+	}
+	wantFields := map[string]interface{}{
+		"task_id":      taskID,
+		"owner":        task.Owner,
+		"smart_wallet": task.SmartWalletAddress,
+		"chain_id":     task.ChainId,
+		"reason":       errMsg,
+	}
+	for k, want := range wantFields {
+		got, found := kvLookup(kvs, k)
+		if !found {
+			t.Fatalf("auto-disable Warn missing %q; got kvs=%v", k, kvs)
+		}
+		if got != want {
+			t.Fatalf("auto-disable Warn %q = %v, want %v", k, got, want)
+		}
+	}
+	createdAt, found := kvLookup(kvs, "created_at")
+	if !found {
+		t.Fatalf("auto-disable Warn missing created_at; got kvs=%v", kvs)
+	}
+	if s, _ := createdAt.(string); s == "" || s == "unknown" {
+		t.Fatalf("created_at should derive from the ULID id, got %v", createdAt)
+	}
+	factoryAddress, found := kvLookup(kvs, "factory_address")
+	if !found {
+		t.Fatalf("auto-disable Warn missing factory_address; got kvs=%v", kvs)
+	}
+	if s, _ := factoryAddress.(string); s == "" {
+		t.Fatalf("factory_address should resolve from smartWalletConfig in test env, got empty string")
 	}
 }

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -45,6 +45,15 @@ func getRealisticBlockNumberForChain(chainID int64) uint64 {
 // RunNodeImmediately executes a node immediately with optional simulation mode
 // useSimulation parameter (bool): true = simulation (default), false = real execution
 func (n *Engine) RunNodeImmediately(nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, user *model.User, useSimulation ...interface{}) (map[string]interface{}, error) {
+	return n.RunNodeImmediatelyWithContext(context.Background(), nodeType, nodeConfig, inputVariables, user, useSimulation...)
+}
+
+// RunNodeImmediatelyWithContext is RunNodeImmediately with a caller-supplied
+// context. RPC handlers pass the request context so a client disconnect /
+// timeout cancels the worker-routed block reads and wallet-salt scan reached
+// from here; the worker reader's withTimeout still bounds each call when ctx
+// carries no deadline.
+func (n *Engine) RunNodeImmediatelyWithContext(ctx context.Context, nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, user *model.User, useSimulation ...interface{}) (map[string]interface{}, error) {
 	// Default to simulation mode
 	simulationMode := true
 
@@ -56,17 +65,17 @@ func (n *Engine) RunNodeImmediately(nodeType string, nodeConfig map[string]inter
 	}
 
 	if IsTriggerNodeType(nodeType) {
-		return n.runTriggerImmediately(nodeType, nodeConfig, inputVariables)
+		return n.runTriggerImmediately(ctx, nodeType, nodeConfig, inputVariables)
 	} else {
-		return n.runProcessingNodeWithInputs(user, nodeType, nodeConfig, inputVariables, simulationMode)
+		return n.runProcessingNodeWithInputs(ctx, user, nodeType, nodeConfig, inputVariables, simulationMode)
 	}
 }
 
 // runTriggerImmediately executes trigger nodes immediately, ignoring any scheduling configuration
-func (n *Engine) runTriggerImmediately(triggerType string, triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
+func (n *Engine) runTriggerImmediately(ctx context.Context, triggerType string, triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
 	switch triggerType {
 	case NodeTypeBlockTrigger:
-		return n.runBlockTriggerImmediately(triggerConfig, inputVariables)
+		return n.runBlockTriggerImmediately(ctx, triggerConfig, inputVariables)
 	case NodeTypeFixedTimeTrigger:
 		return n.runFixedTimeTriggerImmediately(triggerConfig, inputVariables)
 	case NodeTypeCronTrigger:
@@ -81,7 +90,7 @@ func (n *Engine) runTriggerImmediately(triggerType string, triggerConfig map[str
 }
 
 // runBlockTriggerImmediately gets the latest block data immediately, ignoring any interval configuration
-func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
+func (n *Engine) runBlockTriggerImmediately(ctx context.Context, triggerConfig map[string]interface{}, inputVariables map[string]interface{}) (map[string]interface{}, error) {
 	// For immediate execution, we ignore interval and always get the latest block
 	// unless a specific blockNumber is provided
 	var blockNumber uint64
@@ -114,7 +123,7 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 
 	// If no specific block number, get the latest block
 	if blockNumber == 0 {
-		currentBlock, err := reader.GetBlockNumber(context.Background())
+		currentBlock, err := reader.GetBlockNumber(ctx)
 		if err != nil {
 			// For simulations, use a mock block number to avoid RPC rate limiting
 			if strings.Contains(err.Error(), "rate limit") || strings.Contains(err.Error(), "429") {
@@ -134,7 +143,7 @@ func (n *Engine) runBlockTriggerImmediately(triggerConfig map[string]interface{}
 	}
 
 	// Get real block data via the chain's worker
-	header, err := reader.HeaderByNumber(context.Background(), big.NewInt(int64(blockNumber)))
+	header, err := reader.HeaderByNumber(ctx, big.NewInt(int64(blockNumber)))
 	if err != nil {
 		// For simulations, use mock block data to avoid RPC rate limiting
 		if strings.Contains(err.Error(), "rate limit") || strings.Contains(err.Error(), "429") {
@@ -2445,10 +2454,10 @@ func (n *Engine) runManualTriggerImmediately(triggerConfig map[string]interface{
 }
 
 // runProcessingNodeWithInputs handles execution of processing node types
-func (n *Engine) runProcessingNodeWithInputs(user *model.User, nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, useSimulation bool) (map[string]interface{}, error) {
+func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.User, nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, useSimulation bool) (map[string]interface{}, error) {
 	// Check if this is actually a trigger type that was misrouted
 	if IsTriggerNodeType(nodeType) {
-		return n.runTriggerImmediately(nodeType, nodeConfig, inputVariables)
+		return n.runTriggerImmediately(ctx, nodeType, nodeConfig, inputVariables)
 	}
 
 	// Load secrets for immediate execution (global macroSecrets + user-level secrets)
@@ -2572,7 +2581,7 @@ func (n *Engine) runProcessingNodeWithInputs(user *model.User, nodeType string, 
 					factoryAddr := n.smartWalletConfig.FactoryAddress
 					runnerAddr := common.HexToAddress(runnerStr)
 					if reader := GetChainStateReaderForChain(uint64(n.smartWalletConfig.ChainID)); reader != nil {
-						found, salt, derr := reader.FindMatchingWalletSalt(context.Background(), vm.TaskOwner, factoryAddr, runnerAddr, runnerSaltScan)
+						found, salt, derr := reader.FindMatchingWalletSalt(ctx, vm.TaskOwner, factoryAddr, runnerAddr, runnerSaltScan)
 						if derr != nil {
 							return nil, fmt.Errorf("failed to derive addresses for runner validation: %w", derr)
 						}
@@ -2870,6 +2879,13 @@ func (n *Engine) detectNodeTypeFromStep(step *avsproto.Execution_Step) string {
 
 // RunNodeImmediatelyRPC handles the RPC interface for immediate node execution
 func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWithInputsReq) (*avsproto.RunNodeWithInputsResp, error) {
+	return n.RunNodeImmediatelyRPCWithContext(context.Background(), user, req)
+}
+
+// RunNodeImmediatelyRPCWithContext is RunNodeImmediatelyRPC with a
+// caller-supplied context, propagated to the worker-routed block reads and
+// wallet-salt scan so a cancelled request interrupts them.
+func (n *Engine) RunNodeImmediatelyRPCWithContext(ctx context.Context, user *model.User, req *avsproto.RunNodeWithInputsReq) (*avsproto.RunNodeWithInputsResp, error) {
 	// The request now contains a complete TaskNode, consistent with SimulateTask
 	node := req.Node
 	if node == nil {
@@ -2948,7 +2964,7 @@ func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWi
 	// Execute the node immediately with authenticated user
 	// NOTE: lang field conversion for CustomCode is handled by ParseLanguageFromConfig
 	// Pass the isSimulated flag from node config to control simulation/real execution
-	result, err := n.RunNodeImmediately(nodeTypeStr, nodeConfig, inputVariables, user, useSimulation)
+	result, err := n.RunNodeImmediatelyWithContext(ctx, nodeTypeStr, nodeConfig, inputVariables, user, useSimulation)
 	if err != nil {
 		if n.logger != nil {
 			if isExpectedValidationError(err) {
@@ -3109,6 +3125,13 @@ func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWi
 
 // RunTriggerRPC handles the RPC interface for immediate trigger execution
 func (n *Engine) RunTriggerRPC(user *model.User, req *avsproto.RunTriggerReq) (*avsproto.RunTriggerResp, error) {
+	return n.RunTriggerRPCWithContext(context.Background(), user, req)
+}
+
+// RunTriggerRPCWithContext is RunTriggerRPC with a caller-supplied context,
+// propagated to the worker-routed block reads reached from runTriggerImmediately
+// so a cancelled request interrupts them.
+func (n *Engine) RunTriggerRPCWithContext(ctx context.Context, user *model.User, req *avsproto.RunTriggerReq) (*avsproto.RunTriggerResp, error) {
 	// Validate that trigger is provided
 	if req.Trigger == nil {
 		resp := &avsproto.RunTriggerResp{
@@ -3157,7 +3180,7 @@ func (n *Engine) RunTriggerRPC(user *model.User, req *avsproto.RunTriggerReq) (*
 
 	// Execute the trigger immediately with trigger input data
 	// NOTE: lang field conversion for ManualTrigger is handled by ParseLanguageFromConfig
-	result, err := n.runTriggerImmediately(triggerTypeStr, triggerConfig, triggerInput)
+	result, err := n.runTriggerImmediately(ctx, triggerTypeStr, triggerConfig, triggerInput)
 	if err != nil {
 		if n.logger != nil {
 			// Categorize errors to avoid unnecessary stack traces for expected validation errors

--- a/core/taskengine/worker_ctx_cancellation_test.go
+++ b/core/taskengine/worker_ctx_cancellation_test.go
@@ -1,0 +1,89 @@
+package taskengine
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// blockingChainStateReader embeds the ChainStateReader interface so it
+// satisfies the full method set, overriding the two block-read methods the
+// test exercises (GetBlockNumber and HeaderByNumber). GetBlockNumber signals
+// when the worker call has started, then both block until the caller's context
+// is cancelled — mirroring an in-flight worker round-trip that a request
+// cancellation should be able to interrupt.
+type blockingChainStateReader struct {
+	ChainStateReader
+	started chan struct{}
+}
+
+func (b *blockingChainStateReader) GetBlockNumber(ctx context.Context) (uint64, error) {
+	close(b.started)
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func (b *blockingChainStateReader) HeaderByNumber(ctx context.Context, _ *big.Int) (*BlockHeader, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestRunBlockTriggerImmediately_ContextCancellationInterruptsWorkerCall(t *testing.T) {
+	// runBlockTriggerImmediately only reads n.logger (nil-guarded) and the
+	// global chain-state reader registry, so a zero-value Engine is enough —
+	// this keeps the test independent of the gateway config fixture.
+	engine := &Engine{}
+
+	// Start from a clean registry and clear it on exit. A nil-reader
+	// "unregister" is a no-op (RegisterChainStateReader early-returns on nil),
+	// so ClearChainStateReaderRegistry is the real cleanup — matches the
+	// pattern in chain_state_reader_test.go.
+	ClearChainStateReaderRegistry()
+	defer ClearChainStateReaderRegistry()
+
+	const testChainID int64 = 987654321
+	reader := &blockingChainStateReader{started: make(chan struct{})}
+	RegisterChainStateReader(uint64(testChainID), reader)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	triggerConfig := map[string]interface{}{
+		"chain_id": testChainID,
+	}
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, err := engine.runTriggerImmediately(ctx, NodeTypeBlockTrigger, triggerConfig, map[string]interface{}{})
+		done <- result{err: err}
+	}()
+
+	// Wait until the worker call is actually in flight before cancelling, so
+	// the test exercises interruption of an in-flight call rather than a
+	// pre-cancelled context shortcut.
+	select {
+	case <-reader.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker GetBlockNumber was never reached")
+	}
+
+	cancel()
+
+	select {
+	case res := <-done:
+		if res.err == nil {
+			t.Fatal("expected an error after context cancellation, got nil")
+		}
+		if !errors.Is(res.err, context.Canceled) {
+			t.Fatalf("expected error to wrap context.Canceled, got: %v", res.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runBlockTriggerImmediately did not return after context cancellation; " +
+			"cancellation was not propagated to the worker call")
+	}
+}

--- a/migrations/delete_auto_disabled_invalid_tasks.go
+++ b/migrations/delete_auto_disabled_invalid_tasks.go
@@ -73,26 +73,44 @@ func isPermanentValidationError(errorMsg string) bool {
 func DeleteAutoDisabledInvalidTasks(db storage.Storage) (int, error) {
 	disabledToken := storageschema.WorkflowStatusToStorageKey(avsproto.TaskStatus_Disabled)
 
-	items, err := db.GetByPrefix([]byte("t:"))
-	if err != nil {
+	// Phase 1: constant-memory key scan. Collect only the Disabled status keys
+	// (t:<chain>:i:<id>); values are NOT fetched here, so a database full of
+	// Enabled/Completed rows is never materialized in memory. IterateKeysOnly
+	// is the codebase's sanctioned scan for this — GetByPrefix would load every
+	// workflow value at once and can spike memory / OOM at startup on a large DB.
+	var disabledKeys [][]byte
+	if err := db.IterateKeysOnly([]byte("t:"), func(key []byte) error {
+		// Match Disabled workflow rows: t:<chain>:i:<id>. Task IDs are ULIDs
+		// (no colons), so a 4-way split is exact.
+		parts := strings.SplitN(string(key), ":", 4)
+		if len(parts) != 4 || parts[0] != "t" || parts[2] != disabledToken {
+			return nil
+		}
+		// Key bytes are iterator-owned — copy before retaining past the visit.
+		disabledKeys = append(disabledKeys, append([]byte{}, key...))
+		return nil
+	}); err != nil {
 		return 0, err
 	}
 
+	// Phase 2: fetch, validate, and delete each candidate individually. The
+	// iterator's read transaction is already closed, so these writes are safe.
 	deleted := 0
-	for _, it := range items {
-		// Match Disabled workflow rows: t:<chain>:i:<id>. Task IDs are ULIDs
-		// (no colons), so a 4-way split is exact.
-		parts := strings.SplitN(string(it.Key), ":", 4)
-		if len(parts) != 4 || parts[0] != "t" || parts[2] != disabledToken {
-			continue
-		}
+	for _, key := range disabledKeys {
+		parts := strings.SplitN(string(key), ":", 4)
 		chainID, perr := strconv.ParseInt(parts[1], 10, 64)
 		if perr != nil {
 			continue
 		}
 
+		value, gerr := db.GetKey(key)
+		if gerr != nil {
+			// Vanished between scan and fetch (e.g. concurrent delete) — skip.
+			continue
+		}
+
 		task := &model.Workflow{Task: &avsproto.Task{}}
-		if uerr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(it.Value, task); uerr != nil {
+		if uerr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(value, task); uerr != nil {
 			// Undecodable record — leave it alone rather than risk deleting
 			// something we can't interpret.
 			continue
@@ -108,8 +126,8 @@ func DeleteAutoDisabledInvalidTasks(db storage.Storage) (int, error) {
 
 		// Delete the Disabled status row (fail loudly — this key definitely
 		// exists, so an error here is real).
-		if derr := db.Delete(it.Key); derr != nil {
-			return deleted, fmt.Errorf("delete disabled-status key %q: %w", string(it.Key), derr)
+		if derr := db.Delete(key); derr != nil {
+			return deleted, fmt.Errorf("delete disabled-status key %q: %w", string(key), derr)
 		}
 		// Delete the user index and any Enabled orphan. These may be absent
 		// (Delete on a missing key is a no-op), so best-effort is fine.

--- a/migrations/delete_auto_disabled_invalid_tasks.go
+++ b/migrations/delete_auto_disabled_invalid_tasks.go
@@ -1,0 +1,125 @@
+package migrations
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// autoDisableValidationFailureThreshold mirrors validationFailureDisableThreshold
+// in core/taskengine/executor.go — the number of consecutive permanent
+// validation failures the executor tolerates before flipping a task to Disabled.
+// Kept as a local copy so this migration does not import the task engine; it
+// must stay in sync with the executor.
+const autoDisableValidationFailureThreshold uint32 = 10
+
+// permanentValidationErrorPrefixes mirrors the identically-named slice in
+// core/taskengine/executor.go. A task auto-disabled by the executor records the
+// triggering execution.Error in Task.LastValidationError; these prefixes are the
+// permanent (won't self-resolve) reasons that drive an auto-disable. Matching on
+// them lets us reconstruct exactly the auto-disabled cohort. Keep in sync with
+// the executor.
+var permanentValidationErrorPrefixes = []string{
+	"invalid or missing task smart wallet address",
+	"task smart wallet address does not belong to owner",
+	"failed to create VM:",
+}
+
+func isPermanentValidationError(errorMsg string) bool {
+	for _, prefix := range permanentValidationErrorPrefixes {
+		if strings.HasPrefix(errorMsg, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// DeleteAutoDisabledInvalidTasks removes workflow records that the executor
+// auto-disabled after validationFailureDisableThreshold consecutive *permanent*
+// validation failures — overwhelmingly "task smart wallet address does not
+// belong to owner" (see EIGENLAYER-AVS-1X..28). These tasks are structurally
+// valid (they pass ValidateWithError, so the Failed-cohort migration
+// DeleteInvalidFailedTasks deliberately leaves them alone) but can never
+// execute: the wallet/owner relationship is permanently wrong. The executor
+// already fired its one-shot Sentry alert and flipped them to Disabled; this
+// sweep removes the dead rows they leave behind. The auto-disable warning and
+// Sentry event are untouched — future breakage still alerts; this only cleans up
+// after it.
+//
+// Cohort match (reconstructs exactly what the executor's auto-disable produced):
+//   - status Disabled (t:<chain>:i:<id>)
+//   - LastValidationError matches a permanent validation prefix
+//   - ConsecutiveValidationFailures >= autoDisableValidationFailureThreshold
+//
+// Safety properties:
+//   - Only Disabled rows are considered; Enabled/Completed/Failed/Running tasks
+//     are never touched.
+//   - A task a user manually disabled won't match: it carries no permanent
+//     LastValidationError with >= threshold consecutive failures.
+//   - Rows whose JSON can't be decoded are left in place — we never delete data
+//     we can't interpret.
+//   - The migrator takes a full DB backup before this runs, and records the
+//     migration so it executes exactly once. Idempotent: re-running finds none.
+//
+// For each deleted task we remove every key it owns: the Disabled status row,
+// the user index (u:<chain>:<owner>:<wallet>:<id>), and — defensively — any
+// lingering Enabled orphan (t:<chain>:a:<id>).
+func DeleteAutoDisabledInvalidTasks(db storage.Storage) (int, error) {
+	disabledToken := storageschema.WorkflowStatusToStorageKey(avsproto.TaskStatus_Disabled)
+
+	items, err := db.GetByPrefix([]byte("t:"))
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, it := range items {
+		// Match Disabled workflow rows: t:<chain>:i:<id>. Task IDs are ULIDs
+		// (no colons), so a 4-way split is exact.
+		parts := strings.SplitN(string(it.Key), ":", 4)
+		if len(parts) != 4 || parts[0] != "t" || parts[2] != disabledToken {
+			continue
+		}
+		chainID, perr := strconv.ParseInt(parts[1], 10, 64)
+		if perr != nil {
+			continue
+		}
+
+		task := &model.Workflow{Task: &avsproto.Task{}}
+		if uerr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(it.Value, task); uerr != nil {
+			// Undecodable record — leave it alone rather than risk deleting
+			// something we can't interpret.
+			continue
+		}
+
+		// Only delete the auto-disabled-for-permanent-validation cohort. A task
+		// disabled for any other reason (e.g. a user toggling it off) won't
+		// carry a permanent LastValidationError with >= threshold failures.
+		if !isPermanentValidationError(task.GetLastValidationError()) ||
+			task.GetConsecutiveValidationFailures() < autoDisableValidationFailureThreshold {
+			continue
+		}
+
+		// Delete the Disabled status row (fail loudly — this key definitely
+		// exists, so an error here is real).
+		if derr := db.Delete(it.Key); derr != nil {
+			return deleted, fmt.Errorf("delete disabled-status key %q: %w", string(it.Key), derr)
+		}
+		// Delete the user index and any Enabled orphan. These may be absent
+		// (Delete on a missing key is a no-op), so best-effort is fine.
+		userKey := fmt.Sprintf("u:%d:%s:%s:%s", chainID,
+			strings.ToLower(task.GetOwner()), strings.ToLower(task.GetSmartWalletAddress()), task.GetId())
+		_ = db.Delete([]byte(userKey))
+		_ = db.Delete(storageschema.ChainWorkflowStorageKey(chainID, task.GetId(), avsproto.TaskStatus_Enabled))
+
+		deleted++
+	}
+
+	return deleted, nil
+}

--- a/migrations/delete_auto_disabled_invalid_tasks_test.go
+++ b/migrations/delete_auto_disabled_invalid_tasks_test.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// disabledOwnershipTask builds a structurally-valid task carrying the persisted
+// auto-disable bookkeeping the executor writes (LastValidationError +
+// ConsecutiveValidationFailures).
+func disabledOwnershipTask(id, owner, wallet string, chainID int64, lastErr string, failures uint32) *model.Workflow {
+	w := blockTaskWorkflow(id, owner, wallet, chainID, true)
+	w.LastValidationError = lastErr
+	w.ConsecutiveValidationFailures = failures
+	return w
+}
+
+func TestDeleteAutoDisabledInvalidTasks(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	const chainID = int64(11155111)
+	const ownershipErr = "task smart wallet address does not belong to owner"
+
+	// 1) Disabled + ownership error + at threshold → must be deleted. Valid
+	//    config (passes ValidateWithError), proving we don't depend on it.
+	disabled := disabledOwnershipTask("auto-disabled", "0xOwnerA", "0xWalletA", chainID, ownershipErr, autoDisableValidationFailureThreshold)
+	require.NoError(t, disabled.ValidateWithError(), "fixture 1 must be structurally valid")
+	seed(t, db, avsproto.TaskStatus_Disabled, disabled)
+	// Leave a stale Enabled orphan to prove it gets cleaned up too.
+	orphanBytes, _ := disabled.ToJSON()
+	require.NoError(t, db.Set(storageschema.ChainWorkflowStorageKey(chainID, disabled.Id, avsproto.TaskStatus_Enabled), orphanBytes))
+
+	// 2) Disabled + ownership error but below threshold → preserved.
+	belowThreshold := disabledOwnershipTask("below-threshold", "0xOwnerB", "0xWalletB", chainID, ownershipErr, autoDisableValidationFailureThreshold-1)
+	seed(t, db, avsproto.TaskStatus_Disabled, belowThreshold)
+
+	// 3) Disabled with no permanent validation error (e.g. user-disabled) → preserved.
+	userDisabled := disabledOwnershipTask("user-disabled", "0xOwnerC", "0xWalletC", chainID, "", 0)
+	seed(t, db, avsproto.TaskStatus_Disabled, userDisabled)
+
+	// 4) Failed + ownership error + at threshold → untouched (wrong status; the
+	//    Failed cohort belongs to DeleteInvalidFailedTasks, not this sweep).
+	failed := disabledOwnershipTask("failed-ownership", "0xOwnerD", "0xWalletD", chainID, ownershipErr, autoDisableValidationFailureThreshold)
+	seed(t, db, avsproto.TaskStatus_Failed, failed)
+
+	// 5) Enabled → untouched.
+	enabled := blockTaskWorkflow("valid-enabled", "0xOwnerE", "0xWalletE", chainID, true)
+	seed(t, db, avsproto.TaskStatus_Enabled, enabled)
+
+	n, err := DeleteAutoDisabledInvalidTasks(db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only the at-threshold auto-disabled task should be deleted")
+
+	// Deleted task: every key gone (Disabled row, Enabled orphan, user index).
+	for _, k := range [][]byte{
+		storageschema.ChainWorkflowStorageKey(chainID, disabled.Id, avsproto.TaskStatus_Disabled),
+		storageschema.ChainWorkflowStorageKey(chainID, disabled.Id, avsproto.TaskStatus_Enabled),
+		userIndexKey(disabled),
+	} {
+		ex, _ := db.Exist(k)
+		assert.False(t, ex, "auto-disabled task key must be deleted: %s", string(k))
+	}
+
+	// Preserved fixtures.
+	for _, w := range []*model.Workflow{belowThreshold, userDisabled} {
+		ex, _ := db.Exist(storageschema.ChainWorkflowStorageKey(chainID, w.Id, avsproto.TaskStatus_Disabled))
+		assert.True(t, ex, "Disabled task below cohort must be preserved: %s", w.Id)
+	}
+	fex, _ := db.Exist(storageschema.ChainWorkflowStorageKey(chainID, failed.Id, avsproto.TaskStatus_Failed))
+	assert.True(t, fex, "Failed task must be untouched by this migration")
+	eex, _ := db.Exist(storageschema.ChainWorkflowStorageKey(chainID, enabled.Id, avsproto.TaskStatus_Enabled))
+	assert.True(t, eex, "Enabled task must be untouched")
+
+	// Idempotent: a second run deletes nothing.
+	n2, err := DeleteAutoDisabledInvalidTasks(db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n2, "second run must be a no-op")
+}

--- a/migrations/delete_invalid_failed_tasks.go
+++ b/migrations/delete_invalid_failed_tasks.go
@@ -1,0 +1,85 @@
+package migrations
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// DeleteInvalidFailedTasks removes workflow records that are BOTH in Failed
+// status AND still fail config validation — the legacy cohort that the
+// boot-time invalid-task scan (DetectAndHandleInvalidTasks) retired: invalid
+// node names like "send eth", or trigger configs orphaned by an older proto
+// field migration. They can never become valid and persist only as dead rows.
+//
+// Safety properties:
+//   - Only Failed rows (t:<chain>:f:<id>) are considered; Enabled/Completed/
+//     Disabled/Running tasks are never touched.
+//   - A Failed row is deleted ONLY if ValidateWithError still reports it
+//     invalid. A task that is Failed for a legitimate runtime reason (valid
+//     config) is preserved.
+//   - Rows whose JSON can't be decoded are left in place — we never delete
+//     data we can't interpret.
+//   - The migrator takes a full DB backup before this runs, and records the
+//     migration so it executes exactly once.
+//
+// For each deleted task we remove every key it owns: the Failed status row,
+// the user index (u:<chain>:<owner>:<wallet>:<id>), and — defensively — any
+// lingering Enabled orphan (t:<chain>:a:<id>) left by the pre-fix scan.
+func DeleteInvalidFailedTasks(db storage.Storage) (int, error) {
+	failedToken := storageschema.WorkflowStatusToStorageKey(avsproto.TaskStatus_Failed)
+
+	items, err := db.GetByPrefix([]byte("t:"))
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, it := range items {
+		// Match Failed workflow rows: t:<chain>:f:<id>. Task IDs are ULIDs
+		// (no colons), so a 4-way split is exact.
+		parts := strings.SplitN(string(it.Key), ":", 4)
+		if len(parts) != 4 || parts[0] != "t" || parts[2] != failedToken {
+			continue
+		}
+		chainID, perr := strconv.ParseInt(parts[1], 10, 64)
+		if perr != nil {
+			continue
+		}
+
+		task := &model.Workflow{Task: &avsproto.Task{}}
+		if uerr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(it.Value, task); uerr != nil {
+			// Undecodable record — leave it alone rather than risk deleting
+			// something we can't interpret.
+			continue
+		}
+
+		// Only delete genuinely-invalid tasks (the orphaned cohort). A Failed
+		// task with a valid config is a legitimate runtime failure — keep it.
+		if task.ValidateWithError() == nil {
+			continue
+		}
+
+		// Delete the Failed status row (fail loudly — this key definitely
+		// exists, so an error here is real).
+		if derr := db.Delete(it.Key); derr != nil {
+			return deleted, fmt.Errorf("delete failed-status key %q: %w", string(it.Key), derr)
+		}
+		// Delete the user index and any Enabled orphan. These may be absent
+		// (Delete on a missing key is a no-op), so best-effort is fine.
+		userKey := fmt.Sprintf("u:%d:%s:%s:%s", chainID,
+			strings.ToLower(task.GetOwner()), strings.ToLower(task.GetSmartWalletAddress()), task.GetId())
+		_ = db.Delete([]byte(userKey))
+		_ = db.Delete(storageschema.ChainWorkflowStorageKey(chainID, task.GetId(), avsproto.TaskStatus_Enabled))
+
+		deleted++
+	}
+
+	return deleted, nil
+}

--- a/migrations/delete_invalid_failed_tasks.go
+++ b/migrations/delete_invalid_failed_tasks.go
@@ -35,26 +35,44 @@ import (
 func DeleteInvalidFailedTasks(db storage.Storage) (int, error) {
 	failedToken := storageschema.WorkflowStatusToStorageKey(avsproto.TaskStatus_Failed)
 
-	items, err := db.GetByPrefix([]byte("t:"))
-	if err != nil {
+	// Phase 1: constant-memory key scan. Collect only the Failed status keys
+	// (t:<chain>:f:<id>); values are NOT fetched here, so a database full of
+	// Enabled/Completed rows is never materialized in memory. IterateKeysOnly
+	// is the codebase's sanctioned scan for this — GetByPrefix would load every
+	// workflow value at once and can spike memory / OOM at startup on a large DB.
+	var failedKeys [][]byte
+	if err := db.IterateKeysOnly([]byte("t:"), func(key []byte) error {
+		// Match Failed workflow rows: t:<chain>:f:<id>. Task IDs are ULIDs
+		// (no colons), so a 4-way split is exact.
+		parts := strings.SplitN(string(key), ":", 4)
+		if len(parts) != 4 || parts[0] != "t" || parts[2] != failedToken {
+			return nil
+		}
+		// Key bytes are iterator-owned — copy before retaining past the visit.
+		failedKeys = append(failedKeys, append([]byte{}, key...))
+		return nil
+	}); err != nil {
 		return 0, err
 	}
 
+	// Phase 2: fetch, validate, and delete each candidate individually. The
+	// iterator's read transaction is already closed, so these writes are safe.
 	deleted := 0
-	for _, it := range items {
-		// Match Failed workflow rows: t:<chain>:f:<id>. Task IDs are ULIDs
-		// (no colons), so a 4-way split is exact.
-		parts := strings.SplitN(string(it.Key), ":", 4)
-		if len(parts) != 4 || parts[0] != "t" || parts[2] != failedToken {
-			continue
-		}
+	for _, key := range failedKeys {
+		parts := strings.SplitN(string(key), ":", 4)
 		chainID, perr := strconv.ParseInt(parts[1], 10, 64)
 		if perr != nil {
 			continue
 		}
 
+		value, gerr := db.GetKey(key)
+		if gerr != nil {
+			// Vanished between scan and fetch (e.g. concurrent delete) — skip.
+			continue
+		}
+
 		task := &model.Workflow{Task: &avsproto.Task{}}
-		if uerr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(it.Value, task); uerr != nil {
+		if uerr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(value, task); uerr != nil {
 			// Undecodable record — leave it alone rather than risk deleting
 			// something we can't interpret.
 			continue
@@ -68,8 +86,8 @@ func DeleteInvalidFailedTasks(db storage.Storage) (int, error) {
 
 		// Delete the Failed status row (fail loudly — this key definitely
 		// exists, so an error here is real).
-		if derr := db.Delete(it.Key); derr != nil {
-			return deleted, fmt.Errorf("delete failed-status key %q: %w", string(it.Key), derr)
+		if derr := db.Delete(key); derr != nil {
+			return deleted, fmt.Errorf("delete failed-status key %q: %w", string(key), derr)
 		}
 		// Delete the user index and any Enabled orphan. These may be absent
 		// (Delete on a missing key is a no-op), so best-effort is fine.

--- a/migrations/delete_invalid_failed_tasks_test.go
+++ b/migrations/delete_invalid_failed_tasks_test.go
@@ -1,0 +1,96 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	storageschema "github.com/AvaProtocol/EigenLayer-AVS/storage/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func userIndexKey(w *model.Workflow) []byte {
+	return []byte(fmt.Sprintf("u:%d:%s:%s:%s", w.ChainId,
+		strings.ToLower(w.Owner), strings.ToLower(w.SmartWalletAddress), w.Id))
+}
+
+// seed writes a task under its status key plus the matching user index.
+func seed(t *testing.T, db storage.Storage, status avsproto.TaskStatus, w *model.Workflow) {
+	t.Helper()
+	w.Status = status
+	b, err := w.ToJSON()
+	require.NoError(t, err)
+	require.NoError(t, db.Set(storageschema.ChainWorkflowStorageKey(w.ChainId, w.Id, status), b))
+	require.NoError(t, db.Set(userIndexKey(w), []byte("ref")))
+}
+
+func blockTaskWorkflow(id, owner, wallet string, chainID int64, withConfig bool) *model.Workflow {
+	block := &avsproto.BlockTrigger{}
+	if withConfig {
+		block.Config = &avsproto.BlockTrigger_Config{Interval: 1}
+	}
+	return &model.Workflow{Task: &avsproto.Task{
+		Id: id, ChainId: chainID, Owner: owner, SmartWalletAddress: wallet,
+		Trigger: &avsproto.TaskTrigger{
+			Name:        "trigger1",
+			TriggerType: &avsproto.TaskTrigger_Block{Block: block},
+		},
+	}}
+}
+
+func TestDeleteInvalidFailedTasks(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	const chainID = int64(11155111)
+
+	// 1) Invalid + Failed → must be deleted (block trigger with nil config).
+	invalid := blockTaskWorkflow("invalid-failed", "0xOwnerA", "0xWalletA", chainID, false)
+	require.Error(t, invalid.ValidateWithError(), "fixture 1 must be invalid")
+	seed(t, db, avsproto.TaskStatus_Failed, invalid)
+	// Also leave a stale Enabled orphan to prove it gets cleaned up too.
+	orphanBytes, _ := invalid.ToJSON()
+	require.NoError(t, db.Set(storageschema.ChainWorkflowStorageKey(chainID, invalid.Id, avsproto.TaskStatus_Enabled), orphanBytes))
+
+	// 2) Valid + Failed → must be preserved (legitimate runtime failure).
+	validFailed := blockTaskWorkflow("valid-failed", "0xOwnerB", "0xWalletB", chainID, true)
+	require.NoError(t, validFailed.ValidateWithError(), "fixture 2 must be valid")
+	seed(t, db, avsproto.TaskStatus_Failed, validFailed)
+
+	// 3) Valid + Enabled → must be untouched.
+	enabled := blockTaskWorkflow("valid-enabled", "0xOwnerC", "0xWalletC", chainID, true)
+	seed(t, db, avsproto.TaskStatus_Enabled, enabled)
+
+	n, err := DeleteInvalidFailedTasks(db)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only the invalid Failed task should be deleted")
+
+	// Invalid task: every key gone.
+	for _, k := range [][]byte{
+		storageschema.ChainWorkflowStorageKey(chainID, invalid.Id, avsproto.TaskStatus_Failed),
+		storageschema.ChainWorkflowStorageKey(chainID, invalid.Id, avsproto.TaskStatus_Enabled),
+		userIndexKey(invalid),
+	} {
+		ex, _ := db.Exist(k)
+		assert.False(t, ex, "invalid task key must be deleted: %s", string(k))
+	}
+
+	// Valid Failed task: preserved (status row + index).
+	vex, _ := db.Exist(storageschema.ChainWorkflowStorageKey(chainID, validFailed.Id, avsproto.TaskStatus_Failed))
+	assert.True(t, vex, "valid Failed task must be preserved")
+	vuex, _ := db.Exist(userIndexKey(validFailed))
+	assert.True(t, vuex, "valid Failed task user index must be preserved")
+
+	// Enabled task: untouched.
+	eex, _ := db.Exist(storageschema.ChainWorkflowStorageKey(chainID, enabled.Id, avsproto.TaskStatus_Enabled))
+	assert.True(t, eex, "enabled task must be untouched")
+
+	// Idempotent: a second run deletes nothing.
+	n2, err := DeleteInvalidFailedTasks(db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n2, "second run must be a no-op")
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -32,4 +32,12 @@ var Migrations = []migrator.Migration{
 	// ACTIVE MIGRATIONS
 	// ========================================
 	// Add new migrations here that need to be applied
+	{
+		// One-time cleanup of the legacy invalid-task cohort: workflow rows
+		// that are Failed AND still fail config validation (invalid node
+		// names / configs orphaned by an old proto migration). See
+		// delete_invalid_failed_tasks.go. Idempotent: re-running finds none.
+		Name:     "20260618-delete-invalid-failed-tasks",
+		Function: DeleteInvalidFailedTasks,
+	},
 }

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -40,4 +40,15 @@ var Migrations = []migrator.Migration{
 		Name:     "20260618-delete-invalid-failed-tasks",
 		Function: DeleteInvalidFailedTasks,
 	},
+	{
+		// One-time cleanup of the auto-disabled invalid-task cohort: workflow
+		// rows the executor flipped to Disabled after the consecutive-permanent-
+		// validation-failure threshold — overwhelmingly "smart wallet address
+		// does not belong to owner" (EIGENLAYER-AVS-1X..28). They pass config
+		// validation, so DeleteInvalidFailedTasks leaves them; this removes them.
+		// See delete_auto_disabled_invalid_tasks.go. Idempotent: re-running
+		// finds none.
+		Name:     "20260621-delete-auto-disabled-invalid-tasks",
+		Function: DeleteAutoDisabledInvalidTasks,
+	},
 }

--- a/scripts/dev/dump-invalid-tasks/main.go
+++ b/scripts/dev/dump-invalid-tasks/main.go
@@ -1,0 +1,98 @@
+// dump-invalid-tasks — read-only diagnostic that scans a gateway BadgerDB for
+// Enabled workflows failing validation, printing task id / chain / created-at /
+// owner / error so operators can decide whether to repair or delete them
+// (e.g. the legacy "send eth" node-name and missing-trigger-config cohorts).
+//
+// READ-ONLY in intent, but BadgerDB takes an exclusive directory lock, so run
+// this against a COPY/backup of the gateway DB (e.g. /data/gateway-backup),
+// NOT the live directory while the gateway is running.
+//
+// Usage:
+//
+//	go run ./scripts/dev/dump-invalid-tasks --gateway-path /path/to/gateway-db-copy
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// ulidTime decodes the millisecond timestamp embedded in a ULID's first 10
+// Crockford-base32 characters (task IDs are ULIDs).
+func ulidTime(id string) string {
+	const enc = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+	u := strings.ToUpper(id)
+	if len(u) < 10 {
+		return "?"
+	}
+	var ms int64
+	for _, c := range u[:10] {
+		i := strings.IndexRune(enc, c)
+		if i < 0 {
+			return "?"
+		}
+		ms = ms*32 + int64(i)
+	}
+	return time.UnixMilli(ms).UTC().Format("2006-01-02 15:04")
+}
+
+func main() {
+	gatewayPath := flag.String("gateway-path", "", "Path to a COPY of the gateway BadgerDB directory (not the live DB)")
+	flag.Parse()
+	if *gatewayPath == "" {
+		log.Fatalf("--gateway-path is required (point it at a backup/copy, not the live DB)")
+	}
+
+	db, err := storage.NewWithPath(*gatewayPath)
+	if err != nil {
+		log.Fatalf("open BadgerDB at %s: %v", *gatewayPath, err)
+	}
+	defer db.Close()
+
+	items, err := db.GetByPrefix([]byte("t:"))
+	if err != nil {
+		log.Fatalf("scan workflows: %v", err)
+	}
+
+	fmt.Printf("%-28s %-9s %-16s %-44s %s\n", "TaskID", "Chain", "CreatedUTC", "Owner", "Error")
+	fmt.Println(strings.Repeat("-", 150))
+
+	scanned, invalid := 0, 0
+	for _, it := range items {
+		// Only Enabled workflow rows: t:<chain>:a:<id>. ULIDs contain no
+		// colons, so a 4-way split is exact.
+		parts := strings.SplitN(string(it.Key), ":", 4)
+		if len(parts) != 4 || parts[0] != "t" || parts[1] == "" || parts[2] != "a" {
+			continue
+		}
+		scanned++
+
+		task := &model.Workflow{Task: &avsproto.Task{}}
+		if derr := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(it.Value, task); derr != nil {
+			invalid++
+			fmt.Printf("%-28s %-9s %-16s %-44s %s\n", parts[3], parts[1], "?", "?", "DECODE ERROR: "+derr.Error())
+			continue
+		}
+
+		if verr := task.ValidateWithError(); verr != nil {
+			invalid++
+			owner := task.GetOwner()
+			if owner == "" {
+				owner = task.GetSmartWalletAddress()
+			}
+			fmt.Printf("%-28s %-9s %-16s %-44s %s\n",
+				task.GetId(), parts[1], ulidTime(task.GetId()), owner, verr.Error())
+		}
+	}
+
+	fmt.Println(strings.Repeat("-", 150))
+	fmt.Printf("Scanned %d Enabled workflows; %d invalid.\n", scanned, invalid)
+}


### PR DESCRIPTION
Release PR: `staging` → `main`. Bundles the invalid/auto-disabled task cleanup work plus supporting diagnostics. Highest-impact change is a `fix:`, so this is a patch release.

## What's included
- **`chore:` new migration — delete auto-disabled ownership-mismatch tasks** (this PR's head). `DeleteAutoDisabledInvalidTasks` sweeps the cohort the existing migrations miss: tasks the executor flipped to **Disabled** after the consecutive-permanent-validation-failure threshold (overwhelmingly *"smart wallet address does not belong to owner"*, EIGENLAYER-AVS-1X..28). These pass `ValidateWithError`, so `DeleteInvalidFailedTasks` (Failed cohort) deliberately leaves them as dead rows. Pure-DB, reason-keyed on persisted `LastValidationError` + `ConsecutiveValidationFailures`; removes status row + user index + Enabled orphan. Idempotent, backup-protected, only touches Disabled rows.
- `chore:` log owner/smart-wallet/factory/created-at on task auto-disable (#612)
- `test:` guard that CreateWorkflow rejects invalid node names (#610)
- `chore:` migration to delete legacy invalid Failed tasks (#611)
- `chore:` log owner/smart-wallet/created-at for auto-failed invalid tasks
- `chore:` read-only dump-invalid-tasks diagnostic
- `fix:` delete stale Enabled key when auto-failing invalid tasks
- `chore:` clearer errors for invalid controller key / unparseable config

## Why
Production accumulated legacy invalid tasks (created ~2026-05-27..29) that the 3.9.0 executor auto-disabled in a batch on 2026-06-15 (EIGENLAYER-AVS-1X..28). The auto-disable warning + one-shot Sentry alert stay intact (future breakage still alerts); these migrations just clean up the dead rows left behind, across both the Failed (structural) and Disabled (ownership) cohorts.

## Notes
- Run `make storage-check` before merge — these are deletion-only migrations (no key-template or model-struct changes), expected clean.
- New migration verified: `go test ./migrations/` passes (new + sibling tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Update:** staging advanced since this PR opened — also bundles `feat: thread request context to gateway worker-routed chain calls (#603)` and `perf: constant-memory key scan in invalid-task cleanup migrations` (addresses Copilot's GetByPrefix-OOM review by switching both cleanup migrations to `IterateKeysOnly` + `GetKey`). Title intentionally kept at `fix:`.
