### PR TITLE
refactor: notify observability warns + dead-code sweep (carry-over from #628)

### DIFF
--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -332,10 +332,6 @@ func New(db storage.Storage, config *config.Config, queue *apqueue.Queue, logger
 		logger: logger,
 	}
 
-	// Wire global fee rates so Summary.Fees population (in both ComposeSummary
-	// and the context-memory summarizer) uses the aggregator's configured rates.
-	SetFeeRates(config.FeeRates)
-
 	// Initialize AI summarizer (global) from aggregator config
 	// Only context-memory API is supported - all email content generation is delegated to context-memory
 	// The aggregator acts as a pass-through for the context-memory response to SendGrid
@@ -578,10 +574,6 @@ func (n *Engine) GetTenderlyClient() *TenderlyClient {
 
 func (n *Engine) SetPriceService(priceService PriceService) {
 	n.priceService = priceService
-	// Also wire as the package-level price service so Summary.Fees population
-	// (in both ComposeSummary and ContextMemorySummarizer.Summarize) can compute
-	// native-token totals from USD platform fees and value-fee legs.
-	SetPriceService(priceService)
 }
 
 func (n *Engine) Stop() {

--- a/core/taskengine/summarizer.go
+++ b/core/taskengine/summarizer.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
-
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 )
 
@@ -41,14 +39,6 @@ func formatValueConcise(v interface{}) string {
 	}
 }
 
-// Constants for example execution messages shown when no executions are available
-const (
-	// ExampleExecutionMessage is the base message for example executions
-	ExampleExecutionMessage = "On-chain transaction successfully completed"
-	// ExampleExecutionAnnotation is the annotation text explaining that this is an example
-	ExampleExecutionAnnotation = "This is an example. Actual execution details will appear when the workflow is simulated or triggered by a real event."
-)
-
 // globalSummarizer holds the Studio /api/notify payload builder (Path B). It is the only
 // summarizer path: the gateway forwards raw execution data and Studio summarizes + sends.
 var globalSummarizer *ContextMemorySummarizer
@@ -57,30 +47,6 @@ var globalSummarizer *ContextMemorySummarizer
 // Pass nil to disable (notification nodes then forward their body unchanged).
 func SetSummarizer(s *ContextMemorySummarizer) {
 	globalSummarizer = s
-}
-
-// globalFeeRates is the aggregator's fee config, set once at engine startup.
-// Used by Runner/Fees population helpers in both Summarize() and ComposeSummary()
-// so notifications surface the same fee numbers as EstimateFees() and the
-// persisted Execution.Fee — single source of truth.
-var globalFeeRates *config.FeeRatesConfig
-
-// SetFeeRates sets the global fee rates config used by Summary.Fees population.
-// Engine startup wires this from config.FeeRates. nil falls back to defaults.
-func SetFeeRates(rates *config.FeeRatesConfig) {
-	globalFeeRates = rates
-}
-
-// globalPriceService is the chain price oracle used by Summary.Fees population
-// to convert USD platform fees and value-fee legs into native-token amounts.
-// Wired at engine startup via Engine.SetPriceService → SetPriceService.
-var globalPriceService PriceService
-
-// SetPriceService sets the global price service used by Summary.Fees population.
-// nil disables USD/native conversion — Total entries that need a price will be
-// emitted with empty USD amounts (formatter renders "$?" placeholder).
-func SetPriceService(svc PriceService) {
-	globalPriceService = svc
 }
 
 // NewContextMemorySummarizerFromAggregatorConfig builds the workflow summarizer from the
@@ -114,154 +80,4 @@ func NewContextMemorySummarizerFromAggregatorConfig(c *config.Config) (*ContextM
 		authToken:  authToken,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}, nil
-}
-
-// truncateAddress truncates an Ethereum address to format "0x5d814...434f"
-func truncateAddress(addr string) string {
-	if len(addr) < 12 {
-		return addr
-	}
-	return addr[:7] + "..." + addr[len(addr)-4:]
-}
-
-// truncateTxHash truncates a transaction hash to format "0x1234...cdef"
-func truncateTxHash(hash string) string {
-	if len(hash) < 14 {
-		return hash
-	}
-	return hash[:6] + "..." + hash[len(hash)-4:]
-}
-
-// isValidTxHash checks if a string is a valid Ethereum transaction hash (0x + 64 hex chars).
-// This filters out fake hashes like raw BigInt values from Tenderly simulation IDs.
-func isValidTxHash(hash string) bool {
-	if len(hash) != 66 || !strings.HasPrefix(hash, "0x") {
-		return false
-	}
-	for _, c := range hash[2:] {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return false
-		}
-	}
-	return true
-}
-
-// isStepSimulated checks whether an execution step was run in simulation mode
-// by reading the ExecutionContext attached to the step.
-// Handles both naming conventions: "is_simulated" (snake_case from engine.go/node_utils.go)
-// and "isSimulated" (camelCase from execution_providers.go).
-func isStepSimulated(st *avsproto.Execution_Step) bool {
-	if st.GetExecutionContext() == nil {
-		return false
-	}
-	ctx, ok := st.GetExecutionContext().AsInterface().(map[string]interface{})
-	if !ok {
-		return false
-	}
-	for _, key := range []string{"is_simulated", "isSimulated"} {
-		if sim, exists := ctx[key]; exists {
-			switch v := sim.(type) {
-			case bool:
-				if v {
-					return true
-				}
-			case string:
-				if strings.EqualFold(strings.TrimSpace(v), "true") {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-// getBlockExplorerURL returns the block explorer base URL for a chain ID.
-// Returns an empty string for unknown chains — callers must not assume a default.
-func getBlockExplorerURL(chainID int64) string {
-	switch chainID {
-	case 1:
-		return "https://etherscan.io"
-	case 11155111:
-		return "https://sepolia.etherscan.io"
-	case 137:
-		return "https://polygonscan.com"
-	case 42161:
-		return "https://arbiscan.io"
-	case 10:
-		return "https://optimistic.etherscan.io"
-	case 8453:
-		return "https://basescan.org"
-	case 84532:
-		return "https://sepolia.basescan.org"
-	case 56:
-		return "https://bscscan.com"
-	case 43114:
-		return "https://snowtrace.io"
-	default:
-		return ""
-	}
-}
-
-// mapNameToChainID reverse-maps a display chain name to a numeric chain ID.
-// Used as a fallback when chainID is not directly available (e.g. deterministic summarizer path).
-func mapNameToChainID(name string) int64 {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "mainnet", "ethereum":
-		return 1
-	case "sepolia":
-		return 11155111
-	case "polygon":
-		return 137
-	case "arbitrum", "arbitrum one":
-		return 42161
-	case "optimism":
-		return 10
-	case "base":
-		return 8453
-	case "base-sepolia", "base sepolia":
-		return 84532
-	case "bsc", "binance smart chain", "bnb chain":
-		return 56
-	case "avalanche":
-		return 43114
-	default:
-		return 0
-	}
-}
-
-// getChainDisplayName returns a display-friendly chain name from chain ID
-// This provides a local fallback when the API doesn't return a chain name
-func getChainDisplayName(chainID int64) string {
-	switch chainID {
-	case 1:
-		return "Ethereum"
-	case 11155111:
-		return "Sepolia"
-	case 137:
-		return "Polygon"
-	case 80001:
-		return "Polygon Mumbai"
-	case 42161:
-		return "Arbitrum One"
-	case 421614:
-		return "Arbitrum Sepolia"
-	case 10:
-		return "Optimism"
-	case 11155420:
-		return "Optimism Sepolia"
-	case 8453:
-		return "Base"
-	case 84532:
-		return "Base Sepolia"
-	case 56:
-		return "BNB Chain"
-	case 97:
-		return "BNB Testnet"
-	case 43114:
-		return "Avalanche"
-	case 43113:
-		return "Avalanche Fuji"
-	default:
-		return ""
-	}
 }

--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -3,7 +3,6 @@ package taskengine
 import (
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,18 +16,6 @@ import (
 // Constants for mock API testing
 const (
 	MockAPIEndpoint = "https://mock-api.ap-aggregator.local"
-)
-
-// SendGrid Dynamic Template ID for AI-generated workflow summaries
-const (
-	SendGridSummaryTemplateID = "d-3b4b885af0fc45ad822024ebc72f169c"
-)
-
-// Status HTML badge SVG icons for email notifications
-const (
-	statusIconSuccess = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="vertical-align:middle; margin-right:6px"><circle cx="8" cy="8" r="7" fill="#10B981"/><path d="M11 6L7 10L5 8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`
-	statusIconWarn    = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="vertical-align:middle; margin-right:6px"><circle cx="8" cy="8" r="7" fill="#F59E0B"/><circle cx="8" cy="5" r="1" fill="white"/><rect x="7.5" y="7" width="1" height="4" rx="0.5" fill="white"/></svg>`
-	statusIconFailed  = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="vertical-align:middle; margin-right:6px"><circle cx="8" cy="8" r="7" fill="#EF4444"/><path d="M10 6L6 10M6 6L10 10" stroke="white" stroke-width="2" stroke-linecap="round"/></svg>`
 )
 
 // HTTPRequestExecutor interface for making HTTP requests
@@ -678,6 +665,8 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 							}
 						}
 						body = FormatAsJSON(bodyObj)
+					} else if r.vm.logger != nil {
+						r.vm.logger.Warn("REST API notify: body is not JSON, skipping payload injection")
 					}
 				} else if r.vm.logger != nil {
 					r.vm.logger.Warn("REST API notify: failed to build raw payload", "error", err)
@@ -685,6 +674,10 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 			} else if r.vm.logger != nil {
 				r.vm.logger.Warn("REST API notify: no summarizer configured to build payload")
 			}
+		} else if provider == "telegram" && r.vm.logger != nil {
+			// Legacy direct-to-Telegram nodes no longer get gateway-side summary injection
+			// (Path B routes telegram through /api/notify). Warn so the no-op is debuggable.
+			r.vm.logger.Warn("REST API summarize on legacy direct-Telegram node — re-save the workflow in Studio to route through /api/notify")
 		}
 	}
 
