### PR TITLE
feat: route workflow Email node through email-service (Bento)

### DIFF
--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -88,7 +88,7 @@ chains:
 macros:
   secrets:
     ap_notify_bot_token: ""
-    sendgrid_key:        ""
+    email_api_key:       ""
     thegraph_api_key:    ""
     moralis_api_key:     ""
 

--- a/config/test.example.yaml
+++ b/config/test.example.yaml
@@ -88,7 +88,7 @@ chains:
 macros:
   secrets:
     ap_notify_bot_token: ""
-    sendgrid_key:        ""
+    email_api_key:       ""
     thegraph_api_key:    ""
     moralis_api_key:     ""
 

--- a/core/taskengine/summarizer_format_email.go
+++ b/core/taskengine/summarizer_format_email.go
@@ -107,6 +107,24 @@ func (s Summary) SendGridDynamicData() map[string]interface{} {
 	return data
 }
 
+// workflowSummaryTemplateData maps the computed summary fields (built by the
+// vm_runner_rest summarize block into `dynamicData`) to the email-service
+// `workflow-summary` template's props: preheader, summaryHtml, statusHtml, runner,
+// eoaAddress, analysisHtml, year. The one-line `summary` text is wrapped as HTML since
+// the template injects summaryHtml as trusted HTML.
+func workflowSummaryTemplateData(dynamicData map[string]interface{}) map[string]interface{} {
+	data := map[string]interface{}{}
+	for _, key := range []string{"preheader", "statusHtml", "analysisHtml", "runner", "eoaAddress", "year"} {
+		if v, ok := dynamicData[key]; ok {
+			data[key] = v
+		}
+	}
+	if summary, ok := dynamicData["summary"].(string); ok && strings.TrimSpace(summary) != "" {
+		data["summaryHtml"] = `<p style="margin:0">` + html.EscapeString(summary) + `</p>`
+	}
+	return data
+}
+
 // getStatusColor returns the color for the email status badge.
 // Per Studio, a `success` run with branch-skipped steps renders yellow ("warn"),
 // not green — the skip is worth user attention even though nothing failed.

--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -19,10 +19,8 @@ const (
 	MockAPIEndpoint = "https://mock-api.ap-aggregator.local"
 )
 
