### PR TITLE
feat: Path B /api/notify summaries + erc20_overrides for run-node

### DIFF
--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -466,6 +466,30 @@ type CustomCodeNodeConfig struct {
 	Source string `json:"source"`
 }
 
+// ERC20StateOverride Seeds a token's balanceOf / allowance storage slots for a single simulation. balanceOf[owner] lives at keccak256(abi.encode(owner, balanceSlot)); allowance[owner][spender] at keccak256(abi.encode(spender, keccak256(abi.encode(owner, allowanceSlot)))).
+type ERC20StateOverride struct {
+	// Allowance Allowance override (hex 0x… or decimal string).
+	Allowance *string `json:"allowance,omitempty"`
+
+	// AllowanceSlot Storage slot for the allowance mapping. Required when allowance is set; ERC20 storage layout varies per token (OpenZeppelin 1, USDC FiatToken 10).
+	AllowanceSlot *int64 `json:"allowanceSlot,omitempty"`
+
+	// Balance Balance override (hex 0x… or decimal string).
+	Balance *string `json:"balance,omitempty"`
+
+	// BalanceSlot Storage slot for the balanceOf mapping. Required when balance is set; ERC20 storage layout varies per token (OpenZeppelin 0, USDC FiatToken 9).
+	BalanceSlot *int64 `json:"balanceSlot,omitempty"`
+
+	// OwnerAddress Lowercase or checksummed hex EOA / contract address.
+	OwnerAddress EthereumAddress `json:"ownerAddress"`
+
+	// SpenderAddress Lowercase or checksummed hex EOA / contract address.
+	SpenderAddress *EthereumAddress `json:"spenderAddress,omitempty"`
+
+	// TokenAddress Lowercase or checksummed hex EOA / contract address.
+	TokenAddress EthereumAddress `json:"tokenAddress"`
+}
+
 // ETHTransferNode defines model for ETHTransferNode.
 type ETHTransferNode struct {
 	Config *ETHTransferNodeConfig `json:"config,omitempty"`
@@ -1066,6 +1090,9 @@ type RunNodeRequest struct {
 	// chain" — typically only useful in single-chain deployments or for
 	// chain-agnostic operations.
 	ChainId *ChainId `json:"chainId,omitempty"`
+
+	// Erc20Overrides Optional ERC20 balance/allowance state overrides applied only during this isolated node simulation. Lets callers seed token balances and approvals so contract-write simulations (e.g. Uniswap swaps) don't revert with "transfer amount exceeds allowance/balance" before the approval/funding transactions have been run. Simulation-only: a real-execution request (isSimulated=false) that sets these is rejected with an error, never silently ignored.
+	Erc20Overrides *[]ERC20StateOverride `json:"erc20Overrides,omitempty"`
 
 	// InputVariables Free-form key-value bag of values used to resolve `{{variable.path}}`
 	// template references inside trigger and node configs. Conventional

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -54,12 +54,59 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		}
 		req.InputVariables = converted
 	}
+	if body.Erc20Overrides != nil {
+		req.Erc20Overrides = openAPIERC20OverridesToProto(*body.Erc20Overrides)
+	}
 
 	resp, err := s.engine.RunNodeImmediatelyRPCWithContext(ctx.Request().Context(), user, req)
 	if err != nil {
 		return err
 	}
 	return ctx.JSON(http.StatusOK, runNodeRespToOpenAPI(resp))
+}
+
+// openAPIERC20OverridesToProto maps the REST ERC20StateOverride list onto the
+// proto representation consumed by RunNodeImmediately. Slot indices are widened
+// from the spec's int64 to the proto's uint64. A negative slot is invalid (a
+// storage slot is a non-negative index), so it is treated as unset rather than
+// silently coerced to slot 0 — and because the engine requires an explicit slot
+// whenever the corresponding balance/allowance is set, a missing or negative
+// slot surfaces as a clear validation error instead of a wrong-slot seed. The
+// engine validates addresses/values.
+func openAPIERC20OverridesToProto(in []generated.ERC20StateOverride) []*avsproto.ERC20StateOverride {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*avsproto.ERC20StateOverride, 0, len(in))
+	for _, o := range in {
+		po := &avsproto.ERC20StateOverride{
+			TokenAddress: string(o.TokenAddress),
+			OwnerAddress: string(o.OwnerAddress),
+			Balance:      o.Balance,
+			Allowance:    o.Allowance,
+		}
+		if o.SpenderAddress != nil {
+			s := string(*o.SpenderAddress)
+			po.SpenderAddress = &s
+		}
+		po.BalanceSlot = nonNegativeSlotPtr(o.BalanceSlot)
+		po.AllowanceSlot = nonNegativeSlotPtr(o.AllowanceSlot)
+		out = append(out, po)
+	}
+	return out
+}
+
+// nonNegativeSlotPtr widens a spec int64 storage slot to the proto's uint64,
+// returning nil when the slot is absent or negative. A nil slot is then
+// rejected by the engine (an explicit slot is required when balance/allowance
+// is set), so a negative value surfaces as a validation error rather than a
+// silent slot-0 seed.
+func nonNegativeSlotPtr(v *int64) *uint64 {
+	if v == nil || *v < 0 {
+		return nil
+	}
+	u := uint64(*v)
+	return &u
 }
 
 // runNodeRespToOpenAPI maps the engine RunNodeWithInputsResp to the

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1427,6 +1427,46 @@ components:
         node: { $ref: '#/components/schemas/Node' }
         inputVariables: { $ref: '#/components/schemas/InputVariables' }
         chainId: { $ref: '#/components/schemas/ChainId' }
+        erc20Overrides:
+          type: array
+          description: >
+            Optional ERC20 balance/allowance state overrides applied only during
+            this isolated node simulation. Lets callers seed token balances and
+            approvals so contract-write simulations (e.g. Uniswap swaps) don't
+            revert with "transfer amount exceeds allowance/balance" before the
+            approval/funding transactions have been run. Simulation-only: a
+            real-execution request (isSimulated=false) that sets these is rejected
+            with an error, never silently ignored.
+          items: { $ref: '#/components/schemas/ERC20StateOverride' }
+
+    ERC20StateOverride:
+      type: object
+      required: [tokenAddress, ownerAddress]
+      description: >
+        Seeds a token's balanceOf / allowance storage slots for a single
+        simulation. balanceOf[owner] lives at keccak256(abi.encode(owner,
+        balanceSlot)); allowance[owner][spender] at keccak256(abi.encode(spender,
+        keccak256(abi.encode(owner, allowanceSlot)))).
+      properties:
+        tokenAddress: { $ref: '#/components/schemas/EthereumAddress' }
+        ownerAddress: { $ref: '#/components/schemas/EthereumAddress' }
+        spenderAddress: { $ref: '#/components/schemas/EthereumAddress' }
+        balance:
+          type: string
+          description: Balance override (hex 0x… or decimal string).
+        allowance:
+          type: string
+          description: Allowance override (hex 0x… or decimal string).
+        balanceSlot:
+          type: integer
+          format: int64
+          minimum: 0
+          description: 'Storage slot for the balanceOf mapping. Required when balance is set; ERC20 storage layout varies per token (OpenZeppelin 0, USDC FiatToken 9).'
+        allowanceSlot:
+          type: integer
+          format: int64
+          minimum: 0
+          description: 'Storage slot for the allowance mapping. Required when allowance is set; ERC20 storage layout varies per token (OpenZeppelin 1, USDC FiatToken 10).'
 
     RunNodeResponse:
       type: object

--- a/core/taskengine/TENDERLY_STATE_OVERRIDES.md
+++ b/core/taskengine/TENDERLY_STATE_OVERRIDES.md
@@ -8,13 +8,30 @@ When simulating contract writes involving ERC20 tokens (like Uniswap swaps), you
 
 This document explains how to calculate and use Tenderly state overrides for ERC20 tokens.
 
