### PR TITLE
fix: production gateway caps + AP_CONFIG_YAML entrypoint + migration archival

### DIFF
--- a/config/gateway-railway.yaml
+++ b/config/gateway-railway.yaml
@@ -70,12 +70,11 @@ operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
 
 jwt_secret: ${GATEWAY_JWT_SECRET}
 
-# REST rate-limit overrides (default is 10/s, burst 50). Lifted on this
-# test branch so the v4 jest suite — which spreads ~90 requests across
-# parallel workers — doesn't get throttled into spurious "Try again in
-# 1s" failures. Production should keep the conservative default.
-rest_rate_limit_per_second: 200
-rest_rate_limit_burst: 500
+# REST rate-limit. Left unset so the server uses its built-in production
+# default — 10 req/s, burst 50 (aggregator/rest/middleware.DefaultRateLimit).
+# Raise these only on a non-prod gateway that needs to absorb a test suite's
+# burst (the v4 jest suite spreads ~90 requests across parallel workers);
+# production keeps the conservative default.
 
 server_name: "gateway-railway"
 sentry_dsn: https://d304c8708d5097f7787eeb664e4098c6@o1156669.ingest.us.sentry.io/4509386759733248
@@ -124,10 +123,10 @@ chains:
       bundler_url: ${ETHEREUM_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY_MAINNET}
       paymaster_address: ${PAYMASTER_ADDRESS_MAINNET}
-      # Mainnet production cap is 3; this branch (feature/rest-api-migration)
-      # only feeds the testing environment, so we lift the cap to match the
-      # testnet chains and let the v4 test suite churn through wallets.
-      max_wallets_per_owner: 2000
+      # Production cap. ValidWalletOwner validates DB-stored wallets
+      # independently of this value; it bounds NEW wallet creation and the
+      # ownership salt-scan fallback for not-yet-stored wallets.
+      max_wallets_per_owner: 3
 
   - chain_id: 8453
     name: base
@@ -137,8 +136,8 @@ chains:
       bundler_url: ${BASE_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY_MAINNET}
       paymaster_address: ${PAYMASTER_ADDRESS_MAINNET}
-      # See chain 1 note above — relaxed for test-env churn only.
-      max_wallets_per_owner: 2000
+      # See chain 1 note above.
+      max_wallets_per_owner: 3
 
   - chain_id: 11155111
     name: sepolia
@@ -148,7 +147,7 @@ chains:
       bundler_url: ${SEPOLIA_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY_TESTNET}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
-      max_wallets_per_owner: 2000
+      max_wallets_per_owner: 3
 
   - chain_id: 84532
     name: base-sepolia
@@ -158,7 +157,7 @@ chains:
       bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY_TESTNET}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
-      max_wallets_per_owner: 2000
+      max_wallets_per_owner: 3
 
   # BNB Smart Chain mainnet — connectivity-only rollout. The chain
   # has no SmartWallet factory deployed yet (avs-contracts Phase 2
@@ -181,7 +180,7 @@ chains:
       # will then enforce that pairing at boot.
       controller_private_key: ${CONTROLLER_PRIVATE_KEY_MAINNET}
       paymaster_address: ${PAYMASTER_ADDRESS_TESTNET}
-      max_wallets_per_owner: 2000
+      max_wallets_per_owner: 3
 
 macros:
   secrets:

--- a/config/operator-ethereum-railway.yaml
+++ b/config/operator-ethereum-railway.yaml
@@ -26,7 +26,7 @@ ecdsa_private_key_store_path: /app/keys/ecdsa.key.json
 bls_private_key_store_path: /app/keys/bls.key.json
 
 # Gateway address — set via Railway reference variable so the
-# topology is self-discovering. Set on the operator service:
+# topology is self-discovering. Set on the operator-ethereum service:
 #   GATEWAY_ADDRESS=${{gateway.RAILWAY_PRIVATE_DOMAIN}}:2206
 # Both operators (sepolia + ethereum) connect to the single `gateway`
 # service. enforceAuth is currently false so the gateway's AVS

--- a/config/operator-sepolia-railway.yaml
+++ b/config/operator-sepolia-railway.yaml
@@ -23,7 +23,7 @@ ecdsa_private_key_store_path: /app/keys/ecdsa.key.json
 bls_private_key_store_path: /app/keys/bls.key.json
 
 # Gateway address — set via Railway reference variable so the
-# topology is self-discovering. Set on the operator service:
+# topology is self-discovering. Set on the operator-sepolia service:
 #   GATEWAY_ADDRESS=${{gateway.RAILWAY_PRIVATE_DOMAIN}}:2206
 aggregator_server_ip_port_address: ${GATEWAY_ADDRESS}
 