@@ -869,37 +862,6 @@ func detectNotificationProvider(u string) string {
 	return ""
 }
 
-// buildStyledHTMLEmail wraps a plain-text body into a simple, safe HTML layout
-// suitable for email clients. It escapes the input text and preserves paragraph
-// breaks by turning double newlines into <p> blocks and single newlines into <br/>.
-func buildStyledHTMLEmail(subject, body string) string {
-	// Escape HTML to avoid injection
-	safe := html.EscapeString(body)
-	// Normalize newlines
-	safe = strings.ReplaceAll(safe, "\r\n", "\n")
-	// Split by paragraphs (double newline)
-	parts := strings.Split(safe, "\n\n")
-	var paragraphs []string
-	for _, p := range parts {
-		if strings.TrimSpace(p) == "" {
-			continue
-		}
-		// Convert single newlines within a paragraph to <br/>
-		p = strings.ReplaceAll(p, "\n", "<br/>")
-		paragraphs = append(paragraphs, "<p style=\"margin:0 0 16px 0;\">"+p+"</p>")
-	}
-
-	content := strings.Join(paragraphs, "\n")
-	// Minimal, responsive-friendly light theme
-	return "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">" +
-		"<title>" + html.EscapeString(subject) + "</title>" +
-		"<style>body{background:#FFFFFF;color:#1F2937;margin:0;padding:0;font-family:Arial,Helvetica,sans-serif;-webkit-font-smoothing:antialiased;}" +
-		".container{max-width:640px;margin:0 auto;padding:32px 24px;}h1,h2,h3,h4,h5,h6{color:#111827;margin-top:24px;margin-bottom:12px;}a{color:#8B5CF6;text-decoration:none;}" +
-		"p{margin:0 0 16px 0;line-height:1.6;}.divider{border-top:1px solid #E5E7EB;margin:24px 0;}" +
-		"@media(max-width:480px){.container{padding:24px 16px;}h1,h2,h3{font-size:1.2rem;}}</style></head>" +
-		"<body><div class=\"container\">" + content + "</div></body></html>"
-}
-
 // escapeJSONString properly escapes a string for use within JSON
 func escapeJSONString(s string) string {
 	// Use Go's built-in JSON marshaling to properly escape the string
@@ -1009,56 +971,4 @@ func (r *RestProcessor) preprocessJSONWithVariableMapping(text string) string {
 		result = result[:start] + escapedReplacement + result[end+2:]
 	}
 	return result
-}
-
-// shortHex formats a hex string as 0xABCD…WXYZ for compact display. If too short, returns as-is.
-func shortHex(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return s
-	}
-	if strings.HasPrefix(s, "0x") {
-		if len(s) > 10 { // 0x + 4 prefix + … + 4 suffix
-			return s[:6] + "…" + s[len(s)-4:]
-		}
-		return s
-	}
-	if len(s) > 8 {
-		return s[:4] + "…" + s[len(s)-4:]
-	}
-	return s
-}
-
-// extractPreheaderFromSummaryText finds the first meaningful line after the
-// "Workflow Summary" heading and truncates it for email preheader usage.
-func extractPreheaderFromSummaryText(text, fallback string) string {
-	t := strings.TrimSpace(text)
-	if t == "" {
-		return fallback
-	}
-	lines := strings.Split(t, "\n")
-	for _, ln := range lines {
-		s := strings.TrimSpace(ln)
-		if s == "" {
-			continue
-		}
-		if strings.EqualFold(s, "Summary") {
-			continue
-		}
-		// Truncate to ~180 chars to fit preheader best practices
-		if len(s) > 180 {
-			return s[:177] + "..."
-		}
-		return s
-	}
-	return fallback
-}
-
-// getMapKeys returns keys from a map[string]struct{} for logging
-func getMapKeys(m map[string]struct{}) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }


