### PR TITLE
chore: unify config/ naming — test.yaml fixture + drop -dev from gateway/worker, add operator template

### DIFF
--- a/.github/actions/setup-test-config/action.yml
+++ b/.github/actions/setup-test-config/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Test Configuration'
-description: 'Generate config/aggregator.yaml for CI unit tests'
+description: 'Generate config/test.yaml for CI unit tests'
 inputs:
   chain-endpoint:
     description: 'Chain RPC endpoint domain (e.g., sepolia.infura.io/v3/KEY)'
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Generate and verify config/aggregator.yaml
+    - name: Generate and verify config/test.yaml
       env:
         # Unified environment variables
         CHAIN_ENDPOINT: "${{ inputs.chain-endpoint }}"

--- a/.github/scripts/generate-test-config.sh
+++ b/.github/scripts/generate-test-config.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -e
 
-# Generate gateway-dev.yaml for CI unit tests by copying the .example
+# Generate config/test.yaml for CI unit tests by copying the .example
 # template and substituting secrets from the caller's env. This is the
 # test fixture that testutil/utils.go loads (DefaultConfigPath).
 #
-# The aggregator-sepolia.yaml shape that lived here pre-config-cleanup
-# was the legacy single-chain template; gateway-dev.example.yaml is its
-# multi-chain successor and shares the top-level fields the tests read.
+# test.example.yaml is the dedicated test-fixture template (multi-chain
+# shape); it shares the top-level fields the tests read. Despite the
+# neighbouring gateway-dev/operator configs, test.yaml is a fixture only —
+# no server is started from it.
 
-echo "Generating test config files from gateway-dev.example.yaml..."
+echo "Generating test config files from test.example.yaml..."
 
 mkdir -p config
 
@@ -24,7 +25,7 @@ CHAIN_RPC="https://${CHAIN_HOST}"
 CHAIN_WS="wss://${CHAIN_HOST}"
 
 # Copy example file as base
-cp config/gateway-dev.example.yaml config/gateway-dev.yaml
+cp config/test.example.yaml config/test.yaml
 
 # Substitute secret values using unified environment variable names.
 #
@@ -40,24 +41,24 @@ cp config/gateway-dev.example.yaml config/gateway-dev.yaml
 # as opaque strings, which can surface as confusing failures
 # downstream). When a future test does exercise base-sepolia, switch
 # to anchored sed or a yq-based rewrite then.
-sed -i "s|eth_rpc_url:.*|eth_rpc_url: ${CHAIN_RPC}|g" config/gateway-dev.yaml
-sed -i "s|eth_ws_url:.*|eth_ws_url: ${CHAIN_WS}|g" config/gateway-dev.yaml
-sed -i "s|ecdsa_private_key:.*|ecdsa_private_key: ${CONTROLLER_PRIVATE_KEY}|g" config/gateway-dev.yaml
-sed -i "s|bundler_url:.*|bundler_url: ${BUNDLER_RPC}|g" config/gateway-dev.yaml
-sed -i "s|controller_private_key:.*|controller_private_key: ${CONTROLLER_PRIVATE_KEY}|g" config/gateway-dev.yaml
-sed -i "s|paymaster_address:.*|paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92|g" config/gateway-dev.yaml
-sed -i "s|tenderly_account:.*|tenderly_account: ${TENDERLY_ACCOUNT}|g" config/gateway-dev.yaml
-sed -i "s|tenderly_project:.*|tenderly_project: ${TENDERLY_PROJECT}|g" config/gateway-dev.yaml
-sed -i "s|tenderly_access_key:.*|tenderly_access_key: ${TENDERLY_ACCESS_KEY}|g" config/gateway-dev.yaml
-sed -i "s|moralis_api_key:.*|moralis_api_key: ${MORALIS_API_KEY:-}|g" config/gateway-dev.yaml
+sed -i "s|eth_rpc_url:.*|eth_rpc_url: ${CHAIN_RPC}|g" config/test.yaml
+sed -i "s|eth_ws_url:.*|eth_ws_url: ${CHAIN_WS}|g" config/test.yaml
+sed -i "s|ecdsa_private_key:.*|ecdsa_private_key: ${CONTROLLER_PRIVATE_KEY}|g" config/test.yaml
+sed -i "s|bundler_url:.*|bundler_url: ${BUNDLER_RPC}|g" config/test.yaml
+sed -i "s|controller_private_key:.*|controller_private_key: ${CONTROLLER_PRIVATE_KEY}|g" config/test.yaml
+sed -i "s|paymaster_address:.*|paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92|g" config/test.yaml
+sed -i "s|tenderly_account:.*|tenderly_account: ${TENDERLY_ACCOUNT}|g" config/test.yaml
+sed -i "s|tenderly_project:.*|tenderly_project: ${TENDERLY_PROJECT}|g" config/test.yaml
+sed -i "s|tenderly_access_key:.*|tenderly_access_key: ${TENDERLY_ACCESS_KEY}|g" config/test.yaml
+sed -i "s|moralis_api_key:.*|moralis_api_key: ${MORALIS_API_KEY:-}|g" config/test.yaml
 
-echo "Verifying config/gateway-dev.yaml..."
+echo "Verifying config/test.yaml..."
 echo "pwd=$(pwd)"
 ls -la config/ || true
-echo "Generated config/gateway-dev.yaml (redacted first 40 lines):"
-if [ -f config/gateway-dev.yaml ]; then
-  sed -n '1,40p' config/gateway-dev.yaml | sed -e 's/tenderly_access_key:.*/tenderly_access_key: ***REDACTED***/' -e 's/bundler_url:.*/bundler_url: ***REDACTED***/' -e 's/ecdsa_private_key:.*/ecdsa_private_key: ***REDACTED***/' -e 's/controller_private_key:.*/controller_private_key: ***REDACTED***/'
+echo "Generated config/test.yaml (redacted first 40 lines):"
+if [ -f config/test.yaml ]; then
+  sed -n '1,40p' config/test.yaml | sed -e 's/tenderly_access_key:.*/tenderly_access_key: ***REDACTED***/' -e 's/bundler_url:.*/bundler_url: ***REDACTED***/' -e 's/ecdsa_private_key:.*/ecdsa_private_key: ***REDACTED***/' -e 's/controller_private_key:.*/controller_private_key: ***REDACTED***/'
 fi
-test -s config/gateway-dev.yaml || (echo "config/gateway-dev.yaml missing"; exit 1)
+test -s config/test.yaml || (echo "config/test.yaml missing"; exit 1)
 
-echo "✅ config/gateway-dev.yaml generated successfully"
+echo "✅ config/test.yaml generated successfully"

--- a/.github/scripts/generate-test-config.sh
+++ b/.github/scripts/generate-test-config.sh
@@ -7,7 +7,7 @@ set -e
 #
 # test.example.yaml is the dedicated test-fixture template (multi-chain
 # shape); it shares the top-level fields the tests read. Despite the
-# neighbouring gateway-dev/operator configs, test.yaml is a fixture only —
+# neighbouring gateway/operator configs, test.yaml is a fixture only —
 # no server is started from it.
 
 echo "Generating test config files from test.example.yaml..."

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ metadata.json
 
 # Ignores yaml configuration files in the config directory. ONLY the
 # `*.example.yaml` templates that document the file shapes are tracked;
-# every real config (e.g. `gateway.yaml`, `worker-*-dev.yaml`,
-# `gateway-rehearsal.yaml`) stays ignored — they carry testnet
+# every real config (e.g. `gateway.yaml`, `worker-*.yaml`,
+# `operator-*.yaml`) stays ignored — they carry testnet
 # credentials / local paths that should not land in git. Copy the matching
 # `*.example.yaml` and fill in the placeholders to bootstrap one.
 # Production Railway deploy configs live in avs-infra (railway/configs/),

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ metadata.json
 
 # Ignores yaml configuration files in the config directory. ONLY the
 # `*.example.yaml` templates that document the file shapes are tracked;
-# every real config (e.g. `gateway-dev.yaml`, `worker-*-dev.yaml`,
-# `gateway-dev-rehearsal.yaml`) stays ignored — they carry testnet
+# every real config (e.g. `gateway.yaml`, `worker-*-dev.yaml`,
+# `gateway-rehearsal.yaml`) stays ignored — they carry testnet
 # credentials / local paths that should not land in git. Copy the matching
 # `*.example.yaml` and fill in the placeholders to bootstrap one.
 # Production Railway deploy configs live in avs-infra (railway/configs/),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,5 +141,6 @@ The `getWorkflow` output is the ground truth — it shows the trigger's `topics`
 
 - Go 1.22+, Node.js, Docker/Docker Compose, Foundry
 - `config/operator_sample.yaml` - Operator config template
