### PR TITLE
fix: prune old DB backups so they don't bloat the volume

### DIFF
--- a/core/backup/backup.go
+++ b/core/backup/backup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
@@ -99,5 +100,53 @@ func (s *Service) PerformBackup() (string, error) {
 	}
 
 	s.logger.Infof("Backup completed successfully to %s", backupFile)
+	s.pruneOldBackups()
 	return backupFile, nil
+}
+
+// backupRetention is the number of most-recent full-backup directories kept
+// under backupDir; older ones are pruned after each successful backup. These
+// backups are a pre-migration / periodic safety net living on the SAME volume
+// as the DB, so they're redundant with Railway's own volume snapshots — keeping
+// a few is plenty. Not pruning them silently bloats the volume: one
+// ~0.5–0.7 GB full-backup.db is written per migration-bearing release.
+const backupRetention = 3
+
+// pruneOldBackups removes all but the most recent backupRetention timestamped
+// backup directories under backupDir. Names use a lexicographically-sortable
+// timestamp (06-01-02-15-04), so a name sort is a chronological sort. Failures
+// are logged, never returned — a prune problem must not fail the backup (or the
+// migration that triggered it).
+func (s *Service) pruneOldBackups() {
+	entries, err := os.ReadDir(s.backupDir)
+	if err != nil {
+		s.logger.Warnf("backup retention: cannot read %s: %v", s.backupDir, err)
+		return
+	}
+
+	var stamps []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Only real backup dirs — names that parse as the backup timestamp.
+		if _, perr := time.Parse("06-01-02-15-04", e.Name()); perr != nil {
+			continue
+		}
+		stamps = append(stamps, e.Name())
+	}
+
+	if len(stamps) <= backupRetention {
+		return
+	}
+
+	sort.Strings(stamps) // oldest first
+	for _, name := range stamps[:len(stamps)-backupRetention] {
+		path := filepath.Join(s.backupDir, name)
+		if rmErr := os.RemoveAll(path); rmErr != nil {
+			s.logger.Errorf("backup retention: failed to prune %s: %v", path, rmErr)
+		} else {
+			s.logger.Infof("backup retention: pruned old backup %s", path)
+		}
+	}
 }

--- a/core/backup/backup_test.go
+++ b/core/backup/backup_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -77,6 +78,55 @@ func TestBackup(t *testing.T) {
 			t.Errorf("Backup file %s does not exist", backupFile)
 		}
 	})
+}
+
+func TestPruneOldBackups(t *testing.T) {
+	logger := testutil.GetLogger()
+	tempDir := t.TempDir()
+	service := NewService(logger, nil, tempDir) // pruneOldBackups never touches the db
+
+	// backupRetention+2 timestamped backup dirs, oldest → newest.
+	stamps := []string{
+		"24-01-01-00-01", "24-01-01-00-02", "24-01-01-00-03",
+		"24-01-01-00-04", "24-01-01-00-05",
+	}
+	for _, s := range stamps {
+		dir := filepath.Join(tempDir, s)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "full-backup.db"), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Non-backup entries that must survive pruning.
+	if err := os.MkdirAll(filepath.Join(tempDir, "not-a-backup"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "README"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	service.pruneOldBackups()
+
+	// Only the newest backupRetention timestamped dirs remain.
+	for i, s := range stamps {
+		_, err := os.Stat(filepath.Join(tempDir, s))
+		shouldExist := i >= len(stamps)-backupRetention
+		if shouldExist && err != nil {
+			t.Errorf("expected %s to be kept, but it's gone", s)
+		}
+		if !shouldExist && err == nil {
+			t.Errorf("expected %s to be pruned, but it remains", s)
+		}
+	}
+	// Non-backup entries untouched.
+	if _, err := os.Stat(filepath.Join(tempDir, "not-a-backup")); err != nil {
+		t.Error("non-backup dir must not be pruned")
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "README")); err != nil {
+		t.Error("stray file must not be pruned")
+	}
 }
 
 // Mock implementations for testing


### PR DESCRIPTION
## What

`PerformBackup` writes a timestamped `full-backup.db` (before each migration, and on the periodic loop) but **nothing ever pruned old ones** — so each migration-bearing release left a ~0.5–0.7 GB backup on `/data` forever.

Observed live: the gateway Railway volume snapshot jumped **1.34 GB → 1.95 GB** right after the v3.10.x migration backups landed; the volume (and every Railway volume snapshot) grows unbounded over releases.

## Fix

After a successful backup, prune all but the most recent **3** timestamped backup dirs (`backupRetention`). 
- Prune failures are logged, never returned — they cannot fail the backup or the migration that triggered it.
- Only real backup dirs (names that parse as the `06-01-02-15-04` timestamp) are considered; stray files/dirs are left alone.

These in-volume backups are a pre-migration safety net **redundant with Railway\047s own daily/weekly volume backups**, so keeping a few is plenty.

## Note

This only stops *future* growth. One-time cleanup of the existing `/data/gateway_backup/*` on the live gateway (Railway → gateway → Console: `du -sh /data/gateway_backup/* && rm -rf <old dirs>`) reclaims what already accumulated.

Test: `TestPruneOldBackups` covers retention + leaving non-backup entries intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)