-// SendGrid Dynamic Template ID for AI-generated workflow summaries
-const (
-	SendGridSummaryTemplateID = "d-3b4b885af0fc45ad822024ebc72f169c"
-)
+// Email-service template that renders AI-generated workflow summaries.
+const WorkflowSummaryTemplate = "workflow-summary"
 
 // Status HTML badge SVG icons for email notifications
 const (
@@ -417,21 +415,21 @@ func parseJSONBody(body string) interface{} {
 
 // RestProcessor handles REST API calls with template variable support
 //
-// Global secrets like sendgrid_key can be accessed via templates:
-// Example URL: "https://api.sendgrid.com/v3/user/account"
-// Example Headers: "Authorization": "Bearer {{apContext.configVars.sendgrid_key}}"
+// Global secrets like email_api_key can be accessed via templates:
+// Example URL: "https://email-api.avaprotocol.org/api/send"
+// Example Headers: "Authorization": "Bearer {{apContext.configVars.email_api_key}}"
 //
 // Available global secrets (configured in aggregator.yaml):
 // - ap_notify_bot_token: Telegram bot token for notifications
-// - sendgrid_key: SendGrid API key for email services
+// - email_api_key: email-service (Bento transport) API key for email
 //
 // Usage example:
-//   URL: https://api.sendgrid.com/v3/user/account
+//   URL: https://email-api.avaprotocol.org/api/send
 //   Headers: {
-//     "Authorization": "Bearer {{apContext.configVars.sendgrid_key}}",
+//     "Authorization": "Bearer {{apContext.configVars.email_api_key}}",
 //     "Content-Type": "application/json"
 //   }
-//   Method: GET
+//   Method: POST
 //
 // ... existing code ...
 
@@ -707,16 +705,14 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 			var bodyObj map[string]interface{}
 			if err := json.Unmarshal([]byte(body), &bodyObj); err == nil {
 				switch provider {
-				case "sendgrid":
-					// Always use Dynamic Templates for AI summaries - inject template_id automatically
-					bodyObj["template_id"] = SendGridSummaryTemplateID
-
-					// Get dynamic template data from summary (subject/title/analysis...)
+				case "emailservice":
+					// Build the summary's template data (subject/title/analysis...). The
+					// granular fields below populate the workflow-summary template props.
 					dynamicData := s.SendGridDynamicData()
 
-					// Single source of truth: the runner block returned by context-memory,
-					// shared with the Telegram render. SendGrid template variables keep
-					// their existing format — `runner` is full hex, `eoaAddress` is shortened.
+					// Single source of truth: the runner block returned by the summarizer,
+					// shared with the Telegram render — `runner` is full hex, `eoaAddress`
+					// is shortened.
 					if s.Runner != nil {
 						dynamicData["runner"] = s.Runner.SmartWallet
 						dynamicData["eoaAddress"] = shortHex(s.Runner.OwnerEOA)
@@ -1004,34 +1000,18 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 						dynamicData["preheader"] = summaryForClient.Subject
 					}
 
-					// Ensure 'from' object includes a display name for better inbox rendering
-					if fromObj, ok := bodyObj["from"].(map[string]interface{}); ok {
-						if _, hasName := fromObj["name"]; !hasName || strings.TrimSpace(asString(fromObj["name"])) == "" {
-							fromObj["name"] = "AP Studio Notification"
-							bodyObj["from"] = fromObj
-						}
+					// Render via the email-service `workflow-summary` template instead of
+					// SendGrid dynamic templates: map the computed fields to the template's
+					// props and strip all SendGrid-specific keys. The studio Email node
+					// already emits a top-level `to`.
+					if subj, ok := dynamicData["subject"].(string); ok && subj != "" {
+						bodyObj["subject"] = subj
 					}
-
-					// Set SendGrid category for filtering in Activity Feed and Stats
-					bodyObj["categories"] = []string{"workflow-summary"}
-
-					// Provide dynamic_template_data both at top-level and per-personalization to satisfy API variants
-					bodyObj["dynamic_template_data"] = dynamicData
-
-					// Attach dynamic_template_data per-personalization; DO NOT set subject here when using template {{{subject}}}
-					if pers, ok := bodyObj["personalizations"].([]interface{}); ok {
-						for i := range pers {
-							if p, ok := pers[i].(map[string]interface{}); ok {
-								// Pass all dynamic template data (SendGrid expects snake_case)
-								p["dynamic_template_data"] = dynamicData
-								pers[i] = p
-							}
-						}
-						bodyObj["personalizations"] = pers
+					bodyObj["template"] = WorkflowSummaryTemplate
+					bodyObj["data"] = workflowSummaryTemplateData(dynamicData)
+					for _, k := range []string{"personalizations", "from", "reply_to", "template_id", "categories", "dynamic_template_data", "content"} {
+						delete(bodyObj, k)
 					}
-
-					// Remove any content array; Dynamic Templates should not include 'content'
-					delete(bodyObj, "content")
 				case "telegram":
 					// Format summary for Telegram: concise, chat-friendly message
 					// Pass VM so transfer events can be formatted as transfer notifications
@@ -1224,12 +1204,13 @@ func shouldSummarize(vm *VM, node *avsproto.RestAPINode) bool {
 	return false
 }
 
-// detectNotificationProvider returns "sendgrid" or "telegram" based on URL patterns; empty string if unknown
+// detectNotificationProvider returns "emailservice" or "telegram" based on URL patterns; empty string if unknown
 func detectNotificationProvider(u string) string {
 	lu := strings.ToLower(u)
-	// SendGrid: allow detection by path for tests using mock servers
-	if strings.Contains(lu, "/v3/mail/send") || strings.Contains(lu, "/mail/send") || strings.Contains(lu, "api.sendgrid.com") && strings.Contains(lu, "/mail/send") {
-		return "sendgrid"
+	// Email-service: the standalone Bento transport's send endpoint. Path-based so
+	// tests using mock servers (mock-api/api/send) match too.
+	if strings.Contains(lu, "/api/send") {
+		return "emailservice"
 	}
 	if strings.Contains(lu, "api.telegram.org") && strings.Contains(lu, "/sendmessage") {
 		return "telegram"

--- a/core/taskengine/vm_runner_rest_sendgrid_integration_test.go
+++ b/core/taskengine/vm_runner_rest_sendgrid_integration_test.go
@@ -31,12 +31,12 @@ func TestSendGridEmailWithContextMemoryResponse(t *testing.T) {
 	// Extract SendGrid API key from config
 	sendgridKey := ""
 	if testConfig.MacroSecrets != nil {
-		if key, ok := testConfig.MacroSecrets["sendgrid_key"]; ok {
+		if key, ok := testConfig.MacroSecrets["email_api_key"]; ok {
 			sendgridKey = key
 		}
 	}
 	if sendgridKey == "" {
-		t.Skip("sendgrid_key not found in config, skipping SendGrid integration test")
+		t.Skip("email_api_key not found in config, skipping SendGrid integration test")
 	}
 
 	// Mock context-memory API server that returns the exact response from terminal output
@@ -94,7 +94,7 @@ func TestSendGridEmailWithContextMemoryResponse(t *testing.T) {
 	SetSummarizer(summarizer)
 	defer SetSummarizer(nil) // Clean up after test
 
-	// Set global macro secrets so template variables like {{apContext.configVars.sendgrid_key}} can be resolved
+	// Set global macro secrets so template variables like {{apContext.configVars.email_api_key}} can be resolved
 	if testConfig.MacroSecrets != nil {
 		SetMacroSecrets(testConfig.MacroSecrets)
 		defer SetMacroSecrets(nil) // Clean up after test
@@ -133,7 +133,7 @@ func TestSendGridEmailWithContextMemoryResponse(t *testing.T) {
 								Url:    sendgridAPIURL,
 								Method: "POST",
 								Headers: map[string]string{
-									"Authorization": "Bearer {{apContext.configVars.sendgrid_key}}",
+									"Authorization": "Bearer {{apContext.configVars.email_api_key}}",
 									"Content-Type":  "application/json",
 								},
 								Body: `{

--- a/core/taskengine/vm_runner_rest_test.go
+++ b/core/taskengine/vm_runner_rest_test.go
@@ -712,7 +712,7 @@ func TestRestRequestSendGridGlobalSecret(t *testing.T) {
 			t.Errorf("expected GET request, got %s", r.Method)
 		}
 
-		// Verify that the Authorization header is present and uses the sendgrid_key
+		// Verify that the Authorization header is present and uses the email_api_key
 		authHeader := r.Header.Get("Authorization")
 		if !strings.HasPrefix(authHeader, "Bearer ") {
 			t.Errorf("expected Authorization header with Bearer token, got: %s", authHeader)
@@ -721,7 +721,7 @@ func TestRestRequestSendGridGlobalSecret(t *testing.T) {
 		// Check that the API key from the template was properly substituted
 		expectedKey := "SENDGRID_KEY_FOR_UNIT_TESTS"
 		if !strings.Contains(authHeader, expectedKey) {
-			t.Errorf("expected sendgrid_key to be substituted in Authorization header, got: %s", authHeader)
+			t.Errorf("expected email_api_key to be substituted in Authorization header, got: %s", authHeader)
 		}
 
 		// Return mock SendGrid account information response
@@ -738,12 +738,12 @@ func TestRestRequestSendGridGlobalSecret(t *testing.T) {
 	}))
 	defer sendGridServer.Close()
 
-	// Create REST API node that calls our mock SendGrid server using the global sendgrid_key secret
+	// Create REST API node that calls our mock SendGrid server using the global email_api_key secret
 	node := &avsproto.RestAPINode{
 		Config: &avsproto.RestAPINode_Config{
 			Url: sendGridServer.URL + "/v3/user/account",
 			Headers: map[string]string{
-				"Authorization": "Bearer {{apContext.configVars.sendgrid_key}}",
+				"Authorization": "Bearer {{apContext.configVars.email_api_key}}",
 				"Content-Type":  "application/json",
 			},
 			Body:   "",
@@ -775,7 +775,7 @@ func TestRestRequestSendGridGlobalSecret(t *testing.T) {
 
 	// Create VM with SendGrid secret available through global macro secrets
 	globalSecrets := map[string]string{
-		"sendgrid_key": "SENDGRID_KEY_FOR_UNIT_TESTS",
+		"email_api_key": "SENDGRID_KEY_FOR_UNIT_TESTS",
 	}
 
 	vm, err := NewVMWithData(&model.Workflow{
@@ -857,10 +857,10 @@ func TestRestRequestSendGridGlobalSecret(t *testing.T) {
 	}
 
 	t.Logf("✅ SUCCESS: SendGrid global secret test passed!")
-	t.Logf("✅ sendgrid_key global secret was properly substituted in Authorization header")
+	t.Logf("✅ email_api_key global secret was properly substituted in Authorization header")
 	t.Logf("✅ SendGrid API response structure properly accessible: type='%s', reputation=%f",
 		expectedAccountType, expectedReputation)
-	t.Logf("✅ Verified global secret access via {{apContext.configVars.sendgrid_key}} template")
+	t.Logf("✅ Verified global secret access via {{apContext.configVars.email_api_key}} template")
 }
 
 func TestRestSummarizeTelegramHTML(t *testing.T) {


### PR DESCRIPTION
Migrates the AVS REST-runner notification path (workflow **Email node**) off SendGrid to the standalone **email-service** (Bento). Pairs with studio PR `feat/email-node-email-service` — they must ship together.

## Approach
The intricate ~300-line summarize-injection logic is **kept intact** (it builds status, branch selections, skipped nodes, `analysisHtml`, etc.). Only the **output** changes:
- `detectNotificationProvider` recognizes the email-service `/api/send` endpoint (was `api.sendgrid.com/v3/mail/send`).
- At finalization, the body becomes the email-service contract `{ to, subject, template: "workflow-summary", data }` instead of SendGrid `dynamic_template_data` + `personalizations`.
- New `Summary.workflowSummaryTemplateData()` maps the computed fields → the `workflow-summary` template props (preheader, summaryHtml, statusHtml, runner, eoaAddress, analysisHtml, year). The template already exists in email-service.
- Macro secret `sendgrid_key` → `email_api_key` (config examples + docs).

## Clean cutover (confirmed)
Existing Email-node workflows have the old SendGrid URL + `sendgrid_key` baked into their saved config — they must be **re-opened + saved** in the builder to regenerate it. No SendGrid fallback.

## Deploy prerequisite
Set `email_api_key` in the aggregator's macro secrets (avs-infra config) = the email-service API key, before this reaches an env that runs Email-node workflows.

## Verification
- `go build`, `go vet`, `go fmt` pass; all package test files compile.
- ⚠️ The SendGrid-touching tests (`vm_runner_rest_test.go`, `vm_runner_rest_sendgrid_integration_test.go`) require a fully-configured `test.yaml` (BundlerURL) to execute — they couldn't be run in the isolated worktree. **Please run `make test/package PKG=./core/taskengine` in CI, and exercise a real summarize Email-node workflow end-to-end before merging.** The SendGrid integration test is renamed-but-skipped (needs a real key) and should be rewritten for the email-service response in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
