### PR TITLE
feat: per-part chainId (Phases 1-2, G1-G4) — flow + monitor per-trigger/node chains

### DIFF
--- a/PLAN_CHAIN_DECOUPLING.md
+++ b/PLAN_CHAIN_DECOUPLING.md
@@ -11,7 +11,7 @@ contract-write/transfer/read acting on chain Y — so that:
 - a workflow can eventually **bridge across chains mid-run** (act on B after bridging from A).
 
 We lead this **bottom-up from the AVS backend**. The studio client
-(`/Users/mikasa/Code/studio/PLAN_WALLET_CHAIN_DECOUPLING.md`, Phase 3/4) and the v4 SDK
+(the `studio` repo's `PLAN_WALLET_CHAIN_DECOUPLING.md`, Phase 3/4) and the v4 SDK
 (`ava-sdk-js`) follow the model defined here — they must not ship a per-node chain the backend would
 flatten.
 
@@ -413,5 +413,5 @@ Scope this separately once Phases 1–3 land; do not block them on it.
 - Model: `model/user.go` (`SmartWallet` has no chainId; `User.ChainID` from JWT aud),
   `model/workflow.go` (`Workflow` wraps `*avsproto.Task`).
 - OpenAPI: `api/openapi.yaml:402,492,592,618,634`.
-- SDK (`/Users/mikasa/Code/ava-sdk-js`): `packages/sdk-js/src/v4/builders/{nodes,triggers}.ts`,
+- SDK (the `ava-sdk-js` repo): `packages/sdk-js/src/v4/builders/{nodes,triggers}.ts`,
   `packages/types/src/openapi.gen.ts` (per-node/trigger `chainId`).

--- a/PLAN_CHAIN_DECOUPLING.md
+++ b/PLAN_CHAIN_DECOUPLING.md
@@ -47,7 +47,7 @@ task-level chain entirely** (no `Task.chain_id`, chain-agnostic task storage). G
 | # | Gap | Location | Effect today |
 |---|---|---|---|
 | **G1** | ~~EventTrigger.Config.chainId dropped at REST→proto.~~ **FIXED** — `openAPIEventToProto`/`protoEventToOpenAPI` now map `chainId` both directions (mirrors BlockTrigger). Test: `trigger_test.go` event case. | `aggregator/rest/mapping/trigger.go` | Event-trigger chain now reaches the proto. |
-| **G2** | **Operator monitors triggers by task chain, not the trigger's own chain.** `trigger.Config.GetChainId()` is never read at runtime; subscription keys on `TaskMetadata.GetChainId()`. | `operator/worker_loop.go:1055-1090` | An event trigger on chain X attached to a task whose default chain is Y is watched on Y. (Phase 2.) |
+| **G2** | ~~Operator monitors triggers by task chain, not the trigger's own chain.~~ **FIXED** — the aggregator now dispatches `TaskMetadata.ChainId` as the trigger's monitoring chain (`triggerMonitoringChainID`, event/block config chain → task-chain fallback), and computes operator coverage + orphan-scan from it; the operator routes on that value. Test: `chain_per_part_test.go` (`TestTriggerMonitoringChainID`). | `core/taskengine/engine.go`, `operator/worker_loop.go` | An event trigger on chain X attached to a task whose default chain is Y is now watched on X. |
 | **G3** | ~~`ExtractNodeConfiguration` omits `chainId`.~~ **FIXED** — emits `chainId` for contract/transfer nodes; `CreateNodeFromType` reads it back onto the proto; `requireChainIDFromConfig` accepts the camelCase key. Test: `chain_per_part_test.go`. | `core/taskengine/vm.go`, `run_node_immediately.go` | Simulate/preview/`runNodeImmediately`/loop-nested now honor the per-node chain. |
 | **G4** | ~~Unknown explicit chain silently fell back / wasn't validated at create.~~ **FIXED** — `resolveSmartWalletForNode` errors on an explicit unresolvable chain (`vm.go:347`), and `validateExplicitPartChains` rejects an unconfigured explicit part chain at create (gateway mode). Tests: `vm_resolve_smart_wallet_test.go`, `chain_per_part_test.go`. `0`-inherit still allowed until G5. | `core/taskengine/engine.go`, `vm.go:347` | Explicit wrong-chain execution closed at both create and run. |
 | **G5** | **Make `chain_id` required per chain-aware part AND remove the task-level chain entirely** (the decided model). Per the resolution rule, `chain_id` becomes REQUIRED (`>0`, configured) on event/block triggers and contract/transfer nodes, all modes; `0` rejected. `Task.chain_id` / `CreateTaskReq.chain_id` are **removed** and task **storage becomes chain-agnostic** (chain drops out of `t:`/`u:`/execution keys — Decision 1). Requires: drop "0 = inherit" from proto + OpenAPI; remove audit-class-**A** fallback sites; fix the Loop runner; update ~30 `task.ChainId` readers; **wipe-all migration** (storage schema changed; legacy parts unfixable). | proto `avs.proto` (remove fields 16/10 + the 151/222/383/410/455 comments), `api/openapi.yaml`, `storage/schema/workflow.go` + `core/taskengine/schema.go` (key builders), `vm.go:347`/`:1583`, `loop_helpers.go:205`, `executor.go`, `engine.go` (~30 readers), `ChainRegistry.*`, `aggregator/key.go`, `migrations/` | Today chain is baked into the task (field + storage key) and a `0`-chain part silently runs on it. After G5, chain lives **only** on the parts — explicit-or-error — and a task belongs to no chain at all; per-chain views derive from the parts. Only the (B) chain-agnostic operator-routing sentinel for cron/manual survives. |
@@ -293,18 +293,20 @@ the genuinely new protocol work (cross-chain sequencing) and maps to studio Phas
 operator's event subscription (G2). Independent, low-risk, no storage change. `chain_id == 0` still
 inherits the task chain (legacy path) — tightened in Phase 3. Build + targeted tests green.
 
-### Phase 2 — Operator routes the trigger by the trigger's own chain (G2)
+### Phase 2 — Operator routes the trigger by the trigger's own chain (G2) — **IMPLEMENTED**
 
-In `operator/worker_loop.go:1055-1090`, key the EventTrigger (and BlockTrigger) subscription on
-`trigger.GetEvent().GetConfig().GetChainId()` falling back to `TaskMetadata.GetChainId()` (the inherit
-rule). Because there is **one trigger per task**, there is no union-of-chains problem: the
-`operatorsCoveringChain` selection (`engine.go:649-682`) should be driven by the **trigger's** chain, not
-the task's. Confirm that the aggregator computes coverage from the trigger chain when it dispatches the
-task to operators (so a task watching chain X is only sent to operators covering X), and that cron/manual
-triggers remain chain-agnostic (covered by any operator).
+Done at the **aggregator** (single source of truth) rather than only the operator: a new
+`triggerMonitoringChainID(trigger, fallback)` returns the event/block trigger's own configured chain
+(falling back to the task chain when the trigger left it 0 — legacy, until G5). It's applied at all three
+`TaskMetadata.ChainId` dispatch sites, the create-time coverage check (`operatorsCoveringChain`), and the
+orphan-scan coverage map. The operator keeps routing on `TaskMetadata.GetChainId()` — now the trigger's
+monitoring chain — and its variable was renamed `monitorChainID` for clarity. Because there is **one
+trigger per task**, there's no union-of-chains problem. Cron/manual/fixed-time stay chain-agnostic (the
+helper carries the fallback through; the operator's TimeTrigger ignores it).
 
 **Outcome:** event triggers fire on their own chain. A workflow can now *watch* chain X and *act* on
 chain Y within one task, with independent (non-sequential) steps. This fully satisfies studio Phase 3.
+Build + targeted tests (`TestTriggerMonitoringChainID`, operator + engine coverage suites) green.
 
 ### Phase 3 — `chain_id` required per part; remove the task-level chain; chain-agnostic storage (G5)
 

--- a/PLAN_CHAIN_DECOUPLING.md
+++ b/PLAN_CHAIN_DECOUPLING.md
@@ -1,0 +1,415 @@
+# PLAN: Decouple chainId from the workflow — per-trigger / per-node chains
+
+**Owner:** AVS backend (this repo leads). **Status:** proposal / pre-implementation.
+**Date:** 2026-06-26.
+
+Today a workflow (AVS task) is bound to **one** `chainId`, fixed at creation. The goal is to make
+chainId a property of the **parts that need it** — an event trigger watching a contract on chain X, a
+contract-write/transfer/read acting on chain Y — so that:
+
+- a workflow is no longer a single-chain object, and
+- a workflow can eventually **bridge across chains mid-run** (act on B after bridging from A).
+
+We lead this **bottom-up from the AVS backend**. The studio client
+(`/Users/mikasa/Code/studio/PLAN_WALLET_CHAIN_DECOUPLING.md`, Phase 3/4) and the v4 SDK
+(`ava-sdk-js`) follow the model defined here — they must not ship a per-node chain the backend would
+flatten.
+
+---
+
+## TL;DR — per-node chains already work; the task-level chain is being removed
+
+The proto, the REST mapping for nodes, the v4 SDK, and the **deployed-execution** path already support
+per-node chains. The studio plan's premise that *"triggers/nodes carry no chainId of their own"* and that
+Phase 3 is *"blocked on an AVS model change"* is **out of date**. Two tiers of work remain:
+**(1) narrow plumbing** (G1–G4) to make per-node/trigger chains flow on every path; and **(2) the decided
+structural change** (G5) — make `chain_id` **required** on every chain-aware part and **remove the
+task-level chain entirely** (no `Task.chain_id`, chain-agnostic task storage). G5 is a real refactor
+(~30 readers + storage-key change + wipe migration), shipped after the plumbing.
+
+### What already works (verified)
+
+| Layer | Status | Evidence |
+|---|---|---|
+| Proto: `Task.chain_id` (task-level default) | ✅ | `protobuf/avs.proto:817`, `CreateTaskReq.chain_id` `:858` |
+| Proto: per-trigger/per-node `chain_id`, `0 = inherit task` | ✅ | EventTrigger `:222`, BlockTrigger `:152`, ContractWrite `:410`, ContractRead `:455`, ETHTransfer `:384` |
+| REST → proto: per-**node** chainId carried (protojson round-trip) | ✅ | `aggregator/rest/mapping/node.go:203` (`jsonRetargetProto` → `protojson.Unmarshal`); proto json name `chainId` maps onto `Config.ChainId` automatically |
+| REST → proto: **BlockTrigger** config chainId | ✅ | `aggregator/rest/mapping/trigger.go:119-120` |
+| Deployed execution honors per-node chainId | ✅ | `core/taskengine/vm.go:1475,1518,1743` read `node.Config.GetChainId()` → `resolveSmartWalletForNode` (`vm.go:347-361`) |
+| Multi-chain RPC/smart-wallet pool in the engine | ✅ | `Engine.chainConfigs` + `ResolveSmartWalletConfig(chainID)` `core/taskengine/engine.go:426-433`; `chainConfigResolver` wired to VMs at simulation/executor/run-node sites |
+| Inherit logic: node-chain → task-chain → default | ✅ | `resolveSmartWalletForNode` `vm.go:347-361`, tested `vm_resolve_smart_wallet_test.go` (regression for Sentry EIGENLAYER-AVS-1N/1M) |
+| Gateway mode requires explicit task `chain_id` | ✅ | `engine.go:1637-1660` |
+| v4 SDK builders + types expose per-node/per-trigger `chainId` | ✅ | `ava-sdk-js` `builders/nodes.ts`, `builders/triggers.ts`; `packages/types/src/openapi.gen.ts` (`*NodeConfig.chainId`, `*TriggerConfig.chainId`) |
+| OpenAPI spec documents per-node/trigger chainId + inherit | ✅ | `api/openapi.yaml:402,492,592,618,634` |
+
+### The actual gaps (Phases 1–2 are plumbing; G5/Phase 3 is the decided model change)
+
+| # | Gap | Location | Effect today |
+|---|---|---|---|
+| **G1** | ~~EventTrigger.Config.chainId dropped at REST→proto.~~ **FIXED** — `openAPIEventToProto`/`protoEventToOpenAPI` now map `chainId` both directions (mirrors BlockTrigger). Test: `trigger_test.go` event case. | `aggregator/rest/mapping/trigger.go` | Event-trigger chain now reaches the proto. |
+| **G2** | **Operator monitors triggers by task chain, not the trigger's own chain.** `trigger.Config.GetChainId()` is never read at runtime; subscription keys on `TaskMetadata.GetChainId()`. | `operator/worker_loop.go:1055-1090` | An event trigger on chain X attached to a task whose default chain is Y is watched on Y. (Phase 2.) |
+| **G3** | ~~`ExtractNodeConfiguration` omits `chainId`.~~ **FIXED** — emits `chainId` for contract/transfer nodes; `CreateNodeFromType` reads it back onto the proto; `requireChainIDFromConfig` accepts the camelCase key. Test: `chain_per_part_test.go`. | `core/taskengine/vm.go`, `run_node_immediately.go` | Simulate/preview/`runNodeImmediately`/loop-nested now honor the per-node chain. |
+| **G4** | ~~Unknown explicit chain silently fell back / wasn't validated at create.~~ **FIXED** — `resolveSmartWalletForNode` errors on an explicit unresolvable chain (`vm.go:347`), and `validateExplicitPartChains` rejects an unconfigured explicit part chain at create (gateway mode). Tests: `vm_resolve_smart_wallet_test.go`, `chain_per_part_test.go`. `0`-inherit still allowed until G5. | `core/taskengine/engine.go`, `vm.go:347` | Explicit wrong-chain execution closed at both create and run. |
+| **G5** | **Make `chain_id` required per chain-aware part AND remove the task-level chain entirely** (the decided model). Per the resolution rule, `chain_id` becomes REQUIRED (`>0`, configured) on event/block triggers and contract/transfer nodes, all modes; `0` rejected. `Task.chain_id` / `CreateTaskReq.chain_id` are **removed** and task **storage becomes chain-agnostic** (chain drops out of `t:`/`u:`/execution keys — Decision 1). Requires: drop "0 = inherit" from proto + OpenAPI; remove audit-class-**A** fallback sites; fix the Loop runner; update ~30 `task.ChainId` readers; **wipe-all migration** (storage schema changed; legacy parts unfixable). | proto `avs.proto` (remove fields 16/10 + the 151/222/383/410/455 comments), `api/openapi.yaml`, `storage/schema/workflow.go` + `core/taskengine/schema.go` (key builders), `vm.go:347`/`:1583`, `loop_helpers.go:205`, `executor.go`, `engine.go` (~30 readers), `ChainRegistry.*`, `aggregator/key.go`, `migrations/` | Today chain is baked into the task (field + storage key) and a `0`-chain part silently runs on it. After G5, chain lives **only** on the parts — explicit-or-error — and a task belongs to no chain at all; per-chain views derive from the parts. Only the (B) chain-agnostic operator-routing sentinel for cron/manual survives. |
+
+G1–G4 turn the existing infrastructure into working per-node/per-trigger multi-chain execution. **G5 is
+the model change** the team decided on (2026-06-26): make `chain_id` required on chain-aware parts and
+delete inheritance. No backfill — a one-shot delete migration clears pre-existing `0`-chain tasks at boot
+before the strict code runs; owners re-create them with explicit chains.
+
+---
+
+## Backend answers to studio's Phase-3 gate questions
+
+(Responses to `studio/PLAN_WALLET_CHAIN_DECOUPLING.md` → "Open questions to confirm with the AVS backend
+before studio Phase 3". All verified in code.)
+
+1. **Auth granularity — one authKey authorizes the whole task; single-sign, no per-chain user signature.**
+   On-chain execution is signed by the **backend controller key** (`pkg/erc4337/preset/builder.go:1064`,
+   `smartWalletConfig.ControllerPrivateKey`), resolved per chain — **not** by the user. The user authKey/JWT
+   (`aud` = chain) is checked **only at the create-API boundary** (`aggregator/rest/middleware/jwt.go`);
+   the executor never re-validates it. The authKey's chain is just which gateway endpoint the create
+   request used — it does **not** have to match the task's per-node chains. So one create-time authKey
+   authorizes a task whose nodes/triggers span several chains. Per-step user auth is only the bridge case
+   (Phase 4). **Studio's read confirmed.**
+2. **Create-path acceptance — explicit-per-part required; the task-level chain field is removed.**
+   Per-node/trigger chain flows through the protojson round-trip already. Under the decided model (G5),
+   the create path **requires** every chain-aware trigger/node to carry an explicit `chain_id` in the
+   configured set, and **rejects** `chain_id == 0` or an unconfigured chain with `InvalidArgument`. There
+   is **no workflow-level chain at all** — `Task.chain_id` / `CreateTaskReq.chain_id` are deleted and task
+   storage is chain-agnostic (Decision 1). So: studio sends an explicit chain on every event/block trigger
+   and contract/transfer node, and **stops sending / reading any workflow-level `chainId`**. A request that
+   omits a chain-aware part's chain is rejected, not flattened.
+3. **Runner provisioning/funding — automatic deploy, per-chain paymaster, no pre-check.** The wallet
+   deploys counterfactually on first UserOp (initCode injected when code is empty,
+   `pkg/erc4337/preset/builder.go:1331`). Paymaster + bundler are the node-chain's via
+   `ResolveSmartWalletConfig(nodeChainID)`. One CREATE2 address is the runner on all 4 core chains
+   (Decision 2). The backend does **not** pre-check balance; it surfaces `AA21` (prefund) at execution.
+   **Studio must surface per-node-chain readiness** ("needs gas / paymaster on chain Y"); the backend
+   won't block create.
+4. **Cleared chain set — the 4 core chains, enforced.** The usable set = the aggregator's configured
+   `chainConfigs` (bundler + paymaster + controller present). Per `docs/Contract.md` that's **Ethereum,
+   Base, Sepolia, Base Sepolia**. The per-node chain selector **must** restrict to those four — once G5
+   lands, a node naming any other chain is rejected at create. Soneium/Minato out of scope.
+5. **Landing order — align studio with G5, not just G1/G3.** Backend G1 (event-trigger mapping) + G3
+   (extract config) make per-part chains flow; G5 makes them required and removes task-level inheritance.
+   Studio should send **explicit per-part chains from day one** (works after G1+G3) and **never** depend
+   on a workflow-level `chainId` cascading — that contract is exactly what G5 enforces. Net: studio
+   Phase 3 ships after backend G1+G3; the data model it adopts must match G5 (per-part required, no
+   workflow-level inheritance).
+
+---
+
+## Design model (the contract every layer follows)
+
+### chainId is a property of *conditions/actions*, not of the task
+
+A task has **exactly one trigger** (`Task.trigger` is a single field, not `repeated`) and N nodes.
+chainId is intrinsic to the parts that touch a chain, and irrelevant to the rest:
+
+| Part | What it does | chainId relevant? |
+|---|---|---|
+| Manual trigger | fired by API call | no |
+| Cron / FixedTime trigger | watches wall-clock time | no |
+| **Block trigger** | watches block height on a chain | **yes** |
+| **Event trigger** | watches logs on a chain | **yes** |
+| **ContractWrite / ContractRead / ETHTransfer node** | acts on a chain | **yes** |
+| CustomCode / REST / GraphQL / Branch / Filter / Loop node | pure compute / off-chain | no |
+
+So a workflow's multi-chain behavior has **two independent axes**, and the operator only owns the first:
+
+1. **The trigger** decides which chain (or none) to *watch* for the firing condition. The operator
+   monitors exactly this. Because there is one trigger per task, the operator never reconciles multiple
+   chains — it routes the single trigger by *the trigger's own chain* (event/block) or treats it as
+   chain-agnostic (cron/manual). There is no `Task.chain_id` to consult — the event/block trigger carries
+   its own required chain, and the operator routes by it.
+2. **Each node** decides which chain to *act on* during execution. This is the executor/aggregator's
+   concern (already wired via `resolveSmartWalletForNode`), invisible to the operator.
+
+Example: watch a price event on Ethereum → execute a swap on Base. The operator only ever opens the
+Ethereum subscription; Base enters the picture solely at node execution. This is exactly why G2's fix is
+"route by the trigger's chain," not "thread the task chain through."
+
+### Resolution rule — `chain_id` is REQUIRED on chain-aware parts; there is no inheritance
+
+**Decided (2026-06-26):** chain lives **only** on the part that touches a chain. `0` is the protobuf
+zero value — it means "unset", never a real chain — so on any chain-aware trigger/node it is **invalid**
+and rejected. There is **no fallback to the task chain, and no aggregator-default fallback, in any mode
+(gateway or single-chain).**
+
+```
+chain-aware trigger/node Config.chain_id:
+   > 0 and in the configured set   → use it
+   anything else (0 / unconfigured) → ERROR (reject at create AND at execution)
+```
+
+- Applies to: event & block triggers; contractRead / contractWrite / ethTransfer nodes; the Loop runner
+  when it wraps one of those.
+- Does **not** apply to parts that never touch a chain: manual/cron triggers and off-chain nodes
+  (customCode, REST, GraphQL, branch, filter, loop-over-data). Those carry no chain — a task built
+  only from them is genuinely chain-agnostic.
+- **Single-chain dev mode is not exempt** (per decision): even with one configured chain, a chain-aware
+  node must name its `chain_id` explicitly and it must equal the configured chain. No "the one chain
+  stands in for 0" shortcut — we want zero `0`-special-cases.
+
+Why no inheritance: `0`-means-inherit is exactly the coupling that produced the wrong-chain paymaster
+failures (Sentry EIGENLAYER-AVS-1N/1M) and the silent-wrong-chain footgun (G4). Making `chain_id`
+required everywhere collapses ~6 "magic fallback to a default chain" sites (see audit class **A** below)
+into one uniform "explicit-or-error" rule — the pattern the strict guards already use
+(`requireChainIDFromConfig`, worker-routed readers/token services).
+
+> Audit context: `chain_id == 0` is special-cased in ~17 places, in three roles. **(A)** magic fallback
+> to a real default chain (`resolveSmartWalletForNode` node→task→`chains[0]`, `executor.go:256`,
+> `ChainRegistry.ResolveChainID/GetWorker/GetChainConfig`, `operator.triggersForChain`,
+> `aggregator/key.go`, and `chainScopedTaskKey`) — **all removed**; per Decision 1 the task storage key
+> drops the chain entirely (chain-agnostic addressing), so `chainScopedTaskKey` goes away rather than
+> losing only its `0`-default. **(B)** legitimate "chain-agnostic / not applicable" sentinel
+> (`operatorsCoveringChain(0)`, cron/manual tasks, `chainHasOperator[0]`) — **kept**, that's how a
+> chain-free task routes to any operator; **(C)** guards that already hard-error on 0 — **the target
+> pattern**.
+
+### Decision 1 — Remove the task-level chain entirely; task storage is chain-agnostic
+
+**Decided (2026-06-26):** there is **no chain tied to a task** — not for execution, not for storage.
+`Task.chain_id` and `CreateTaskReq.chain_id` are **removed**. A task is addressed by id (+ owner index),
+not by chain. Chain lives **only** on the chain-aware parts (G5); any "by chain" view is *derived* from
+the trigger/node chains, never stored on the task. This is the full structural decoupling — a workflow
+does not belong to a chain in any sense.
+
+What this changes:
+
+- **Storage keys drop the chain.** `t:<chain>:<status>:<id>` → `t:<status>:<id>`; the user index
+  `u:<chain>:<owner>:<wallet>:<id>` → `u:<owner>:<wallet>:<id>`; execution keys
+  (`ChainTaskExecutionKey`) drop the chain too (an execution can span chains, so keying it by one is the
+  same coupling). **Breaking storage-key change** — `make storage-check` will flag it; lands with the
+  migration below.
+- **Proto.** Remove `Task.chain_id` (16) and `CreateTaskReq.chain_id` (10); reserve the field numbers.
+  Update mappers (`aggregator/rest/mapping/workflow.go`), drop the REST handler's authKey-aud backfill
+  (`handlers_workflows.go:56`), run `make protoc-gen`. The JWT `aud` chain stays — it's **API auth scope**,
+  no longer a task field.
+- **Listing/CRUD goes chain-agnostic.** `get(id)` / `cancel` / `pause` key on id alone; `list(owner)`
+  returns all of an owner's tasks. A "tasks on chain Y" filter is computed server-side from the parts'
+  chains, not a key prefix. Studio's per-chain client (`getClientWithToken(chainId)`) moves to a
+  chain-agnostic list; the dashboard (their #4) shows all chains with an optional derived per-chain filter.
+- **Execution has no task-default chain.** `NewExecutor`/`NewVMWithData` no longer pass
+  `ResolveSmartWalletConfig(task.ChainId)`; the VM default smart-wallet config is **nil**, so every
+  chain-aware node must resolve its *own* chain or error (exactly G5's rule). The ~30 `task.ChainId`
+  readers (engine.go, vm.go, summarizer, executor) are updated to derive chain from the relevant part:
+  operator coverage at create → the **trigger's** chain; summarizer enrichment → the node's chain.
+- **Wallet-salt keys stay per-chain (separate concern).** `wsalt:%d:…` and `GetWallet(db, chainID, …)`
+  (`vm.go:1583`) are about wallet derivation, not task identity. The runner address is chain-invariant
+  across the 4 core chains (Decision 2), so these can pass *any* configured chain (e.g. the node's). Not
+  part of this decoupling — leave the wallet keys as-is for now; flag for a follow-up if desired.
+
+This dissolves studio's "which chain is `CreateTaskReq.chain_id`?" loose end entirely: **there is no such
+field.** Studio sends explicit per-part chains and nothing else; the create endpoint's authKey is API auth
+only. Their dashboard lists across chains and derives any per-chain view from the parts.
+
+**Migration: wipe all tasks (decided 2026-06-26).** Two facts make a selective migration pointless:
+(1) the storage-key schema changes (`t:<chain>:…` → `t:…`), so *every* existing row is on the old layout;
+(2) legacy tasks carry `chain_id == 0` on their parts and can't be made executable by re-keying — they'd
+fail G5's required-chain rule anyway. Re-keying buys nothing. So the one-shot migration **deletes all
+existing tasks** (and their user-index / execution rows) at boot — taking a full DB backup, recording
+completion so it runs once, *before* the engine serves — and owners re-create with explicit per-part
+chains. The deployed set is tiny and we've accepted breaking it; cleanliness over preservation.
+
+Follows the established delete-task pattern (`DeleteAutoDisabledInvalidTasks`,
+`docs/historical-migrations/2026-completed/`): constant-memory `IterateKeysOnly` scan of the old `t:`
+prefix, delete every key each task owns. Undecodable rows are deleted too (the whole old namespace is
+being retired). *(If preserving chain-agnostic cron/off-chain-only tasks later matters, those — and only
+those — could be re-keyed instead of deleted, since they have no chain-aware part to fix. Out of scope
+unless asked.)*
+
+### Decision 2 — One `smart_wallet_address` (runner) stays task-level; chain varies per step
+
+The studio plan assumes per-node chains require *"multiple runners (a smart wallet per chain)."* **They
+do not.** `model.SmartWallet` is keyed by `(owner, factory, salt)` with **no chainId**
+(`model/user.go`); the CREATE2 address is deterministic in the **deployer** (Factory Proxy) and the
+**wallet init-code hash** (which embeds the Wallet Implementation). So:
+
+- The task carries **one** `smart_wallet_address`; the same address is the runner on every chain where
+  those two inputs match.
+- What is per-chain is **deployment + funding + paymaster**, which the engine already resolves per chain
+  via `ResolveSmartWalletConfig(chainID)`.
+
+**Audit result (`docs/Contract.md`, 2026-06-26) — scoped to the supported chains (Ethereum, Base,
+Sepolia, Base Sepolia):**
+
+| Input to the CREATE2 address | Value | Across the 4 supported chains |
+|---|---|---|
+| Factory **Proxy** (the deployer) | `0xB99BC2E399e06CddCF5E725c0ea341E8f0322834` | identical ✅ |
+| Wallet **Implementation** (in wallet init code) | `0xf5d0c65516f0724242343c4eAA5D9de3ee4291fB` | identical ✅ |
+| Factory **Implementation** | varies | irrelevant — the Proxy is the deployer; the impl runs via delegatecall in the proxy context |
+
+**Decision 2 holds.** Same deployer + same wallet implementation ⇒ identical CREATE2 address across all
+four supported chains. One runner address serves all of them; safe to ship per-node multi-chain now.
+
+(Soneium/Minato are out of scope — not currently supported — so their differing wallet implementation is
+not a concern for this work.)
+
+### Decision 3 — `chain_id` required on every chain-aware part, all modes
+
+Supersedes the old "gateway requires task chain_id" carve-out: the requirement is now uniform and lives
+on the **part**, not the task. Gateway and single-chain mode behave identically — a chain-aware
+trigger/node with `chain_id ≤ 0` or an unconfigured chain is rejected at create and at execution. The
+existing gateway task-chain check (`engine.go:1637-1660`) is **deleted** along with `Task.chain_id`
+(Decision 1) — there is no task chain left to validate.
+
+---
+
+## Implementation — bottom-up phases
+
+Phases 1–2 are **pure plumbing on the existing model** (per-node/trigger chains already representable)
+and unblock studio Phase 3. Phase 3 is the **decided model change** — make `chain_id` required, delete
+inheritance (a one-shot delete migration clears stale `0`-chain tasks at boot; no backfill). Phase 4 is
+the genuinely new protocol work (cross-chain sequencing) and maps to studio Phase 4.
+
+### Phase 0 — Lock the contract & prove the gaps (no behavior change)
+
+- Add a backend integration test that builds a task whose **node** chain ≠ **task** chain and asserts the
+  deployed execution dials the node's chain (this should already pass — it pins the working path so the
+  later fixes don't regress it).
+- Add tests that assert G1/G3 currently drop the chain (red), to be flipped green by Phases 1–2.
+- Audit `SmartWalletConfig.FactoryAddress` equality across all configured chains (Decision 2 risk).
+- `make storage-check` baseline.
+
+### Phase 1 — Close the ingestion + simulation gaps (G1, G3, G4) — **IMPLEMENTED**
+
+1. **G1 — EventTrigger chain mapping. ✅** `openAPIEventToProto`/`protoEventToOpenAPI`
+   (`aggregator/rest/mapping/trigger.go`) map `chainId` both directions, mirroring BlockTrigger. Covered
+   by the `event` case in `trigger_test.go`.
+2. **G3 — `ExtractNodeConfiguration` chain. ✅** Emits `chainId` for ContractWrite/ContractRead/ETHTransfer;
+   `CreateNodeFromType` reads it back onto the proto Config; `requireChainIDFromConfig` now accepts the
+   camelCase `chainId` key (node maps) alongside snake `chain_id` (trigger maps). Covered by
+   `chain_per_part_test.go`.
+3. **G4 — reject unknown explicit chains at create. ✅** `validateExplicitPartChains`
+   (`core/taskengine/engine.go`), called in `CreateTask`, rejects a chain-aware trigger/node naming an
+   unconfigured explicit chain with `InvalidArgument` (gateway mode; checks against `knownChainIDs()`,
+   walks Loop runners). Pairs with the runtime guard in `resolveSmartWalletForNode`. `chain_id == 0`
+   (inherit) is still allowed — G5 tightens that. Covered by `chain_per_part_test.go` +
+   `vm_resolve_smart_wallet_test.go`.
+
+**Outcome:** per-node and per-event-trigger chains are honored on **every** execution path *except* the
+operator's event subscription (G2). Independent, low-risk, no storage change. `chain_id == 0` still
+inherits the task chain (legacy path) — tightened in Phase 3. Build + targeted tests green.
+
+### Phase 2 — Operator routes the trigger by the trigger's own chain (G2)
+
+In `operator/worker_loop.go:1055-1090`, key the EventTrigger (and BlockTrigger) subscription on
+`trigger.GetEvent().GetConfig().GetChainId()` falling back to `TaskMetadata.GetChainId()` (the inherit
+rule). Because there is **one trigger per task**, there is no union-of-chains problem: the
+`operatorsCoveringChain` selection (`engine.go:649-682`) should be driven by the **trigger's** chain, not
+the task's. Confirm that the aggregator computes coverage from the trigger chain when it dispatches the
+task to operators (so a task watching chain X is only sent to operators covering X), and that cron/manual
+triggers remain chain-agnostic (covered by any operator).
+
+**Outcome:** event triggers fire on their own chain. A workflow can now *watch* chain X and *act* on
+chain Y within one task, with independent (non-sequential) steps. This fully satisfies studio Phase 3.
+
+### Phase 3 — `chain_id` required per part; remove the task-level chain; chain-agnostic storage (G5)
+
+The decided model change — the big structural one. Ships as one release with a **wipe-all migration** at
+boot (the storage schema changes, so all old rows go; owners re-create with explicit per-part chains).
+The migrator runs before the engine serves, so the new schema is clean from first request.
+
+1. **Wipe-all migration.** Delete every task on the old `t:<chain>:…` schema (status rows, `u:` user
+   index, execution rows). Pattern: `DeleteAutoDisabledInvalidTasks` (constant-memory `IterateKeysOnly`,
+   full DB backup, recorded once) — but scanning the whole old `t:` namespace, not a subset. Register in
+   `migrations/migrations.go`.
+2. **Chain-agnostic storage.** Drop the chain from the key builders — `storage/schema/workflow.go` +
+   `core/taskengine/schema.go` (`ChainWorkflowStorageKey`→`WorkflowStorageKey`, `ChainTaskUserKey`,
+   `ChainTaskExecutionKey`). Update list/get/cancel/pause to key on id; the per-chain filter is derived
+   server-side from the parts. `make storage-check` will flag the template change — that's expected, the
+   migration covers it.
+3. **Remove the task chain field.** Delete `Task.chain_id` (16) + `CreateTaskReq.chain_id` (10) from the
+   proto (reserve the numbers), update mappers, drop the authKey-aud backfill (`handlers_workflows.go:56`),
+   `make protoc-gen`. Update the ~30 `task.ChainId` readers to derive chain from the relevant part
+   (operator coverage at create → trigger chain; summarizer → node chain; executor → nil VM default).
+4. **Flip to explicit-or-error.** Make `resolveSmartWalletForNode` reject `chain_id <= 0` (no fallbacks);
+   the create validator rejects `0`/unconfigured on chain-aware parts in **all** modes; remove the
+   remaining audit-class-**A** sites (`executor.go`, `ChainRegistry.ResolveChainID/GetWorker/GetChainConfig`,
+   `operator.triggersForChain`, `aggregator/key.go`).
+5. **Fix the Loop runner.** `createNestedNodeFromLoop` (`loop_helpers.go:205`) must carry an explicit
+   chain on the nested node — from the Loop runner's own config. (Once nodes require a chain, the inner
+   node already has it; verify the nested-node path preserves it.)
+6. **Drop the docs/comments.** Remove "0 = inherit task's chain_id" from `protobuf/avs.proto` (151/222/
+   383/410/455) and the `ChainId` schema note in `api/openapi.yaml:117-124`.
+7. **Keep the (B) sentinel.** Do **not** touch `operatorsCoveringChain(0)` / cron-manual chain-agnostic
+   routing — a chain-free task legitimately has no chain.
+8. **SDK + tests.** SDK always writes explicit per-part chains and stops sending a workflow-level chain;
+   update tests that assumed `0`-inherit or a task chain.
+
+**Outcome:** chain lives **only** on the parts — explicit-or-error — and a task belongs to no chain in
+any sense (not execution, not storage, not listing). Per-chain views are derived. This is the full
+structural decoupling.
+
+### Phase 4 — True cross-chain sequencing (bridge mid-workflow)
+
+This is the genuinely unbuilt protocol work (studio Phase 4). Per-node chains give *independent*
+multi-chain steps; a real bridge needs **sequential cross-chain settlement**: act on B only after the
+bridge from A confirms. Requires, at minimum:
+
+- a node/primitive that submits a bridge and **waits for finality on the destination chain** before
+  downstream nodes run;
+- execution state that survives a cross-chain wait (re-entrant executor, not a single synchronous pass);
+- per-step authKey/paymaster minting on the destination chain (the engine already resolves per-chain
+  configs; the executor must request the right one per step — already true for per-node chains, but the
+  **wait/resume** is new).
+
+Scope this separately once Phases 1–3 land; do not block them on it.
+
+---
+
+## Coordination & sequencing
+
+- **AVS backend (this repo): Phases 0→1→2→3** — self-contained. Phases 1–2 are non-breaking plumbing;
+  Phase 3 (G5) is the breaking model change, shipped with a one-shot delete migration that clears stale
+  `0`-chain tasks at boot (no backfill).
+- **v4 SDK (`ava-sdk-js`):** already exposes the fields; add a **multi-chain template test** (per-part
+  explicit chains) once Phase 1 lands, to lock the wire contract. Ensure it always writes explicit chains
+  (G5 makes that mandatory). No type changes needed.
+- **Studio:** its Phase 1/2 (identity/chain decoupling from the live wallet) are independent and can
+  proceed now. Its Phase 3 (per-node chain in the canvas data model) is unblocked the moment backend
+  Phase 1–2 ship — and must adopt the **G5 contract**: explicit chain per chain-aware part, no
+  workflow-level `chainId` inheritance.
+- Every change touching `model/` or `protobuf/` must pass `make storage-check` against `origin/main`
+  before staging→main.
+
+## Correction to send to the studio plan
+
+`PLAN_WALLET_CHAIN_DECOUPLING.md` should be amended:
+
+- Line ~59 *"Triggers/nodes carry no chainId of their own"* — **false** at the AVS/proto/SDK layer; the
+  fields exist and (for nodes) are already honored end-to-end. The gap is studio's DTO not populating
+  them, plus backend G1/G2/G3.
+- Phase 3 *"Blocked on AVS: confirm the task schema can represent a multi-chain task"* — **unblocked**;
+  it can. Reframe Phase 3 as "populate per-node/per-trigger chainId; reconcile deploy-time runner."
+- Line ~106 *"multiple runners (a smart wallet per chain)"* — **not required**; one CREATE2 address
+  serves all chains (per the Decision 2 audit, for the 4 core chains).
+- **New (decided model):** chain is **required per chain-aware part**, and the **workflow-level `chainId`
+  is removed entirely** — no `CreateTaskReq.chain_id`, no `Task.chain_id`, and task storage is
+  chain-agnostic. Studio must drop the workflow-level `chainId` from both the request it sends *and* the
+  record it reads: set chain explicitly on each event/block trigger and contract/transfer node (restricted
+  to the 4 configured chains); a part left without a chain is rejected at create. The dashboard lists
+  across chains and derives any per-chain view from the parts; the create endpoint's authKey remains
+  API-auth scope only, not a task chain.
+
+---
+
+## References (code, exact locations)
+
+- Proto: `protobuf/avs.proto` — task `:817`, CreateTaskReq `:858`, EventTrigger.Config `:222`,
+  BlockTrigger `:152`, ContractWrite `:410`, ContractRead `:455`, ETHTransfer `:384`.
+- REST mapping: `aggregator/rest/mapping/node.go:203` (protojson round-trip),
+  `aggregator/rest/mapping/trigger.go:117-135` (BlockTrigger maps chainId), `:190-205` (EventTrigger
+  **does not** — G1).
+- Execution: `core/taskengine/vm.go:347-361` (`resolveSmartWalletForNode`), `:1475/1518/1743`
+  (deployed nodes read proto chain), `:3493` (`ExtractNodeConfiguration` — G3).
+- Engine multi-chain pool: `core/taskengine/engine.go:426-433` (`ResolveSmartWalletConfig`),
+  `:649-682` (`operatorsCoveringChain`), `:1637-1660` (task chain resolution / gateway requirement).
+- Operator: `operator/worker_loop.go:1055-1090` (event routing by task chain — G2).
+- Model: `model/user.go` (`SmartWallet` has no chainId; `User.ChainID` from JWT aud),
+  `model/workflow.go` (`Workflow` wraps `*avsproto.Task`).
+- OpenAPI: `api/openapi.yaml:402,492,592,618,634`.
+- SDK (`/Users/mikasa/Code/ava-sdk-js`): `packages/sdk-js/src/v4/builders/{nodes,triggers}.ts`,
+  `packages/types/src/openapi.gen.ts` (per-node/trigger `chainId`).

--- a/aggregator/rest/mapping/trigger.go
+++ b/aggregator/rest/mapping/trigger.go
@@ -191,6 +191,9 @@ func openAPIEventToProto(in generated.EventTrigger) *avsproto.EventTrigger {
 	out := &avsproto.EventTrigger{Config: &avsproto.EventTrigger_Config{}}
 	if in.Config != nil {
 		out.Config.Queries = openAPIEventQueriesToProto(in.Config.Queries)
+		if in.Config.ChainId != nil {
+			out.Config.ChainId = *in.Config.ChainId
+		}
 	}
 	return out
 }
@@ -199,7 +202,11 @@ func protoEventToOpenAPI(in *avsproto.EventTrigger) generated.EventTrigger {
 	t := generated.Event
 	out := generated.EventTrigger{Type: &t}
 	if cfg := in.GetConfig(); cfg != nil {
-		out.Config = &generated.EventTriggerConfig{Queries: protoEventQueriesToOpenAPI(cfg.GetQueries())}
+		c := generated.EventTriggerConfig{Queries: protoEventQueriesToOpenAPI(cfg.GetQueries())}
+		if cid := cfg.GetChainId(); cid != 0 {
+			c.ChainId = &cid
+		}
+		out.Config = &c
 	}
 	return out
 }

--- a/aggregator/rest/mapping/trigger_test.go
+++ b/aggregator/rest/mapping/trigger_test.go
@@ -87,10 +87,12 @@ func TestTriggerRoundTrip(t *testing.T) {
 				tr := generated.Trigger{Name: "eventTrigger", Type: generated.TriggerTypeEvent}
 				addr := generated.EthereumAddress("0x1234567890123456789012345678901234567890")
 				sig := "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+				eventChainID := int64(8453)
 				typ := generated.Event
 				inner := generated.EventTrigger{
 					Type: &typ,
 					Config: &generated.EventTriggerConfig{
+						ChainId: &eventChainID,
 						Queries: []generated.EventTriggerQuery{{
 							Addresses: &[]generated.EthereumAddress{addr},
 							Topics:    &[]string{sig, ""},
@@ -109,6 +111,8 @@ func TestTriggerRoundTrip(t *testing.T) {
 			check: func(t *testing.T, out generated.Trigger) {
 				v, err := out.AsEventTrigger()
 				require.NoError(t, err)
+				require.NotNil(t, v.Config.ChainId, "event trigger chain_id must survive the round-trip (G1)")
+				assert.Equal(t, int64(8453), *v.Config.ChainId)
 				require.Len(t, v.Config.Queries, 1)
 				require.NotNil(t, v.Config.Queries[0].Addresses)
 				assert.Equal(t, "0x1234567890123456789012345678901234567890", string((*v.Config.Queries[0].Addresses)[0]))

--- a/core/taskengine/chain_per_part_test.go
+++ b/core/taskengine/chain_per_part_test.go
@@ -138,3 +138,36 @@ func TestValidateExplicitPartChains(t *testing.T) {
 		require.NoError(t, single.validateExplicitPartChains(task))
 	})
 }
+
+// TestTriggerMonitoringChainID locks G2: the operator monitors a chain-watching
+// trigger on the trigger's OWN chain, falling back to the task chain only when
+// the trigger leaves its chain at 0 (legacy). Non-chain triggers carry the
+// fallback through.
+func TestTriggerMonitoringChainID(t *testing.T) {
+	const taskChain = int64(11155111)
+
+	eventTrigger := func(chainID int64) *avsproto.TaskTrigger {
+		return &avsproto.TaskTrigger{TriggerType: &avsproto.TaskTrigger_Event{
+			Event: &avsproto.EventTrigger{Config: &avsproto.EventTrigger_Config{ChainId: chainID}},
+		}}
+	}
+	blockTrigger := func(chainID int64) *avsproto.TaskTrigger {
+		return &avsproto.TaskTrigger{TriggerType: &avsproto.TaskTrigger_Block{
+			Block: &avsproto.BlockTrigger{Config: &avsproto.BlockTrigger_Config{ChainId: chainID, Interval: 1}},
+		}}
+	}
+	cronTrigger := &avsproto.TaskTrigger{TriggerType: &avsproto.TaskTrigger_Cron{
+		Cron: &avsproto.CronTrigger{Config: &avsproto.CronTrigger_Config{Schedules: []string{"* * * * *"}}},
+	}}
+
+	assert.Equal(t, int64(8453), triggerMonitoringChainID(eventTrigger(8453), taskChain),
+		"event trigger uses its own chain, not the task chain")
+	assert.Equal(t, taskChain, triggerMonitoringChainID(eventTrigger(0), taskChain),
+		"event trigger chain 0 falls back to the task chain (legacy)")
+	assert.Equal(t, int64(8453), triggerMonitoringChainID(blockTrigger(8453), taskChain),
+		"block trigger uses its own chain")
+	assert.Equal(t, taskChain, triggerMonitoringChainID(cronTrigger, taskChain),
+		"cron trigger carries the fallback (chain-agnostic)")
+	assert.Equal(t, taskChain, triggerMonitoringChainID(nil, taskChain),
+		"nil trigger carries the fallback")
+}

--- a/core/taskengine/chain_per_part_test.go
+++ b/core/taskengine/chain_per_part_test.go
@@ -1,0 +1,140 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestExtractNodeConfiguration_CarriesChainId locks G3: the per-node chain must
+// survive ExtractNodeConfiguration (the map-based config used by
+// runNodeImmediately / simulation / loop-nested) and be readable back by
+// CreateNodeFromType. Before the fix these paths dropped chainId and ran on the
+// wrong chain.
+func TestExtractNodeConfiguration_CarriesChainId(t *testing.T) {
+	const chainID = int64(8453)
+
+	cases := []struct {
+		name string
+		node *avsproto.TaskNode
+		read func(*avsproto.TaskNode) int64
+	}{
+		{
+			name: "contractWrite",
+			node: &avsproto.TaskNode{
+				Id: "cw1", Name: "cw", Type: avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE,
+				TaskType: &avsproto.TaskNode_ContractWrite{ContractWrite: &avsproto.ContractWriteNode{
+					Config: &avsproto.ContractWriteNode_Config{
+						ContractAddress: "0x1234567890123456789012345678901234567890",
+						ChainId:         chainID,
+					},
+				}},
+			},
+			read: func(n *avsproto.TaskNode) int64 { return n.GetContractWrite().GetConfig().GetChainId() },
+		},
+		{
+			name: "contractRead",
+			node: &avsproto.TaskNode{
+				Id: "cr1", Name: "cr", Type: avsproto.NodeType_NODE_TYPE_CONTRACT_READ,
+				TaskType: &avsproto.TaskNode_ContractRead{ContractRead: &avsproto.ContractReadNode{
+					Config: &avsproto.ContractReadNode_Config{
+						ContractAddress: "0x1234567890123456789012345678901234567890",
+						ChainId:         chainID,
+					},
+				}},
+			},
+			read: func(n *avsproto.TaskNode) int64 { return n.GetContractRead().GetConfig().GetChainId() },
+		},
+		{
+			name: "ethTransfer",
+			node: &avsproto.TaskNode{
+				Id: "et1", Name: "et", Type: avsproto.NodeType_NODE_TYPE_ETH_TRANSFER,
+				TaskType: &avsproto.TaskNode_EthTransfer{EthTransfer: &avsproto.ETHTransferNode{
+					Config: &avsproto.ETHTransferNode_Config{
+						Destination: "0x1234567890123456789012345678901234567890",
+						Amount:      "1",
+						ChainId:     chainID,
+					},
+				}},
+			},
+			read: func(n *avsproto.TaskNode) int64 { return n.GetEthTransfer().GetConfig().GetChainId() },
+		},
+	}
+
+	nodeTypeString := map[string]string{
+		"contractWrite": "contractWrite",
+		"contractRead":  "contractRead",
+		"ethTransfer":   "ethTransfer",
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ExtractNodeConfiguration(tc.node)
+			require.NotNil(t, cfg)
+			assert.EqualValues(t, chainID, cfg["chainId"], "ExtractNodeConfiguration must emit chainId")
+
+			rebuilt, err := CreateNodeFromType(nodeTypeString[tc.name], cfg, tc.node.Id)
+			require.NoError(t, err)
+			assert.Equal(t, chainID, tc.read(rebuilt), "CreateNodeFromType must read chainId back onto the proto")
+		})
+	}
+}
+
+// TestValidateExplicitPartChains locks G4: in gateway mode, a chain-aware part
+// naming an explicit chain the aggregator isn't configured for is rejected at
+// create; chain_id == 0 (inherit) and configured chains are accepted.
+func TestValidateExplicitPartChains(t *testing.T) {
+	// Engine configured (gateway) for chains 1 and 8453 only.
+	n := &Engine{
+		config:       &config.Config{IsGateway: true},
+		chainConfigs: map[int64]*config.ChainConfig{1: {ChainID: 1}, 8453: {ChainID: 8453}},
+	}
+
+	cwNode := func(chainID int64) *avsproto.TaskNode {
+		return &avsproto.TaskNode{
+			Id: "cw", Name: "cw", Type: avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE,
+			TaskType: &avsproto.TaskNode_ContractWrite{ContractWrite: &avsproto.ContractWriteNode{
+				Config: &avsproto.ContractWriteNode_Config{ChainId: chainID},
+			}},
+		}
+	}
+
+	t.Run("configured node chain passes", func(t *testing.T) {
+		task := &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{cwNode(8453)}}}
+		require.NoError(t, n.validateExplicitPartChains(task))
+	})
+
+	t.Run("chain_id 0 (inherit) passes", func(t *testing.T) {
+		task := &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{cwNode(0)}}}
+		require.NoError(t, n.validateExplicitPartChains(task))
+	})
+
+	t.Run("unconfigured explicit node chain is rejected", func(t *testing.T) {
+		task := &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{cwNode(137)}}}
+		err := n.validateExplicitPartChains(task)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "137")
+	})
+
+	t.Run("unconfigured event trigger chain is rejected", func(t *testing.T) {
+		task := &model.Workflow{Task: &avsproto.Task{Trigger: &avsproto.TaskTrigger{
+			TriggerType: &avsproto.TaskTrigger_Event{Event: &avsproto.EventTrigger{
+				Config: &avsproto.EventTrigger_Config{ChainId: 999999},
+			}},
+		}}}
+		err := n.validateExplicitPartChains(task)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "event trigger")
+	})
+
+	t.Run("non-gateway mode skips validation", func(t *testing.T) {
+		single := &Engine{config: &config.Config{IsGateway: false}}
+		task := &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{cwNode(137)}}}
+		require.NoError(t, single.validateExplicitPartChains(task))
+	})
+}