### PR DESCRIPTION
Carries over the ultrareview fixes for #628 (the deterministic-summarizer teardown), which was merged before these landed.

## Observability (ultrareview finding 1)
- **Legacy direct-Telegram + `summarize=true`** is now a no-op (the gateway-side telegram branch was removed in #628). Added a **Warn** so the no-op is debuggable instead of logging a misleading `Info("...summarize enabled", provider=telegram)`.
- **studio-notify branch**: added the `"body is not JSON, skipping injection"` **Warn** the deleted telegram branch used to emit (the `json.Unmarshal` guard had no `else`).

## Dead-code sweep (ultrareview finding 2 — the cleanup #628 promised)
- `summarizer.go`: removed orphaned helpers (`truncateAddress`/`truncateTxHash`/`isValidTxHash`/`isStepSimulated`/`getBlockExplorerURL`/`mapNameToChainID`/`getChainDisplayName`), the `Example*` constants, the `avsproto` import, and the **fee/price globals** (`globalFeeRates`/`globalPriceService` + setters) — all zero-reader after the deterministic summarizer was removed.
- `engine.go`: dropped the two dead `SetFeeRates`/`SetPriceService` package-global call sites. `Engine.SetPriceService` still wires `n.priceService` for `EstimateFees`.
- `vm_runner_rest.go`: removed `SendGridSummaryTemplateID`, the `statusIcon*` SVGs, `buildStyledHTMLEmail`/`shortHex`/`extractPreheaderFromSummaryText`/`getMapKeys`, and the now-unused `html` import.

**+6 / −288.** Verified: `go build ./...` ✅, `go vet` ✅, REST/summarizer/BuildNotify tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