+## Status
+
+State overrides are implemented and accumulated by `SimulationStateMap`
+(`simulation_state.go`), applied to every Tenderly call via
+`BuildStateObjects()` (`tenderly_client.go`). There are two ways state overrides
+get populated:
+
+1. **Automatic** — event-trigger / multi-step workflow simulation. A Transfer
+   event replayed during simulation injects a balance delta
+   (`InjectERC20BalanceChange`), and each step's `raw_state_diff` is carried
+   forward (`MergeRawStateDiff`) so later steps see a consistent view.
+2. **User-supplied** — the `erc20_overrides` field on `RunNodeWithInputsReq`
+   (REST: `erc20Overrides` on `POST /api/v1/nodes:run`). This lets a caller
+   testing an isolated `RunNodeImmediately` swap seed an arbitrary balance and
+   allowance up front, with no preceding trigger. See
+   [User-facing API](#user-facing-api-erc20_overrides) below.
+
 ## How ERC20 Storage Works
 
 ERC20 tokens use Solidity mappings to store balances and allowances:
 
 ```solidity
 mapping(address => uint256) public balanceOf;           // Usually at storage slot 0
-mapping(address => mapping(address => uint256)) public allowance;  // Usually at slot 3 or 4
+mapping(address => mapping(address => uint256)) public allowance;  // OpenZeppelin: slot 1 (varies by token)
 ```
 
 ## Calculating Storage Slots
@@ -43,31 +60,35 @@ storage_slot = keccak256(abi.encode(spender_address, inner_hash))
 Where:
 - `owner_address` is the token owner (32 bytes, left-padded)
 - `spender_address` is the approved spender (32 bytes, left-padded)
-- `allowance_mapping_slot` is usually 3 or 4 (check the token contract)
+- `allowance_mapping_slot` is 1 for standard OpenZeppelin ERC20 (varies by token — e.g. USDC FiatToken uses 10; check the token contract)
 
 ## Go Implementation
 
-Example implementation for calculating ERC20 storage slots:
+The slot math lives in `simulation_state.go` as `erc20BalanceSlot` and
+`erc20AllowanceSlot`:
 
 ```go
-func calculateERC20StorageSlots(owner, spender, tokenAddress common.Address, balanceSlot, allowanceSlot uint64) (balanceStorageSlot, allowanceStorageSlot string) {
-	// Balance slot: keccak256(abi.encode(owner, balanceSlot))
-	ownerPadded := common.LeftPadBytes(owner.Bytes(), 32)
-	balanceSlotPadded := common.LeftPadBytes(big.NewInt(int64(balanceSlot)).Bytes(), 32)
-	balanceData := append(ownerPadded, balanceSlotPadded...)
-	balanceHash := crypto.Keccak256Hash(balanceData)
-	
-	// Allowance slot: keccak256(abi.encode(spender, keccak256(abi.encode(owner, allowanceSlot))))
-	allowanceSlotPadded := common.LeftPadBytes(big.NewInt(int64(allowanceSlot)).Bytes(), 32)
-	innerData := append(ownerPadded, allowanceSlotPadded...)
-	innerHash := crypto.Keccak256Hash(innerData)
-	
-	spenderPadded := common.LeftPadBytes(spender.Bytes(), 32)
-	outerData := append(spenderPadded, innerHash.Bytes()...)
-	allowanceHash := crypto.Keccak256Hash(outerData)
-	
-	return balanceHash.Hex(), allowanceHash.Hex()
-}
+// keccak256(abi.encode(holder, mappingSlot))
+func erc20BalanceSlot(holder common.Address, mappingSlot int64) common.Hash
+
+// keccak256(abi.encode(spender, keccak256(abi.encode(owner, mappingSlot))))
+func erc20AllowanceSlot(owner, spender common.Address, mappingSlot int64) common.Hash
+```
+
+To seed a balance and/or allowance directly, use the higher-level helper
+`SimulationStateMap.ApplyUserERC20Override`, which parses hex/decimal values,
+computes the mapping slots from the caller-supplied slot indices, and records
+the storage override. The slot is required whenever the corresponding value is
+set — ERC20 storage layout is not standardized, so there is no safe default:
+
+```go
+err := vm.simulationState.ApplyUserERC20Override(
+    tokenAddress, ownerAddress, spenderAddress,
+    "0x38d7ea4c68000", // balance: 1,000,000,000 USDC
+    "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // allowance: max uint256
+    balanceSlotPtr,   // *uint64, required when balance is set (e.g. USDC: 9)
+    allowanceSlotPtr, // *uint64, required when allowance is set (e.g. USDC: 10)
+)
 ```
 
 ## Tenderly API Format
@@ -98,31 +119,81 @@ When calling the Tenderly simulation API, include state overrides in the `state_
 ```
 
 Where:
-- Token balance: `0x38d7ea4c68000` = 1,000,000 USDC (6 decimals)
+- Token balance: `0x38d7ea4c68000` = 1,000,000,000 USDC (6 decimals)
 - Token allowance: `0xffff...ffff` = max uint256 (unlimited approval)
 
 ## Common Token Storage Slots
 
 | Token Type | balanceOf Slot | allowance Slot |
 |------------|----------------|----------------|
-| Standard ERC20 | 0 | 3 |
-| OpenZeppelin ERC20 | 0 | 1 |
+| OpenZeppelin ERC20 (v4/v5) | 0 | 1 |
 | USDC (FiatToken) | 9 | 10 |
 
 **Note:** Always verify the actual storage layout by checking the token's contract source code or using tools like `cast storage` from Foundry.
 
-## Implementation TODO
+## User-facing API: `erc20_overrides`
 
-To enable state overrides in production code, the `TenderlyClient.SimulateContractWrite()` method needs to be enhanced to:
+`RunNodeImmediately` accepts optional ERC20 overrides so an isolated
+contract-write simulation can seed balances/approvals up front. The overrides
+are **simulation-only** — `RunNodeImmediately` rejects them in real-execution
+mode, and they never apply to deployed workflows.
 
-1. Accept optional parameters for ERC20 overrides:
-   - Token addresses to override
-   - Balance and allowance values
-   - Storage slot numbers
+### Request shape
 
-2. Calculate storage slots using the helper function
+Protobuf (`RunNodeWithInputsReq`):
 
-3. Include the `state_objects` in the Tenderly API payload
+```protobuf
+repeated ERC20StateOverride erc20_overrides = 5;
+
+message ERC20StateOverride {
+  string token_address = 1;            // ERC20 token contract address
+  string owner_address = 2;            // Address whose balance/allowance to override
+  optional string spender_address = 3; // Spender to approve (required for allowance override)
+  optional string balance = 4;         // Balance override (hex 0x… or decimal string)
+  optional string allowance = 5;       // Allowance override (hex 0x… or decimal string)
+  optional uint64 balance_slot = 6;    // Storage slot for the balanceOf mapping (required when balance is set; layout varies per token)
+  optional uint64 allowance_slot = 7;  // Storage slot for the allowance mapping (required when allowance is set; layout varies per token)
+}
+```
+
+REST (`POST /api/v1/nodes:run`, camelCase): `erc20Overrides` is an array of the
+same fields (`tokenAddress`, `ownerAddress`, `spenderAddress`, `balance`,
+`allowance`, `balanceSlot`, `allowanceSlot`).
+
+### SDK example
+
+```javascript
+const result = await client.runNodeWithInputs({
+  node: { /* contractWrite node */ },
+  inputVariables: { settings: { runner: '0x71c8f4D…' } },
+  erc20Overrides: [
+    {
+      tokenAddress: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238', // USDC
+      ownerAddress: '0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e',
+      spenderAddress: '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E', // SwapRouter02
+      balance: '0x38d7ea4c68000',  // 1,000,000,000 USDC (6 decimals)
+      allowance: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', // max uint256
+      balanceSlot: 9,    // USDC FiatToken layout (required — see table below)
+      allowanceSlot: 10, // USDC FiatToken layout (required — see table below)
+    },
+  ],
+});
+```
+
+### Validation
+
+- `token_address` / `owner_address` must be valid hex addresses.
+- An allowance override requires a valid `spender_address`.
+- At least one of `balance` / `allowance` must be set.
+- `balance` / `allowance` must be non-negative and fit in a `uint256`.
+- `balance_slot` is required when `balance` is set, and `allowance_slot` is
+  required when `allowance` is set. ERC20 storage layout is not standardized —
+  OpenZeppelin uses `_balances` at slot 0 / `_allowances` at slot 1, USDC
+  (FiatToken) uses 9/10, others differ — so there is no safe default and a
+  missing slot is a validation error (a guessed slot would silently seed the
+  wrong storage word). Look up your token's layout (see the
+  [table below](#common-token-storage-slots)); if unsure, send several overrides
+  for the same token, one per candidate slot.
 
 ## Example Use Case: Uniswap Swap
 

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -21,6 +21,11 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// erc20OverridesConfigKey is the reserved nodeConfig key used to thread
+// caller-supplied ERC20 state overrides from the RPC request down to the VM's
+// simulation state. It is stripped from the config before the node is built.
+const erc20OverridesConfigKey = "__erc20Overrides"
+
 // getRealisticBlockNumberForChain returns a realistic block number for simulation based on chain ID
 // Only includes chains that the aggregator actually supports: Ethereum and Base
 func getRealisticBlockNumberForChain(chainID int64) uint64 {
@@ -2453,6 +2458,56 @@ func (n *Engine) runManualTriggerImmediately(triggerConfig map[string]interface{
 	return result, nil
 }
 
+// applyERC20Overrides seeds the VM's simulation state with caller-supplied
+// ERC20 balance/allowance overrides. rawOverrides is the value stashed under
+// erc20OverridesConfigKey — a []*avsproto.ERC20StateOverride. Overrides are
+// honored only in simulation mode; in real-execution mode they are rejected so
+// a caller can never silently fake balances/approvals against a live wallet.
+func (n *Engine) applyERC20Overrides(vm *VM, useSimulation bool, rawOverrides interface{}) error {
+	overrides, ok := rawOverrides.([]*avsproto.ERC20StateOverride)
+	if !ok {
+		// The value is only ever stashed by RunNodeImmediatelyRPCWithContext as a
+		// []*avsproto.ERC20StateOverride. A different type here means an internal
+		// wiring/serialization bug — surface it rather than silently dropping the
+		// caller's overrides.
+		return fmt.Errorf("erc20_overrides: internal error, expected []*ERC20StateOverride under %s but got %T", erc20OverridesConfigKey, rawOverrides)
+	}
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	if !useSimulation {
+		return fmt.Errorf("erc20_overrides are only supported in simulation mode")
+	}
+	if vm.simulationState == nil {
+		// Should not happen when useSimulation is true, but guard anyway.
+		return fmt.Errorf("erc20_overrides require an active simulation state")
+	}
+
+	for i, o := range overrides {
+		if o == nil {
+			continue
+		}
+		if err := vm.simulationState.ApplyUserERC20Override(
+			o.GetTokenAddress(),
+			o.GetOwnerAddress(),
+			o.GetSpenderAddress(),
+			o.GetBalance(),
+			o.GetAllowance(),
+			o.BalanceSlot,
+			o.AllowanceSlot,
+		); err != nil {
+			return fmt.Errorf("erc20_overrides[%d]: %w", i, err)
+		}
+	}
+
+	if n.logger != nil {
+		n.logger.Info("Applied caller-supplied ERC20 state overrides for simulation",
+			"count", len(overrides))
+	}
+	return nil
+}
+
 // runProcessingNodeWithInputs handles execution of processing node types
 func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.User, nodeType string, nodeConfig map[string]interface{}, inputVariables map[string]interface{}, useSimulation bool) (map[string]interface{}, error) {
 	// Check if this is actually a trigger type that was misrouted
@@ -2657,6 +2712,18 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 	processedInputVariables := inputVariables
 	for key, processedValue := range processedInputVariables {
 		vm.AddVar(key, processedValue)
+	}
+
+	// Apply caller-supplied ERC20 state overrides to the simulation state.
+	// These seed token balances/allowances so contract-write simulations
+	// (e.g. Uniswap swaps) don't revert before approval/funding txs are run.
+	// Only honored in simulation mode — strip the reserved key either way so
+	// it never reaches CreateNodeFromType.
+	if rawOverrides, ok := nodeConfig[erc20OverridesConfigKey]; ok {
+		delete(nodeConfig, erc20OverridesConfigKey)
+		if err := n.applyERC20Overrides(vm, useSimulation, rawOverrides); err != nil {
+			return nil, err
+		}
 	}
 
 	// Create node from type and config
@@ -2950,6 +3017,14 @@ func (n *Engine) RunNodeImmediatelyRPCWithContext(ctx context.Context, user *mod
 				RestApi: &avsproto.RestAPINode_Output{},
 			},
 		}, nil
+	}
+
+	// Carry any caller-supplied ERC20 state overrides through to the VM's
+	// simulation state. These are simulation-only seeds for token
+	// balances/allowances (see runProcessingNodeWithInputs); they are
+	// stashed under a reserved key and stripped before CreateNodeFromType.
+	if len(req.GetErc20Overrides()) > 0 {
+		nodeConfig[erc20OverridesConfigKey] = req.GetErc20Overrides()
 	}
 
 	// Extract isSimulated from node config (defaults to true if not specified)

--- a/core/taskengine/run_node_immediately_rpc_test.go
+++ b/core/taskengine/run_node_immediately_rpc_test.go
@@ -1,7 +1,9 @@
 package taskengine
 
 import (
+	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
@@ -9,6 +11,7 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -402,4 +405,199 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 
 		t.Logf("✅ ETHTransfer RPC test completed successfully")
 	})
+
+	// ERC20Overrides_UniswapSwap drives the new erc20_overrides request field
+	// end-to-end: it builds a RunNodeWithInputsReq with populated overrides and
+	// calls the real RunNodeImmediatelyRPC entrypoint on a Uniswap swap node. This
+	// exercises the whole new path — proto field → RunNodeImmediately threading →
+	// SimulationStateMap → Tenderly state_objects — rather than calling
+	// ApplyUserERC20Override directly.
+	//
+	// It uses a deterministic, never-funded owner so the counterfactual salt:0
+	// runner is guaranteed to hold 0 USDC and 0 allowance. That makes the proof
+	// self-contained and robust (no dependency on a shared wallet staying
+	// funded/unapproved) and lets us isolate BOTH override paths:
+	//
+	//   1. no overrides      → reverts on the allowance precondition
+	//   2. allowance only    → reverts on the *balance* precondition (so the
+	//                          balance override is provably load-bearing)
+	//   3. balance+allowance → swap simulates cleanly
+	//
+	// This requires Tenderly creds (config/test.yaml); per project convention for
+	// integration tests we hard-fail rather than skip when they are missing.
+	t.Run("ERC20Overrides_UniswapSwap", func(t *testing.T) {
+		db := testutil.TestMustDB()
+		defer storage.Destroy(db.(*storage.BadgerStorage))
+
+		config := testutil.GetAggregatorConfig()
+		require.NotEmpty(t, config.TenderlyAccessKey,
+			"erc20_overrides E2E test requires Tenderly creds in config/test.yaml (tenderly_account/project/access_key)")
+		engine := New(db, config, nil, testutil.GetLogger())
+
+		// Deterministic throwaway owner — its salt:0 smart wallet has never held
+		// USDC nor approved SwapRouter02 on Sepolia, so the control reverts
+		// reliably and the balance override is never masked by a real balance.
+		ownerEOA := common.HexToAddress("0xe8a78b476AE1403b7fD39b662545AE608Aced7c7")
+
+		aa.SetFactoryAddress(config.SmartWallet.FactoryAddress)
+		client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
+		require.NoError(t, err, "Failed to connect to RPC")
+		defer client.Close()
+
+		runnerAddr, err := aa.GetSenderAddress(client, ownerEOA, big.NewInt(0))
+		require.NoError(t, err, "Failed to derive smart wallet address")
+
+		user := &model.User{Address: ownerEOA}
+		require.NoError(t, StoreWallet(db, int64(1), ownerEOA, &model.SmartWallet{
+			Owner:   &ownerEOA,
+			Address: runnerAddr,
+			Factory: &config.SmartWallet.FactoryAddress,
+			Salt:    big.NewInt(0),
+		}))
+
+		runner := runnerAddr.Hex()
+		settingsVal, err := structpb.NewValue(map[string]interface{}{
+			"runner":   runner,
+			"chain_id": 11155111, // Sepolia
+		})
+		require.NoError(t, err)
+
+		runSwap := func(overrides []*avsproto.ERC20StateOverride) *avsproto.RunNodeWithInputsResp {
+			resp, err := engine.RunNodeImmediatelyRPC(user, &avsproto.RunNodeWithInputsReq{
+				Node:           exactInputSingleSwapNode(t, runner),
+				InputVariables: map[string]*structpb.Value{"settings": settingsVal},
+				Erc20Overrides: overrides,
+			})
+			require.NoError(t, err, "RunNodeImmediatelyRPC should not error")
+			require.NotNil(t, resp)
+			return resp
+		}
+
+		// USDC on Sepolia is Circle's FiatToken: balanceOf at storage slot 9 and
+		// allowance at slot 10 (confirmed empirically against the deployed token).
+		maxAllowance := "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+		bigBalance := "0x38d7ea4c68000" // 1,000,000,000 USDC (6 decimals)
+		balanceOverride := &avsproto.ERC20StateOverride{
+			TokenAddress: overridesUSDC,
+			OwnerAddress: runner,
+			Balance:      strPtr(bigBalance),
+			BalanceSlot:  u64Ptr(9),
+		}
+		allowanceOverride := &avsproto.ERC20StateOverride{
+			TokenAddress:   overridesUSDC,
+			OwnerAddress:   runner,
+			SpenderAddress: strPtr(overridesSwapRouter02),
+			Allowance:      strPtr(maxAllowance),
+			AllowanceSlot:  u64Ptr(10),
+		}
+
+		// 1. No overrides → reverts because the runner has no SwapRouter02 approval.
+		control := runSwap(nil)
+		t.Logf("no overrides       : success=%v error=%q", control.Success, control.Error)
+		require.False(t, control.Success, "unfunded/unapproved runner must not swap without overrides")
+		require.True(t, isFundingOrApprovalRevert(control.Error),
+			"control should revert on the allowance/balance precondition, got: "+control.Error)
+
+		// 2. Allowance only → approval now satisfied, so it must revert on the
+		//    *balance* precondition. This proves the balance override is necessary
+		//    and that the allowance override already flowed through the RPC path.
+		allowOnly := runSwap([]*avsproto.ERC20StateOverride{allowanceOverride})
+		t.Logf("allowance only     : success=%v error=%q", allowOnly.Success, allowOnly.Error)
+		require.False(t, allowOnly.Success, "swap must still fail with balance unseeded")
+		assert.NotContains(t, allowOnly.Error, "transfer amount exceeds allowance",
+			"allowance override should have seeded the approval through the RPC path")
+		// The remaining revert must be the balance precondition. SwapRouter02's
+		// transferFrom surfaces that either as the inner token revert
+		// ("transfer amount exceeds balance") or as TransferHelper "STF",
+		// depending on how Tenderly extracts the revert — accept either.
+		balanceRevert := strings.Contains(allowOnly.Error, "transfer amount exceeds balance") ||
+			strings.Contains(allowOnly.Error, "STF")
+		assert.Truef(t, balanceRevert,
+			"with approval seeded but balance unseeded, the swap must revert on the balance precondition (exceeds balance / STF), got: %q", allowOnly.Error)
+
+		// 3. Balance + allowance → both preconditions seeded through the request,
+		//    so the swap simulates cleanly. The flip from (2) to (3) is the
+		//    decisive proof that the balance override reaches the Tenderly sim.
+		result := runSwap([]*avsproto.ERC20StateOverride{balanceOverride, allowanceOverride})
+		t.Logf("balance + allowance: success=%v error=%q", result.Success, result.Error)
+		assert.NotContains(t, result.Error, "transfer amount exceeds allowance")
+		assert.NotContains(t, result.Error, "transfer amount exceeds balance")
+		assert.NotContains(t, result.Error, "STF",
+			"Uniswap TransferHelper 'STF' means transferFrom failed — overrides should prevent it")
+		assert.Truef(t, result.Success,
+			"swap simulation should succeed once erc20_overrides seed balance+allowance, got error=%q", result.Error)
+	})
+}
+
+// Sepolia Uniswap V3 + token addresses (shared with execute_uniswap_approval_test.go).
+const (
+	overridesUSDC         = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238" // token1 (FiatToken: balance slot 9, allowance slot 10)
+	overridesWETH         = "0xfff9976782d46cc05630d1f6ebab18b2324d6b14" // token0
+	overridesSwapRouter02 = "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E"
+	overridesFeeTier      = "3000"
+	overridesAmountIn     = "100" // 0.0001 USDC (6 decimals)
+)
+
+func strPtr(s string) *string { return &s }
+func u64Ptr(v uint64) *uint64 { return &v }
+
+// isFundingOrApprovalRevert reports whether a simulation error is the
+// ERC20 funding/approval precondition that erc20_overrides exist to seed —
+// either the OpenZeppelin-style messages or Uniswap's TransferHelper "STF".
+func isFundingOrApprovalRevert(errMsg string) bool {
+	return strings.Contains(errMsg, "transfer amount exceeds allowance") ||
+		strings.Contains(errMsg, "transfer amount exceeds balance") ||
+		strings.Contains(errMsg, "STF")
+}
+
+// exactInputSingleSwapNode builds a SwapRouter02.exactInputSingle contractWrite
+// node that pulls `amountIn` USDC from the runner via transferFrom — the exact
+// path that reverts with "transfer amount exceeds allowance/balance" (Uniswap
+// surfaces it as "STF") unless the runner is funded and has approved the router.
+func exactInputSingleSwapNode(t *testing.T, runner string) *avsproto.TaskNode {
+	t.Helper()
+	abi, err := structpb.NewValue(map[string]interface{}{
+		"inputs": []interface{}{
+			map[string]interface{}{
+				"name": "params",
+				"type": "tuple",
+				"components": []interface{}{
+					map[string]interface{}{"name": "tokenIn", "type": "address"},
+					map[string]interface{}{"name": "tokenOut", "type": "address"},
+					map[string]interface{}{"name": "fee", "type": "uint24"},
+					map[string]interface{}{"name": "recipient", "type": "address"},
+					map[string]interface{}{"name": "amountIn", "type": "uint256"},
+					map[string]interface{}{"name": "amountOutMinimum", "type": "uint256"},
+					map[string]interface{}{"name": "sqrtPriceLimitX96", "type": "uint160"},
+				},
+			},
+		},
+		"name":            "exactInputSingle",
+		"outputs":         []interface{}{map[string]interface{}{"name": "amountOut", "type": "uint256"}},
+		"stateMutability": "payable",
+		"type":            "function",
+	})
+	require.NoError(t, err, "failed to build exactInputSingle ABI value")
+
+	// amountOutMinimum=0 so the swap can't revert on slippage — keeps the test
+	// focused on the allowance/balance precondition the overrides target.
+	params := fmt.Sprintf(`["%s", "%s", "%s", "%s", "%s", "0", 0]`,
+		overridesUSDC, overridesWETH, overridesFeeTier, runner, overridesAmountIn)
+
+	return &avsproto.TaskNode{
+		Id:   "execute_swap",
+		Name: "execute_swap",
+		Type: avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE,
+		TaskType: &avsproto.TaskNode_ContractWrite{
+			ContractWrite: &avsproto.ContractWriteNode{
+				Config: &avsproto.ContractWriteNode_Config{
+					ContractAddress: overridesSwapRouter02,
+					ContractAbi:     []*structpb.Value{abi},
+					MethodCalls: []*avsproto.ContractWriteNode_MethodCall{
+						{MethodName: "exactInputSingle", MethodParams: []string{params}},
+					},
+				},
+			},
+		},
+	}
 }

--- a/core/taskengine/simulation_state.go
+++ b/core/taskengine/simulation_state.go
@@ -3,6 +3,7 @@ package taskengine
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -433,6 +434,136 @@ func (s *SimulationStateMap) InjectETHBalanceChange(
 			"currentBalance", currentBalance.String(),
 			"delta", delta.String(),
 			"newBalance", newBalance.String())