--- a/docs/historical-migrations/2026-completed/README.md
+++ b/docs/historical-migrations/2026-completed/README.md
@@ -1,0 +1,26 @@
+# Historical migrations — 2026 completed
+
+Migrations that have been successfully applied in production and archived out
+of the active `migrations.Migrations` list to reduce startup overhead. The Go
+files here carry a `//go:build historical_migrations` tag, so they are excluded
+from normal builds; they are kept for reference and audit only.
+
+Migration completion is recorded per-database under `migration:<name>` keys, so
+these never re-run on an environment that already applied them.
+
+| Migration | Applied | Records | What it did |
+|---|---|---|---|
+| `20260618-delete-invalid-failed-tasks` | v3.10.3 (2026-06-21) | 33 | Deleted workflow rows that were `Failed` **and** still failed `ValidateWithError` — the legacy cohort the boot-time scan retired (invalid node names like "send eth", trigger configs orphaned by an older proto migration). Removed the Failed status row, the user index, and any stale Enabled orphan. |
+| `20260621-delete-auto-disabled-invalid-tasks` | v3.10.3 (2026-06-21) | 12 | Deleted workflow rows the executor flipped to `Disabled` after the consecutive-permanent-validation-failure threshold — overwhelmingly "task smart wallet address does not belong to owner" (Sentry EIGENLAYER-AVS-1X..28). These passed `ValidateWithError`, so the Failed-cohort migration above deliberately left them. Matched on persisted `LastValidationError` + `ConsecutiveValidationFailures >= 10`; removed the Disabled status row, the user index, and any Enabled orphan. |
+
+Both took a full DB backup first (handled by the migrator) and are idempotent.
+
+## Running an archived migration (rare)
+
+If you ever need to re-run one against a fresh database that legitimately
+contains the legacy data (e.g. a restore from a pre-migration backup), build
+with the tag and re-register it temporarily:
+
+```bash
+go build -tags historical_migrations ./...
+```