-- `config/aggregator.yaml` - Aggregator config (development)
+- `config/gateway-dev.yaml` - Local-dev gateway config (copy from `gateway-dev.example.yaml`)
+- `config/test.yaml` - Go test-suite fixture (copy from `test.example.yaml`); loaded as `testutil.DefaultConfigPath`, not a server config
 - Contract addresses in README.md (Ethereum Mainnet, Sepolia Testnet)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,6 @@ The `getWorkflow` output is the ground truth — it shows the trigger's `topics`
 
 - Go 1.22+, Node.js, Docker/Docker Compose, Foundry
 - `config/operator_sample.yaml` - Operator config template
-- `config/gateway-dev.yaml` - Local-dev gateway config (copy from `gateway-dev.example.yaml`)
+- `config/gateway.yaml` - Local-dev gateway config (copy from `gateway.example.yaml`)
 - `config/test.yaml` - Go test-suite fixture (copy from `test.example.yaml`); loaded as `testutil.DefaultConfigPath`, not a server config
 - Contract addresses in README.md (Ethereum Mainnet, Sepolia Testnet)

--- a/Makefile
+++ b/Makefile
@@ -202,24 +202,24 @@ build:
 		-o ./out/ap \
 		-ldflags "$(VERSION_LDFLAGS)"
 
-## gateway-dev: start the local-dev gateway (replaces the legacy per-chain aggregator targets)
+## gateway: start the local-dev gateway (replaces the legacy per-chain aggregator targets)
 ##
 ## The pre-Railway "one aggregator per chain" Makefile targets
 ## (aggregator-sepolia / aggregator-ethereum / aggregator-base /
 ## aggregator-base-sepolia) have been consolidated into this single
-## gateway target. The gateway-dev.yaml config carries the per-chain
+## gateway target. The gateway.yaml config carries the per-chain
 ## blocks (Sepolia + Base Sepolia by default; add more under
 ## `chains:` to fan out further). See config/README.md for the
 ## current layout.
-.PHONY: gateway-dev
-gateway-dev: build
-	@echo "🚀 Starting local-dev gateway (config/gateway-dev.yaml)..."
-	@echo "📝 Logs will be written to gateway-dev.log"
-	./out/ap aggregator --config=config/gateway-dev.yaml 2>&1 | tee gateway-dev.log
+.PHONY: gateway
+gateway: build
+	@echo "🚀 Starting local-dev gateway (config/gateway.yaml)..."
+	@echo "📝 Logs will be written to gateway.log"
+	./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway.log
 
 # Legacy per-chain aggregator targets retained as redirects so muscle
 # memory and old runbooks still work. They print a deprecation notice
-# pointing at `make gateway-dev`, then fail rather than silently doing
+# pointing at `make gateway`, then fail rather than silently doing
 # something different from what the caller meant.
 .PHONY: aggregator aggregator-sepolia aggregator-ethereum aggregator-base aggregator-base-sepolia
 aggregator aggregator-sepolia aggregator-ethereum aggregator-base aggregator-base-sepolia:
@@ -227,10 +227,10 @@ aggregator aggregator-sepolia aggregator-ethereum aggregator-base aggregator-bas
 	@echo "   The pre-Railway per-chain aggregator pattern has been"
 	@echo "   consolidated into the multi-chain gateway. Use:"
 	@echo ""
-	@echo "       make gateway-dev"
+	@echo "       make gateway"
 	@echo ""
 	@echo "   to start the local-dev gateway. The chains it serves are"
-	@echo "   listed under \`chains:\` in config/gateway-dev.yaml."
+	@echo "   listed under \`chains:\` in config/gateway.yaml."
 	@exit 1
 ## operator: show usage for operator commands
 .PHONY: operator operator-sepolia operator-ethereum operator-base operator-base-sepolia
@@ -276,21 +276,21 @@ dev-gateway: build
 	@mkdir -p logs
 	@echo "🚀 Starting gateway (dev) — REST :8080, gRPC :2206"
 	@echo "📝 Logs: logs/gateway.log"
-	./out/ap aggregator --config=config/gateway-dev.yaml 2>&1 | tee logs/gateway.log
+	./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee logs/gateway.log
 
 ## dev-worker-sepolia: run the sepolia chain worker (gRPC 50051)
 dev-worker-sepolia: build
 	@mkdir -p logs
 	@echo "🛠  Starting worker:sepolia (dev) — gRPC :50051"
 	@echo "📝 Logs: logs/worker-sepolia.log"
-	./out/ap worker --config=config/worker-sepolia-dev.yaml 2>&1 | tee logs/worker-sepolia.log
+	./out/ap worker --config=config/worker-sepolia.yaml 2>&1 | tee logs/worker-sepolia.log
 
 ## dev-worker-base-sepolia: run the base-sepolia chain worker (gRPC 50052)
 dev-worker-base-sepolia: build
 	@mkdir -p logs
 	@echo "🛠  Starting worker:base-sepolia (dev) — gRPC :50052"
 	@echo "📝 Logs: logs/worker-base-sepolia.log"
-	./out/ap worker --config=config/worker-base-sepolia-dev.yaml 2>&1 | tee logs/worker-base-sepolia.log
+	./out/ap worker --config=config/worker-base-sepolia.yaml 2>&1 | tee logs/worker-base-sepolia.log
 
 ## dev-operator-sepolia: run the sepolia operator pointed at the dev gateway
 dev-operator-sepolia: build
@@ -320,10 +320,10 @@ dev-stack: build
 	@echo ""
 	@set -m; \
 		trap 'echo; echo "🛑 Stopping dev stack..."; kill 0 2>/dev/null; exit 0' INT TERM; \
-		./out/ap worker --config=config/worker-sepolia-dev.yaml      > logs/worker-sepolia.log      2>&1 & \
-		./out/ap worker --config=config/worker-base-sepolia-dev.yaml > logs/worker-base-sepolia.log 2>&1 & \
+		./out/ap worker --config=config/worker-sepolia.yaml      > logs/worker-sepolia.log      2>&1 & \
+		./out/ap worker --config=config/worker-base-sepolia.yaml > logs/worker-base-sepolia.log 2>&1 & \
 		sleep 1; \
-		./out/ap aggregator --config=config/gateway-dev.yaml         > logs/gateway.log             2>&1 & \
+		./out/ap aggregator --config=config/gateway.yaml         > logs/gateway.log             2>&1 & \
 		sleep 3; \
 		./out/ap operator   --config=config/operator-sepolia.yaml    > logs/operator-sepolia.log    2>&1 & \
 		wait

--- a/README.md
+++ b/README.md
@@ -249,6 +249,36 @@ SEPOLIA_BUNDLER_RPC=https://your-sepolia-bundler-endpoint
 
 ## Testing
 
+### Test configuration
+
+Tests come in two tiers, and most contributors only ever need the first:
+
+- **Unit tests** — need **no configuration**. Just run `go test`. The override
+  logic, slot math, mappings, and validation are all covered here (e.g.
+  `core/taskengine/simulation_state_override_test.go`). These run anywhere,
+  including CI on forks.
+- **Integration / simulation tests** — exercise real RPC reads and Tenderly
+  contract-write simulations. These load a config fixture at
+  `config/test.yaml` (this is `testutil.DefaultConfigPath`). **You do not run
+  any server for this** — `test.yaml` is purely a test fixture, not the gateway
+  or operator config. Create it once from the template:
+
+  ```bash
+  cp config/test.example.yaml config/test.yaml
+  # then fill in:
+  #   eth_rpc_url        — a Sepolia RPC endpoint (your own Infura/Alchemy/etc.)
+  #   tenderly_account / tenderly_project / tenderly_access_key — your Tenderly creds
+  ```
+
+  A test that can't find `config/test.yaml` either `t.Skip`s or panics with
+  `testConfig is nil - test.yaml config must be loaded` — that just means the
+  fixture is missing, not that your change is broken. No operator, bundler, or
+  paymaster needs to run: simulation tests never broadcast on-chain.
+
+  > These are the same values CI substitutes in the "Setup test configuration"
+  > step of `.github/workflows/run-test-on-pr.yml`. Repo secrets are not exposed
+  > to pull requests from forks, so to run these on a fork you supply your own.
+
 ### Standard Tests
 
 The Makefile includes two primary test configurations:

--- a/README.md
+++ b/README.md
@@ -213,104 +213,14 @@ Before merging changes from `staging` to `main`, ensure any storage structure ch
 
 # Development guide
 
-View docs/Development.md
+See the [development guide](docs/Development.md).
 
 ## Testing
 