+	}
+
+	return nil
+}
+
+// maxUint256 is 2^256 - 1, the largest value an EVM storage word can hold.
+var maxUint256 = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+
+// parseUint256 parses a balance/allowance override value supplied as either a
+// 0x-prefixed hex string or a plain decimal string. The result is validated to
+// be a non-negative value that fits in a uint256, so it can never produce an
+// invalid EVM storage word.
+func parseUint256(value string) (*big.Int, error) {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return nil, fmt.Errorf("empty value")
+	}
+	var n *big.Int
+	var ok bool
+	if strings.HasPrefix(v, "0x") || strings.HasPrefix(v, "0X") {
+		n, ok = new(big.Int).SetString(v[2:], 16)
+		if !ok {
+			return nil, fmt.Errorf("invalid hex value %q", value)
+		}
+	} else {
+		n, ok = new(big.Int).SetString(v, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid decimal value %q", value)
+		}
+	}
+	if n.Sign() < 0 {
+		return nil, fmt.Errorf("value %q must be non-negative", value)
+	}
+	if n.Cmp(maxUint256) > 0 {
+		return nil, fmt.Errorf("value %q exceeds uint256 max", value)
+	}
+	return n, nil
+}
+
+// requireERC20Slot resolves the storage mapping slot for an override. The slot
+// is required: ERC20 storage layout is not standardized (OpenZeppelin uses
+// _balances at slot 0 / _allowances at slot 1, USDC FiatToken uses 9/10, others
+// differ), so there is no safe default — a guessed slot would silently seed the
+// wrong storage word and produce a misleading simulation. The caller must state
+// the layout explicitly. The value is bounds-checked so an out-of-range uint64
+// can't overflow into a bogus int64. See TENDERLY_STATE_OVERRIDES.md.
+func requireERC20Slot(explicit *uint64, field string) (int64, error) {
+	if explicit == nil {
+		return 0, fmt.Errorf("%s is required (ERC20 storage layout varies per token: "+
+			"OpenZeppelin uses 0/1, USDC FiatToken uses 9/10 — see TENDERLY_STATE_OVERRIDES.md)", field)
+	}
+	if *explicit > math.MaxInt64 {
+		return 0, fmt.Errorf("storage slot %d exceeds the supported range", *explicit)
+	}
+	return int64(*explicit), nil
+}
+
+// ApplyUserERC20Override seeds the simulation state with a caller-supplied ERC20
+// balance and/or allowance override. Unlike InjectERC20BalanceChange, the values
+// are absolute (not deltas) and no RPC call is made — the caller provides the
+// exact balance/allowance and the mapping slots, so this is a pure, synchronous
+// state mutation suitable for isolated RunNodeImmediately simulations.
+//
+// balance overrides the holder's balanceOf and requires balanceSlot; allowance
+// overrides allowance[owner][spender] and requires both a spender address and
+// allowanceSlot. The slots are required because ERC20 storage layout is not
+// standardized — see requireERC20Slot.
+func (s *SimulationStateMap) ApplyUserERC20Override(
+	tokenAddress, ownerAddress, spenderAddress string,
+	balance, allowance string,
+	balanceSlot, allowanceSlot *uint64,
+) error {
+	if !common.IsHexAddress(tokenAddress) {
+		return fmt.Errorf("invalid token_address %q", tokenAddress)
+	}
+	if !common.IsHexAddress(ownerAddress) {
+		return fmt.Errorf("invalid owner_address %q", ownerAddress)
+	}
+	token := common.HexToAddress(tokenAddress)
+	owner := common.HexToAddress(ownerAddress)
+
+	if balance == "" && allowance == "" {
+		return fmt.Errorf("ERC20 override for token %s specifies neither balance nor allowance", tokenAddress)
+	}
+
+	if balance != "" {
+		bal, err := parseUint256(balance)
+		if err != nil {
+			return fmt.Errorf("balance override: %w", err)
+		}
+		slot, err := requireERC20Slot(balanceSlot, "balance_slot")
+		if err != nil {
+			return fmt.Errorf("balance override: %w", err)
+		}
+		slotHash := erc20BalanceSlot(owner, slot)
+		s.SetStorageSlot(token.Hex(), slotHash.Hex(), fmt.Sprintf("0x%064x", bal))
+
+		if s.logger != nil {
+			s.logger.Info("Applied user ERC20 balance override for simulation",
+				"token", token.Hex(),
+				"owner", owner.Hex(),
+				"balance", bal.String(),
+				"slot", slotHash.Hex())
+		}
+	}
+
+	if allowance != "" {
+		if !common.IsHexAddress(spenderAddress) {
+			return fmt.Errorf("allowance override for token %s requires a valid spender_address", tokenAddress)
+		}
+		spender := common.HexToAddress(spenderAddress)
+		allow, err := parseUint256(allowance)
+		if err != nil {
+			return fmt.Errorf("allowance override: %w", err)
+		}
+		slot, err := requireERC20Slot(allowanceSlot, "allowance_slot")
+		if err != nil {
+			return fmt.Errorf("allowance override: %w", err)
+		}
+		slotHash := erc20AllowanceSlot(owner, spender, slot)
+		s.SetStorageSlot(token.Hex(), slotHash.Hex(), fmt.Sprintf("0x%064x", allow))
+
+		if s.logger != nil {
+			s.logger.Info("Applied user ERC20 allowance override for simulation",
+				"token", token.Hex(),
+				"owner", owner.Hex(),
+				"spender", spender.Hex(),
+				"allowance", allow.String(),
+				"slot", slotHash.Hex())
+		}
 	}
 
 	return nil

--- a/core/taskengine/simulation_state_override_test.go
+++ b/core/taskengine/simulation_state_override_test.go
@@ -1,0 +1,164 @@
+package taskengine
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUint256(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    *big.Int
+		wantErr bool
+	}{
+		{"decimal", "1000000", big.NewInt(1000000), false},
+		{"hex lower", "0x38d7ea4c68000", big.NewInt(1000000000000000), false},
+		{"hex upper prefix", "0X10", big.NewInt(16), false},
+		{"max uint256", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)), false},
+		{"whitespace", "  42  ", big.NewInt(42), false},
+		{"empty", "", nil, true},
+		{"garbage", "0xnothex", nil, true},
+		{"not decimal", "12ab", nil, true},
+		{"negative decimal", "-1", nil, true},
+		{"exceeds uint256", "0x1" + strings.Repeat("0", 64), nil, true}, // 2^256 > 2^256-1
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseUint256(tc.in)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, 0, tc.want.Cmp(got), "want %s got %s", tc.want, got)
+		})
+	}
+}
+
+func TestApplyUserERC20Override_BalanceAndAllowance(t *testing.T) {
+	logger := testutil.GetLogger()
+	state := NewSimulationStateMap(logger)
+
+	token := "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+	owner := "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e"
+	spender := "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E"
+
+	balSlot := uint64(0)
+	allowSlot := uint64(3)
+	err := state.ApplyUserERC20Override(
+		token, owner, spender,
+		"1000000", // balance (decimal)
+		"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // allowance (max uint256)
+		&balSlot, &allowSlot,
+	)
+	require.NoError(t, err)
+
+	objects := state.BuildStateObjects(owner, "0x100")
+	tokenObj, ok := objects[common.HexToAddress(token).Hex()]
+	// BuildStateObjects lowercases keys, so look it up lowercased.
+	if !ok {
+		tokenObj, ok = objects["0x1c7d4b196cb0c7b01d743fbc6116a902379c7238"]
+	}
+	require.True(t, ok, "token should appear in state_objects: %v", objects)
+	storage, ok := tokenObj.(map[string]interface{})["storage"].(map[string]string)
+	require.True(t, ok)
+
+	// Balance slot value: keccak256(abi.encode(owner, 0)) -> 0x...0f4240 (1,000,000)
+	wantBalSlot := erc20BalanceSlot(common.HexToAddress(owner), 0).Hex()
+	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000f4240", storage[wantBalSlot])
+
+	// Allowance slot value: max uint256
+	wantAllowSlot := erc20AllowanceSlot(common.HexToAddress(owner), common.HexToAddress(spender), 3).Hex()
+	assert.Equal(t, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", storage[wantAllowSlot])
+}
+
+func TestApplyUserERC20Override_SlotRequired(t *testing.T) {
+	token := "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+	owner := "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e"
+	spender := "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E"
+	bal := uint64(9)
+	allow := uint64(10)
+
+	// ERC20 storage layout is not standardized, so the slot is required when the
+	// corresponding value is set — omitting it is a validation error, never a
+	// silently-guessed default.
+	t.Run("balance without slot is rejected", func(t *testing.T) {
+		state := NewSimulationStateMap(testutil.GetLogger())
+		err := state.ApplyUserERC20Override(token, owner, "", "5", "", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "balance_slot is required")
+	})
+
+	t.Run("allowance without slot is rejected", func(t *testing.T) {
+		state := NewSimulationStateMap(testutil.GetLogger())
+		err := state.ApplyUserERC20Override(token, owner, spender, "", "10", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "allowance_slot is required")
+	})
+
+	t.Run("explicit slots are honored", func(t *testing.T) {
+		state := NewSimulationStateMap(testutil.GetLogger())
+		require.NoError(t, state.ApplyUserERC20Override(token, owner, spender, "5", "10", &bal, &allow))
+
+		objects := state.BuildStateObjects(owner, "0x0")
+		tokenObj := objects["0x1c7d4b196cb0c7b01d743fbc6116a902379c7238"].(map[string]interface{})
+		storage := tokenObj["storage"].(map[string]string)
+
+		wantBal := erc20BalanceSlot(common.HexToAddress(owner), int64(bal)).Hex()
+		wantAllow := erc20AllowanceSlot(common.HexToAddress(owner), common.HexToAddress(spender), int64(allow)).Hex()
+		_, hasBal := storage[wantBal]
+		_, hasAllow := storage[wantAllow]
+		assert.True(t, hasBal, "balance override at explicit slot 9")
+		assert.True(t, hasAllow, "allowance override at explicit slot 10")
+	})
+}
+
+func TestApplyUserERC20Override_Validation(t *testing.T) {
+	state := NewSimulationStateMap(testutil.GetLogger())
+	owner := "0x71c8f4D7D5291EdCb3A081802e7efB2788Bd232e"
+	token := "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+
+	t.Run("bad token address", func(t *testing.T) {
+		err := state.ApplyUserERC20Override("not-an-address", owner, "", "1", "", nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("bad owner address", func(t *testing.T) {
+		err := state.ApplyUserERC20Override(token, "0x123", "", "1", "", nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("neither balance nor allowance", func(t *testing.T) {
+		err := state.ApplyUserERC20Override(token, owner, "", "", "", nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("allowance without spender", func(t *testing.T) {
+		err := state.ApplyUserERC20Override(token, owner, "", "", "10", nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("balance only is fine with an explicit slot", func(t *testing.T) {
+		slot := uint64(0)
+		err := state.ApplyUserERC20Override(token, owner, "", "1", "", &slot, nil)
+		assert.NoError(t, err)
+	})
+	t.Run("balance only without a slot is rejected", func(t *testing.T) {
+		err := state.ApplyUserERC20Override(token, owner, "", "1", "", nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("negative balance value rejected", func(t *testing.T) {
+		err := state.ApplyUserERC20Override(token, owner, "", "-1", "", nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("slot index out of int64 range rejected", func(t *testing.T) {
+		hugeSlot := uint64(math.MaxInt64) + 1
+		err := state.ApplyUserERC20Override(token, owner, "", "1", "", &hugeSlot, nil)
+		assert.Error(t, err)
+	})
+}

--- a/core/taskengine/summarizer_context_memory.go
+++ b/core/taskengine/summarizer_context_memory.go
@@ -369,6 +369,45 @@ func composePlainTextBodyFromAPI(body contextMemorySummarizeBody) string {
 	return strings.TrimSpace(sb.String())
 }
 
+// BuildNotifyPayload builds the raw execution-data payload (the same SummarizeRequest the
+// summarizer would POST to /api/summarize) as a generic map, for the gateway to merge into a
+// Studio /api/notify call. Path B: Studio summarizes AND distributes, so the gateway forwards
+// raw data instead of summarizing + sending locally. Reuses buildRequest (incl. token
+// enrichment) and the same status/executionError derivation as Summarize.
+func (c *ContextMemorySummarizer) BuildNotifyPayload(vm *VM, currentStepName string) (map[string]interface{}, error) {
+	if c == nil {
+		return nil, fmt.Errorf("summarizer not initialized")
+	}
+
+	// Derive the execution verdict BEFORE buildRequest acquires vm.mu (same as Summarize).
+	// Empty ExecutionLogs = single-node RunNodeImmediately: treat as success (nothing failed yet).
+	var status, executionError string
+	if len(vm.ExecutionLogs) == 0 {
+		status = "success"
+	} else {
+		var resultStatus ExecutionResultStatus
+		executionError, _, resultStatus = vm.AnalyzeExecutionResult()
+		status = mapExecutionStatusToAPIString(resultStatus)
+	}
+
+	req, err := c.buildRequest(vm, currentStepName, status, executionError)
+	if err != nil {
+		return nil, err
+	}
+
+	// Round-trip through JSON so the merged body carries the exact field names/shapes the
+	// /api/summarize (and /api/notify) contract expects.
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
 func (c *ContextMemorySummarizer) buildRequest(vm *VM, currentStepName, status, executionError string) (*contextMemorySummarizeRequest, error) {
 	vm.mu.Lock()
 	defer vm.mu.Unlock()

--- a/core/taskengine/summarizer_deterministic.go
+++ b/core/taskengine/summarizer_deterministic.go
@@ -2141,8 +2141,8 @@ func convertInterfaceToInt(val interface{}) int {
 
 func providerDisplayName(provider string) string {
 	switch strings.ToLower(provider) {
-	case "sendgrid":
-		return "SendGrid"
+	case "studio-notify":
+		return "Ava Protocol"
 	case "telegram":
 		return "Telegram"
 	default:
@@ -2237,8 +2237,8 @@ func isNotificationNode(node *avsproto.TaskNode) bool {
 		return false
 	}
 
-	// SendGrid
-	if strings.Contains(url, "sendgrid") || strings.Contains(url, "/mail/send") {
+	// Studio /api/notify (Path B distribution endpoint)
+	if strings.Contains(url, "/api/notify") {
 		return true
 	}
 	// Telegram

--- a/core/taskengine/summarizer_run_node_test.go
+++ b/core/taskengine/summarizer_run_node_test.go
@@ -28,7 +28,7 @@ func TestComposeSummary_RunNodeRestSubjectAndBody(t *testing.T) {
 	restPayload := map[string]interface{}{
 		"status":     202,
 		"statusText": "Accepted",
-		"url":        "https://api.sendgrid.com/v3/mail/send",
+		"url":        "https://app.avaprotocol.org/api/notify",
 	}
 	restValue, err := structpb.NewValue(restPayload)
 	if err != nil {
@@ -64,7 +64,7 @@ func TestComposeSummary_RunNodeRestSubjectAndBody(t *testing.T) {
 		t.Fatalf("expected body to mention HTTP status, got: %q", summary.Body)
 	}
 
-	if !strings.Contains(summary.Body, "SendGrid") {
-		t.Fatalf("expected body to mention SendGrid provider, got: %q", summary.Body)
+	if !strings.Contains(summary.Body, "Ava Protocol") {
+		t.Fatalf("expected body to mention the Ava Protocol notification provider, got: %q", summary.Body)
 	}
 }

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -2438,6 +2438,11 @@ func (v *VM) RunNodeWithInputs(node *avsproto.TaskNode, inputVariables map[strin
 	tempVM.TaskOwner = v.TaskOwner
 	// Propagate shared clients (e.g., Tenderly)
 	tempVM.tenderlyClient = v.tenderlyClient
+	// Share the accumulated simulation state so caller-seeded overrides
+	// (e.g. erc20_overrides) and any earlier nodes' state diffs reach this
+	// node's Tenderly simulation. Without this the node would run against a
+	// fresh, empty state and the seeded balances/allowances would be lost.
+	tempVM.simulationState = v.simulationState
 
 	// Log simulation mode for debugging
 	if v.logger != nil {

--- a/core/taskengine/vm_runner_contract_write_uniswap_test.go
+++ b/core/taskengine/vm_runner_contract_write_uniswap_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -26,7 +25,7 @@ func TestContractWriteNode_UniswapV3Quote(t *testing.T) {
 	// Get test configuration and create Tenderly client
 	logger := testutil.GetLogger()
 	testConfig := testutil.GetTestConfig()
-	require.NotNil(t, testConfig, "Test config must be loaded from aggregator.yaml")
+	require.NotNil(t, testConfig, "Test config must be loaded from config/test.yaml (Tenderly creds required)")
 
 	// Create Tenderly client
 	tenderlyClient := NewTenderlyClient(testConfig, logger)
@@ -140,60 +139,29 @@ func TestContractWriteNode_UniswapV3Quote(t *testing.T) {
 		},
 	}
 
-	// Execute the node
+	// Execute the node. This test validates tuple-parameter calldata generation,
+	// not erc20_overrides: QuoterV2.quoteExactInputSingle is a view function that
+	// reverts by design to return the quote and never performs a transferFrom, so
+	// seeding balances/allowances here would prove nothing. The erc20_overrides
+	// request path is covered end-to-end by
+	// TestRunNodeImmediatelyRPC/ERC20Overrides_UniswapSwap.
 	step, err := vm.RunNodeWithInputs(node, inputVars)
 	require.NoError(t, err)
-	assert.NotNil(t, step)
+	require.NotNil(t, step)
 
-	// Currently this test will fail with "ERC20: transfer amount exceeds allowance"
-	// because the USDC token hasn't been approved for the SwapRouter02.
-	//
-	// TO FIX: The TenderlyClient needs to be enhanced to support ERC20 state overrides:
-	// 1. Token balance: keccak256(abi.encode(owner, balanceSlot)) where balanceSlot is typically 0
-	// 2. Token allowance: keccak256(abi.encode(spender, keccak256(abi.encode(owner, allowanceSlot))))
-	//    where allowanceSlot is typically 3 or 4
-	//
-	// Example state_objects for Tenderly API:
-	// "state_objects": {
-	//   "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238": {  // USDC token
-	//     "storage": {
-	//       "<allowance_slot>": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // max approval
-	//       "<balance_slot>": "0x38d7ea4c68000"  // 1,000,000 USDC (6 decimals)
-	//     }
-	//   }
-	// }
-
-	if !step.Success {
-		t.Logf("Expected failure: %s", step.Error)
-
-		// Expected error: either "execution reverted" (QuoterV2's internal revert) or
-		// "transfer amount exceeds allowance" (if it reaches the transferFrom call)
-		// Both are valid since they indicate the calldata generation worked
-		hasExpectedError := assert.Contains(t, step.Error, "execution reverted",
-			"Expected revert error from QuoterV2 or allowance error") ||
-			assert.Contains(t, step.Error, "transfer amount exceeds allowance",
-				"Expected allowance error because test doesn't set up ERC20 approval state overrides")
-
-		require.True(t, hasExpectedError, "Expected either 'execution reverted' or 'transfer amount exceeds allowance', got: %s", step.Error)
-
-		// The important validations that DID work:
-		// ✅ Tuple parameter was correctly parsed from JSON array format
-		// ✅ Calldata was successfully generated
-		// ✅ Tenderly simulation was called
-		// ✅ The contract execution reached the point where it would fail (proving calldata is valid)
-		t.Logf("✅ SUCCESS: Calldata generation for tuple parameters works correctly")
-		t.Logf("ℹ️  To make the swap succeed, enhance TenderlyClient to support ERC20 state overrides")
-	} else {
-		t.Logf("✅ UNEXPECTED SUCCESS: Swap simulation passed!")
-
-		// Validate the output structure
+	if step.Success {
+		t.Logf("✅ Quote simulation succeeded")
 		contractWrite, ok := step.OutputData.(*avsproto.Execution_Step_ContractWrite)
 		require.True(t, ok, "Step output should be ContractWrite")
 		require.NotNil(t, contractWrite)
 		require.NotNil(t, contractWrite.ContractWrite)
 		require.NotNil(t, contractWrite.ContractWrite.Data)
-
-		// Log the swap output
-		t.Logf("Swap output: %v", contractWrite.ContractWrite.Data.AsInterface())
+		t.Logf("Quote output: %v", contractWrite.ContractWrite.Data.AsInterface())
+	} else {
+		// QuoterV2 returns its result via revert, so "execution reverted" is the
+		// expected outcome and confirms the tuple calldata reached the contract.
+		require.Contains(t, step.Error, "execution reverted",
+			"QuoterV2 quote should revert by design once calldata reaches it, got: %s", step.Error)
+		t.Logf("ℹ️  QuoterV2 reverted by design; tuple calldata generation validated")
 	}
 }

--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -686,364 +686,46 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 	// Keep a reference to the composed summary so we can return it to clients even
 	// when the external notification provider (e.g., SendGrid) returns an empty body.
 	var summaryForClient *Summary
+	isStudioNotify := false
 	if shouldSummarize(r.vm, node) {
 		provider := detectNotificationProvider(url)
 		if r.vm.logger != nil {
 			r.vm.logger.Info("REST API summarize enabled", "provider", provider, "url", url)
 		}
-		if provider != "" {
-			// Build summary from current VM context (AI if enabled, else deterministic)
+		if provider == "studio-notify" {
+			// Path B: forward raw execution data to Studio /api/notify, which summarizes AND
+			// sends and returns the summary (surfaced to the SDK after the POST). The gateway no
+			// longer summarizes or sends email itself.
+			isStudioNotify = true
+			if cm, ok := globalSummarizer.(*ContextMemorySummarizer); ok && cm != nil {
+				if payload, err := cm.BuildNotifyPayload(r.vm, r.vm.GetNodeNameAsVar(stepID)); err == nil {
+					var bodyObj map[string]interface{}
+					if json.Unmarshal([]byte(body), &bodyObj) == nil {
+						// Node fields (channel/format/recipient/...) win; add the raw execution data.
+						for k, v := range payload {
+							if _, exists := bodyObj[k]; !exists {
+								bodyObj[k] = v
+							}
+						}
+						body = FormatAsJSON(bodyObj)
+					}
+				} else if r.vm.logger != nil {
+					r.vm.logger.Warn("REST API notify: failed to build raw payload", "error", err)
+				}
+			} else if r.vm.logger != nil {
+				r.vm.logger.Warn("REST API notify: no summarizer configured to build payload")
+			}
+		} else if provider == "telegram" {
+			// Legacy gateway-side Telegram send (moves to /api/notify in Phase 3).
 			currentName := r.vm.GetNodeNameAsVar(stepID)
-			if r.vm.logger != nil {
-				r.vm.logger.Info("REST API calling ComposeSummarySmart", "currentName", currentName)
-			}
 			s := ComposeSummarySmart(r.vm, currentName)
-			if r.vm.logger != nil {
-				r.vm.logger.Info("REST API summary generated", "subject", s.Subject, "bodyLength", len(s.Body))
-			}
 			summaryForClient = &s
-
-			// Attempt to parse body as JSON and inject subject/body accordingly
 			var bodyObj map[string]interface{}
-			if err := json.Unmarshal([]byte(body), &bodyObj); err == nil {
-				switch provider {
-				case "sendgrid":
-					// Always use Dynamic Templates for AI summaries - inject template_id automatically
-					bodyObj["template_id"] = SendGridSummaryTemplateID
-
-					// Get dynamic template data from summary (subject/title/analysis...)
-					dynamicData := s.SendGridDynamicData()
-
-					// Single source of truth: the runner block returned by context-memory,
-					// shared with the Telegram render. SendGrid template variables keep
-					// their existing format — `runner` is full hex, `eoaAddress` is shortened.
-					if s.Runner != nil {
-						dynamicData["runner"] = s.Runner.SmartWallet
-						dynamicData["eoaAddress"] = shortHex(s.Runner.OwnerEOA)
-					}
-					// Get execution index from VM field (set by executor)
-					executionIndex := r.vm.ExecutionIndex
-					dynamicData["year"] = fmt.Sprintf("%d", time.Now().Year()) // Current year for email footer
-
-					// Compute skipped nodes (by name) = workflow nodes - executed step names
-					// Skip branch condition pseudo-nodes which are routing points, not actual nodes
-					// Include the CURRENT node since it's executing (not yet in ExecutionLogs)
-					executedNames := make(map[string]struct{})
-					for _, st := range r.vm.ExecutionLogs {
-						name := st.GetName()
-						if name == "" {
-							name = st.GetId()
-						}
-						if name != "" {
-							executedNames[name] = struct{}{}
-						}
-					}
-					// Add current node name to executed list (it's executing but not yet in logs)
-					currentNodeName := ""
-					r.vm.mu.Lock()
-					if currentTaskNode, ok := r.vm.TaskNodes[stepID]; ok && currentTaskNode != nil {
-						currentNodeName = currentTaskNode.Name
-					}
-					r.vm.mu.Unlock()
-					if currentNodeName == "" {
-						currentNodeName = stepID
-					}
-					if currentNodeName != "" {
-						executedNames[currentNodeName] = struct{}{}
-					}
-
-					skippedNodes := make([]string, 0, len(r.vm.TaskNodes))
-					r.vm.mu.Lock()
-					taskNodeCount := len(r.vm.TaskNodes)
-					for nodeID, n := range r.vm.TaskNodes {
-						if n != nil {
-							// Skip branch condition nodes (they have IDs like "nodeId.conditionId")
-							// These are routing/edge nodes, not actual executable nodes
-							if strings.Contains(nodeID, ".") {
-								continue
-							}
-							if _, ok := executedNames[n.Name]; !ok {
-								skippedNodes = append(skippedNodes, n.Name)
-							}
-						}
-					}
-					r.vm.mu.Unlock()
-
-					// Debug logging for skipped nodes calculation
-					r.vm.logger.Debug("Skipped nodes calculation",
-						"totalTaskNodes", taskNodeCount,
-						"executedCount", len(executedNames),
-						"executedNames", getMapKeys(executedNames),
-						"skippedCount", len(skippedNodes),
-						"skippedNodes", skippedNodes)
-
-					if len(skippedNodes) > 0 {
-						dynamicData["skippedNodes"] = skippedNodes
-					}
-
-					// Collect branch selections with condition expressions
-					branchSelections := make([]map[string]interface{}, 0, 2)
-					for _, st := range r.vm.ExecutionLogs {
-						t := strings.ToUpper(st.GetType())
-						if !strings.Contains(t, "BRANCH") {
-							continue
-						}
-						entry := map[string]interface{}{}
-						name := st.GetName()
-						if name == "" {
-							name = st.GetId()
-						}
-						entry["step"] = name
-						// selected conditionId from branch output
-						if br := st.GetBranch(); br != nil && br.GetData() != nil {
-							if m, ok := br.GetData().AsInterface().(map[string]interface{}); ok {
-								if cid, ok := m["conditionId"].(string); ok {
-									entry["condition_id"] = cid
-									if idx := strings.LastIndex(cid, "."); idx >= 0 && idx+1 < len(cid) {
-										switch cid[idx+1:] {
-										case "0":
-											entry["path"] = "if"
-										case "1":
-											entry["path"] = "else"
-										default:
-											entry["path"] = cid[idx+1:]
-										}
-									}
-								}
-							}
-						}
-						// conditions array from config
-						if st.GetConfig() != nil {
-							if cfgMap, ok := st.GetConfig().AsInterface().(map[string]interface{}); ok {
-								if conds, ok := cfgMap["conditions"].([]interface{}); ok {
-									condList := make([]map[string]interface{}, 0, len(conds))
-									for _, c := range conds {
-										if cm, ok := c.(map[string]interface{}); ok {
-											condList = append(condList, map[string]interface{}{
-												"id":         cm["id"],
-												"type":       cm["type"],
-												"expression": cm["expression"],
-											})
-										}
-									}
-									if len(condList) > 0 {
-										entry["conditions"] = condList
-									}
-								}
-							}
-						}
-						branchSelections = append(branchSelections, entry)
-					}
-					if len(branchSelections) > 0 {
-						dynamicData["branchSelections"] = branchSelections
-					}
-
-					// Check if we have a summary from context-memory API
-					// If so, use it as-is (pass-through) instead of overwriting with deterministic summary
-					// Check for structured fields (Trigger, Executions) to determine if we have an AI summary
-					hasAISummary := (strings.TrimSpace(summaryForClient.Subject) != "" || summaryForClient.Trigger != "" || len(summaryForClient.Executions) > 0) && strings.TrimSpace(summaryForClient.Body) != ""
-
-					// Compose deterministic branch/skip summary strings
-					// When branches/skips are present, use the structured summary as the primary analysisHtml
-					// Pass currentNodeName so BuildBranchAndSkippedSummary uses the same calculation logic
-					// BUT: Skip this if we have an AI summary (context-memory) - use original response as pass-through
-					if !isSingleNodeImmediate(r.vm) && !hasAISummary {
-						if text, html := BuildBranchAndSkippedSummary(r.vm, currentNodeName); strings.TrimSpace(html) != "" {
-							// Replace analysisHtml with the structured branch summary
-							// The old analysisHtml (from Summary.Body) often duplicates this information
-							dynamicData["analysisHtml"] = html
-							dynamicData["branchSummaryHtml"] = html
-
-							// Compute and set status, statusHtml, subject, and summary (deterministic)
-							executedSteps := len(r.vm.ExecutionLogs)
-
-							// Count actual skipped nodes by name (not by alternate branch paths)
-							// vm.TaskNodes includes nodes on ALL branch paths, but only one path is taken
-							skippedCount := len(skippedNodes) // Use actual skipped node names count
-
-							// For summary display, use executedSteps as total if nothing was truly skipped
-							totalSteps := executedSteps
-							if skippedCount > 0 {
-								totalSteps = executedSteps + skippedCount
-							}
-
-							failed, failedName, failedReason := findEarliestFailure(r.vm)
-
-							// Use ExecutionResultStatus enum
-							var resultStatus ExecutionResultStatus
-							var statusText, statusBgColor, statusTextColor, iconSvg string
-							skippedNote := ""
-							if failed {
-								resultStatus = ExecutionFailed
-								statusText = fmt.Sprintf("but failed at the '%s' step due to %s.", safeName(failedName), firstLine(failedReason))
-								statusBgColor = "#FEE2E2"
-								statusTextColor = "#991B1B"
-								iconSvg = statusIconFailed
-							} else if skippedCount > 0 {
-								resultStatus = ExecutionSuccess
-								// Per Studio: success with branch-skipped steps renders yellow "warn".
-								// The skip count lives in the badge, never appended to the title.
-								skippedNote = buildSkippedNote(skippedCount)
-								statusText = skippedNote
-								statusBgColor = "#FEF3C7"
-								statusTextColor = "#92400E"
-								iconSvg = statusIconWarn
-							} else {
-								resultStatus = ExecutionSuccess
-								statusText = "All steps completed successfully"
-								statusBgColor = "#D1FAE5"
-								statusTextColor = "#065F46"
-								iconSvg = statusIconSuccess
-							}
-
-							statusHtml := fmt.Sprintf(
-								`<div style="display:inline-block; padding:8px 16px; background-color:%s; color:%s; border-radius:8px; font-weight:500; margin:8px 0">%s%s</div>`,
-								statusBgColor,
-								statusTextColor,
-								iconSvg,
-								statusText,
-							)
-							if skippedNote != "" {
-								dynamicData["skipped_note"] = skippedNote
-							}
-
-							workflowName := resolveWorkflowName(r.vm)
-							summaryLine := fmt.Sprintf("Your workflow '%s' executed %d out of %d total steps", workflowName, executedSteps, totalSteps)
-
-							// Update subject based on status
-							var subjectStatusText string
-							switch resultStatus {
-							case ExecutionSuccess:
-								subjectStatusText = "successfully completed"
-							case ExecutionFailed:
-								subjectStatusText = "failed to execute"
-							}
-
-							// Build subject with appropriate prefix
-							var newSubject string
-							if r.vm.IsSimulation {
-								// Simulation: workflow_name status
-								newSubject = fmt.Sprintf("Simulation: %s %s", workflowName, subjectStatusText)
-								if r.vm.logger != nil {
-									r.vm.logger.Info("Using Simulation prefix for email subject", "subject", newSubject, "isSimulation", r.vm.IsSimulation)
-								}
-							} else {
-								// Deployed run: Run #X: workflow_name status
-								if executionIndex >= 0 {
-									newSubject = fmt.Sprintf("Run #%d: %s %s", executionIndex+1, workflowName, subjectStatusText) // +1 for 1-based display
-									if r.vm.logger != nil {
-										r.vm.logger.Info("Using Run # prefix for email subject", "subject", newSubject, "executionIndex", executionIndex, "displayIndex", executionIndex+1)
-									}
-								} else {
-									// Fallback if execution index not available
-									newSubject = fmt.Sprintf("%s %s", workflowName, subjectStatusText)
-									if r.vm.logger != nil {
-										r.vm.logger.Warn("Execution index not available, using basic subject format", "subject", newSubject)
-									}
-								}
-							}
-
-							dynamicData["statusHtml"] = statusHtml
-							dynamicData["summary"] = summaryLine
-							dynamicData["subject"] = newSubject
-
-							// Set preheader from deterministic summary line (fallback to subject)
-							preheader := extractPreheaderFromSummaryText(text, newSubject)
-							dynamicData["preheader"] = preheader
-						}
-					} else if hasAISummary {
-						// Use structured summary data - aggregator builds HTML from structured fields
-						if r.vm.logger != nil {
-							r.vm.logger.Info("Using structured summary data",
-								"subject", summaryForClient.Subject,
-								"hasTrigger", summaryForClient.Trigger != "",
-								"executionsCount", len(summaryForClient.Executions),
-								"errorsCount", len(summaryForClient.Errors))
-						}
-
-						// Use SendGridDynamicData() to build all template variables from structured fields
-						sgData := summaryForClient.SendGridDynamicData()
-						for k, v := range sgData {
-							dynamicData[k] = v
-						}
-
-						if summaryForClient.Body != "" {
-							dynamicData["body"] = summaryForClient.Body
-						}
-
-						// Generate statusHtml from the context-memory API status.
-						// If status is empty (API didn't set it), fall back to VM inspection.
-						if summaryForClient.Status != "" {
-							dynamicData["statusHtml"] = buildStatusHtml(*summaryForClient)
-						} else {
-							failed, _, _ := findEarliestFailure(r.vm)
-							fallback := *summaryForClient
-							if failed {
-								fallback.Status = "failed"
-							} else {
-								fallback.Status = "success"
-							}
-							dynamicData["statusHtml"] = buildStatusHtml(fallback)
-						}
-
-						// Use SummaryLine if available, otherwise extract from body
-						summaryLine := summaryForClient.SummaryLine
-						if summaryLine == "" {
-							// Fallback: extract summary line from body or use subject
-							summaryLine = summaryForClient.Subject
-							if strings.Contains(summaryForClient.Body, "\n\n") {
-								firstPara := strings.Split(summaryForClient.Body, "\n\n")[0]
-								if len(firstPara) > 0 && len(firstPara) < 200 {
-									summaryLine = firstPara
-								}
-							}
-						}
-						dynamicData["summary"] = summaryLine
-
-						// Set preheader from subject (context-memory API provides correct subject format)
-						dynamicData["preheader"] = summaryForClient.Subject
-					}
-
-					// Ensure 'from' object includes a display name for better inbox rendering
-					if fromObj, ok := bodyObj["from"].(map[string]interface{}); ok {
-						if _, hasName := fromObj["name"]; !hasName || strings.TrimSpace(asString(fromObj["name"])) == "" {
-							fromObj["name"] = "AP Studio Notification"
-							bodyObj["from"] = fromObj
-						}
-					}
-
-					// Set SendGrid category for filtering in Activity Feed and Stats
-					bodyObj["categories"] = []string{"workflow-summary"}
-
-					// Provide dynamic_template_data both at top-level and per-personalization to satisfy API variants
-					bodyObj["dynamic_template_data"] = dynamicData
-
-					// Attach dynamic_template_data per-personalization; DO NOT set subject here when using template {{{subject}}}
-					if pers, ok := bodyObj["personalizations"].([]interface{}); ok {
-						for i := range pers {
-							if p, ok := pers[i].(map[string]interface{}); ok {
-								// Pass all dynamic template data (SendGrid expects snake_case)
-								p["dynamic_template_data"] = dynamicData
-								pers[i] = p
-							}
-						}
-						bodyObj["personalizations"] = pers
-					}
-
-					// Remove any content array; Dynamic Templates should not include 'content'
-					delete(bodyObj, "content")
-				case "telegram":
-					// Format summary for Telegram: concise, chat-friendly message
-					// Pass VM so transfer events can be formatted as transfer notifications
-					telegramMsg := FormatForMessageChannels(s, "telegram", r.vm)
-					bodyObj["parse_mode"] = "HTML"
-					bodyObj["text"] = telegramMsg
-				}
-				// Use FormatAsJSON to ensure HTML characters are not escaped in the body
+			if json.Unmarshal([]byte(body), &bodyObj) == nil {
+				telegramMsg := FormatForMessageChannels(s, "telegram", r.vm)
+				bodyObj["parse_mode"] = "HTML"
+				bodyObj["text"] = telegramMsg
 				body = FormatAsJSON(bodyObj)
-				if r.vm.logger != nil {
-					r.vm.logger.Debug("REST API injected composed summary into provider payload", "provider", provider)
-				}
 			} else if r.vm.logger != nil {
 				r.vm.logger.Warn("REST API summarize enabled but body is not JSON, skipping injection")
 			}
@@ -1133,6 +815,21 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 		var jsonData interface{}
 		if err := json.Unmarshal(response.Body(), &jsonData); err == nil {
 			bodyData = jsonData
+			if isStudioNotify {
+				// /api/notify returns { ok, summary }. Surface the run summary (subject + body
+				// line) to the SDK so the UI keeps showing it — same shape the legacy local
+				// summary produced. Omitted for format=plain (no summary in the response).
+				if m, ok := jsonData.(map[string]interface{}); ok {
+					if summaryVal, ok := m["summary"].(map[string]interface{}); ok {
+						subj, _ := summaryVal["subject"].(string)
+						bodyText := ""
+						if bodyMap, ok := summaryVal["body"].(map[string]interface{}); ok {
+							bodyText, _ = bodyMap["summary"].(string)
+						}
+						bodyData = map[string]interface{}{"subject": subj, "body": bodyText}
+					}
+				}
+			}
 		} else {
 			bodyData = bodyStr
 		}
@@ -1224,12 +921,12 @@ func shouldSummarize(vm *VM, node *avsproto.RestAPINode) bool {
 	return false
 }
 
-// detectNotificationProvider returns "sendgrid" or "telegram" based on URL patterns; empty string if unknown
+// detectNotificationProvider returns "studio-notify" or "telegram" based on URL patterns; empty string if unknown
 func detectNotificationProvider(u string) string {
 	lu := strings.ToLower(u)
-	// SendGrid: allow detection by path for tests using mock servers
-	if strings.Contains(lu, "/v3/mail/send") || strings.Contains(lu, "/mail/send") || strings.Contains(lu, "api.sendgrid.com") && strings.Contains(lu, "/mail/send") {
-		return "sendgrid"
+	// Studio /api/notify — Path B distribution endpoint (path-based so mock servers match).
+	if strings.Contains(lu, "/api/notify") {
+		return "studio-notify"
 	}
 	if strings.Contains(lu, "api.telegram.org") && strings.Contains(lu, "/sendmessage") {
 		return "telegram"

--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -684,7 +684,7 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 
 	// Optionally compose summary and inject into provider payloads when enabled via nodeConfig.options.summarize
 	// Keep a reference to the composed summary so we can return it to clients even
-	// when the external notification provider (e.g., SendGrid) returns an empty body.
+	// when the notification provider (Studio /api/notify) returns an empty body.
 	var summaryForClient *Summary
 	isStudioNotify := false
 	if shouldSummarize(r.vm, node) {

--- a/core/testutil/utils.go
+++ b/core/testutil/utils.go
@@ -47,8 +47,19 @@ const (
 
 var testConfig *config.Config
 
-// LoadDotEnv loads environment variables from .env file in the repository root.
-// This allows tests to access OWNER_EOA and other secrets from .env
+// LoadDotEnv loads environment variables from the repository root dotenv files
+// so tests can resolve ${VAR} references in config/test.yaml (e.g. the
+// ${SEPOLIA_BUNDLER_URL} / ${BASE_SEPOLIA_BUNDLER_URL} bundler URLs) and read
+// secrets like OWNER_EOA.
+//
+// Files are loaded in order: .env.local first, then .env. The first file to set
+// a given key wins, so .env.local overrides .env (dotenv convention), and a real
+// process environment variable overrides both. Each file is optional.
+//
+// Note: both files are gitignored. In a fresh git worktree they are absent, so
+// ${VAR} references resolve to empty — that is the cause of the "BundlerURL is
+// empty in test.yaml config" panic in worktrees. Copy or symlink the dotenv
+// files (or export the vars) before running bundler-dependent tests there.
 func LoadDotEnv() error {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
@@ -56,18 +67,37 @@ func LoadDotEnv() error {
 	}
 
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "../.."))
-	envPath := filepath.Join(repoRoot, ".env")
 
-	// Check if .env file exists
-	if _, err := os.Stat(envPath); os.IsNotExist(err) {
-		// .env file doesn't exist, skip silently (tests may use env vars from other sources)
-		return nil
+	loadedAny := false
+	for _, name := range []string{".env.local", ".env"} {
+		loaded, err := loadDotEnvFile(filepath.Join(repoRoot, name))
+		if err != nil {
+			return err
+		}
+		loadedAny = loadedAny || loaded
 	}
 
-	// Read .env file
+	if !loadedAny {
+		// Not fatal — vars may come from the real environment (e.g. CI) — but
+		// surface it so a missing dotenv in a worktree isn't a silent mystery.
+		log.Printf("testutil: no .env.local or .env found under %s; ${VAR} refs in test.yaml rely on the process environment", repoRoot)
+	}
+
+	return nil
+}
+
+// loadDotEnvFile reads a single KEY=VALUE dotenv file, setting each key only if
+// it is not already present in the environment. Returns (false, nil) when the
+// file does not exist. Existing env vars (and earlier-loaded files) take
+// precedence, so callers should load higher-priority files first.
+func loadDotEnvFile(envPath string) (bool, error) {
+	if _, err := os.Stat(envPath); os.IsNotExist(err) {
+		return false, nil
+	}
+
 	file, err := os.Open(envPath)
 	if err != nil {
-		return fmt.Errorf("failed to open .env file: %w", err)
+		return false, fmt.Errorf("failed to open %s: %w", envPath, err)
 	}
 	defer file.Close()
 
@@ -92,17 +122,17 @@ func LoadDotEnv() error {
 		// Remove quotes if present
 		value = strings.Trim(value, `"'`)
 
-		// Only set if not already set in environment (env vars take precedence)
+		// Only set if not already set (real env + earlier files take precedence)
 		if os.Getenv(key) == "" {
 			os.Setenv(key, value)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading .env file: %w", err)
+		return false, fmt.Errorf("error reading %s: %w", envPath, err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // init loads environment variables from .env file only.

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -5362,9 +5362,17 @@ type RunNodeWithInputsReq struct {
 	InputVariables map[string]*structpb.Value `protobuf:"bytes,3,rep,name=input_variables,json=inputVariables,proto3" json:"input_variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Input variables for the node
 	// Chain to run the node against. 0 = aggregator default chain.
 	// node.config.chain_id (if non-zero) takes precedence over this field.
-	ChainId       int64 `protobuf:"varint,4,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ChainId int64 `protobuf:"varint,4,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	// Optional ERC20 balance/allowance state overrides applied only during this
+	// isolated node simulation (RunNodeImmediately). Lets callers seed token
+	// balances and approvals so contract-write simulations (e.g. Uniswap swaps)
+	// don't revert with "transfer amount exceeds allowance/balance" before the
+	// approval/funding transactions have been run. Simulation-only: a
+	// real-execution request (isSimulated=false) that sets these is rejected with
+	// an error, never silently ignored.
+	Erc20Overrides []*ERC20StateOverride `protobuf:"bytes,5,rep,name=erc20_overrides,json=erc20Overrides,proto3" json:"erc20_overrides,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *RunNodeWithInputsReq) Reset() {
@@ -5418,6 +5426,110 @@ func (x *RunNodeWithInputsReq) GetChainId() int64 {
 	return 0
 }
 
+func (x *RunNodeWithInputsReq) GetErc20Overrides() []*ERC20StateOverride {
+	if x != nil {
+		return x.Erc20Overrides
+	}
+	return nil
+}
+
+// ERC20StateOverride seeds a token's balanceOf / allowance storage slots for a
+// single simulation. The slot for balanceOf[owner] is
+// keccak256(abi.encode(owner, balance_slot)); the slot for
+// allowance[owner][spender] is
+// keccak256(abi.encode(spender, keccak256(abi.encode(owner, allowance_slot)))).
+type ERC20StateOverride struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	TokenAddress   string                 `protobuf:"bytes,1,opt,name=token_address,json=tokenAddress,proto3" json:"token_address,omitempty"`             // ERC20 token contract address
+	OwnerAddress   string                 `protobuf:"bytes,2,opt,name=owner_address,json=ownerAddress,proto3" json:"owner_address,omitempty"`             // Address whose balance/allowance to override
+	SpenderAddress *string                `protobuf:"bytes,3,opt,name=spender_address,json=spenderAddress,proto3,oneof" json:"spender_address,omitempty"` // Spender to approve (required for allowance override)
+	Balance        *string                `protobuf:"bytes,4,opt,name=balance,proto3,oneof" json:"balance,omitempty"`                                     // Balance override (hex 0x… or decimal string)
+	Allowance      *string                `protobuf:"bytes,5,opt,name=allowance,proto3,oneof" json:"allowance,omitempty"`                                 // Allowance override (hex 0x… or decimal string)
+	BalanceSlot    *uint64                `protobuf:"varint,6,opt,name=balance_slot,json=balanceSlot,proto3,oneof" json:"balance_slot,omitempty"`         // Storage slot for the balanceOf mapping (required when balance is set; layout varies per token)
+	AllowanceSlot  *uint64                `protobuf:"varint,7,opt,name=allowance_slot,json=allowanceSlot,proto3,oneof" json:"allowance_slot,omitempty"`   // Storage slot for the allowance mapping (required when allowance is set; layout varies per token)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ERC20StateOverride) Reset() {
+	*x = ERC20StateOverride{}
+	mi := &file_avs_proto_msgTypes[67]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ERC20StateOverride) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ERC20StateOverride) ProtoMessage() {}
+
+func (x *ERC20StateOverride) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[67]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ERC20StateOverride.ProtoReflect.Descriptor instead.
+func (*ERC20StateOverride) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{67}
+}
+
+func (x *ERC20StateOverride) GetTokenAddress() string {
+	if x != nil {
+		return x.TokenAddress
+	}
+	return ""
+}
+
+func (x *ERC20StateOverride) GetOwnerAddress() string {
+	if x != nil {
+		return x.OwnerAddress
+	}
+	return ""
+}
+
+func (x *ERC20StateOverride) GetSpenderAddress() string {
+	if x != nil && x.SpenderAddress != nil {
+		return *x.SpenderAddress
+	}
+	return ""
+}
+
+func (x *ERC20StateOverride) GetBalance() string {
+	if x != nil && x.Balance != nil {
+		return *x.Balance
+	}
+	return ""
+}
+
+func (x *ERC20StateOverride) GetAllowance() string {
+	if x != nil && x.Allowance != nil {
+		return *x.Allowance
+	}
+	return ""
+}
+
+func (x *ERC20StateOverride) GetBalanceSlot() uint64 {
+	if x != nil && x.BalanceSlot != nil {
+		return *x.BalanceSlot
+	}
+	return 0
+}
+
+func (x *ERC20StateOverride) GetAllowanceSlot() uint64 {
+	if x != nil && x.AllowanceSlot != nil {
+		return *x.AllowanceSlot
+	}
+	return 0
+}
+
 // Response message for RunNodeWithInputs
 type RunNodeWithInputsResp struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
@@ -5449,7 +5561,7 @@ type RunNodeWithInputsResp struct {
 
 func (x *RunNodeWithInputsResp) Reset() {
 	*x = RunNodeWithInputsResp{}
-	mi := &file_avs_proto_msgTypes[67]
+	mi := &file_avs_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5461,7 +5573,7 @@ func (x *RunNodeWithInputsResp) String() string {
 func (*RunNodeWithInputsResp) ProtoMessage() {}
 
 func (x *RunNodeWithInputsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[67]
+	mi := &file_avs_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5474,7 +5586,7 @@ func (x *RunNodeWithInputsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunNodeWithInputsResp.ProtoReflect.Descriptor instead.
 func (*RunNodeWithInputsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{67}
+	return file_avs_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *RunNodeWithInputsResp) GetSuccess() bool {
@@ -5686,7 +5798,7 @@ type RunTriggerReq struct {
 
 func (x *RunTriggerReq) Reset() {
 	*x = RunTriggerReq{}
-	mi := &file_avs_proto_msgTypes[68]
+	mi := &file_avs_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5698,7 +5810,7 @@ func (x *RunTriggerReq) String() string {
 func (*RunTriggerReq) ProtoMessage() {}
 
 func (x *RunTriggerReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[68]
+	mi := &file_avs_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5711,7 +5823,7 @@ func (x *RunTriggerReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTriggerReq.ProtoReflect.Descriptor instead.
 func (*RunTriggerReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{68}
+	return file_avs_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *RunTriggerReq) GetTrigger() *TaskTrigger {
@@ -5754,7 +5866,7 @@ type RunTriggerResp struct {
 
 func (x *RunTriggerResp) Reset() {
 	*x = RunTriggerResp{}
-	mi := &file_avs_proto_msgTypes[69]
+	mi := &file_avs_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5766,7 +5878,7 @@ func (x *RunTriggerResp) String() string {
 func (*RunTriggerResp) ProtoMessage() {}
 
 func (x *RunTriggerResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[69]
+	mi := &file_avs_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5779,7 +5891,7 @@ func (x *RunTriggerResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTriggerResp.ProtoReflect.Descriptor instead.
 func (*RunTriggerResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{69}
+	return file_avs_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *RunTriggerResp) GetSuccess() bool {
@@ -5920,7 +6032,7 @@ type SimulateTaskReq struct {
 
 func (x *SimulateTaskReq) Reset() {
 	*x = SimulateTaskReq{}
-	mi := &file_avs_proto_msgTypes[70]
+	mi := &file_avs_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5932,7 +6044,7 @@ func (x *SimulateTaskReq) String() string {
 func (*SimulateTaskReq) ProtoMessage() {}
 
 func (x *SimulateTaskReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[70]
+	mi := &file_avs_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5945,7 +6057,7 @@ func (x *SimulateTaskReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SimulateTaskReq.ProtoReflect.Descriptor instead.
 func (*SimulateTaskReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{70}
+	return file_avs_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *SimulateTaskReq) GetTrigger() *TaskTrigger {
@@ -6007,7 +6119,7 @@ type EstimateFeesReq struct {
 
 func (x *EstimateFeesReq) Reset() {
 	*x = EstimateFeesReq{}
-	mi := &file_avs_proto_msgTypes[71]
+	mi := &file_avs_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6019,7 +6131,7 @@ func (x *EstimateFeesReq) String() string {
 func (*EstimateFeesReq) ProtoMessage() {}
 
 func (x *EstimateFeesReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[71]
+	mi := &file_avs_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6032,7 +6144,7 @@ func (x *EstimateFeesReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeesReq.ProtoReflect.Descriptor instead.
 func (*EstimateFeesReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{71}
+	return file_avs_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *EstimateFeesReq) GetTrigger() *TaskTrigger {
@@ -6111,7 +6223,7 @@ type FeeAmount struct {
 
 func (x *FeeAmount) Reset() {
 	*x = FeeAmount{}
-	mi := &file_avs_proto_msgTypes[72]
+	mi := &file_avs_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6123,7 +6235,7 @@ func (x *FeeAmount) String() string {
 func (*FeeAmount) ProtoMessage() {}
 
 func (x *FeeAmount) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[72]
+	mi := &file_avs_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6136,7 +6248,7 @@ func (x *FeeAmount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeAmount.ProtoReflect.Descriptor instead.
 func (*FeeAmount) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{72}
+	return file_avs_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *FeeAmount) GetNativeTokenAmount() string {
@@ -6184,7 +6296,7 @@ type GasFeeBreakdown struct {
 
 func (x *GasFeeBreakdown) Reset() {
 	*x = GasFeeBreakdown{}
-	mi := &file_avs_proto_msgTypes[73]
+	mi := &file_avs_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6196,7 +6308,7 @@ func (x *GasFeeBreakdown) String() string {
 func (*GasFeeBreakdown) ProtoMessage() {}
 
 func (x *GasFeeBreakdown) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[73]
+	mi := &file_avs_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6209,7 +6321,7 @@ func (x *GasFeeBreakdown) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GasFeeBreakdown.ProtoReflect.Descriptor instead.
 func (*GasFeeBreakdown) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{73}
+	return file_avs_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GasFeeBreakdown) GetTotalGasFees() *FeeAmount {
@@ -6268,7 +6380,7 @@ type GasOperationFee struct {
 
 func (x *GasOperationFee) Reset() {
 	*x = GasOperationFee{}
-	mi := &file_avs_proto_msgTypes[74]
+	mi := &file_avs_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6280,7 +6392,7 @@ func (x *GasOperationFee) String() string {
 func (*GasOperationFee) ProtoMessage() {}
 
 func (x *GasOperationFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[74]
+	mi := &file_avs_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6293,7 +6405,7 @@ func (x *GasOperationFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GasOperationFee.ProtoReflect.Descriptor instead.
 func (*GasOperationFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{74}
+	return file_avs_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GasOperationFee) GetOperationType() string {
@@ -6344,7 +6456,7 @@ type SmartWalletCreationFee struct {
 
 func (x *SmartWalletCreationFee) Reset() {
 	*x = SmartWalletCreationFee{}
-	mi := &file_avs_proto_msgTypes[75]
+	mi := &file_avs_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6356,7 +6468,7 @@ func (x *SmartWalletCreationFee) String() string {
 func (*SmartWalletCreationFee) ProtoMessage() {}
 
 func (x *SmartWalletCreationFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[75]
+	mi := &file_avs_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6369,7 +6481,7 @@ func (x *SmartWalletCreationFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SmartWalletCreationFee.ProtoReflect.Descriptor instead.
 func (*SmartWalletCreationFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{75}
+	return file_avs_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SmartWalletCreationFee) GetCreationRequired() bool {
@@ -6412,7 +6524,7 @@ type Fee struct {
 
 func (x *Fee) Reset() {
 	*x = Fee{}
-	mi := &file_avs_proto_msgTypes[76]
+	mi := &file_avs_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6424,7 +6536,7 @@ func (x *Fee) String() string {
 func (*Fee) ProtoMessage() {}
 
 func (x *Fee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[76]
+	mi := &file_avs_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6437,7 +6549,7 @@ func (x *Fee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Fee.ProtoReflect.Descriptor instead.
 func (*Fee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{76}
+	return file_avs_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *Fee) GetAmount() string {
@@ -6465,7 +6577,7 @@ type NativeToken struct {
 
 func (x *NativeToken) Reset() {
 	*x = NativeToken{}
-	mi := &file_avs_proto_msgTypes[77]
+	mi := &file_avs_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6477,7 +6589,7 @@ func (x *NativeToken) String() string {
 func (*NativeToken) ProtoMessage() {}
 
 func (x *NativeToken) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[77]
+	mi := &file_avs_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6490,7 +6602,7 @@ func (x *NativeToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NativeToken.ProtoReflect.Descriptor instead.
 func (*NativeToken) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{77}
+	return file_avs_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *NativeToken) GetSymbol() string {
@@ -6520,7 +6632,7 @@ type NodeCOGS struct {
 
 func (x *NodeCOGS) Reset() {
 	*x = NodeCOGS{}
-	mi := &file_avs_proto_msgTypes[78]
+	mi := &file_avs_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6532,7 +6644,7 @@ func (x *NodeCOGS) String() string {
 func (*NodeCOGS) ProtoMessage() {}
 
 func (x *NodeCOGS) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[78]
+	mi := &file_avs_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6545,7 +6657,7 @@ func (x *NodeCOGS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeCOGS.ProtoReflect.Descriptor instead.
 func (*NodeCOGS) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{78}
+	return file_avs_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *NodeCOGS) GetNodeId() string {
@@ -6592,7 +6704,7 @@ type ValueFee struct {
 
 func (x *ValueFee) Reset() {
 	*x = ValueFee{}
-	mi := &file_avs_proto_msgTypes[79]
+	mi := &file_avs_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6604,7 +6716,7 @@ func (x *ValueFee) String() string {
 func (*ValueFee) ProtoMessage() {}
 
 func (x *ValueFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[79]
+	mi := &file_avs_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6617,7 +6729,7 @@ func (x *ValueFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValueFee.ProtoReflect.Descriptor instead.
 func (*ValueFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{79}
+	return file_avs_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ValueFee) GetFee() *Fee {
@@ -6676,7 +6788,7 @@ type FeeDiscount struct {
 
 func (x *FeeDiscount) Reset() {
 	*x = FeeDiscount{}
-	mi := &file_avs_proto_msgTypes[80]
+	mi := &file_avs_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6688,7 +6800,7 @@ func (x *FeeDiscount) String() string {
 func (*FeeDiscount) ProtoMessage() {}
 
 func (x *FeeDiscount) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[80]
+	mi := &file_avs_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6701,7 +6813,7 @@ func (x *FeeDiscount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeDiscount.ProtoReflect.Descriptor instead.
 func (*FeeDiscount) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{80}
+	return file_avs_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *FeeDiscount) GetDiscountType() string {
@@ -6767,7 +6879,7 @@ type EstimateFeesResp struct {
 
 func (x *EstimateFeesResp) Reset() {
 	*x = EstimateFeesResp{}
-	mi := &file_avs_proto_msgTypes[81]
+	mi := &file_avs_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6779,7 +6891,7 @@ func (x *EstimateFeesResp) String() string {
 func (*EstimateFeesResp) ProtoMessage() {}
 
 func (x *EstimateFeesResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[81]
+	mi := &file_avs_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6792,7 +6904,7 @@ func (x *EstimateFeesResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeesResp.ProtoReflect.Descriptor instead.
 func (*EstimateFeesResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{81}
+	return file_avs_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *EstimateFeesResp) GetSuccess() bool {
@@ -6872,7 +6984,11 @@ func (x *EstimateFeesResp) GetWarnings() []string {
 	return nil
 }
 
-// EventCondition represents a condition to evaluate on decoded event data
+// EventCondition represents a condition to evaluate on decoded event data.
+// MIRRORED in api/openapi.yaml (components.schemas.EventCondition). The two
+// schemas must agree on every field's type — `value` in particular MUST stay
+// `string` in both. Past schema drift here (OpenAPI authored as an object,
+// proto as a string) broke production simulate requests; see PR #601.
 type EventCondition struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	FieldName     string                 `protobuf:"bytes,1,opt,name=field_name,json=fieldName,proto3" json:"field_name,omitempty"` // Event field name (e.g., "answer", "roundId")
@@ -6885,7 +7001,7 @@ type EventCondition struct {
 
 func (x *EventCondition) Reset() {
 	*x = EventCondition{}
-	mi := &file_avs_proto_msgTypes[82]
+	mi := &file_avs_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6897,7 +7013,7 @@ func (x *EventCondition) String() string {
 func (*EventCondition) ProtoMessage() {}
 
 func (x *EventCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[82]
+	mi := &file_avs_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6910,7 +7026,7 @@ func (x *EventCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventCondition.ProtoReflect.Descriptor instead.
 func (*EventCondition) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{82}
+	return file_avs_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *EventCondition) GetFieldName() string {
@@ -6950,7 +7066,7 @@ type FixedTimeTrigger_Config struct {
 
 func (x *FixedTimeTrigger_Config) Reset() {
 	*x = FixedTimeTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[83]
+	mi := &file_avs_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6962,7 +7078,7 @@ func (x *FixedTimeTrigger_Config) String() string {
 func (*FixedTimeTrigger_Config) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[83]
+	mi := &file_avs_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6994,7 +7110,7 @@ type FixedTimeTrigger_Output struct {
 
 func (x *FixedTimeTrigger_Output) Reset() {
 	*x = FixedTimeTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[84]
+	mi := &file_avs_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7006,7 +7122,7 @@ func (x *FixedTimeTrigger_Output) String() string {
 func (*FixedTimeTrigger_Output) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[84]
+	mi := &file_avs_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7038,7 +7154,7 @@ type CronTrigger_Config struct {
 
 func (x *CronTrigger_Config) Reset() {
 	*x = CronTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7050,7 +7166,7 @@ func (x *CronTrigger_Config) String() string {
 func (*CronTrigger_Config) ProtoMessage() {}
 
 func (x *CronTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7082,7 +7198,7 @@ type CronTrigger_Output struct {
 
 func (x *CronTrigger_Output) Reset() {
 	*x = CronTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7094,7 +7210,7 @@ func (x *CronTrigger_Output) String() string {
 func (*CronTrigger_Output) ProtoMessage() {}
 
 func (x *CronTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7128,7 +7244,7 @@ type BlockTrigger_Config struct {
 
 func (x *BlockTrigger_Config) Reset() {
 	*x = BlockTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7140,7 +7256,7 @@ func (x *BlockTrigger_Config) String() string {
 func (*BlockTrigger_Config) ProtoMessage() {}
 
 func (x *BlockTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7179,7 +7295,7 @@ type BlockTrigger_Output struct {
 
 func (x *BlockTrigger_Output) Reset() {
 	*x = BlockTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7191,7 +7307,7 @@ func (x *BlockTrigger_Output) String() string {
 func (*BlockTrigger_Output) ProtoMessage() {}
 
 func (x *BlockTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7251,7 +7367,7 @@ type EventTrigger_Query struct {
 
 func (x *EventTrigger_Query) Reset() {
 	*x = EventTrigger_Query{}
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7263,7 +7379,7 @@ func (x *EventTrigger_Query) String() string {
 func (*EventTrigger_Query) ProtoMessage() {}
 
 func (x *EventTrigger_Query) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7334,7 +7450,7 @@ type EventTrigger_MethodCall struct {
 
 func (x *EventTrigger_MethodCall) Reset() {
 	*x = EventTrigger_MethodCall{}
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7346,7 +7462,7 @@ func (x *EventTrigger_MethodCall) String() string {
 func (*EventTrigger_MethodCall) ProtoMessage() {}
 
 func (x *EventTrigger_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7409,7 +7525,7 @@ type EventTrigger_Config struct {
 
 func (x *EventTrigger_Config) Reset() {
 	*x = EventTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7421,7 +7537,7 @@ func (x *EventTrigger_Config) String() string {
 func (*EventTrigger_Config) ProtoMessage() {}
 
 func (x *EventTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7467,7 +7583,7 @@ type EventTrigger_Output struct {
 
 func (x *EventTrigger_Output) Reset() {
 	*x = EventTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7479,7 +7595,7 @@ func (x *EventTrigger_Output) String() string {
 func (*EventTrigger_Output) ProtoMessage() {}
 
 func (x *EventTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7519,7 +7635,7 @@ type ManualTrigger_Config struct {
 
 func (x *ManualTrigger_Config) Reset() {
 	*x = ManualTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7531,7 +7647,7 @@ func (x *ManualTrigger_Config) String() string {
 func (*ManualTrigger_Config) ProtoMessage() {}
 
 func (x *ManualTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7585,7 +7701,7 @@ type ManualTrigger_Output struct {
 
 func (x *ManualTrigger_Output) Reset() {
 	*x = ManualTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7597,7 +7713,7 @@ func (x *ManualTrigger_Output) String() string {
 func (*ManualTrigger_Output) ProtoMessage() {}
 
 func (x *ManualTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7632,7 +7748,7 @@ type ETHTransferNode_Config struct {
 
 func (x *ETHTransferNode_Config) Reset() {
 	*x = ETHTransferNode_Config{}
-	mi := &file_avs_proto_msgTypes[97]
+	mi := &file_avs_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7644,7 +7760,7 @@ func (x *ETHTransferNode_Config) String() string {
 func (*ETHTransferNode_Config) ProtoMessage() {}
 
 func (x *ETHTransferNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[97]
+	mi := &file_avs_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7690,7 +7806,7 @@ type ETHTransferNode_Output struct {
 
 func (x *ETHTransferNode_Output) Reset() {
 	*x = ETHTransferNode_Output{}
-	mi := &file_avs_proto_msgTypes[98]
+	mi := &file_avs_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7702,7 +7818,7 @@ func (x *ETHTransferNode_Output) String() string {
 func (*ETHTransferNode_Output) ProtoMessage() {}
 
 func (x *ETHTransferNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[98]
+	mi := &file_avs_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7747,7 +7863,7 @@ type ContractWriteNode_Config struct {
 
 func (x *ContractWriteNode_Config) Reset() {
 	*x = ContractWriteNode_Config{}
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7759,7 +7875,7 @@ func (x *ContractWriteNode_Config) String() string {
 func (*ContractWriteNode_Config) ProtoMessage() {}
 
 func (x *ContractWriteNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7843,7 +7959,7 @@ type ContractWriteNode_MethodCall struct {
 
 func (x *ContractWriteNode_MethodCall) Reset() {
 	*x = ContractWriteNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7855,7 +7971,7 @@ func (x *ContractWriteNode_MethodCall) String() string {
 func (*ContractWriteNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7910,7 +8026,7 @@ type ContractWriteNode_Output struct {
 
 func (x *ContractWriteNode_Output) Reset() {
 	*x = ContractWriteNode_Output{}
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7922,7 +8038,7 @@ func (x *ContractWriteNode_Output) String() string {
 func (*ContractWriteNode_Output) ProtoMessage() {}
 
 func (x *ContractWriteNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7960,7 +8076,7 @@ type ContractWriteNode_MethodResult struct {
 
 func (x *ContractWriteNode_MethodResult) Reset() {
 	*x = ContractWriteNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7972,7 +8088,7 @@ func (x *ContractWriteNode_MethodResult) String() string {
 func (*ContractWriteNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8049,7 +8165,7 @@ type ContractReadNode_MethodCall struct {
 
 func (x *ContractReadNode_MethodCall) Reset() {
 	*x = ContractReadNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8061,7 +8177,7 @@ func (x *ContractReadNode_MethodCall) String() string {
 func (*ContractReadNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8120,7 +8236,7 @@ type ContractReadNode_Config struct {
 
 func (x *ContractReadNode_Config) Reset() {
 	*x = ContractReadNode_Config{}
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8132,7 +8248,7 @@ func (x *ContractReadNode_Config) String() string {
 func (*ContractReadNode_Config) ProtoMessage() {}
 
 func (x *ContractReadNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8189,7 +8305,7 @@ type ContractReadNode_MethodResult struct {
 
 func (x *ContractReadNode_MethodResult) Reset() {
 	*x = ContractReadNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8201,7 +8317,7 @@ func (x *ContractReadNode_MethodResult) String() string {
 func (*ContractReadNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8256,7 +8372,7 @@ type ContractReadNode_Output struct {
 
 func (x *ContractReadNode_Output) Reset() {
 	*x = ContractReadNode_Output{}
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8268,7 +8384,7 @@ func (x *ContractReadNode_Output) String() string {
 func (*ContractReadNode_Output) ProtoMessage() {}
 
 func (x *ContractReadNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8303,7 +8419,7 @@ type ContractReadNode_MethodResult_StructuredField struct {
 
 func (x *ContractReadNode_MethodResult_StructuredField) Reset() {
 	*x = ContractReadNode_MethodResult_StructuredField{}
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8315,7 +8431,7 @@ func (x *ContractReadNode_MethodResult_StructuredField) String() string {
 func (*ContractReadNode_MethodResult_StructuredField) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult_StructuredField) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8364,7 +8480,7 @@ type GraphQLQueryNode_Config struct {
 
 func (x *GraphQLQueryNode_Config) Reset() {
 	*x = GraphQLQueryNode_Config{}
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8376,7 +8492,7 @@ func (x *GraphQLQueryNode_Config) String() string {
 func (*GraphQLQueryNode_Config) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8424,7 +8540,7 @@ type GraphQLQueryNode_Output struct {
 
 func (x *GraphQLQueryNode_Output) Reset() {
 	*x = GraphQLQueryNode_Output{}
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8436,7 +8552,7 @@ func (x *GraphQLQueryNode_Output) String() string {
 func (*GraphQLQueryNode_Output) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8473,7 +8589,7 @@ type RestAPINode_Config struct {
 
 func (x *RestAPINode_Config) Reset() {
 	*x = RestAPINode_Config{}
-	mi := &file_avs_proto_msgTypes[111]
+	mi := &file_avs_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8485,7 +8601,7 @@ func (x *RestAPINode_Config) String() string {
 func (*RestAPINode_Config) ProtoMessage() {}
 
 func (x *RestAPINode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[111]
+	mi := &file_avs_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8546,7 +8662,7 @@ type RestAPINode_Output struct {
 
 func (x *RestAPINode_Output) Reset() {
 	*x = RestAPINode_Output{}
-	mi := &file_avs_proto_msgTypes[112]
+	mi := &file_avs_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8558,7 +8674,7 @@ func (x *RestAPINode_Output) String() string {
 func (*RestAPINode_Output) ProtoMessage() {}
 
 func (x *RestAPINode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[112]
+	mi := &file_avs_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8591,7 +8707,7 @@ type CustomCodeNode_Config struct {
 
 func (x *CustomCodeNode_Config) Reset() {
 	*x = CustomCodeNode_Config{}
-	mi := &file_avs_proto_msgTypes[114]
+	mi := &file_avs_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8603,7 +8719,7 @@ func (x *CustomCodeNode_Config) String() string {
 func (*CustomCodeNode_Config) ProtoMessage() {}
 
 func (x *CustomCodeNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[114]
+	mi := &file_avs_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8643,7 +8759,7 @@ type CustomCodeNode_Output struct {
 
 func (x *CustomCodeNode_Output) Reset() {
 	*x = CustomCodeNode_Output{}
-	mi := &file_avs_proto_msgTypes[115]
+	mi := &file_avs_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8655,7 +8771,7 @@ func (x *CustomCodeNode_Output) String() string {
 func (*CustomCodeNode_Output) ProtoMessage() {}
 
 func (x *CustomCodeNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[115]
+	mi := &file_avs_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8720,7 +8836,7 @@ type BalanceNode_Config struct {
 
 func (x *BalanceNode_Config) Reset() {
 	*x = BalanceNode_Config{}
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8732,7 +8848,7 @@ func (x *BalanceNode_Config) String() string {
 func (*BalanceNode_Config) ProtoMessage() {}
 
 func (x *BalanceNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8803,7 +8919,7 @@ type BalanceNode_Output struct {
 
 func (x *BalanceNode_Output) Reset() {
 	*x = BalanceNode_Output{}
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8815,7 +8931,7 @@ func (x *BalanceNode_Output) String() string {
 func (*BalanceNode_Output) ProtoMessage() {}
 
 func (x *BalanceNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8849,7 +8965,7 @@ type BranchNode_Condition struct {
 
 func (x *BranchNode_Condition) Reset() {
 	*x = BranchNode_Condition{}
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8861,7 +8977,7 @@ func (x *BranchNode_Condition) String() string {
 func (*BranchNode_Condition) ProtoMessage() {}
 
 func (x *BranchNode_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8907,7 +9023,7 @@ type BranchNode_Config struct {
 
 func (x *BranchNode_Config) Reset() {
 	*x = BranchNode_Config{}
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8919,7 +9035,7 @@ func (x *BranchNode_Config) String() string {
 func (*BranchNode_Config) ProtoMessage() {}
 
 func (x *BranchNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8954,7 +9070,7 @@ type BranchNode_Output struct {
 
 func (x *BranchNode_Output) Reset() {
 	*x = BranchNode_Output{}
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8966,7 +9082,7 @@ func (x *BranchNode_Output) String() string {
 func (*BranchNode_Output) ProtoMessage() {}
 
 func (x *BranchNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9002,7 +9118,7 @@ type FilterNode_Config struct {
 
 func (x *FilterNode_Config) Reset() {
 	*x = FilterNode_Config{}
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9014,7 +9130,7 @@ func (x *FilterNode_Config) String() string {
 func (*FilterNode_Config) ProtoMessage() {}
 
 func (x *FilterNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9054,7 +9170,7 @@ type FilterNode_Output struct {
 
 func (x *FilterNode_Output) Reset() {
 	*x = FilterNode_Output{}
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9066,7 +9182,7 @@ func (x *FilterNode_Output) String() string {
 func (*FilterNode_Output) ProtoMessage() {}
 
 func (x *FilterNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9110,7 +9226,7 @@ type LoopNode_Config struct {
 
 func (x *LoopNode_Config) Reset() {
 	*x = LoopNode_Config{}
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9122,7 +9238,7 @@ func (x *LoopNode_Config) String() string {
 func (*LoopNode_Config) ProtoMessage() {}
 
 func (x *LoopNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9182,7 +9298,7 @@ type LoopNode_Output struct {
 
 func (x *LoopNode_Output) Reset() {
 	*x = LoopNode_Output{}
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9194,7 +9310,7 @@ func (x *LoopNode_Output) String() string {
 func (*LoopNode_Output) ProtoMessage() {}
 
 func (x *LoopNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9269,7 +9385,7 @@ type Execution_Step struct {
 
 func (x *Execution_Step) Reset() {
 	*x = Execution_Step{}
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9281,7 +9397,7 @@ func (x *Execution_Step) String() string {
 func (*Execution_Step) ProtoMessage() {}
 
 func (x *Execution_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10231,14 +10347,30 @@ const file_avs_proto_rawDesc = "" +
 	"\x05total\x18\x01 \x01(\x03R\x05total\x12\x1c\n" +
 	"\tsucceeded\x18\x02 \x01(\x03R\tsucceeded\x12\x16\n" +
 	"\x06failed\x18\x03 \x01(\x03R\x06failed\x12,\n" +
-	"\x12avg_execution_time\x18\x04 \x01(\x01R\x10avgExecutionTime\"\x95\x02\n" +
+	"\x12avg_execution_time\x18\x04 \x01(\x01R\x10avgExecutionTime\"\xde\x02\n" +
 	"\x14RunNodeWithInputsReq\x12(\n" +
 	"\x04node\x18\x01 \x01(\v2\x14.aggregator.TaskNodeR\x04node\x12]\n" +
 	"\x0finput_variables\x18\x03 \x03(\v24.aggregator.RunNodeWithInputsReq.InputVariablesEntryR\x0einputVariables\x12\x19\n" +
-	"\bchain_id\x18\x04 \x01(\x03R\achainId\x1aY\n" +
+	"\bchain_id\x18\x04 \x01(\x03R\achainId\x12G\n" +
+	"\x0ferc20_overrides\x18\x05 \x03(\v2\x1e.aggregator.ERC20StateOverrideR\x0eerc20Overrides\x1aY\n" +
 	"\x13InputVariablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
-	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"\x8e\a\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"\xf4\x02\n" +
+	"\x12ERC20StateOverride\x12#\n" +
+	"\rtoken_address\x18\x01 \x01(\tR\ftokenAddress\x12#\n" +
+	"\rowner_address\x18\x02 \x01(\tR\fownerAddress\x12,\n" +
+	"\x0fspender_address\x18\x03 \x01(\tH\x00R\x0espenderAddress\x88\x01\x01\x12\x1d\n" +
+	"\abalance\x18\x04 \x01(\tH\x01R\abalance\x88\x01\x01\x12!\n" +
+	"\tallowance\x18\x05 \x01(\tH\x02R\tallowance\x88\x01\x01\x12&\n" +
+	"\fbalance_slot\x18\x06 \x01(\x04H\x03R\vbalanceSlot\x88\x01\x01\x12*\n" +
+	"\x0eallowance_slot\x18\a \x01(\x04H\x04R\rallowanceSlot\x88\x01\x01B\x12\n" +
+	"\x10_spender_addressB\n" +
+	"\n" +
+	"\b_balanceB\f\n" +
+	"\n" +
+	"_allowanceB\x0f\n" +
+	"\r_balance_slotB\x11\n" +
+	"\x0f_allowance_slot\"\x8e\a\n" +
 	"\x15RunNodeWithInputsResp\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\x122\n" +
@@ -10482,7 +10614,7 @@ func file_avs_proto_rawDescGZIP() []byte {
 }
 
 var file_avs_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 133)
+var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 134)
 var file_avs_proto_goTypes = []any{
 	(TriggerType)(0),                                      // 0: aggregator.TriggerType
 	(NodeType)(0),                                         // 1: aggregator.NodeType
@@ -10559,103 +10691,104 @@ var file_avs_proto_goTypes = []any{
 	(*GetExecutionStatsReq)(nil),                          // 72: aggregator.GetExecutionStatsReq
 	(*GetExecutionStatsResp)(nil),                         // 73: aggregator.GetExecutionStatsResp
 	(*RunNodeWithInputsReq)(nil),                          // 74: aggregator.RunNodeWithInputsReq
-	(*RunNodeWithInputsResp)(nil),                         // 75: aggregator.RunNodeWithInputsResp
-	(*RunTriggerReq)(nil),                                 // 76: aggregator.RunTriggerReq
-	(*RunTriggerResp)(nil),                                // 77: aggregator.RunTriggerResp
-	(*SimulateTaskReq)(nil),                               // 78: aggregator.SimulateTaskReq
-	(*EstimateFeesReq)(nil),                               // 79: aggregator.EstimateFeesReq
-	(*FeeAmount)(nil),                                     // 80: aggregator.FeeAmount
-	(*GasFeeBreakdown)(nil),                               // 81: aggregator.GasFeeBreakdown
-	(*GasOperationFee)(nil),                               // 82: aggregator.GasOperationFee
-	(*SmartWalletCreationFee)(nil),                        // 83: aggregator.SmartWalletCreationFee
-	(*Fee)(nil),                                           // 84: aggregator.Fee
-	(*NativeToken)(nil),                                   // 85: aggregator.NativeToken
-	(*NodeCOGS)(nil),                                      // 86: aggregator.NodeCOGS
-	(*ValueFee)(nil),                                      // 87: aggregator.ValueFee
-	(*FeeDiscount)(nil),                                   // 88: aggregator.FeeDiscount
-	(*EstimateFeesResp)(nil),                              // 89: aggregator.EstimateFeesResp
-	(*EventCondition)(nil),                                // 90: aggregator.EventCondition
-	(*FixedTimeTrigger_Config)(nil),                       // 91: aggregator.FixedTimeTrigger.Config
-	(*FixedTimeTrigger_Output)(nil),                       // 92: aggregator.FixedTimeTrigger.Output
-	(*CronTrigger_Config)(nil),                            // 93: aggregator.CronTrigger.Config
-	(*CronTrigger_Output)(nil),                            // 94: aggregator.CronTrigger.Output
-	(*BlockTrigger_Config)(nil),                           // 95: aggregator.BlockTrigger.Config
-	(*BlockTrigger_Output)(nil),                           // 96: aggregator.BlockTrigger.Output
-	(*EventTrigger_Query)(nil),                            // 97: aggregator.EventTrigger.Query
-	(*EventTrigger_MethodCall)(nil),                       // 98: aggregator.EventTrigger.MethodCall
-	(*EventTrigger_Config)(nil),                           // 99: aggregator.EventTrigger.Config
-	(*EventTrigger_Output)(nil),                           // 100: aggregator.EventTrigger.Output
-	(*ManualTrigger_Config)(nil),                          // 101: aggregator.ManualTrigger.Config
-	(*ManualTrigger_Output)(nil),                          // 102: aggregator.ManualTrigger.Output
-	nil,                                                   // 103: aggregator.ManualTrigger.Config.HeadersEntry
-	nil,                                                   // 104: aggregator.ManualTrigger.Config.PathParamsEntry
-	(*ETHTransferNode_Config)(nil),                        // 105: aggregator.ETHTransferNode.Config
-	(*ETHTransferNode_Output)(nil),                        // 106: aggregator.ETHTransferNode.Output
-	(*ContractWriteNode_Config)(nil),                      // 107: aggregator.ContractWriteNode.Config
-	(*ContractWriteNode_MethodCall)(nil),                  // 108: aggregator.ContractWriteNode.MethodCall
-	(*ContractWriteNode_Output)(nil),                      // 109: aggregator.ContractWriteNode.Output
-	(*ContractWriteNode_MethodResult)(nil),                // 110: aggregator.ContractWriteNode.MethodResult
-	(*ContractReadNode_MethodCall)(nil),                   // 111: aggregator.ContractReadNode.MethodCall
-	(*ContractReadNode_Config)(nil),                       // 112: aggregator.ContractReadNode.Config
-	(*ContractReadNode_MethodResult)(nil),                 // 113: aggregator.ContractReadNode.MethodResult
-	(*ContractReadNode_Output)(nil),                       // 114: aggregator.ContractReadNode.Output
-	(*ContractReadNode_MethodResult_StructuredField)(nil), // 115: aggregator.ContractReadNode.MethodResult.StructuredField
-	(*GraphQLQueryNode_Config)(nil),                       // 116: aggregator.GraphQLQueryNode.Config
-	(*GraphQLQueryNode_Output)(nil),                       // 117: aggregator.GraphQLQueryNode.Output
-	nil,                                                   // 118: aggregator.GraphQLQueryNode.Config.VariablesEntry
-	(*RestAPINode_Config)(nil),                            // 119: aggregator.RestAPINode.Config
-	(*RestAPINode_Output)(nil),                            // 120: aggregator.RestAPINode.Output
-	nil,                                                   // 121: aggregator.RestAPINode.Config.HeadersEntry
-	(*CustomCodeNode_Config)(nil),                         // 122: aggregator.CustomCodeNode.Config
-	(*CustomCodeNode_Output)(nil),                         // 123: aggregator.CustomCodeNode.Output
-	(*BalanceNode_Config)(nil),                            // 124: aggregator.BalanceNode.Config
-	(*BalanceNode_Output)(nil),                            // 125: aggregator.BalanceNode.Output
-	(*BranchNode_Condition)(nil),                          // 126: aggregator.BranchNode.Condition
-	(*BranchNode_Config)(nil),                             // 127: aggregator.BranchNode.Config
-	(*BranchNode_Output)(nil),                             // 128: aggregator.BranchNode.Output
-	(*FilterNode_Config)(nil),                             // 129: aggregator.FilterNode.Config
-	(*FilterNode_Output)(nil),                             // 130: aggregator.FilterNode.Output
-	(*LoopNode_Config)(nil),                               // 131: aggregator.LoopNode.Config
-	(*LoopNode_Output)(nil),                               // 132: aggregator.LoopNode.Output
-	(*Execution_Step)(nil),                                // 133: aggregator.Execution.Step
-	nil,                                                   // 134: aggregator.Task.InputVariablesEntry
-	nil,                                                   // 135: aggregator.CreateTaskReq.InputVariablesEntry
-	nil,                                                   // 136: aggregator.TriggerTaskReq.TriggerInputEntry
-	nil,                                                   // 137: aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	nil,                                                   // 138: aggregator.RunTriggerReq.TriggerInputEntry
-	nil,                                                   // 139: aggregator.SimulateTaskReq.InputVariablesEntry
-	nil,                                                   // 140: aggregator.EstimateFeesReq.InputVariablesEntry
-	(*structpb.Value)(nil),                                // 141: google.protobuf.Value
+	(*ERC20StateOverride)(nil),                            // 75: aggregator.ERC20StateOverride
+	(*RunNodeWithInputsResp)(nil),                         // 76: aggregator.RunNodeWithInputsResp
+	(*RunTriggerReq)(nil),                                 // 77: aggregator.RunTriggerReq
+	(*RunTriggerResp)(nil),                                // 78: aggregator.RunTriggerResp
+	(*SimulateTaskReq)(nil),                               // 79: aggregator.SimulateTaskReq
+	(*EstimateFeesReq)(nil),                               // 80: aggregator.EstimateFeesReq
+	(*FeeAmount)(nil),                                     // 81: aggregator.FeeAmount
+	(*GasFeeBreakdown)(nil),                               // 82: aggregator.GasFeeBreakdown
+	(*GasOperationFee)(nil),                               // 83: aggregator.GasOperationFee
+	(*SmartWalletCreationFee)(nil),                        // 84: aggregator.SmartWalletCreationFee
+	(*Fee)(nil),                                           // 85: aggregator.Fee
+	(*NativeToken)(nil),                                   // 86: aggregator.NativeToken
+	(*NodeCOGS)(nil),                                      // 87: aggregator.NodeCOGS
+	(*ValueFee)(nil),                                      // 88: aggregator.ValueFee
+	(*FeeDiscount)(nil),                                   // 89: aggregator.FeeDiscount
+	(*EstimateFeesResp)(nil),                              // 90: aggregator.EstimateFeesResp
+	(*EventCondition)(nil),                                // 91: aggregator.EventCondition
+	(*FixedTimeTrigger_Config)(nil),                       // 92: aggregator.FixedTimeTrigger.Config
+	(*FixedTimeTrigger_Output)(nil),                       // 93: aggregator.FixedTimeTrigger.Output
+	(*CronTrigger_Config)(nil),                            // 94: aggregator.CronTrigger.Config
+	(*CronTrigger_Output)(nil),                            // 95: aggregator.CronTrigger.Output
+	(*BlockTrigger_Config)(nil),                           // 96: aggregator.BlockTrigger.Config
+	(*BlockTrigger_Output)(nil),                           // 97: aggregator.BlockTrigger.Output
+	(*EventTrigger_Query)(nil),                            // 98: aggregator.EventTrigger.Query
+	(*EventTrigger_MethodCall)(nil),                       // 99: aggregator.EventTrigger.MethodCall
+	(*EventTrigger_Config)(nil),                           // 100: aggregator.EventTrigger.Config
+	(*EventTrigger_Output)(nil),                           // 101: aggregator.EventTrigger.Output
+	(*ManualTrigger_Config)(nil),                          // 102: aggregator.ManualTrigger.Config
+	(*ManualTrigger_Output)(nil),                          // 103: aggregator.ManualTrigger.Output
+	nil,                                                   // 104: aggregator.ManualTrigger.Config.HeadersEntry
+	nil,                                                   // 105: aggregator.ManualTrigger.Config.PathParamsEntry
+	(*ETHTransferNode_Config)(nil),                        // 106: aggregator.ETHTransferNode.Config
+	(*ETHTransferNode_Output)(nil),                        // 107: aggregator.ETHTransferNode.Output
+	(*ContractWriteNode_Config)(nil),                      // 108: aggregator.ContractWriteNode.Config
+	(*ContractWriteNode_MethodCall)(nil),                  // 109: aggregator.ContractWriteNode.MethodCall
+	(*ContractWriteNode_Output)(nil),                      // 110: aggregator.ContractWriteNode.Output
+	(*ContractWriteNode_MethodResult)(nil),                // 111: aggregator.ContractWriteNode.MethodResult
+	(*ContractReadNode_MethodCall)(nil),                   // 112: aggregator.ContractReadNode.MethodCall
+	(*ContractReadNode_Config)(nil),                       // 113: aggregator.ContractReadNode.Config
+	(*ContractReadNode_MethodResult)(nil),                 // 114: aggregator.ContractReadNode.MethodResult
+	(*ContractReadNode_Output)(nil),                       // 115: aggregator.ContractReadNode.Output
+	(*ContractReadNode_MethodResult_StructuredField)(nil), // 116: aggregator.ContractReadNode.MethodResult.StructuredField
+	(*GraphQLQueryNode_Config)(nil),                       // 117: aggregator.GraphQLQueryNode.Config
+	(*GraphQLQueryNode_Output)(nil),                       // 118: aggregator.GraphQLQueryNode.Output
+	nil,                                                   // 119: aggregator.GraphQLQueryNode.Config.VariablesEntry
+	(*RestAPINode_Config)(nil),                            // 120: aggregator.RestAPINode.Config
+	(*RestAPINode_Output)(nil),                            // 121: aggregator.RestAPINode.Output
+	nil,                                                   // 122: aggregator.RestAPINode.Config.HeadersEntry
+	(*CustomCodeNode_Config)(nil),                         // 123: aggregator.CustomCodeNode.Config
+	(*CustomCodeNode_Output)(nil),                         // 124: aggregator.CustomCodeNode.Output
+	(*BalanceNode_Config)(nil),                            // 125: aggregator.BalanceNode.Config
+	(*BalanceNode_Output)(nil),                            // 126: aggregator.BalanceNode.Output
+	(*BranchNode_Condition)(nil),                          // 127: aggregator.BranchNode.Condition
+	(*BranchNode_Config)(nil),                             // 128: aggregator.BranchNode.Config
+	(*BranchNode_Output)(nil),                             // 129: aggregator.BranchNode.Output
+	(*FilterNode_Config)(nil),                             // 130: aggregator.FilterNode.Config
+	(*FilterNode_Output)(nil),                             // 131: aggregator.FilterNode.Output
+	(*LoopNode_Config)(nil),                               // 132: aggregator.LoopNode.Config
+	(*LoopNode_Output)(nil),                               // 133: aggregator.LoopNode.Output
+	(*Execution_Step)(nil),                                // 134: aggregator.Execution.Step
+	nil,                                                   // 135: aggregator.Task.InputVariablesEntry
+	nil,                                                   // 136: aggregator.CreateTaskReq.InputVariablesEntry
+	nil,                                                   // 137: aggregator.TriggerTaskReq.TriggerInputEntry
+	nil,                                                   // 138: aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	nil,                                                   // 139: aggregator.RunTriggerReq.TriggerInputEntry
+	nil,                                                   // 140: aggregator.SimulateTaskReq.InputVariablesEntry
+	nil,                                                   // 141: aggregator.EstimateFeesReq.InputVariablesEntry
+	(*structpb.Value)(nil),                                // 142: google.protobuf.Value
 }
 var file_avs_proto_depIdxs = []int32{
 	8,   // 0: aggregator.GetTokenMetadataResp.token:type_name -> aggregator.TokenMetadata
-	91,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
-	93,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
-	95,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
-	99,  // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
-	101, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
+	92,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
+	94,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
+	96,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
+	100, // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
+	102, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
 	0,   // 6: aggregator.TaskTrigger.type:type_name -> aggregator.TriggerType
 	16,  // 7: aggregator.TaskTrigger.manual:type_name -> aggregator.ManualTrigger
 	12,  // 8: aggregator.TaskTrigger.fixed_time:type_name -> aggregator.FixedTimeTrigger
 	13,  // 9: aggregator.TaskTrigger.cron:type_name -> aggregator.CronTrigger
 	14,  // 10: aggregator.TaskTrigger.block:type_name -> aggregator.BlockTrigger
 	15,  // 11: aggregator.TaskTrigger.event:type_name -> aggregator.EventTrigger
-	105, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
-	107, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
-	112, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
-	116, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
-	119, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
-	122, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
-	124, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
-	127, // 19: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
-	129, // 20: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
+	106, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
+	108, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
+	113, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
+	117, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
+	120, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
+	123, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
+	125, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
+	128, // 19: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
+	130, // 20: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
 	18,  // 21: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
 	19,  // 22: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
 	20,  // 23: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
 	21,  // 24: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
 	22,  // 25: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
 	23,  // 26: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
-	131, // 27: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
+	132, // 27: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
 	1,   // 28: aggregator.TaskNode.type:type_name -> aggregator.NodeType
 	18,  // 29: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
 	19,  // 30: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
@@ -10668,19 +10801,19 @@ var file_avs_proto_depIdxs = []int32{
 	23,  // 37: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
 	24,  // 38: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
 	7,   // 39: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
-	84,  // 40: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
-	86,  // 41: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
-	87,  // 42: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
-	133, // 43: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
+	85,  // 40: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
+	87,  // 41: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
+	88,  // 42: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
+	134, // 43: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
 	6,   // 44: aggregator.Task.status:type_name -> aggregator.TaskStatus
 	17,  // 45: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
 	29,  // 46: aggregator.Task.nodes:type_name -> aggregator.TaskNode
 	28,  // 47: aggregator.Task.edges:type_name -> aggregator.TaskEdge
-	134, // 48: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
+	135, // 48: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
 	17,  // 49: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
 	29,  // 50: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
 	28,  // 51: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
-	135, // 52: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
+	136, // 52: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
 	37,  // 53: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
 	31,  // 54: aggregator.ListTasksResp.items:type_name -> aggregator.Task
 	56,  // 55: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
@@ -10688,132 +10821,133 @@ var file_avs_proto_depIdxs = []int32{
 	56,  // 57: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
 	7,   // 58: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
 	0,   // 59: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
-	96,  // 60: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	92,  // 61: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	94,  // 62: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	100, // 63: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
-	102, // 64: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	136, // 65: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
+	97,  // 60: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	93,  // 61: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	95,  // 62: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	101, // 63: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
+	103, // 64: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	137, // 65: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
 	7,   // 66: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
-	133, // 67: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
+	134, // 67: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
 	57,  // 68: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
 	56,  // 69: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
 	29,  // 70: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
-	137, // 71: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	141, // 72: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
-	141, // 73: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 74: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
-	106, // 75: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	117, // 76: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	114, // 77: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
-	109, // 78: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	123, // 79: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	120, // 80: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
-	128, // 81: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
-	130, // 82: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
-	132, // 83: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
-	125, // 84: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
-	17,  // 85: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
-	138, // 86: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
-	141, // 87: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
-	141, // 88: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 89: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
-	96,  // 90: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	92,  // 91: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	94,  // 92: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	100, // 93: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
-	102, // 94: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	17,  // 95: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 96: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 97: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
-	139, // 98: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
-	17,  // 99: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 100: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 101: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
-	140, // 102: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
-	80,  // 103: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
-	82,  // 104: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
-	80,  // 105: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
-	80,  // 106: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
-	80,  // 107: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
-	84,  // 108: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
-	84,  // 109: aggregator.ValueFee.fee:type_name -> aggregator.Fee
-	2,   // 110: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
-	84,  // 111: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
-	5,   // 112: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
-	85,  // 113: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
-	84,  // 114: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
-	86,  // 115: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
-	87,  // 116: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
-	88,  // 117: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
-	141, // 118: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
-	141, // 119: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
-	141, // 120: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
-	141, // 121: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
-	90,  // 122: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
-	98,  // 123: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
-	97,  // 124: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
-	141, // 125: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
-	141, // 126: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
-	103, // 127: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
-	104, // 128: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
-	4,   // 129: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
-	141, // 130: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
-	141, // 131: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
-	141, // 132: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
-	108, // 133: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
-	141, // 134: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
-	141, // 135: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
-	141, // 136: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
-	141, // 137: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
-	141, // 138: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
-	111, // 139: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
-	115, // 140: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
-	141, // 141: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
-	118, // 142: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
-	141, // 143: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
-	121, // 144: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
-	141, // 145: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
-	141, // 146: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
-	4,   // 147: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
-	141, // 148: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
-	141, // 149: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
-	126, // 150: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	141, // 151: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	141, // 152: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	3,   // 153: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	141, // 154: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	5,   // 155: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
-	141, // 156: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	141, // 157: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	141, // 158: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	96,  // 159: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	92,  // 160: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	94,  // 161: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	100, // 162: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	102, // 163: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	106, // 164: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	117, // 165: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	114, // 166: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	109, // 167: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	123, // 168: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	120, // 169: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	128, // 170: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	130, // 171: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	132, // 172: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	125, // 173: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
-	141, // 174: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	141, // 175: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	141, // 176: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	141, // 177: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	141, // 178: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	141, // 179: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	141, // 180: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	181, // [181:181] is the sub-list for method output_type
-	181, // [181:181] is the sub-list for method input_type
-	181, // [181:181] is the sub-list for extension type_name
-	181, // [181:181] is the sub-list for extension extendee
-	0,   // [0:181] is the sub-list for field type_name
+	138, // 71: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	75,  // 72: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
+	142, // 73: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
+	142, // 74: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 75: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
+	107, // 76: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	118, // 77: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	115, // 78: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
+	110, // 79: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	124, // 80: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	121, // 81: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
+	129, // 82: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
+	131, // 83: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
+	133, // 84: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
+	126, // 85: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
+	17,  // 86: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
+	139, // 87: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
+	142, // 88: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
+	142, // 89: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 90: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
+	97,  // 91: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	93,  // 92: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	95,  // 93: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	101, // 94: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
+	103, // 95: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	17,  // 96: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	29,  // 97: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
+	28,  // 98: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
+	140, // 99: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
+	17,  // 100: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
+	29,  // 101: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
+	28,  // 102: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
+	141, // 103: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
+	81,  // 104: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
+	83,  // 105: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
+	81,  // 106: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
+	81,  // 107: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
+	81,  // 108: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
+	85,  // 109: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
+	85,  // 110: aggregator.ValueFee.fee:type_name -> aggregator.Fee
+	2,   // 111: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
+	85,  // 112: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
+	5,   // 113: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
+	86,  // 114: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
+	85,  // 115: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
+	87,  // 116: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
+	88,  // 117: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
+	89,  // 118: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
+	142, // 119: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
+	142, // 120: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
+	142, // 121: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
+	142, // 122: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
+	91,  // 123: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
+	99,  // 124: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
+	98,  // 125: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
+	142, // 126: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
+	142, // 127: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
+	104, // 128: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
+	105, // 129: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
+	4,   // 130: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
+	142, // 131: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
+	142, // 132: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
+	142, // 133: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
+	109, // 134: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
+	142, // 135: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
+	142, // 136: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
+	142, // 137: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
+	142, // 138: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
+	142, // 139: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
+	112, // 140: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
+	116, // 141: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
+	142, // 142: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
+	119, // 143: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
+	142, // 144: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
+	122, // 145: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
+	142, // 146: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
+	142, // 147: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
+	4,   // 148: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
+	142, // 149: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
+	142, // 150: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
+	127, // 151: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	142, // 152: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	142, // 153: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	3,   // 154: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	142, // 155: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	5,   // 156: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
+	142, // 157: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	142, // 158: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	142, // 159: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	97,  // 160: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	93,  // 161: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	95,  // 162: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	101, // 163: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	103, // 164: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	107, // 165: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	118, // 166: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	115, // 167: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	110, // 168: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	124, // 169: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	121, // 170: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	129, // 171: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	131, // 172: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	133, // 173: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	126, // 174: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
+	142, // 175: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	142, // 176: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	142, // 177: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	142, // 178: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	142, // 179: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	142, // 180: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	142, // 181: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	182, // [182:182] is the sub-list for method output_type
+	182, // [182:182] is the sub-list for method input_type
+	182, // [182:182] is the sub-list for extension type_name
+	182, // [182:182] is the sub-list for extension extendee
+	0,   // [0:182] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }
@@ -10856,7 +10990,8 @@ func file_avs_proto_init() {
 		(*TriggerTaskReq_ManualTrigger)(nil),
 	}
 	file_avs_proto_msgTypes[45].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[67].OneofWrappers = []any{
+	file_avs_proto_msgTypes[67].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[68].OneofWrappers = []any{
 		(*RunNodeWithInputsResp_EthTransfer)(nil),
 		(*RunNodeWithInputsResp_Graphql)(nil),
 		(*RunNodeWithInputsResp_ContractRead)(nil),
@@ -10868,22 +11003,22 @@ func file_avs_proto_init() {
 		(*RunNodeWithInputsResp_Loop)(nil),
 		(*RunNodeWithInputsResp_Balance)(nil),
 	}
-	file_avs_proto_msgTypes[69].OneofWrappers = []any{
+	file_avs_proto_msgTypes[70].OneofWrappers = []any{
 		(*RunTriggerResp_BlockTrigger)(nil),
 		(*RunTriggerResp_FixedTimeTrigger)(nil),
 		(*RunTriggerResp_CronTrigger)(nil),
 		(*RunTriggerResp_EventTrigger)(nil),
 		(*RunTriggerResp_ManualTrigger)(nil),
 	}
-	file_avs_proto_msgTypes[89].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[90].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[91].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[99].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[92].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[100].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[102].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[101].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[103].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[111].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[125].OneofWrappers = []any{
+	file_avs_proto_msgTypes[104].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[112].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[126].OneofWrappers = []any{
 		(*Execution_Step_BlockTrigger)(nil),
 		(*Execution_Step_FixedTimeTrigger)(nil),
 		(*Execution_Step_CronTrigger)(nil),
@@ -10906,7 +11041,7 @@ func file_avs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_avs_proto_rawDesc), len(file_avs_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   133,
+			NumMessages:   134,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -1242,6 +1242,29 @@ message RunNodeWithInputsReq {
   // Chain to run the node against. 0 = aggregator default chain.
   // node.config.chain_id (if non-zero) takes precedence over this field.
   int64 chain_id = 4;
+  // Optional ERC20 balance/allowance state overrides applied only during this
+  // isolated node simulation (RunNodeImmediately). Lets callers seed token
+  // balances and approvals so contract-write simulations (e.g. Uniswap swaps)
+  // don't revert with "transfer amount exceeds allowance/balance" before the
+  // approval/funding transactions have been run. Simulation-only: a
+  // real-execution request (isSimulated=false) that sets these is rejected with
+  // an error, never silently ignored.
+  repeated ERC20StateOverride erc20_overrides = 5;
+}
+
+// ERC20StateOverride seeds a token's balanceOf / allowance storage slots for a
+// single simulation. The slot for balanceOf[owner] is
+// keccak256(abi.encode(owner, balance_slot)); the slot for
+// allowance[owner][spender] is
+// keccak256(abi.encode(spender, keccak256(abi.encode(owner, allowance_slot)))).
+message ERC20StateOverride {
+  string token_address = 1;            // ERC20 token contract address
+  string owner_address = 2;            // Address whose balance/allowance to override
+  optional string spender_address = 3; // Spender to approve (required for allowance override)
+  optional string balance = 4;         // Balance override (hex 0x… or decimal string)
+  optional string allowance = 5;       // Allowance override (hex 0x… or decimal string)
+  optional uint64 balance_slot = 6;    // Storage slot for the balanceOf mapping (required when balance is set; layout varies per token)
+  optional uint64 allowance_slot = 7;  // Storage slot for the allowance mapping (required when allowance is set; layout varies per token)
 }
 
 // Response message for RunNodeWithInputs


### PR DESCRIPTION
Staging → main release. Storage-check: ✅ no breaking changes (additive-only).

## Included

- **feat: gateway forwards Email-node summaries to Studio /api/notify (Path B)** (#626)
  Workflow Email/Telegram nodes POST raw execution data to Studio's `/api/notify`, which summarizes AND distributes. Replaces the gateway-side SendGrid coupling; `detectNotificationProvider` now routes `/api/notify` → `studio-notify`. Config: `email_url` / `email_api_token` (reuses `SUMMARIZER_API_URL`/`SUMMARIZER_API_KEY`).

- **feat: user-facing erc20_overrides for RunNodeImmediately** (#624)
  Adds `erc20_overrides` (+ simulation-state fix & RPC E2E proof) — proto additive (`protobuf/avs.proto` +23), regenerated bindings.

- **test: auto-load .env.local + .env in testutil** so `test.yaml` `${VAR}` bundler URLs resolve.

## Pre-merge checks
- `make storage-check` → ✅ key templates unchanged, model structs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