--- a/core/taskengine/chain_per_part_test.go
+++ b/core/taskengine/chain_per_part_test.go
@@ -132,6 +132,26 @@ func TestValidateExplicitPartChains(t *testing.T) {
 		assert.Contains(t, err.Error(), "event trigger")
 	})
 
+	t.Run("unconfigured block trigger chain is rejected", func(t *testing.T) {
+		task := &model.Workflow{Task: &avsproto.Task{Trigger: &avsproto.TaskTrigger{
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{
+				Config: &avsproto.BlockTrigger_Config{ChainId: 999999, Interval: 1},
+			}},
+		}}}
+		err := n.validateExplicitPartChains(task)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "block trigger")
+	})
+
+	t.Run("configured block trigger chain passes", func(t *testing.T) {
+		task := &model.Workflow{Task: &avsproto.Task{Trigger: &avsproto.TaskTrigger{
+			TriggerType: &avsproto.TaskTrigger_Block{Block: &avsproto.BlockTrigger{
+				Config: &avsproto.BlockTrigger_Config{ChainId: 1, Interval: 1},
+			}},
+		}}}
+		require.NoError(t, n.validateExplicitPartChains(task))
+	})
+
 	t.Run("non-gateway mode skips validation", func(t *testing.T) {
 		single := &Engine{config: &config.Config{IsGateway: false}}
 		task := &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{cwNode(137)}}}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -2298,7 +2298,9 @@ func (n *Engine) StreamCheckToOperator(payload *avsproto.SyncMessagesReq, srv av
 						ExpiredAt: task.ExpiredAt,
 						Trigger:   task.Trigger,
 						StartAt:   task.StartAt,
-						ChainId:   task.ChainId,
+						// Operators route by the trigger's monitoring chain (G2),
+						// not the task chain — watch X, act Y.
+						ChainId: triggerMonitoringChainID(task.Trigger, task.ChainId),
 					},
 				}
 