--- a/docs/historical-migrations/2026-completed/delete_auto_disabled_invalid_tasks.go
+++ b/docs/historical-migrations/2026-completed/delete_auto_disabled_invalid_tasks.go
@@ -1,3 +1,11 @@
+//go:build historical_migrations
+
+// Archived 2026-06-21 after applying in production (release v3.10.3): the
+// boot log reported "Migration 20260621-delete-auto-disabled-invalid-tasks
+// completed successfully. 12 records updated" — the EIGENLAYER-AVS-1X..28
+// cohort. Excluded from normal builds via the historical_migrations build
+// tag; kept for reference. See migrations/migrations.go (COMPLETED
+// MIGRATIONS) and docs/historical-migrations/2026-completed/README.md.
 package migrations
 
 import (

--- a/docs/historical-migrations/2026-completed/delete_auto_disabled_invalid_tasks_test.go
+++ b/docs/historical-migrations/2026-completed/delete_auto_disabled_invalid_tasks_test.go
@@ -1,3 +1,5 @@
+//go:build historical_migrations
+
 package migrations
 
 import (

--- a/docs/historical-migrations/2026-completed/delete_invalid_failed_tasks.go
+++ b/docs/historical-migrations/2026-completed/delete_invalid_failed_tasks.go
@@ -1,3 +1,11 @@
+//go:build historical_migrations
+
+// Archived 2026-06-21 after applying in production (release v3.10.3): the
+// boot log reported "Migration 20260618-delete-invalid-failed-tasks completed
+// successfully. 33 records updated." Excluded from normal builds via the
+// historical_migrations build tag; kept for reference. See
+// migrations/migrations.go (COMPLETED MIGRATIONS) and
+// docs/historical-migrations/2026-completed/README.md.
 package migrations
 
 import (

--- a/docs/historical-migrations/2026-completed/delete_invalid_failed_tasks_test.go
+++ b/docs/historical-migrations/2026-completed/delete_invalid_failed_tasks_test.go
@@ -1,3 +1,5 @@
+//go:build historical_migrations
+
 package migrations
 
 import (

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -23,32 +23,16 @@ var Migrations = []migrator.Migration{
 	// - 20250603-183034-token-metadata-fields (moved to docs/historical-migrations/2025-completed/)
 	// - 20250128-120000-protobuf-structure-cleanup (moved to docs/historical-migrations/2025-completed/)
 	// - 20250913-185000-add-execution-indexes (moved to docs/historical-migrations/2025-completed/)
+	// - 20260618-delete-invalid-failed-tasks (moved to docs/historical-migrations/2026-completed/ — applied in v3.10.3, 33 records)
+	// - 20260621-delete-auto-disabled-invalid-tasks (moved to docs/historical-migrations/2026-completed/ — applied in v3.10.3, 12 records: EIGENLAYER-AVS-1X..28)
 	//
-	// These migrations have been successfully applied in production and consistently
-	// report 0 records updated. They have been archived to reduce startup overhead.
-	// Migration completion records remain in the database (migration:* keys).
+	// These migrations have been successfully applied in production. They have
+	// been archived (behind the historical_migrations build tag) to reduce
+	// startup overhead. Migration completion records remain in the database
+	// (migration:* keys), so even if re-registered they would be skipped.
 
 	// ========================================
 	// ACTIVE MIGRATIONS
 	// ========================================
 	// Add new migrations here that need to be applied
-	{
-		// One-time cleanup of the legacy invalid-task cohort: workflow rows
-		// that are Failed AND still fail config validation (invalid node
-		// names / configs orphaned by an old proto migration). See
-		// delete_invalid_failed_tasks.go. Idempotent: re-running finds none.
-		Name:     "20260618-delete-invalid-failed-tasks",
-		Function: DeleteInvalidFailedTasks,
-	},
-	{
-		// One-time cleanup of the auto-disabled invalid-task cohort: workflow
-		// rows the executor flipped to Disabled after the consecutive-permanent-
-		// validation-failure threshold — overwhelmingly "smart wallet address
-		// does not belong to owner" (EIGENLAYER-AVS-1X..28). They pass config
-		// validation, so DeleteInvalidFailedTasks leaves them; this removes them.
-		// See delete_auto_disabled_invalid_tasks.go. Idempotent: re-running
-		// finds none.
-		Name:     "20260621-delete-auto-disabled-invalid-tasks",
-		Function: DeleteAutoDisabledInvalidTasks,
-	},
 }

--- a/scripts/operator-entrypoint.sh
+++ b/scripts/operator-entrypoint.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
-# Entrypoint for operator on Railway
-# Writes key files from environment variables, then starts the operator.
+# Shared runtime entrypoint for Railway services (gateway, workers,
+# operators). It materializes per-deployment inputs that we deliberately
+# keep OUT of the public avaprotocol/ap-avs image — delivered instead as
+# environment variables — then execs the AVS binary with the given args.
 #
-# Required env vars:
-#   ECDSA_KEY_JSON - contents of the ECDSA keystore JSON file
-#   BLS_KEY_JSON   - contents of the BLS keystore JSON file
-#   OPERATOR_KEY_PASSWORD - password for both keystores
+# Optional env vars:
+#   AP_CONFIG_YAML - full service config YAML. When set, written verbatim to
+#                    /app/config/runtime.yaml so the service can run with
+#                    `--config=config/runtime.yaml`. This lets the public image
+#                    ship no deployment-specific config; the per-service YAML
+#                    lives in avs-infra. Any ${VAR} placeholders inside are
+#                    expanded later by core/config.ReadYamlConfig from the other
+#                    env vars, so they are written here untouched.
+#   ECDSA_KEY_JSON - contents of the ECDSA keystore JSON file (operators)
+#   BLS_KEY_JSON   - contents of the BLS keystore JSON file (operators)
+#   OPERATOR_KEY_PASSWORD - password for both keystores (operators)
 
 set -e
 
@@ -19,6 +28,16 @@ fi
 if [ -n "$BLS_KEY_JSON" ]; then
     echo "$BLS_KEY_JSON" > /app/keys/bls.key.json
     echo "Wrote BLS key file"
+fi
+
+# Runtime config injection (env-var-driven deployment). When AP_CONFIG_YAML is
+# set, write it verbatim to /app/config/runtime.yaml so the start command can
+# point at `--config=config/runtime.yaml`. printf '%s' avoids interpreting
+# backslashes and leaves ${VAR} placeholders intact for ReadYamlConfig.
+if [ -n "$AP_CONFIG_YAML" ]; then
+    mkdir -p /app/config
+    printf '%s' "$AP_CONFIG_YAML" > /app/config/runtime.yaml
+    echo "Wrote runtime config to /app/config/runtime.yaml ($(wc -c < /app/config/runtime.yaml) bytes)"
 fi
 
 # Auto-detect which binary this image carries:


### PR DESCRIPTION
Release PR: `staging` → `main`. Ships the work merged to staging since the v3.10.3 release (#613). The true `main`↔`staging` diff is exactly the changes below — #613's squash already shipped everything prior.

## What ships

- **`fix:` gateway production caps + rate-limit** (#614) — `max_wallets_per_owner: 2000 → 3` on all chains and the REST rate-limit restored to the built-in default (10/s, burst 50). Test-branch relaxations that had leaked into the production gateway. **Takes effect on deploy.** Safe: `ValidWalletOwner` validates DB-stored wallets independently of the cap (pure DB lookup before the salt scan), so registered wallets keep validating.
- **`feat:` `AP_CONFIG_YAML` entrypoint** — the shared entrypoint writes a per-service config from a single env var to `/app/config/runtime.yaml`. Backward compatible (no-op when unset). **Once deployed, this unblocks Phase 2** of moving the Railway deploy configs out of this repo into avs-infra.
- **`chore:`/`perf:` migration archival** — the two invalid-task cleanup migrations (applied in v3.10.3: 33 + 12 records) moved to `docs/historical-migrations/2026-completed/` behind the `historical_migrations` build tag and dropped from the active list.
- **`docs:` operator config-comment fixes** — `operator`→`operator-sepolia`/`-ethereum` service-name comments.

## Notes
- Run `make storage-check` before merge — no key-template or model-struct changes, expected clean.
- Title is `fix:` (headline change is the production gateway fix; the `feat:` entrypoint is internal deploy groundwork with no runtime effect until cutover). Switch the title to `feat:` if you want a minor bump instead of a patch.
- After deploy: the gateway caps are live, and the migration **Phase 2 canary cutover** (operator-sepolia) becomes possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