-### Test configuration
-
-Tests come in two tiers, and most contributors only ever need the first:
-
-- **Unit tests** — need **no configuration**. Just run `go test`. The override
-  logic, slot math, mappings, and validation are all covered here (e.g.
-  `core/taskengine/simulation_state_override_test.go`). These run anywhere,
-  including CI on forks.
-- **Integration / simulation tests** — exercise real RPC reads and Tenderly
-  contract-write simulations. These load a config fixture at
-  `config/test.yaml` (this is `testutil.DefaultConfigPath`). **You do not run
-  any server for this** — `test.yaml` is purely a test fixture, not the gateway
-  or operator config. Create it once from the template:
-
-  ```bash
-  cp config/test.example.yaml config/test.yaml
-  # then fill in:
-  #   eth_rpc_url        — a Sepolia RPC endpoint (your own Infura/Alchemy/etc.)
-  #   tenderly_account / tenderly_project / tenderly_access_key — your Tenderly creds
-  ```
-
-  A test that can't find `config/test.yaml` either `t.Skip`s or panics with
-  `testConfig is nil - test.yaml config must be loaded` — that just means the
-  fixture is missing, not that your change is broken. No operator, bundler, or
-  paymaster needs to run: simulation tests never broadcast on-chain.
-
-  The owner EOA of the testing smart wallets is read separately from the
-  environment (or a `.env` file in the repo root), **not** from `test.yaml`.
-  It must be funded with testnet tokens so the tests can derive and exercise
-  the smart wallet:
-
-  ```bash
-  # Owner EOA of the testing smart wallets (must have testnet funds)
-  OWNER_EOA=0x...
-  ```
-
-  > These are the same values CI substitutes in the "Setup test configuration"
-  > step of `.github/workflows/run-test-on-pr.yml`. Repo secrets are not exposed
-  > to pull requests from forks, so to run these on a fork you supply your own.
-
-#### Security notice
-
-⚠️ **SECURITY WARNING** — only ever use throwaway test keys here:
-
-- Never use private keys that hold real funds for testing.
-- Use dedicated test keys funded only with testnet tokens.
-- The fallback private key (all 1's) is insecure and only for local development.
-- Always supply proper test keys via environment variables or `config/test.yaml`.
-
-### Standard Tests
-
-The Makefile includes two primary test configurations:
-
-```bash
-# Default test suite
-go test -race -buildvcs -vet=off ./...
-
-# Verbose test output
-go test -v -race -buildvcs ./...
-```
-
-### Enhanced Test Output
-
-For improved test result formatting, use `gotestfmt`:
-
-1. Install the formatter:
-
-   ```bash
-   go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-   ```
-
-2. Run once in the current terminal session to make Bash scripts more robust and error-aware.
-
-   ```bash
-   set -euo pipefail
-   ```
-
-3. Run tests with formatted output:
-
-   Run all tests with complete output:
-
-   ```base
-   go test -v ./...
-   ```
-
-   or, run selected test cases:
-
-   ```bash
-   go test -json -run ^TestRestRequestErrorHandling$ ./... 2>&1 | gotestfmt --hide=all
-   ```
-
-   The `--hide=all` flag suppresses output for skipped and successful tests, showing only failures. For more output configuration options, see the [gotestfmt documentation](https://github.com/GoTestTools/gotestfmt?tab=readme-ov-file#how-do-i-make-the-output-less-verbose).
-
-=======
+How to run the test suite locally — unit vs. integration tiers, the
+`config/test.yaml` fixture and `OWNER_EOA` setup, the security notes, and
+formatted output — lives in the development guide:
+**[Testing](docs/Development.md#testing)**.
 
 ## Linting and Code Quality
 

--- a/README.md
+++ b/README.md
@@ -217,38 +217,6 @@ View docs/Development.md
 
 ## Testing
 
-### Test Configuration
-
-For integration tests that require interaction with blockchain networks, you need to configure test credentials:
-
-#### Required Environment Variables
-
-```bash
-# Owner EOA wallet of testing smart wallets (must have funds on test networks)
-OWNER_EOA=
-
-# Test network endpoints  
-SEPOLIA_RPC=https://your-sepolia-rpc-endpoint
-SEPOLIA_BUNDLER_RPC=https://your-sepolia-bundler-endpoint
-```
-
-#### Security Notice
-
-⚠️ **SECURITY WARNING**: 
-- Never use private keys containing real funds for testing
-- Use dedicated test keys funded only with testnet tokens
-- The fallback private key (all 1's) is insecure and only for development
-- Always configure proper test keys via environment variables or config files
-
-#### Test Key Setup
-
-1. Generate a new private key for testing (or use an existing test key)
-2. Fund the corresponding address with testnet tokens (Sepolia ETH, test USDC, etc.)
-3. Set the `OWNER_EOA` environment variable or add it to your config
-4. Ensure the key has sufficient balance for test transactions
-
-## Testing
-
 ### Test configuration
 
 Tests come in two tiers, and most contributors only ever need the first:
@@ -275,9 +243,28 @@ Tests come in two tiers, and most contributors only ever need the first:
   fixture is missing, not that your change is broken. No operator, bundler, or
   paymaster needs to run: simulation tests never broadcast on-chain.
 
+  The owner EOA of the testing smart wallets is read separately from the
+  environment (or a `.env` file in the repo root), **not** from `test.yaml`.
+  It must be funded with testnet tokens so the tests can derive and exercise
+  the smart wallet:
+
+  ```bash
+  # Owner EOA of the testing smart wallets (must have testnet funds)
+  OWNER_EOA=0x...
+  ```
+
   > These are the same values CI substitutes in the "Setup test configuration"
   > step of `.github/workflows/run-test-on-pr.yml`. Repo secrets are not exposed
   > to pull requests from forks, so to run these on a fork you supply your own.
+
+#### Security notice
+
+⚠️ **SECURITY WARNING** — only ever use throwaway test keys here:
+
+- Never use private keys that hold real funds for testing.
+- Use dedicated test keys funded only with testnet tokens.
+- The fallback private key (all 1's) is insecure and only for local development.
+- Always supply proper test keys via environment variables or `config/test.yaml`.
 
 ### Standard Tests
 

--- a/config/README.md
+++ b/config/README.md
@@ -16,6 +16,9 @@ YAML config passed via `--config=<path>`.
 ```
 config/
 ├── README.md                            — this file
+├── test.example.yaml                    — Go test-suite fixture template
+├── test.yaml                            — Go test-suite fixture, real (gitignored)
+│
 ├── gateway-dev.example.yaml             — local-dev gateway template
 ├── gateway-dev.yaml                     — local-dev gateway, real (gitignored)
 │
@@ -33,6 +36,7 @@ not here — see the note above.
 | Scenario | Config file |
 |---|---|
 | Production (any role) on Railway | `avs-infra` → `railway/configs/<svc>-railway.yaml`, delivered via `AP_CONFIG_YAML` |
+| Running the Go test suite | `test.yaml` (copy from `test.example.yaml`, fill in RPC + Tenderly). Loaded as `testutil.DefaultConfigPath`; **not** a server config. |
 | Local dev gateway | `gateway-dev.yaml` (copy from `gateway-dev.example.yaml`, fill in secrets) |
 | Local dev worker for chain N | `worker-<chain>-dev.yaml` (same copy pattern) |
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,85 +1,72 @@
-# `config/` — service configuration
+# `config/` — service & test configuration
 
-The aggregator binary (`ap`) runs as one of three roles depending on its
-subcommand: **gateway**, **worker**, or **operator**. Each role needs a
-YAML config passed via `--config=<path>`.
+The `ap` binary runs as one of three roles depending on its subcommand:
+**gateway**, **worker**, or **operator**. Each role needs a YAML config passed
+via `--config=<path>`. This directory holds the **local-dev** templates for
+those roles plus the **Go test-suite** fixture.
 
-> **Production Railway configs moved.** The prod `*-railway.yaml` configs now
-> live in the `avs-infra` repo (`railway/configs/`) and are delivered to each
-> Railway service via the `AP_CONFIG_YAML` env var (the image entrypoint writes
-> it to `config/runtime.yaml` at boot). They are no longer in this repo or baked
-> into the public image. This directory now holds only **local-dev and sample**
-> configs.
+> **Production configs live in `avs-infra`.** The prod `*-railway.yaml` configs
+> are maintained in the `avs-infra` repo and delivered to each service via the
+> `AP_CONFIG_YAML` env var (the image entrypoint writes it to
+> `config/runtime.yaml` at boot). They are not kept in this repo.
 
 ## Layout
 
 ```
 config/
-├── README.md                            — this file
-├── test.example.yaml                    — Go test-suite fixture template
-├── test.yaml                            — Go test-suite fixture, real (gitignored)
+├── README.md                         — this file
 │
-├── gateway-dev.example.yaml             — local-dev gateway template
-├── gateway-dev.yaml                     — local-dev gateway, real (gitignored)
+├── test.example.yaml                 — Go test-suite fixture template
+├── test.yaml                         — real fixture, gitignored
 │
-├── worker-<chain>-dev.example.yaml      — per-chain local-dev worker template
-├── worker-<chain>-dev.yaml              — per-chain local-dev worker, real (gitignored)
+├── gateway.example.yaml              — local-dev gateway template
+├── gateway.yaml                      — real, gitignored
 │
-└── operator-<chain>.yaml                — local operator configs (gitignored symlinks)
+├── worker-<chain>.example.yaml       — per-chain local-dev worker template
+├── worker-<chain>.yaml               — real, gitignored
+│
+├── operator-<chain>.example.yaml     — per-chain local-dev operator template
+└── operator-<chain>.yaml             — real, gitignored
 ```
 
-Production `*-railway.yaml` configs live in `avs-infra` (`railway/configs/`),
-not here — see the note above.
+Naming is uniform across the three roles: `<role>[-<chain>].yaml` for the local
+config, `<role>[-<chain>].example.yaml` for the checked-in template. Production
+counterparts are `<role>[-<chain>]-railway.yaml` over in `avs-infra`.
 
 ## When to use which
 
 | Scenario | Config file |
 |---|---|
-| Production (any role) on Railway | `avs-infra` → `railway/configs/<svc>-railway.yaml`, delivered via `AP_CONFIG_YAML` |
+| Production (any role) | `avs-infra` → `railway/configs/<svc>-railway.yaml`, delivered via `AP_CONFIG_YAML` |
 | Running the Go test suite | `test.yaml` (copy from `test.example.yaml`, fill in RPC + Tenderly). Loaded as `testutil.DefaultConfigPath`; **not** a server config. |
-| Local dev gateway | `gateway-dev.yaml` (copy from `gateway-dev.example.yaml`, fill in secrets) |
-| Local dev worker for chain N | `worker-<chain>-dev.yaml` (same copy pattern) |
-
-`scripts/start.sh` in the studio repo wires up the local-dev gateway +
-all workers + operator pane via these config files. See that script
-for the exact `--config=` invocations.
+| Local dev gateway | `gateway.yaml` (copy from `gateway.example.yaml`) — `make gateway` |
+| Local dev worker for chain N | `worker-<chain>.yaml` (copy from the template) |
+| Local dev operator for chain N | `operator-<chain>.yaml` (copy from the template) |
 
 ## `.example` template convention
 
-Templates checked into git carry the `.example.yaml` suffix. The real
-file (same name, no `.example.`) is gitignored and carries actual
-secrets — controller keys, JWT signing keys, paymaster ownership keys.
-Copy template → real:
+Templates checked into git carry the `.example.yaml` suffix. The real file
+(same name, no `.example.`) is gitignored because it carries secrets —
+controller keys, JWT signing keys, key-store paths. Copy template → real:
 
 ```bash
-cp config/gateway-dev.example.yaml config/gateway-dev.yaml
-$EDITOR config/gateway-dev.yaml      # fill in <placeholder> values
+cp config/gateway.example.yaml config/gateway.yaml
+$EDITOR config/gateway.yaml      # fill in <placeholder> values
 ```
 
-The `.gitignore` excludes any `config/*-dev.yaml` and a few specific
-names (`gateway-dev.yaml`, `aggregator.yaml`, `operator.yaml`) — see
-the top-level `.gitignore` for the full list.
-
-## Pre-Railway bare-metal templates (moved)
-
-The pre-Railway deployment model (one aggregator per chain + a single
-operator binary) and its config templates moved to **avs-infra**
-(`terraform/docs/archived-baremetal-templates/`), next to the terraform
-that deployed that bare-metal stack — which is now being decommissioned.
-Per-chain aggregator configs that may still exist locally as gitignored
-symlinks to a secrets-sync directory are no longer referenced by any
-in-repo code path, except the one documented exception below.
+`.gitignore` ignores every `config/*.yaml` and keeps `config/*.example.yaml`,
+so the real configs stay untracked while the templates are versioned.
 
 ## Known config exception
 
 `core/taskengine/userops_withdraw_test.go:30` still loads
 `config/aggregator-base.yaml` — but the test is gated by
 `TEST_CHAIN=base` and gracefully skips when the config is missing.
-Base mainnet (chain ID 8453) isn't in `gateway-dev.yaml`'s default
+Base mainnet (chain ID 8453) isn't in `gateway.yaml`'s default
 `chains:` block (which covers Sepolia + Base Sepolia for local dev),
 so this developer-only opt-in test keeps its own per-chain fixture
 until either:
 
-- Base mainnet is added to `gateway-dev.yaml`'s `chains:` and the
+- Base mainnet is added to `gateway.yaml`'s `chains:` and the
   test is refactored to select that block, or
 - The test is removed as obsolete.

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -3,8 +3,8 @@
 # This is a checked-in template. The real file is gitignored — copy it
 # and fill in the placeholder values:
 #
-#   cp config/gateway-dev.example.yaml config/gateway-dev.yaml
-#   $EDITOR config/gateway-dev.yaml
+#   cp config/gateway.example.yaml config/gateway.yaml
+#   $EDITOR config/gateway.yaml
 #
 # Replaces per-chain aggregator configs. Routes tasks to chain workers
 # based on chain_id. Single DB for all chains; keys are chain-scoped
@@ -38,7 +38,7 @@ jwt_secret: <random-hex-string>
 rest_rate_limit_per_second: 200
 rest_rate_limit_burst: 1000
 
-server_name: "gateway-dev"
+server_name: "gateway"
 # Optional: Sentry DSN for error reporting (leave empty for no reporting).
 sentry_dsn: ""
 

--- a/config/operator-sepolia.example.yaml
+++ b/config/operator-sepolia.example.yaml
@@ -1,0 +1,62 @@
+# Operator configuration TEMPLATE for Sepolia (chain 11155111).
+#
+# This is a checked-in template. The real file is gitignored — copy it
+# and fill in the placeholder values:
+#
+#   cp config/operator-sepolia.example.yaml config/operator-sepolia.yaml
+#   $EDITOR config/operator-sepolia.yaml
+#
+# The operator registers with EigenLayer, signs task results with its BLS
+# key, and connects to a gateway/aggregator. Running operators in any
+# hosted environment is configured from the avs-infra repo; this template
+# is for local development only.
+environment: development
+
+# Your operator EOA (must be registered with EigenLayer).
+operator_address: <operator-eoa-address>
+
+# AVS contracts (Sepolia testnet — the AVS registration chain).
+avs_registry_coordinator_address: 0xcA95381802FD1398d5BF2D01243210cFb3a2b3BD
+operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
+
+# RPC endpoints for AVS operations (Sepolia). Public RPC works for dev.
+eth_rpc_url: https://ethereum-sepolia-rpc.publicnode.com
+eth_ws_url:  wss://ethereum-sepolia-rpc.publicnode.com
+
+# Local key store paths (absolute paths to your testnet key files).
+ecdsa_private_key_store_path: <path-to-ecdsa-key.json>
+bls_private_key_store_path:   <path-to-bls-key.json>
+
+# Optional BLS remote signer (skip bls_private_key_store_path when used).
+# bls_remote_signer:
+#   grpc_url:   "127.0.0.1:50051"
+#   public_key: "<bls-public-key>"
+#   password:   ""
+
+# Gateway/aggregator the operator connects to (local dev gateway).
+aggregator_server_ip_port_address: "127.0.0.1:2206"
+
+# AVS node spec metrics / node API (https://eigen.nethermind.io/docs/spec/intro).
+eigen_metrics_ip_port_address: localhost:9090
+enable_metrics:                true
+node_api_ip_port_address:      localhost:9010
+enable_node_api:               true
+
+# Operator-local storage path.
+db_path: /tmp/ap-avs-operator
+
+# Optional error reporting.
+# sentry_dsn: ""
+# server_name: operator-sepolia-1
+# sentry_environment: staging
+
+# Destination chain where tasks run (Sepolia).
+target_chain:
+  eth_rpc_url: https://ethereum-sepolia-rpc.publicnode.com
+  eth_ws_url:  wss://ethereum-sepolia-rpc.publicnode.com
+
+# Feature toggles.
+enabled_features:
+  # Event triggers need a websocket RPC that streams all on-chain events;
+  # this can be billing-heavy depending on your provider.
+  event_trigger: true

--- a/config/test.example.yaml
+++ b/config/test.example.yaml
@@ -1,0 +1,101 @@
+# Test configuration TEMPLATE for running the Go test suite locally.
+#
+# This is the fixture that the test suite loads (testutil.DefaultConfigPath).
+# Despite living next to the gateway/operator configs, you do NOT run any
+# server with it — it only supplies the RPC endpoint + Tenderly credentials
+# that integration/simulation tests read.
+#
+# This is a checked-in template. The real file is gitignored — copy it
+# and fill in the placeholder values:
+#
+#   cp config/test.example.yaml config/test.yaml
+#   $EDITOR config/test.yaml
+#
+# Pure unit tests need none of this. Only integration/simulation tests
+# (Tenderly contract-write sims, on-chain reads) require a populated
+# config/test.yaml; without it they t.Skip or panic with "testConfig is nil".
+environment: development
+
+db_path: /tmp/ap-avs/test
+backup_dir: /tmp/ap-avs-test-backup
+
+# AVS operator EOA private key (testnet). Anything funded on Sepolia
+# will do — a throwaway key is fine for tests.
+ecdsa_private_key: <testnet-ecdsa-private-key-hex>
+
+# EigenLayer contracts live on Sepolia (the AVS registration chain).
+# Bring your own provider — public RPC works for low-volume dev.
+eth_rpc_url: https://ethereum-sepolia-rpc.publicnode.com
+eth_ws_url:  wss://ethereum-sepolia-rpc.publicnode.com
+
+rpc_bind_address:  "0.0.0.0:2206"
+http_bind_address: "0.0.0.0:8080"
+
+avs_registry_coordinator_address: 0xcA95381802FD1398d5BF2D01243210cFb3a2b3BD
+operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
+
+# HS256 signing key for client JWTs. Generate locally: `openssl rand -hex 16`
+jwt_secret: <random-hex-string>
+
+# Dev REST rate limits — high enough that the full v4 test suite
+# (~80 requests in a couple seconds) doesn't trip the bucket.
+rest_rate_limit_per_second: 200
+rest_rate_limit_burst: 1000
+
+server_name: "test"
+sentry_dsn: ""
+
+# Tenderly integration — REQUIRED for contract-write simulation tests
+# (e.g. the Uniswap override tests). Fill in your own Tenderly account.
+tenderly_account: ""
+tenderly_project: ""
+tenderly_access_key: ""
+
+# Top-level smart_wallet — required by the aa package globals (factory +
+# entrypoint) and any test that takes the default chain context.
+smart_wallet:
+  eth_rpc_url:            https://ethereum-sepolia-rpc.publicnode.com
+  bundler_url:            ${SEPOLIA_BUNDLER_URL}
+  controller_private_key: <testnet-controller-private-key-hex>
+  paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
+
+# Chain worker registry. Tests read the top-level fields above; the
+# chains[] block mirrors the gateway shape so the config loader is happy.
+chains:
+  - chain_id: 11155111
+    name: sepolia
+    worker_addr: "127.0.0.1:50051"
+    smart_wallet:
+      eth_rpc_url:            https://ethereum-sepolia-rpc.publicnode.com
+      eth_ws_url:             wss://ethereum-sepolia-rpc.publicnode.com
+      bundler_url:            ${SEPOLIA_BUNDLER_URL}
+      controller_private_key: <testnet-controller-private-key-hex>
+      paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
+      max_wallets_per_owner:  2000
+
+  - chain_id: 84532
+    name: base-sepolia
+    worker_addr: "127.0.0.1:50052"
+    smart_wallet:
+      eth_rpc_url:            https://sepolia.base.org
+      eth_ws_url:             wss://base-sepolia-rpc.publicnode.com
+      bundler_url:            ${BASE_SEPOLIA_BUNDLER_URL}
+      controller_private_key: <testnet-controller-private-key-hex>
+      paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
+      max_wallets_per_owner:  3
+
+# Optional: per-macro secret values referenced from workflow JSON.
+macros:
+  secrets:
+    ap_notify_bot_token: ""
+    sendgrid_key:        ""
+    thegraph_api_key:    ""
+    moralis_api_key:     ""
+
+# Optional: post-execution AI summarization. Disabled by default in tests.
+notifications:
+  summary:
+    enabled:      false
+    provider:     context-memory
+    api_endpoint: "http://localhost:3010"
+    api_key:      ""

--- a/config/worker-base-sepolia.example.yaml
+++ b/config/worker-base-sepolia.example.yaml
@@ -1,35 +1,35 @@
-# Worker configuration TEMPLATE for Sepolia (chain 11155111).
+# Worker configuration TEMPLATE for Base Sepolia (chain 84532).
 #
 # This is a checked-in template. The real file is gitignored — copy it
 # and fill in the placeholder values:
 #
-#   cp config/worker-sepolia-dev.example.yaml config/worker-sepolia-dev.yaml
-#   $EDITOR config/worker-sepolia-dev.yaml
+#   cp config/worker-base-sepolia.example.yaml config/worker-base-sepolia.yaml
+#   $EDITOR config/worker-base-sepolia.yaml
 #
 # Handles chain-specific execution: UserOps, contract writes, token
 # enrichment. Stateless — no local DB (gateway owns storage).
 environment: development
 
-chain_id:   11155111
-chain_name: sepolia
+chain_id:   84532
+chain_name: base-sepolia
 
 # Internal gRPC listen address (gateway connects here).
-# In production (Railway): worker-sepolia.railway.internal:50051
-listen_address: "0.0.0.0:50051"
+# In production (Railway): worker-base-sepolia.railway.internal:50051
+listen_address: "0.0.0.0:50052"
 
 # Health check endpoint (Railway requires HTTP health checks).
-health_address: "0.0.0.0:8090"
+health_address: "0.0.0.0:8091"
 
 # Gateway address (worker registers with gateway on startup).
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC endpoints. Public RPC works for low-volume dev.
-eth_rpc_url: https://ethereum-sepolia-rpc.publicnode.com
-eth_ws_url:  wss://ethereum-sepolia-rpc.publicnode.com
+# Chain RPC endpoints (Base Sepolia). Public RPC works for low-volume dev.
+eth_rpc_url: https://sepolia.base.org
+eth_ws_url:  wss://base-sepolia-rpc.publicnode.com
 
 # Third-party bundler endpoint (no self-hosted bundler).
-# Set the SEPOLIA_BUNDLER_URL env var via .env.local before launching.
-bundler_url: ${SEPOLIA_BUNDLER_URL}
+# Set the BASE_SEPOLIA_BUNDLER_URL env var via .env.local before launching.
+bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}
 
 # Smart wallet / account abstraction config.
 smart_wallet:

--- a/config/worker-sepolia.example.yaml
+++ b/config/worker-sepolia.example.yaml
@@ -1,35 +1,35 @@
-# Worker configuration TEMPLATE for Base Sepolia (chain 84532).
+# Worker configuration TEMPLATE for Sepolia (chain 11155111).
 #
 # This is a checked-in template. The real file is gitignored — copy it
 # and fill in the placeholder values:
 #
-#   cp config/worker-base-sepolia-dev.example.yaml config/worker-base-sepolia-dev.yaml
-#   $EDITOR config/worker-base-sepolia-dev.yaml
+#   cp config/worker-sepolia.example.yaml config/worker-sepolia.yaml
+#   $EDITOR config/worker-sepolia.yaml
 #
 # Handles chain-specific execution: UserOps, contract writes, token
 # enrichment. Stateless — no local DB (gateway owns storage).
 environment: development
 
-chain_id:   84532
-chain_name: base-sepolia
+chain_id:   11155111
+chain_name: sepolia
 
 # Internal gRPC listen address (gateway connects here).
-# In production (Railway): worker-base-sepolia.railway.internal:50051
-listen_address: "0.0.0.0:50052"
+# In production (Railway): worker-sepolia.railway.internal:50051
+listen_address: "0.0.0.0:50051"
 
 # Health check endpoint (Railway requires HTTP health checks).
-health_address: "0.0.0.0:8091"
+health_address: "0.0.0.0:8090"
 
 # Gateway address (worker registers with gateway on startup).
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC endpoints (Base Sepolia). Public RPC works for low-volume dev.
-eth_rpc_url: https://sepolia.base.org
-eth_ws_url:  wss://base-sepolia-rpc.publicnode.com
+# Chain RPC endpoints. Public RPC works for low-volume dev.
+eth_rpc_url: https://ethereum-sepolia-rpc.publicnode.com
+eth_ws_url:  wss://ethereum-sepolia-rpc.publicnode.com
 
 # Third-party bundler endpoint (no self-hosted bundler).
-# Set the BASE_SEPOLIA_BUNDLER_URL env var via .env.local before launching.
-bundler_url: ${BASE_SEPOLIA_BUNDLER_URL}
+# Set the SEPOLIA_BUNDLER_URL env var via .env.local before launching.
+bundler_url: ${SEPOLIA_BUNDLER_URL}
 
 # Smart wallet / account abstraction config.
 smart_wallet:

--- a/core/taskengine/summarizer_format_integration_test.go
+++ b/core/taskengine/summarizer_format_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// sepoliaConfig holds the notifications.summary section from gateway-dev.yaml
+// sepoliaConfig holds the notifications.summary section from test.yaml
 type sepoliaConfig struct {
 	Notifications struct {
 		Summary struct {
@@ -28,7 +28,7 @@ type sepoliaConfig struct {
 	} `yaml:"notifications"`
 }
 
-// loadSepoliaConfig loads the context-memory API config from the local gateway-dev.yaml
+// loadSepoliaConfig loads the context-memory API config from the local test.yaml
 func loadSepoliaConfig(t *testing.T) (string, string) {
 	t.Helper()
 
@@ -45,10 +45,10 @@ func loadSepoliaConfig(t *testing.T) (string, string) {
 		return url, token
 	}
 
-	// Try to load from gateway-dev.yaml
+	// Try to load from the test fixture config (config/test.yaml)
 	configPaths := []string{
-		"../../config/gateway-dev.yaml",
-		"config/gateway-dev.yaml",
+		"../../config/test.yaml",
+		"config/test.yaml",
 	}
 
 	for _, path := range configPaths {
@@ -73,7 +73,7 @@ func loadSepoliaConfig(t *testing.T) (string, string) {
 		return apiURL, apiKey
 	}
 
-	t.Skip("Could not load gateway-dev.yaml config")
+	t.Skip("Could not load test.yaml config")
 	return "", ""
 }
 

--- a/core/taskengine/token_metadata_engine_test.go
+++ b/core/taskengine/token_metadata_engine_test.go
@@ -25,7 +25,7 @@ func TestEngine_GetTokenMetadata(t *testing.T) {
 	err := os.Chdir("../..")
 	require.NoError(t, err)
 
-	// Load config from test config (gateway-dev.yaml)
+	// Load config from test config (test.yaml)
 	cfg := testutil.GetAggregatorConfig()
 
 	// Create engine with nil storage and queue (we only need token service for this test)

--- a/core/taskengine/userops_withdraw_all_test.go
+++ b/core/taskengine/userops_withdraw_all_test.go
@@ -34,9 +34,9 @@ func TestWithdrawAllETH_Sepolia(t *testing.T) {
 
 	if err != nil {
 		// Fallback to explicit path if GetConfigPath fails
-		cfg, err = config.NewConfig("../../config/gateway-dev.yaml")
+		cfg, err = config.NewConfig("../../config/test.yaml")
 		if err != nil {
-			t.Skipf("Failed to load gateway-dev.yaml: %v", err)
+			t.Skipf("Failed to load test.yaml: %v", err)
 		}
 	}
 

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -438,9 +438,9 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 	cfg, err := config.NewConfig(testutil.GetConfigPath(testutil.DefaultConfigPath))
 	if err != nil {
 		// Fallback to explicit path if GetConfigPath fails
-		cfg, err = config.NewConfig("../../config/gateway-dev.yaml")
+		cfg, err = config.NewConfig("../../config/test.yaml")
 		if err != nil {
-			t.Skipf("Failed to load gateway-dev.yaml: %v", err)
+			t.Skipf("Failed to load test.yaml: %v", err)
 		}
 	}
 

--- a/core/taskengine/vm_runner_rest_sendgrid_integration_test.go
+++ b/core/taskengine/vm_runner_rest_sendgrid_integration_test.go
@@ -20,12 +20,12 @@ import (
 // is correctly used to send a SendGrid email with the proper subject and summary fields.
 // This test uses the actual response format from the context-memory API.
 func TestSendGridEmailWithContextMemoryResponse(t *testing.T) {
-	// Load test config from gateway-dev.yaml
+	// Load test config from test.yaml
 	// Use GetTestRPC() to ensure config is loaded (it calls loadTestConfigOnce internally)
 	_ = testutil.GetTestRPC()
 	testConfig := testutil.GetTestConfig()
 	if testConfig == nil {
-		t.Fatal("Test config must be loaded from gateway-dev.yaml")
+		t.Fatal("Test config must be loaded from test.yaml")
 	}
 
 	// Extract SendGrid API key from config

--- a/core/taskengine/wallet_chain_id_test.go
+++ b/core/taskengine/wallet_chain_id_test.go
@@ -18,7 +18,7 @@ import (
 // single-chain config (ChainID=1) by design. The routing tests need
 // gateway-mode + at least two configured chains; this constant +
 // withGatewayMultiChain() supplies both without depending on whatever
-// gateway-dev.yaml happens to advertise.
+// test.yaml happens to advertise.
 const chainIDOverrideForTest int64 = 11_155_111
 
 // withGatewayMultiChain promotes a single-chain testutil config to the

--- a/core/testutil/utils.go
+++ b/core/testutil/utils.go
@@ -35,14 +35,14 @@ import (
 
 const (
 	// DefaultConfigPath is the default config file tests load. Points at
-	// the gateway-dev.yaml fixture (multi-chain shape), whose top-level
+	// the test.yaml fixture (multi-chain shape), whose top-level
 	// fields — eth_rpc_url, ecdsa_private_key, smart_wallet block,
 	// tenderly_* — are read by testutil/utils.go just like the legacy
 	// aggregator-sepolia.yaml's were. Tests that need a chain other than
 	// the default Sepolia can still call config.NewConfig() with an
 	// explicit path (see GetConfigPath below) — e.g. a Base-specific
 	// integration test.
-	DefaultConfigPath = "gateway-dev.yaml"
+	DefaultConfigPath = "test.yaml"
 )
 
 var testConfig *config.Config
@@ -134,7 +134,7 @@ func loadTestConfigOnce() {
 
 // GetConfigPath returns the absolute path to a config file from the repo root.
 // This is useful for tests that need to load config files explicitly.
-// Example: GetConfigPath(testutil.DefaultConfigPath) or GetConfigPath("gateway-dev.yaml")
+// Example: GetConfigPath(testutil.DefaultConfigPath) or GetConfigPath("test.yaml")
 func GetConfigPath(configFileName string) string {
 	if _, thisFile, _, ok := runtime.Caller(0); ok {
 		repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "../.."))
@@ -155,10 +155,10 @@ func GetTestConfig() *config.Config {
 func GetTestRPC() string {
 	loadTestConfigOnce()
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.EthHttpRpcUrl == "" {
-		panic("EthHttpRpcUrl is empty in gateway-dev.yaml config")
+		panic("EthHttpRpcUrl is empty in test.yaml config")
 	}
 	return testConfig.EthHttpRpcUrl
 }
@@ -168,7 +168,7 @@ func GetTestRPC() string {
 func GetTestWsRPC() string {
 	loadTestConfigOnce()
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.EthWsRpcUrl != "" {
 		return testConfig.EthWsRpcUrl
@@ -177,7 +177,7 @@ func GetTestWsRPC() string {
 	if http := GetTestRPC(); strings.HasPrefix(http, "https://") {
 		return strings.Replace(http, "https://", "wss://", 1)
 	}
-	panic("EthWsRpcUrl is empty in gateway-dev.yaml config and cannot derive from EthHttpRpcUrl")
+	panic("EthWsRpcUrl is empty in test.yaml config and cannot derive from EthHttpRpcUrl")
 }
 
 // GetTestBundlerRPC returns the bundler RPC URL for tests from aggregator config
@@ -185,13 +185,13 @@ func GetTestWsRPC() string {
 func GetTestBundlerRPC() string {
 	loadTestConfigOnce()
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.SmartWallet == nil {
-		panic("SmartWallet config is nil in gateway-dev.yaml")
+		panic("SmartWallet config is nil in test.yaml")
 	}
 	if testConfig.SmartWallet.BundlerURL == "" {
-		panic("BundlerURL is empty in gateway-dev.yaml config")
+		panic("BundlerURL is empty in test.yaml config")
 	}
 	return testConfig.SmartWallet.BundlerURL
 }
@@ -201,10 +201,10 @@ func GetTestBundlerRPC() string {
 func GetTestTenderlyAccount() string {
 	loadTestConfigOnce()
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.TenderlyAccount == "" {
-		panic("TenderlyAccount is empty in gateway-dev.yaml config")
+		panic("TenderlyAccount is empty in test.yaml config")
 	}
 	return testConfig.TenderlyAccount
 }
@@ -214,10 +214,10 @@ func GetTestTenderlyAccount() string {
 func GetTestTenderlyProject() string {
 	loadTestConfigOnce()
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.TenderlyProject == "" {
-		panic("TenderlyProject is empty in gateway-dev.yaml config")
+		panic("TenderlyProject is empty in test.yaml config")
 	}
 	return testConfig.TenderlyProject
 }
@@ -227,10 +227,10 @@ func GetTestTenderlyProject() string {
 func GetTestTenderlyAccessKey() string {
 	loadTestConfigOnce()
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.TenderlyAccessKey == "" {
-		panic("TenderlyAccessKey is empty in gateway-dev.yaml config")
+		panic("TenderlyAccessKey is empty in test.yaml config")
 	}
 	return testConfig.TenderlyAccessKey
 }
@@ -271,13 +271,13 @@ func MustGetTestOwnerAddress() (*common.Address, bool) {
 func GetTestControllerPrivateKey() string {
 	loadTestConfigOnce()
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.SmartWallet == nil {
-		panic("SmartWallet config is nil in gateway-dev.yaml")
+		panic("SmartWallet config is nil in test.yaml")
 	}
 	if testConfig.SmartWallet.ControllerPrivateKey == nil {
-		panic("ControllerPrivateKey is nil in gateway-dev.yaml config")
+		panic("ControllerPrivateKey is nil in test.yaml config")
 	}
 	return fmt.Sprintf("%x", testConfig.SmartWallet.ControllerPrivateKey.D)
 }
@@ -286,10 +286,10 @@ func GetTestControllerPrivateKey() string {
 // Panics if config is not loaded or SmartWallet is nil
 func GetTestFactoryAddress() string {
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.SmartWallet == nil {
-		panic("SmartWallet config is nil in gateway-dev.yaml")
+		panic("SmartWallet config is nil in test.yaml")
 	}
 	return testConfig.SmartWallet.FactoryAddress.Hex()
 }
@@ -298,10 +298,10 @@ func GetTestFactoryAddress() string {
 // Panics if config is not loaded or SmartWallet is nil
 func GetTestEntrypointAddress() string {
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 	if testConfig.SmartWallet == nil {
-		panic("SmartWallet config is nil in gateway-dev.yaml")
+		panic("SmartWallet config is nil in test.yaml")
 	}
 	return testConfig.SmartWallet.EntrypointAddress.Hex()
 }
@@ -310,11 +310,11 @@ func GetTestEntrypointAddress() string {
 // Panics if config is not loaded or SmartWallet is nil
 func GetTestPaymasterAddress() string {
 	if testConfig == nil {
-		panic("testConfig is nil - gateway-dev.yaml config must be loaded")
+		panic("testConfig is nil - test.yaml config must be loaded")
 	}
 
 	if testConfig.SmartWallet == nil {
-		panic("SmartWallet config is nil in gateway-dev.yaml")
+		panic("SmartWallet config is nil in test.yaml")
 	}
 
 	return testConfig.SmartWallet.PaymasterAddress.Hex()
@@ -503,7 +503,7 @@ func GetAggregatorConfig() *config.Config {
 		TenderlyAccount:   GetTestTenderlyAccount(),
 		TenderlyProject:   GetTestTenderlyProject(),
 		TenderlyAccessKey: GetTestTenderlyAccessKey(),
-		// Include MacroSecrets from loaded gateway-dev.yaml
+		// Include MacroSecrets from loaded test.yaml
 		MacroSecrets: macroSecrets,
 	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -273,7 +273,7 @@ Data format: Protocol Buffer JSON serialization. Migrations run on startup (idem
 
 Environment-specific YAML files in `config/`:
 - `archived/aggregator.example.yaml` — Reference config with all fields documented
-- `gateway-dev.yaml` — Local-dev gateway config (multi-chain; replaces the pre-Railway per-chain configs)
+- `gateway.yaml` — Local-dev gateway config (multi-chain; replaces the pre-Railway per-chain configs)
 - `operator-*.yaml` — Operator configs per chain
 
 Key config sections: smart wallet (RPC, bundler, factory, entrypoint), fee rates (tier-based pricing), macros/secrets (global workflow variables), approved operators list.

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -21,8 +21,8 @@ For a node that connects to Ava's pre-deployed AVS contract, copy the
 template config and fill in the placeholder values:
 
 ```bash
-cp config/gateway-dev.example.yaml config/gateway-dev.yaml
-$EDITOR config/gateway-dev.yaml
+cp config/gateway.example.yaml config/gateway.yaml
+$EDITOR config/gateway.yaml
 ```
 
 The default `chains:` block in the template covers Sepolia + Base
@@ -35,14 +35,14 @@ Then build + run:
 # Build the application
 make build
 
-# Start the local-dev gateway (serves every chain in config/gateway-dev.yaml)
-make gateway-dev
+# Start the local-dev gateway (serves every chain in config/gateway.yaml)
+make gateway
 ```
 
 The legacy `make aggregator-<chain>` targets were retired when the
 Hetzner→Railway migration consolidated the per-chain aggregator
 pattern into a single multi-chain gateway. They now print a
-deprecation notice pointing at `make gateway-dev`.
+deprecation notice pointing at `make gateway`.
 
 Or use Docker Compose directly:
 
@@ -96,7 +96,7 @@ make dev-live
 - WebSocket connections from operators (they must reconnect)
 - In-memory state and queued jobs
 
-Persistent storage (BadgerDB) survives restarts. For testing complete workflows or debugging stateful operations, consider using manual restarts (`make gateway-dev`) instead.
+Persistent storage (BadgerDB) survives restarts. For testing complete workflows or debugging stateful operations, consider using manual restarts (`make gateway`) instead.
 
 ## Client SDK
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -98,6 +98,101 @@ make dev-live
 
 Persistent storage (BadgerDB) survives restarts. For testing complete workflows or debugging stateful operations, consider using manual restarts (`make gateway`) instead.
 
+## Testing
+
+### Test configuration
+
+Tests come in two tiers, and most contributors only ever need the first:
+
+- **Unit tests** — need **no configuration**. Just run `go test`. The override
+  logic, slot math, mappings, and validation are all covered here (e.g.
+  `core/taskengine/simulation_state_override_test.go`). These run anywhere,
+  including CI on forks.
+- **Integration / simulation tests** — exercise real RPC reads and Tenderly
+  contract-write simulations. These load a config fixture at
+  `config/test.yaml` (this is `testutil.DefaultConfigPath`). **You do not run
+  any server for this** — `test.yaml` is purely a test fixture, not the gateway
+  or operator config. Create it once from the template:
+
+  ```bash
+  cp config/test.example.yaml config/test.yaml
+  # then fill in:
+  #   eth_rpc_url        — a Sepolia RPC endpoint (your own Infura/Alchemy/etc.)
+  #   tenderly_account / tenderly_project / tenderly_access_key — your Tenderly creds
+  ```
+
+  A test that can't find `config/test.yaml` either `t.Skip`s or panics with
+  `testConfig is nil - test.yaml config must be loaded` — that just means the
+  fixture is missing, not that your change is broken. No operator, bundler, or
+  paymaster needs to run: simulation tests never broadcast on-chain.
+
+  The owner EOA of the testing smart wallets is read separately from the
+  environment (or a `.env` file in the repo root), **not** from `test.yaml`.
+  It must be funded with testnet tokens so the tests can derive and exercise
+  the smart wallet:
+
+  ```bash
+  # Owner EOA of the testing smart wallets (must have testnet funds)
+  OWNER_EOA=0x...
+  ```
+
+  > These are the same values CI substitutes in the "Setup test configuration"
+  > step of `.github/workflows/run-test-on-pr.yml`. Repo secrets are not exposed
+  > to pull requests from forks, so to run these on a fork you supply your own.
+
+#### Security notice
+
+⚠️ **SECURITY WARNING** — only ever use throwaway test keys here:
+
+- Never use private keys that hold real funds for testing.
+- Use dedicated test keys funded only with testnet tokens.
+- The fallback private key (all 1's) is insecure and only for local development.
+- Always supply proper test keys via environment variables or `config/test.yaml`.
+
+### Standard Tests
+
+The Makefile includes two primary test configurations:
+
+```bash
+# Default test suite
+go test -race -buildvcs -vet=off ./...
+
+# Verbose test output
+go test -v -race -buildvcs ./...
+```
+
+### Enhanced Test Output
+
+For improved test result formatting, use `gotestfmt`:
+
+1. Install the formatter:
+
+   ```bash
+   go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+   ```
+
+2. Run once in the current terminal session to make Bash scripts more robust and error-aware.
+
+   ```bash
+   set -euo pipefail
+   ```
+
+3. Run tests with formatted output:
+
+   Run all tests with complete output:
+
+   ```bash
+   go test -v ./...
+   ```
+
+   or, run selected test cases:
+
+   ```bash
+   go test -json -run ^TestRestRequestErrorHandling$ ./... 2>&1 | gotestfmt --hide=all
+   ```
+
+   The `--hide=all` flag suppresses output for skipped and successful tests, showing only failures. For more output configuration options, see the [gotestfmt documentation](https://github.com/GoTestTools/gotestfmt?tab=readme-ov-file#how-do-i-make-the-output-less-verbose).
+
 ## Client SDK
 
 We generate the client SDK for JavaScript. The code is generated based on our protobuf definition files.

--- a/integration_test/activation_deactivation_sync_test.go
+++ b/integration_test/activation_deactivation_sync_test.go
@@ -25,8 +25,10 @@ func TestActivationDeactivationSyncWithConfigs(t *testing.T) {
 	logger := testutil.GetLogger()
 	taskengine.SetLogger(logger)
 
-	// Load aggregator config from YAML
-	aggCfgPath := testutil.GetConfigPath(testutil.DefaultConfigPath) // config/gateway.yaml
+	// Load aggregator config from YAML. This is an integration test that drives a
+	// real aggregator, so it loads the gateway server config — not test.yaml, which
+	// is the unit/simulation fixture (testutil.DefaultConfigPath).
+	aggCfgPath := testutil.GetConfigPath("gateway.yaml")
 	aggCfg, err := config.NewConfig(aggCfgPath)
 	if err != nil {
 		t.Skipf("Failed to load aggregator config at %s: %v", aggCfgPath, err)

--- a/integration_test/activation_deactivation_sync_test.go
+++ b/integration_test/activation_deactivation_sync_test.go
@@ -26,7 +26,7 @@ func TestActivationDeactivationSyncWithConfigs(t *testing.T) {
 	taskengine.SetLogger(logger)
 
 	// Load aggregator config from YAML
-	aggCfgPath := testutil.GetConfigPath(testutil.DefaultConfigPath) // config/gateway-dev.yaml
+	aggCfgPath := testutil.GetConfigPath(testutil.DefaultConfigPath) // config/gateway.yaml
 	aggCfg, err := config.NewConfig(aggCfgPath)
 	if err != nil {
 		t.Skipf("Failed to load aggregator config at %s: %v", aggCfgPath, err)

--- a/scripts/start-gateway-dev.sh
+++ b/scripts/start-gateway-dev.sh
@@ -125,7 +125,7 @@ tmux split-window -t "$WIN" -v -p 50 -c "$PROJECT_DIR"
 tmux select-pane  -t "$WIN.2"
 tmux split-window -t "$WIN" -v -p 50 -c "$PROJECT_DIR"
 
-tmux send-keys -t "$WIN.0" "./out/ap aggregator --config=config/gateway-dev.yaml 2>&1 | tee gateway-dev.log" Enter
+tmux send-keys -t "$WIN.0" "./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway-dev.log" Enter
 
 if [[ "$START_OPERATOR" == "true" ]]; then
     tmux send-keys -t "$WIN.1" "./out/ap operator --config=config/operator-sepolia.yaml 2>&1 | tee operator-dev.log" Enter
@@ -133,8 +133,8 @@ else
     tmux send-keys -t "$WIN.1" "echo 'Operator not started. Re-run with --operator (or pass operator as the first positional arg).'" Enter
 fi
 
-tmux send-keys -t "$WIN.2" "./out/ap worker --config=config/worker-sepolia-dev.yaml 2>&1 | tee worker-sepolia-dev.log" Enter
-tmux send-keys -t "$WIN.3" "./out/ap worker --config=config/worker-base-sepolia-dev.yaml 2>&1 | tee worker-base-sepolia-dev.log" Enter
+tmux send-keys -t "$WIN.2" "./out/ap worker --config=config/worker-sepolia.yaml 2>&1 | tee worker-sepolia-dev.log" Enter
+tmux send-keys -t "$WIN.3" "./out/ap worker --config=config/worker-base-sepolia.yaml 2>&1 | tee worker-base-sepolia-dev.log" Enter
 
 tmux select-pane -t "$WIN.0"
 

--- a/scripts/start-gateway.sh
+++ b/scripts/start-gateway.sh
@@ -3,13 +3,13 @@
 # Run `brew install tmux` to install tmux
 #
 # Usage:
-#   ./scripts/start-gateway-dev.sh [--operator] [--session NAME] [--window NAME] [--no-attach] [--no-build]
-#   ./scripts/start-gateway-dev.sh operator                                   # legacy positional form
+#   ./scripts/start-gateway.sh [--operator] [--session NAME] [--window NAME] [--no-attach] [--no-build]
+#   ./scripts/start-gateway.sh operator                                   # legacy positional form
 #
-# Standalone:                ./scripts/start-gateway-dev.sh --operator
-#   → creates session 'gateway-dev' with one 4-pane window and attaches.
+# Standalone:                ./scripts/start-gateway.sh --operator
+#   → creates session 'gateway' with one 4-pane window and attaches.
 #
-# Called by another script:  ./scripts/start-gateway-dev.sh --session studio --window avs --operator --no-attach
+# Called by another script:  ./scripts/start-gateway.sh --session studio --window avs --operator --no-attach
 #   → if 'studio' session exists, adds an 'avs' window with the 4 panes; if not, creates 'studio' and uses its
 #     first window. Returns without attaching so the caller controls the session.
 #
@@ -27,7 +27,7 @@
 
 set -e
 
-SESSION_NAME="gateway-dev"
+SESSION_NAME="gateway"
 WINDOW_NAME=""           # empty → don't rename the first window of a new session
 START_OPERATOR=false
 ATTACH=true
@@ -125,16 +125,16 @@ tmux split-window -t "$WIN" -v -p 50 -c "$PROJECT_DIR"
 tmux select-pane  -t "$WIN.2"
 tmux split-window -t "$WIN" -v -p 50 -c "$PROJECT_DIR"
 
-tmux send-keys -t "$WIN.0" "./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway-dev.log" Enter
+tmux send-keys -t "$WIN.0" "./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway.log" Enter
 
 if [[ "$START_OPERATOR" == "true" ]]; then
-    tmux send-keys -t "$WIN.1" "./out/ap operator --config=config/operator-sepolia.yaml 2>&1 | tee operator-dev.log" Enter
+    tmux send-keys -t "$WIN.1" "./out/ap operator --config=config/operator-sepolia.yaml 2>&1 | tee operator.log" Enter
 else
     tmux send-keys -t "$WIN.1" "echo 'Operator not started. Re-run with --operator (or pass operator as the first positional arg).'" Enter
 fi
 
-tmux send-keys -t "$WIN.2" "./out/ap worker --config=config/worker-sepolia.yaml 2>&1 | tee worker-sepolia-dev.log" Enter
-tmux send-keys -t "$WIN.3" "./out/ap worker --config=config/worker-base-sepolia.yaml 2>&1 | tee worker-base-sepolia-dev.log" Enter
+tmux send-keys -t "$WIN.2" "./out/ap worker --config=config/worker-sepolia.yaml 2>&1 | tee worker-sepolia.log" Enter
+tmux send-keys -t "$WIN.3" "./out/ap worker --config=config/worker-base-sepolia.yaml 2>&1 | tee worker-base-sepolia.log" Enter
 
 tmux select-pane -t "$WIN.0"
 


### PR DESCRIPTION
## Summary

Makes `config/` clear and internally consistent, without removing anything. Two commits:

### 1. Rename the test fixture to `config/test.yaml`
The test suite loaded its config via `testutil.DefaultConfigPath`, which pointed at `config/gateway-dev.yaml` — the same name as the gateway *server* config. That overloading made it unclear that running tests needs a config file at all (contributors on #620 hit `testConfig is nil - gateway-dev.yaml config must be loaded` with no obvious cause).

- `testutil.DefaultConfigPath` → `test.yaml`; panic messages updated.
- New `config/test.example.yaml` template.
- `.github/scripts/generate-test-config.sh` now generates `config/test.yaml`.
- Test files that loaded the fixture by name updated.
- README gains a "Test configuration" section.

### 2. Unify the local-dev config naming (drop `-dev`, add operator template)
The three role configs were named inconsistently — `gateway-dev.yaml` and `worker-<chain>-dev.yaml` carried a `-dev` suffix, but `operator-<chain>.yaml` did not. Now all three local-dev configs share one scheme:

```
gateway.yaml
worker-<chain>.yaml
operator-<chain>.yaml
```

(Production counterparts stay `<role>[-<chain>]-railway.yaml` in `avs-infra`.)

- Renamed `gateway-dev.example.yaml` → `gateway.example.yaml` and `worker-{sepolia,base-sepolia}-dev.example.yaml` → `worker-*.example.yaml`.
- **Added `config/operator-sepolia.example.yaml`** so all three roles have an in-repo template (operator previously had none).
- Renamed the `gateway-dev` make target → `gateway`; updated all `--config` paths in the Makefile, scripts, docs, and the integration test.
- Rewrote `config/README.md` around the uniform `<role>[-<chain>].yaml` scheme.

## Notes

- **No code behavior change** — config file/target names and the test-fixture path only. `go build ./...` and `go vet` (incl. the `integration` tag) are clean.
- All three components' local-dev configs are preserved; nothing was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWr2N3kZQZ1miN66TNPwqU