@@ -3254,7 +3256,8 @@ func (n *Engine) instructOperatorImmediateTrigger(ctx context.Context, taskID st
 					ExpiredAt: task.ExpiredAt,
 					Trigger:   task.Trigger,
 					StartAt:   task.StartAt,
-					ChainId:   task.ChainId,
+					// Operators route by the trigger's monitoring chain (G2).
+					ChainId: triggerMonitoringChainID(task.Trigger, task.ChainId),
 				},
 			}
 

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -508,6 +508,86 @@ func (n *Engine) chainScopedTaskKey(task *model.Workflow) []byte {
 	return ChainWorkflowStorageKey(chainID, task.Id, task.Status)
 }
 
+// isChainConfigured reports whether the aggregator serves chainID, using the
+// canonical set knownChainIDs() (default chain + chainConfigs). ResolveSmart-
+// WalletConfig is NOT a substitute — it falls back to the default config for
+// an unknown chain, so it can't tell "configured" from "unconfigured".
+func (n *Engine) isChainConfigured(chainID int64) bool {
+	for _, id := range n.knownChainIDs() {
+		if id == chainID {
+			return true
+		}
+	}
+	return false
+}
+
+// validateExplicitPartChains rejects a task whose chain-aware trigger or nodes
+// name an explicit chain_id (>0) the aggregator isn't configured for — the
+// create-time half of G4. Without it such a task saves and only fails later at
+// execution (resolveSmartWalletForNode errors on an unconfigured explicit
+// chain). Only enforced in gateway mode, where chainConfigs enumerates the
+// served chains; single-chain mode has one chain and nothing to validate
+// against. chain_id == 0 (inherit) is still permitted here — G5 tightens that.
+func (n *Engine) validateExplicitPartChains(task *model.Workflow) error {
+	if n.config == nil || !n.config.IsGateway || task == nil {
+		return nil
+	}
+	check := func(kind string, chainID int64) error {
+		if chainID == 0 || n.isChainConfigured(chainID) {
+			return nil
+		}
+		return status.Errorf(codes.InvalidArgument,
+			"%s targets chain_id=%d, which is not configured on this aggregator", kind, chainID)
+	}
+	if t := task.Trigger; t != nil {
+		if et := t.GetEvent(); et != nil && et.Config != nil {
+			if err := check("event trigger", et.Config.GetChainId()); err != nil {
+				return err
+			}
+		}
+		if bt := t.GetBlock(); bt != nil && bt.Config != nil {
+			if err := check("block trigger", bt.Config.GetChainId()); err != nil {
+				return err
+			}
+		}
+	}
+	for _, node := range task.Nodes {
+		if err := checkNodeChain(node, check); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkNodeChain runs check against a node's chain-aware config, looking inside
+// a Loop runner too (it wraps one chain-aware node inline).
+func checkNodeChain(node *avsproto.TaskNode, check func(string, int64) error) error {
+	if node == nil {
+		return nil
+	}
+	if cw := node.GetContractWrite(); cw != nil && cw.Config != nil {
+		return check("contract write node", cw.Config.GetChainId())
+	}
+	if cr := node.GetContractRead(); cr != nil && cr.Config != nil {
+		return check("contract read node", cr.Config.GetChainId())
+	}
+	if et := node.GetEthTransfer(); et != nil && et.Config != nil {
+		return check("eth transfer node", et.Config.GetChainId())
+	}
+	if loop := node.GetLoop(); loop != nil {
+		if cw := loop.GetContractWrite(); cw != nil && cw.Config != nil {
+			return check("loop contract write runner", cw.Config.GetChainId())
+		}
+		if cr := loop.GetContractRead(); cr != nil && cr.Config != nil {
+			return check("loop contract read runner", cr.Config.GetChainId())
+		}
+		if et := loop.GetEthTransfer(); et != nil && et.Config != nil {
+			return check("loop eth transfer runner", et.Config.GetChainId())
+		}
+	}
+	return nil
+}
+
 // findTaskKey searches every known chain bucket for a task by id at the
 // given status, returning the matching chain-scoped key. Used by lookup
 // paths that have only a task_id (no chain context). Returns the
@@ -1699,6 +1779,11 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 	// Validate all node names for JavaScript compatibility
 	if err := validateAllNodeNamesForJavaScript(task); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "node name validation failed: %v", err)
+	}
+
+	// Reject chain-aware parts that name an explicit, unconfigured chain (G4).
+	if err := n.validateExplicitPartChains(task); err != nil {
+		return nil, err
 	}
 
 	updates := map[string][]byte{}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -712,6 +712,25 @@ func chainNeedsOperatorMonitoring(tt avsproto.TriggerType) bool {
 	}
 }
 
+// triggerMonitoringChainID returns the chain an operator must subscribe to in
+// order to watch this task's trigger fire (G2). For chain-watching triggers
+// (event/block) it is the trigger's OWN configured chain — so a workflow can
+// watch chain X while its nodes act on chain Y. A 0 on the trigger means
+// "inherit", so we fall back to the task chain (legacy, until G5 removes the
+// task chain). Non-chain triggers (cron/fixedtime/manual) carry the fallback
+// through unchanged — the operator's TimeTrigger is chain-agnostic and ignores
+// it. Proto getters are nil-safe, so the GetEvent()/GetBlock() chain reads are
+// safe for any trigger type.
+func triggerMonitoringChainID(trigger *avsproto.TaskTrigger, fallbackChainID int64) int64 {
+	if cid := trigger.GetEvent().GetConfig().GetChainId(); cid != 0 {
+		return cid
+	}
+	if cid := trigger.GetBlock().GetConfig().GetChainId(); cid != 0 {
+		return cid
+	}
+	return fallbackChainID
+}
+
 // operatorsCoveringChain returns the addresses of currently-connected
 // operators that advertise the given chain_id. Empty
 // SupportedChainIDs is "covers everything" ONLY when
@@ -824,10 +843,13 @@ func (n *Engine) collectOrphans() []orphanedTaskInfo {
 		if hasLegacyOperator {
 			continue
 		}
-		if !chainHasOperator[task.ChainId] {
+		// Coverage is judged on the trigger's monitoring chain (G2), which is
+		// where the operator actually subscribes — not the task chain.
+		monitorChainID := triggerMonitoringChainID(task.Trigger, task.ChainId)
+		if !chainHasOperator[monitorChainID] {
 			out = append(out, orphanedTaskInfo{
 				taskID:      taskID,
-				chainID:     task.ChainId,
+				chainID:     monitorChainID,
 				triggerType: task.Trigger.Type.String(),
 			})
 		}
@@ -1740,16 +1762,19 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 	// and the legacy back-compat path counts no-chain-list operators
 	// as covering everything.
 	if n.config != nil && n.config.IsGateway && task.Trigger != nil && chainNeedsOperatorMonitoring(task.Trigger.Type) {
+		// Coverage is judged on the trigger's monitoring chain (G2) — the chain
+		// the operator subscribes to — not the task chain.
+		monitorChainID := triggerMonitoringChainID(task.Trigger, task.ChainId)
 		n.lock.Lock()
-		covering := n.operatorsCoveringChain(task.ChainId)
+		covering := n.operatorsCoveringChain(monitorChainID)
 		n.lock.Unlock()
 		if len(covering) == 0 {
 			n.logger.Warn("🚫 CreateTask rejected: no operator advertises this chain",
-				"chain_id", task.ChainId, "trigger_type", task.Trigger.Type.String(), "user", userAddr)
+				"chain_id", monitorChainID, "trigger_type", task.Trigger.Type.String(), "user", userAddr)
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"no connected operator currently monitors chain_id=%d for %s triggers; "+
 					"task cannot fire until coverage is restored",
-				task.ChainId, task.Trigger.Type.String())
+				monitorChainID, task.Trigger.Type.String())
 		}
 	}
 
@@ -2568,7 +2593,9 @@ func (n *Engine) sendMonitorTaskTriggerToOperators(task *model.Workflow) {
 			ExpiredAt: task.ExpiredAt,
 			Trigger:   task.Trigger,
 			StartAt:   task.StartAt,
-			ChainId:   task.ChainId,
+			// Operators route by the trigger's monitoring chain (G2), not the
+			// task chain — a workflow may watch chain X and act on chain Y.
+			ChainId: triggerMonitoringChainID(task.Trigger, task.ChainId),
 		},
 	}
 

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -194,6 +194,12 @@ func (n *Engine) runBlockTriggerImmediately(ctx context.Context, triggerConfig m
 func requireChainIDFromConfig(config map[string]interface{}) (int64, error) {
 	raw, ok := config["chain_id"]
 	if !ok {
+		// Node config maps (ExtractNodeConfiguration) carry the camelCase
+		// `chainId`; trigger config maps carry snake_case `chain_id`. Accept
+		// either so per-node chains resolve on the isolated-run output path.
+		raw, ok = config["chainId"]
+	}
+	if !ok {
 		return 0, fmt.Errorf("chain_id not specified in trigger config")
 	}
 	var chainID int64

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -200,7 +200,7 @@ func requireChainIDFromConfig(config map[string]interface{}) (int64, error) {
 		raw, ok = config["chainId"]
 	}
 	if !ok {
-		return 0, fmt.Errorf("chain_id not specified in trigger config")
+		return 0, fmt.Errorf("chain_id not specified in trigger/node config")
 	}
 	var chainID int64
 	switch v := raw.(type) {

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -327,37 +327,43 @@ func (v *VM) WithChainConfigResolver(resolver func(chainID int64) *config.SmartW
 	return v
 }
 
-// resolveSmartWalletForNode picks the SmartWalletConfig a node should
-// use, walking three sources in order:
+// resolveSmartWalletForNode picks the SmartWalletConfig a node should use.
 //
-//  1. The node's own chain_id override (set on Config when the SDK or
-//     UI threads it through explicitly).
-//  2. The task's ChainId (the workflow's target chain). Loop iterations
-//     create nested nodes via createNestedNodeFromLoop, which returns
-//     the inner node proto verbatim — those inner nodes don't carry a
-//     per-iteration chain_id, so without this fallback the resolver
-//     would land on v.smartWalletConfig. In gateway mode that default
-//     is populated from chains[0] (mainnet by convention; see
-//     core/config/config.go:367), causing paymaster ops for any other
-//     chain's workflow to dial the wrong RPC and surface as
-//     "no contract code at given address" (Sentry EIGENLAYER-AVS-1N/1M).
-//  3. v.smartWalletConfig as a last-resort default — correct in
-//     single-chain mode where chainConfigResolver is nil and the VM
-//     was constructed with the only smart_wallet config that exists.
-func (v *VM) resolveSmartWalletForNode(nodeChainID int64) *config.SmartWalletConfig {
+// An explicit, non-zero node chain_id is AUTHORITATIVE: if it can't be
+// resolved against the aggregator's configured chain set, that's a hard
+// error. We deliberately do NOT fall back to the task chain in that case —
+// silently retargeting a node the user explicitly pinned to chain Y onto the
+// task's chain X would execute it on the wrong chain with no signal, a
+// footgun once a multi-chain UI lets users pick per-node chains.
+//
+// A zero node chain_id means "inherit", and walks two further sources:
+//  1. The task's ChainId (the workflow's target chain). Loop iterations
+//     create nested nodes via createNestedNodeFromLoop, which returns the
+//     inner node proto verbatim — those inner nodes don't carry a
+//     per-iteration chain_id, so without this fallback the resolver would
+//     land on v.smartWalletConfig. In gateway mode that default is populated
+//     from chains[0] (mainnet by convention; see core/config/config.go:367),
+//     causing paymaster ops for any other chain's workflow to dial the wrong
+//     RPC and surface as "no contract code at given address"
+//     (Sentry EIGENLAYER-AVS-1N/1M).
+//  2. v.smartWalletConfig as a last-resort default — correct in single-chain
+//     mode where chainConfigResolver is nil and the VM was constructed with
+//     the only smart_wallet config that exists.
+func (v *VM) resolveSmartWalletForNode(nodeChainID int64) (*config.SmartWalletConfig, error) {
 	if v.chainConfigResolver != nil {
 		if nodeChainID > 0 {
 			if resolved := v.chainConfigResolver(nodeChainID); resolved != nil {
-				return resolved
+				return resolved, nil
 			}
+			return nil, fmt.Errorf("chain_id %d is not configured on this aggregator; the node explicitly targets an unsupported chain", nodeChainID)
 		}
 		if taskChainID := v.taskChainID(); taskChainID > 0 {
 			if resolved := v.chainConfigResolver(taskChainID); resolved != nil {
-				return resolved
+				return resolved, nil
 			}
 		}
 	}
-	return v.smartWalletConfig
+	return v.smartWalletConfig, nil
 }
 
 // taskChainID returns the chain id of the workflow this VM is executing,
@@ -1472,7 +1478,12 @@ func (v *VM) runContractRead(taskNode *avsproto.TaskNode) (*avsproto.Execution_S
 		return executionLog, err
 	}
 
-	swConfig := v.resolveSmartWalletForNode(node.Config.GetChainId())
+	swConfig, err := v.resolveSmartWalletForNode(node.Config.GetChainId())
+	if err != nil {
+		executionLog = v.createExecutionStep(stepID, false, err.Error(), "", time.Now().UnixMilli())
+		executionLog.EndAt = time.Now().UnixMilli()
+		return executionLog, err
+	}
 	if swConfig == nil || swConfig.EthRpcUrl == "" {
 		err := fmt.Errorf("smart wallet config or ETH RPC URL not set for contract read (chain_id=%d)", node.Config.GetChainId())
 		executionLog = v.createExecutionStep(stepID, false, err.Error(), "", time.Now().UnixMilli())
@@ -1515,7 +1526,12 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 	}
 	stepID := taskNode.Id
 	var executionLog *avsproto.Execution_Step
-	swConfig := v.resolveSmartWalletForNode(node.Config.GetChainId())
+	swConfig, err := v.resolveSmartWalletForNode(node.Config.GetChainId())
+	if err != nil {
+		executionLog = v.createExecutionStep(stepID, false, err.Error(), "", time.Now().UnixMilli())
+		executionLog.EndAt = time.Now().UnixMilli()
+		return executionLog, err
+	}
 	if swConfig == nil || swConfig.EthRpcUrl == "" {
 		err := fmt.Errorf("smart wallet config or ETH RPC URL not set for contract write (chain_id=%d)", node.Config.GetChainId())
 		executionLog = v.createExecutionStep(stepID, false, err.Error(), "", time.Now().UnixMilli())
@@ -1740,7 +1756,12 @@ func (v *VM) runEthTransfer(taskNode *avsproto.TaskNode) (*avsproto.Execution_St
 	}
 	stepID := taskNode.Id
 	var executionLog *avsproto.Execution_Step
-	swConfig := v.resolveSmartWalletForNode(node.Config.GetChainId())
+	swConfig, err := v.resolveSmartWalletForNode(node.Config.GetChainId())
+	if err != nil {
+		executionLog = v.createExecutionStep(stepID, false, err.Error(), "", time.Now().UnixMilli())
+		executionLog.EndAt = time.Now().UnixMilli()
+		return executionLog, err
+	}
 	if swConfig == nil || swConfig.EthRpcUrl == "" {
 		err := fmt.Errorf("smart wallet config or ETH RPC URL not set for ETH transfer (chain_id=%d)", node.Config.GetChainId())
 		executionLog = v.createExecutionStep(stepID, false, err.Error(), "", time.Now().UnixMilli())
@@ -2591,6 +2612,7 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 		node.Type = avsproto.NodeType_NODE_TYPE_CONTRACT_READ
 		// Create contract read node with proper configuration
 		contractConfig := &avsproto.ContractReadNode_Config{}
+		contractConfig.ChainId = int64(chainIDFromSettingsValue(config["chainId"]))
 
 		// Use camelCase only for consistency with JavaScript SDK
 		if address, ok := config["contractAddress"].(string); ok {
@@ -2663,6 +2685,7 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 		node.Type = avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE
 		// Create contract write node with proper configuration
 		contractConfig := &avsproto.ContractWriteNode_Config{}
+		contractConfig.ChainId = int64(chainIDFromSettingsValue(config["chainId"]))
 
 		// Use camelCase only for consistency with JavaScript SDK
 		if address, ok := config["contractAddress"].(string); ok {
@@ -2841,6 +2864,7 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 		node.Type = avsproto.NodeType_NODE_TYPE_ETH_TRANSFER
 		// Create ETH transfer node with proper configuration
 		ethConfig := &avsproto.ETHTransferNode_Config{}
+		ethConfig.ChainId = int64(chainIDFromSettingsValue(config["chainId"]))
 		if destination, ok := config["destination"].(string); ok {
 			ethConfig.Destination = destination
 		}
@@ -3594,6 +3618,12 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 				"contractAbi":     contractAbiArray,
 			}
 
+			// Carry the per-node chain so isolated paths (runNodeImmediately,
+			// simulation, loop-nested) don't lose it and run on the wrong chain.
+			if cid := contractRead.Config.GetChainId(); cid != 0 {
+				config["chainId"] = cid
+			}
+
 			// Handle method calls - extract fields to simple map for protobuf compatibility
 			if len(contractRead.Config.MethodCalls) > 0 {
 				methodCallsArray := make([]interface{}, len(contractRead.Config.MethodCalls))
@@ -3645,6 +3675,12 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 			config := map[string]interface{}{
 				"contractAddress": contractWrite.Config.ContractAddress,
 				"contractAbi":     contractAbiArray,
+			}
+
+			// Carry the per-node chain so isolated paths (runNodeImmediately,
+			// simulation, loop-nested) don't lose it and run on the wrong chain.
+			if cid := contractWrite.Config.GetChainId(); cid != 0 {
+				config["chainId"] = cid
 			}
 
 			// Extract optional value field (ETH to send with transaction)
@@ -3748,6 +3784,12 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 			config := map[string]interface{}{
 				"destination": ethTransfer.Config.Destination,
 				"amount":      ethTransfer.Config.Amount,
+			}
+
+			// Carry the per-node chain so isolated paths (runNodeImmediately,
+			// simulation, loop-nested) don't lose it and run on the wrong chain.
+			if cid := ethTransfer.Config.GetChainId(); cid != 0 {
+				config["chainId"] = cid
 			}
 
 			// Clean up complex protobuf types before returning

--- a/core/taskengine/vm_resolve_smart_wallet_test.go
+++ b/core/taskengine/vm_resolve_smart_wallet_test.go
@@ -70,6 +70,7 @@ func TestResolveSmartWalletForNode_TaskChainIDFallback(t *testing.T) {
 		taskChainID int64
 		vmDefault   *config.SmartWalletConfig
 		want        *config.SmartWalletConfig
+		wantErr     bool
 	}{
 		{
 			name:        "node chain_id takes precedence over task chain_id",
@@ -93,25 +94,38 @@ func TestResolveSmartWalletForNode_TaskChainIDFallback(t *testing.T) {
 			want:        mainnetCfg,
 		},
 		{
-			name:        "unknown node chain_id but known task chain_id resolves to task",
+			// An explicit, unresolvable node chain_id is a hard error — we do
+			// NOT silently retarget it onto the task chain (the G4 footgun).
+			name:        "explicit unknown node chain_id errors instead of falling back to task",
 			nodeChainID: 999999, // not registered
 			taskChainID: sepoliaChainID,
 			vmDefault:   mainnetCfg,
-			want:        sepoliaCfg,
+			wantErr:     true,
 		},
 		{
-			name:        "both unknown falls back to vm default",
+			name:        "explicit unknown node chain_id errors even with no task chain",
 			nodeChainID: 999998,
 			taskChainID: 0,
 			vmDefault:   mainnetCfg,
-			want:        mainnetCfg,
+			wantErr:     true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vm := newVM(tt.taskChainID, tt.vmDefault)
-			got := vm.resolveSmartWalletForNode(tt.nodeChainID)
+			got, err := vm.resolveSmartWalletForNode(tt.nodeChainID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveSmartWalletForNode(%d) with task=%d: expected error, got chain %d (%s)",
+						tt.nodeChainID, tt.taskChainID, chainIDOrZero(got), rpcOrEmpty(got))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveSmartWalletForNode(%d) with task=%d: unexpected error: %v",
+					tt.nodeChainID, tt.taskChainID, err)
+			}
 			if got != tt.want {
 				t.Fatalf("resolveSmartWalletForNode(%d) with task=%d: got chain %d (%s), want chain %d (%s)",
 					tt.nodeChainID, tt.taskChainID,
@@ -132,11 +146,11 @@ func TestResolveSmartWalletForNode_NoResolver(t *testing.T) {
 	vm.smartWalletConfig = defaultCfg
 	vm.task = &model.Workflow{Task: &avsproto.Task{ChainId: 11_155_111}}
 
-	if got := vm.resolveSmartWalletForNode(8453); got != defaultCfg {
-		t.Fatalf("expected default config when chainConfigResolver is nil, got %v", got)
+	if got, err := vm.resolveSmartWalletForNode(8453); err != nil || got != defaultCfg {
+		t.Fatalf("expected default config when chainConfigResolver is nil, got %v (err %v)", got, err)
 	}
-	if got := vm.resolveSmartWalletForNode(0); got != defaultCfg {
-		t.Fatalf("expected default config when chainConfigResolver is nil (chain_id 0), got %v", got)
+	if got, err := vm.resolveSmartWalletForNode(0); err != nil || got != defaultCfg {
+		t.Fatalf("expected default config when chainConfigResolver is nil (chain_id 0), got %v (err %v)", got, err)
 	}
 }
 

--- a/operator/worker_loop.go
+++ b/operator/worker_loop.go
@@ -1052,15 +1052,18 @@ func (o *Operator) StreamMessages() {
 					continue
 				}
 
-				taskChainID := resp.TaskMetadata.GetChainId()
+				// TaskMetadata.ChainId is the trigger's MONITORING chain (G2),
+				// set by the aggregator from the event/block trigger's own
+				// config — which may differ from where the task's nodes act.
+				monitorChainID := resp.TaskMetadata.GetChainId()
 
 				if trigger := triggerObj.GetEvent(); trigger != nil {
-					o.logger.Info("📥 Monitoring event trigger", "task_id", resp.Id, "chain_id", taskChainID)
+					o.logger.Info("📥 Monitoring event trigger", "task_id", resp.Id, "chain_id", monitorChainID)
 
-					set, ok := o.triggersForChain(taskChainID)
+					set, ok := o.triggersForChain(monitorChainID)
 					if !ok {
 						o.logger.Warn("⚠️ Dropping event task — operator does not monitor this chain",
-							"task_id", resp.Id, "chain_id", taskChainID,
+							"task_id", resp.Id, "chain_id", monitorChainID,
 							"supported", o.supportedChainIDs())
 						continue
 					}
@@ -1080,12 +1083,12 @@ func (o *Operator) StreamMessages() {
 						}
 					}()
 				} else if trigger := triggerObj.GetBlock(); trigger != nil {
-					o.logger.Info("📦 Monitoring block trigger", "task_id", resp.Id, "chain_id", taskChainID, "interval", trigger.Config.GetInterval())
+					o.logger.Info("📦 Monitoring block trigger", "task_id", resp.Id, "chain_id", monitorChainID, "interval", trigger.Config.GetInterval())
 
-					set, ok := o.triggersForChain(taskChainID)
+					set, ok := o.triggersForChain(monitorChainID)
 					if !ok {
 						o.logger.Warn("⚠️ Dropping block task — operator does not monitor this chain",
-							"task_id", resp.Id, "chain_id", taskChainID,
+							"task_id", resp.Id, "chain_id", monitorChainID,
 							"supported", o.supportedChainIDs())
 						continue
 					}


### PR DESCRIPTION
- **feat: per-part chainId Phase 1 — event-trigger mapping, node config chain, create-time validation**

Decouple chain from the workflow toward per-trigger/per-node chains. Phase 1 of
PLAN_CHAIN_DECOUPLING.md — the non-breaking plumbing so per-part chains flow on every path:

- G1: map EventTrigger.Config.chainId both directions in the REST<->proto mapper
  (it previously copied only Queries, unlike BlockTrigger), so an event trigger's
  chain reaches the proto.
- G3: ExtractNodeConfiguration emits chainId for contract/transfer nodes;
  CreateNodeFromType reads it back onto the proto Config; requireChainIDFromConfig
  accepts the camelCase `chainId` key — so runNodeImmediately / simulation /
  loop-nested execution honor the per-node chain instead of silently using chain 0.
- G4: resolveSmartWalletForNode errors on an explicit, unresolvable node chain
  (no silent fallback to the task chain); validateExplicitPartChains rejects a
  chain-aware part naming an unconfigured explicit chain at create (gateway mode,
  validated against knownChainIDs, walks Loop runners). chain_id == 0 (inherit)
  still allowed — tightened in Phase 3 (G5).

Adds chain_per_part_test.go (G3 round-trip + G4 validator) and an event-trigger
chainId assertion in the mapping round-trip test. No storage/proto schema change.


- **feat: per-part chainId Phase 2 (G2) — operators route triggers by the trigger's own chain**

Phase 2 of PLAN_CHAIN_DECOUPLING.md. An event/block trigger is now monitored on
its OWN configured chain, not the task chain — so a workflow can watch chain X
while its nodes act on chain Y.

Fixed at the aggregator (single source of truth) so the operator and the
aggregator stay consistent:
- triggerMonitoringChainID(trigger, fallback) returns the event/block trigger's
  own chain, falling back to the task chain when the trigger left it 0 (legacy,
  until G5). Nil-safe proto getters make it a no-op for cron/manual/fixedtime.
- Applied at all three TaskMetadata.ChainId dispatch sites, the create-time
  operatorsCoveringChain check, and the orphan-scan coverage map.
- Operator keeps routing on TaskMetadata.GetChainId() (now the trigger's
  monitoring chain); its variable renamed taskChainID -> monitorChainID with a
  clarifying comment.

Adds TestTriggerMonitoringChainID. Operator + engine coverage suites green.