### PR TITLE
feat: enforce explicit chain_id everywhere (strict reject-0)

### DIFF
--- a/PLAN_CHAIN_DECOUPLING.md
+++ b/PLAN_CHAIN_DECOUPLING.md
@@ -1,6 +1,6 @@
 # PLAN: Decouple chainId from the workflow — per-trigger / per-node chains
 
-**Owner:** AVS backend (this repo leads). **Status:** proposal / pre-implementation.
+**Owner:** AVS backend (this repo leads). **Status:** backend implemented (strict enforcement in review).
 **Date:** 2026-06-26.
 
 Today a workflow (AVS task) is bound to **one** `chainId`, fixed at creation. The goal is to make
@@ -14,6 +14,42 @@ We lead this **bottom-up from the AVS backend**. The studio client
 (the `studio` repo's `PLAN_WALLET_CHAIN_DECOUPLING.md`, Phase 3/4) and the v4 SDK
 (`ava-sdk-js`) follow the model defined here — they must not ship a per-node chain the backend would
 flatten.
+
+---
+
+## ✅ Completion checklist (status)
+
+Backend gaps (this repo):
+
+- [x] **G1** — EventTrigger `chainId` mapped REST↔proto — **merged #630**
+- [x] **G2** — operator routes/coverage by the trigger's own chain (`triggerMonitoringChainID`) — **merged #630**
+- [x] **G3** — `ExtractNodeConfiguration` carries `chainId`; `CreateNodeFromType` reads it back — **merged #630**
+- [x] **G4** — explicit unresolvable/unconfigured chain rejected at run + create — **merged #630**
+- [x] **G5b** — `Task.chain_id` / `CreateTaskReq.chain_id` removed from proto; ~60 readers rerouted — **merged #631**
+- [x] **G5c** — task storage chain-agnostic (`t:<status>:<id>`); per-chain read iteration collapsed — **merged #631**
+- [x] **G5d** — `wipe-chain-bucketed-task-keys` boot migration — **merged #631**
+- [x] **G5e** — proto/OpenAPI "0 = inherit" comments dropped; loop-runner chain wiring fixed — **merged #631**
+- [x] **Strict reject-0** — `chain_id <= 0` invalid in all modes (resolver + create validator); no default fallback — **PR #632 (green, awaiting client-lockstep merge)**
+
+Wallet/exec defaults (decided): wallet-ownership checks across all configured chains
+(`userOwnsWalletOnAnyChain`); VM-default config = aggregator default; salt is chain-invariant. ✅ done.
+
+Client (separate repos — required to land in lockstep with #632):
+
+- [ ] **`ava-sdk-js`** — always send per-part `chainId` (create / runNode / simulate); drop workflow-level `chainId`
+- [ ] **studio** — Phase 3: per-part chains in the canvas; drop workflow-level `chainId`; chain-agnostic workflow list
+- [ ] Spec handed off: *"what the client must send"* (per node/trigger type) — see the chat handoff / `## Client contract` below
+
+Release / ops:
+
+- [ ] **staging → main** promotion: confirm the wipe migration runs at boot; `make storage-check` will flag the
+      breaking proto + key-template change (expected — the migration is the handler)
+- [ ] Heads-up to the studio/SDK team before merging #632 (strict rejects chain-less calls)
+
+Future (not started):
+
+- [ ] **Phase 4** — true cross-chain *sequencing* (bridge A→B then act on B): wait-for-finality primitive +
+      re-entrant executor. Independent multi-chain (watch X / act Y) already works; this is the bridge case only.
 
 ---
 
@@ -395,6 +431,47 @@ Scope this separately once Phases 1–3 land; do not block them on it.
   to the 4 configured chains); a part left without a chain is rejected at create. The dashboard lists
   across chains and derives any per-chain view from the parts; the create endpoint's authKey remains
   API-auth scope only, not a task chain.
+
+---
+
+## Client contract — what the client must send (after #632)
+
+**Rule:** every **chain-aware** part carries its own `chainId` (`>0`, configured). No workflow-level
+chain; no default fallback. Omitting it on a chain-aware part is rejected (`InvalidArgument`); non-chain
+parts must not send one.
+
+**Chain-aware parts** (source of truth: `checkNodeChain` / `validateExplicitPartChains`):
+
+| Part | needs `chainId`? | proto field |
+|---|---|---|
+| EventTrigger | ✅ | `EventTrigger.Config.chain_id` |
+| BlockTrigger | ✅ | `BlockTrigger.Config.chain_id` |
+| ContractWrite node | ✅ | `ContractWriteNode.Config.chain_id` |
+| ContractRead node | ✅ | `ContractReadNode.Config.chain_id` |
+| ETHTransfer node | ✅ | `ETHTransferNode.Config.chain_id` |
+| Loop node with a chain-aware runner | ✅ on the **runner's** config | runner `Config.chain_id` |
+| Manual / Cron / FixedTime trigger | ❌ chain-agnostic | — |
+| CustomCode / RestAPI / GraphQL / Branch / Filter | ❌ | — |
+| Balance node | ⚠️ uses its own `chain` **string** (name or id), not `chain_id` | `BalanceNode.Config.chain` |
+
+**Per API surface:**
+
+- **CreateWorkflow** — set `chainId` on every chain-aware part; **stop sending a workflow-level `chainId`**
+  (`Task.chain_id` / `CreateWorkflowRequest.chainId` removed/ignored). Missing/`0` on any chain-aware part → rejected.
+- **RunNodeWithInputs / runNodeImmediately** — set `RunNodeWithInputsReq.chain_id` (or the node's own
+  `chainId`); the backend stamps the request chain onto the node (`stampNodeChainIfUnset`).
+- **SimulateTask** — per-part chains, or `SimulateTaskReq.chain_id`.
+- **List / Get / Cancel / Pause / SetEnabled** — chain-agnostic (storage no longer per-chain); don't pass
+  a workflow chain to scope these. "Workflows on chain Y" is derived client-side from the parts.
+- **Unchanged** (still take their own `chain_id`): `WithdrawFundsReq`, `EstimateFeesReq`, `GetTokenMetadataReq`.
+- **Ignored:** `TriggerTaskReq.chain_id` (a task has no chain to override).
+
+**Allowed values** (the configured set; else "chain_id N is not configured on this aggregator"):
+Ethereum `1`, Base `8453`, Sepolia `11155111`, Base Sepolia `84532`. (Soneium/Minato out of scope.)
+
+**SDK (`ava-sdk-js`) mapping** — builders already expose the params; the change is to always populate:
+`Triggers.event/block({chainId})`, `Nodes.contractWrite/contractRead/ethTransfer({chainId})`, the Loop
+runner's `chainId`, `runNodeWithInputs` request `chainId`; remove any workflow-level `chainId`.
 
 ---
 

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -296,10 +296,10 @@ type BlockTriggerType string
 
 // BlockTriggerConfig Fires every N blocks on the target chain.
 type BlockTriggerConfig struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
-	ChainId *ChainId `json:"chainId,omitempty"`
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
 
 	// Interval Fire every N blocks.
 	Interval int64 `json:"interval"`
@@ -330,9 +330,9 @@ type BranchNodeConfig struct {
 	Conditions []BranchCondition `json:"conditions"`
 }
 
-// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-// chain" — typically only useful in single-chain deployments or for
-// chain-agnostic operations.
+// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+// chain-aware trigger/node configs this is required and must be a
+// configured chain; on query/filter params it is optional.
 type ChainId = int64
 
 // ContractReadNode defines model for ContractReadNode.
@@ -346,10 +346,10 @@ type ContractReadNodeType string
 
 // ContractReadNodeConfig defines model for ContractReadNodeConfig.
 type ContractReadNodeConfig struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
-	ChainId     *ChainId                  `json:"chainId,omitempty"`
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId     ChainId                   `json:"chainId"`
 	ContractAbi *[]map[string]interface{} `json:"contractAbi,omitempty"`
 
 	// ContractAddress Lowercase or checksummed hex EOA / contract address.
@@ -371,10 +371,10 @@ type ContractWriteNodeConfig struct {
 	// CallData Arbitrary-length hex-encoded byte string.
 	CallData *Hex `json:"callData,omitempty"`
 
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
-	ChainId     *ChainId                  `json:"chainId,omitempty"`
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId     ChainId                   `json:"chainId"`
 	ContractAbi *[]map[string]interface{} `json:"contractAbi,omitempty"`
 
 	// ContractAddress Lowercase or checksummed hex EOA / contract address.
@@ -393,9 +393,9 @@ type ContractWriteNodeConfig struct {
 
 // CreateWalletRequest defines model for CreateWalletRequest.
 type CreateWalletRequest struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId *ChainId `json:"chainId,omitempty"`
 
 	// FactoryAddress Lowercase or checksummed hex EOA / contract address.
@@ -407,9 +407,9 @@ type CreateWalletRequest struct {
 
 // CreateWorkflowRequest defines model for CreateWorkflowRequest.
 type CreateWorkflowRequest struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId   *ChainId `json:"chainId,omitempty"`
 	Edges     *[]Edge  `json:"edges,omitempty"`
 	ExpiredAt *int64   `json:"expiredAt,omitempty"`
@@ -504,10 +504,10 @@ type ETHTransferNodeConfig struct {
 	// Amount Amount in wei (decimal string for big-int safety). Special value `max` withdraws the entire balance.
 	Amount string `json:"amount"`
 
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
-	ChainId *ChainId `json:"chainId,omitempty"`
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
 
 	// Destination Lowercase or checksummed hex EOA / contract address.
 	Destination EthereumAddress `json:"destination"`
@@ -526,9 +526,9 @@ type Edge struct {
 
 // EstimateFeesRequest defines model for EstimateFeesRequest.
 type EstimateFeesRequest struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId   *ChainId `json:"chainId,omitempty"`
 	CreatedAt int64    `json:"createdAt"`
 	Edges     *[]Edge  `json:"edges,omitempty"`
@@ -550,9 +550,9 @@ type EstimateFeesRequest struct {
 
 // EstimateFeesResponse defines model for EstimateFeesResponse.
 type EstimateFeesResponse struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId ChainId `json:"chainId"`
 
 	// Cogs Per-node operational costs (gas, external API).
@@ -608,10 +608,10 @@ type EventTriggerType string
 
 // EventTriggerConfig Fires when matching on-chain events are observed.
 type EventTriggerConfig struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
-	ChainId *ChainId `json:"chainId,omitempty"`
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
 
 	// CooldownSeconds Seconds to wait after a fire before allowing the same task to
 	// trigger again. Default 300. 0 disables cooldown.
@@ -644,9 +644,9 @@ type EventTriggerQuery struct {
 
 // Execution defines model for Execution.
 type Execution struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId *ChainId `json:"chainId,omitempty"`
 
 	// Cogs Per-node actual costs (gas, external API).
@@ -831,9 +831,9 @@ type GraphQLQueryNodeConfig struct {
 
 // HealthStatus defines model for HealthStatus.
 type HealthStatus struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId *ChainId           `json:"chainId,omitempty"`
 	Status  HealthStatusStatus `json:"status"`
 
@@ -1086,9 +1086,9 @@ type RestAPINodeConfig_Options struct {
 
 // RunNodeRequest defines model for RunNodeRequest.
 type RunNodeRequest struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId *ChainId `json:"chainId,omitempty"`
 
 	// Erc20Overrides Optional ERC20 balance/allowance state overrides applied only during this isolated node simulation. Lets callers seed token balances and approvals so contract-write simulations (e.g. Uniswap swaps) don't revert with "transfer amount exceeds allowance/balance" before the approval/funding transactions have been run. Simulation-only: a real-execution request (isSimulated=false) that sets these is rejected with an error, never silently ignored.
@@ -1164,9 +1164,9 @@ type SecretList struct {
 
 // SimulateWorkflowRequest defines model for SimulateWorkflowRequest.
 type SimulateWorkflowRequest struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId *ChainId `json:"chainId,omitempty"`
 	Edges   *[]Edge  `json:"edges,omitempty"`
 
@@ -1188,9 +1188,9 @@ type TokenMetadataResponse struct {
 	// Address Lowercase or checksummed hex EOA / contract address.
 	Address *EthereumAddress `json:"address,omitempty"`
 
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId  *ChainId                     `json:"chainId,omitempty"`
 	Decimals *int32                       `json:"decimals,omitempty"`
 	Found    bool                         `json:"found"`
@@ -1307,9 +1307,9 @@ type WithdrawRequest struct {
 	// Amount Amount in wei (decimal string) or `max` for the full balance.
 	Amount string `json:"amount"`
 
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId *ChainId `json:"chainId,omitempty"`
 
 	// RecipientAddress Lowercase or checksummed hex EOA / contract address.
@@ -1345,9 +1345,9 @@ type WithdrawResponseStatus string
 
 // Workflow defines model for Workflow.
 type Workflow struct {
-	// ChainId Numeric chain ID. `0` or omitted means "use the aggregator's default
-	// chain" — typically only useful in single-chain deployments or for
-	// chain-agnostic operations.
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
 	ChainId *ChainId `json:"chainId,omitempty"`
 
 	// CompletedAt Unix-epoch milliseconds — when the workflow reached a terminal state.

--- a/aggregator/rest/mapping/trigger.go
+++ b/aggregator/rest/mapping/trigger.go
@@ -192,6 +192,10 @@ func openAPIEventToProto(in generated.EventTrigger) *avsproto.EventTrigger {
 		out.Config.Queries = openAPIEventQueriesToProto(in.Config.Queries)
 		// chainId is required on the EventTrigger config (G5) — a plain value.
 		out.Config.ChainId = int64(in.Config.ChainId)
+		if in.Config.CooldownSeconds != nil {
+			cs := uint32(*in.Config.CooldownSeconds)
+			out.Config.CooldownSeconds = &cs
+		}
 	}
 	return out
 }
@@ -203,6 +207,10 @@ func protoEventToOpenAPI(in *avsproto.EventTrigger) generated.EventTrigger {
 		c := generated.EventTriggerConfig{
 			Queries: protoEventQueriesToOpenAPI(cfg.GetQueries()),
 			ChainId: generated.ChainId(cfg.GetChainId()),
+		}
+		if cfg.CooldownSeconds != nil {
+			cs := int32(cfg.GetCooldownSeconds())
+			c.CooldownSeconds = &cs
 		}
 		out.Config = &c
 	}

--- a/aggregator/rest/mapping/trigger.go
+++ b/aggregator/rest/mapping/trigger.go
@@ -116,9 +116,8 @@ func openAPIBlockToProto(in generated.BlockTrigger) *avsproto.BlockTrigger {
 	out := &avsproto.BlockTrigger{Config: &avsproto.BlockTrigger_Config{}}
 	if in.Config != nil {
 		out.Config.Interval = in.Config.Interval
-		if in.Config.ChainId != nil {
-			out.Config.ChainId = *in.Config.ChainId
-		}
+		// chainId is required on the BlockTrigger config (G5) — a plain value.
+		out.Config.ChainId = int64(in.Config.ChainId)
 	}
 	return out
 }
@@ -127,9 +126,9 @@ func protoBlockToOpenAPI(in *avsproto.BlockTrigger) generated.BlockTrigger {
 	t := generated.BlockTriggerTypeBlock
 	out := generated.BlockTrigger{Type: &t}
 	if cfg := in.GetConfig(); cfg != nil {
-		c := generated.BlockTriggerConfig{Interval: cfg.GetInterval()}
-		if cid := cfg.GetChainId(); cid != 0 {
-			c.ChainId = &cid
+		c := generated.BlockTriggerConfig{
+			Interval: cfg.GetInterval(),
+			ChainId:  generated.ChainId(cfg.GetChainId()),
 		}
 		out.Config = &c
 	}
@@ -191,9 +190,8 @@ func openAPIEventToProto(in generated.EventTrigger) *avsproto.EventTrigger {
 	out := &avsproto.EventTrigger{Config: &avsproto.EventTrigger_Config{}}
 	if in.Config != nil {
 		out.Config.Queries = openAPIEventQueriesToProto(in.Config.Queries)
-		if in.Config.ChainId != nil {
-			out.Config.ChainId = *in.Config.ChainId
-		}
+		// chainId is required on the EventTrigger config (G5) — a plain value.
+		out.Config.ChainId = int64(in.Config.ChainId)
 	}
 	return out
 }
@@ -202,9 +200,9 @@ func protoEventToOpenAPI(in *avsproto.EventTrigger) generated.EventTrigger {
 	t := generated.Event
 	out := generated.EventTrigger{Type: &t}
 	if cfg := in.GetConfig(); cfg != nil {
-		c := generated.EventTriggerConfig{Queries: protoEventQueriesToOpenAPI(cfg.GetQueries())}
-		if cid := cfg.GetChainId(); cid != 0 {
-			c.ChainId = &cid
+		c := generated.EventTriggerConfig{
+			Queries: protoEventQueriesToOpenAPI(cfg.GetQueries()),
+			ChainId: generated.ChainId(cfg.GetChainId()),
 		}
 		out.Config = &c
 	}

--- a/aggregator/rest/mapping/trigger_test.go
+++ b/aggregator/rest/mapping/trigger_test.go
@@ -24,7 +24,7 @@ func TestTriggerRoundTrip(t *testing.T) {
 				tr := generated.Trigger{Name: "blockTrigger", Type: generated.TriggerTypeBlock}
 				chainID := int64(11155111)
 				typ := generated.BlockTriggerTypeBlock
-				inner := generated.BlockTrigger{Type: &typ, Config: &generated.BlockTriggerConfig{Interval: 10, ChainId: &chainID}}
+				inner := generated.BlockTrigger{Type: &typ, Config: &generated.BlockTriggerConfig{Interval: 10, ChainId: generated.ChainId(chainID)}}
 				require.NoError(t, tr.FromBlockTrigger(inner))
 				return tr
 			},
@@ -32,8 +32,7 @@ func TestTriggerRoundTrip(t *testing.T) {
 				v, err := out.AsBlockTrigger()
 				require.NoError(t, err)
 				assert.Equal(t, int64(10), v.Config.Interval)
-				require.NotNil(t, v.Config.ChainId)
-				assert.Equal(t, int64(11155111), *v.Config.ChainId)
+				assert.Equal(t, int64(11155111), int64(v.Config.ChainId))
 			},
 		},
 		{
@@ -92,7 +91,7 @@ func TestTriggerRoundTrip(t *testing.T) {
 				inner := generated.EventTrigger{
 					Type: &typ,
 					Config: &generated.EventTriggerConfig{
-						ChainId: &eventChainID,
+						ChainId: generated.ChainId(eventChainID),
 						Queries: []generated.EventTriggerQuery{{
 							Addresses: &[]generated.EthereumAddress{addr},
 							Topics:    &[]string{sig, ""},
@@ -111,8 +110,7 @@ func TestTriggerRoundTrip(t *testing.T) {
 			check: func(t *testing.T, out generated.Trigger) {
 				v, err := out.AsEventTrigger()
 				require.NoError(t, err)
-				require.NotNil(t, v.Config.ChainId, "event trigger chain_id must survive the round-trip (G1)")
-				assert.Equal(t, int64(8453), *v.Config.ChainId)
+				assert.Equal(t, int64(8453), int64(v.Config.ChainId), "event trigger chain_id must survive the round-trip (G1)")
 				require.Len(t, v.Config.Queries, 1)
 				require.NotNil(t, v.Config.Queries[0].Addresses)
 				assert.Equal(t, "0x1234567890123456789012345678901234567890", string((*v.Config.Queries[0].Addresses)[0]))

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -118,9 +118,9 @@ components:
       type: integer
       format: int64
       description: |
-        Numeric chain ID. `0` or omitted means "use the aggregator's default
-        chain" — typically only useful in single-chain deployments or for
-        chain-agnostic operations.
+        Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+        chain-aware trigger/node configs this is required and must be a
+        configured chain; on query/filter params it is optional.
       example: 11155111
 
     EthereumAddress:
@@ -392,7 +392,7 @@ components:
     BlockTriggerConfig:
       type: object
       description: Fires every N blocks on the target chain.
-      required: [interval]
+      required: [interval, chainId]
       properties:
         interval:
           type: integer
@@ -401,7 +401,7 @@ components:
           description: Fire every N blocks.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to watch blocks on. Required: a workflow carries no chain to inherit.
+          description: Chain to watch blocks on. Required — a workflow carries no chain to inherit.
 
     EventTriggerQuery:
       type: object
@@ -476,7 +476,7 @@ components:
     EventTriggerConfig:
       type: object
       description: Fires when matching on-chain events are observed.
-      required: [queries]
+      required: [queries, chainId]
       properties:
         queries:
           type: array
@@ -491,7 +491,7 @@ components:
             trigger again. Default 300. 0 disables cooldown.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to watch events on. Required: a workflow carries no chain to inherit.
+          description: Chain to watch events on. Required — a workflow carries no chain to inherit.
 
     # ---- Trigger union ----
 
@@ -583,7 +583,7 @@ components:
 
     ETHTransferNodeConfig:
       type: object
-      required: [destination, amount]
+      required: [destination, amount, chainId]
       properties:
         destination: { $ref: '#/components/schemas/EthereumAddress' }
         amount:
@@ -591,11 +591,11 @@ components:
           description: Amount in wei (decimal string for big-int safety). Special value `max` withdraws the entire balance.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to execute on. Required: a workflow carries no chain to inherit.
+          description: Chain to execute on. Required — a workflow carries no chain to inherit.
 
     ContractWriteNodeConfig:
       type: object
-      required: [contractAddress]
+      required: [contractAddress, chainId]
       properties:
         contractAddress: { $ref: '#/components/schemas/EthereumAddress' }
         callData: { $ref: '#/components/schemas/Hex' }
@@ -617,11 +617,11 @@ components:
           description: Custom gas limit (decimal string).
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to execute on. Required: a workflow carries no chain to inherit.
+          description: Chain to execute on. Required — a workflow carries no chain to inherit.
 
     ContractReadNodeConfig:
       type: object
-      required: [contractAddress]
+      required: [contractAddress, chainId]
       properties:
         contractAddress: { $ref: '#/components/schemas/EthereumAddress' }
         contractAbi:
@@ -633,7 +633,7 @@ components:
           items: { $ref: '#/components/schemas/MethodCall' }
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to read from. Required: a workflow carries no chain to inherit.
+          description: Chain to read from. Required — a workflow carries no chain to inherit.
 
     GraphQLQueryNodeConfig:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -401,7 +401,7 @@ components:
           description: Fire every N blocks.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to watch blocks on. 0 = the aggregator's default chain (a workflow carries no chain).
+          description: Chain to watch blocks on. Required: a workflow carries no chain to inherit.
 
     EventTriggerQuery:
       type: object
@@ -491,7 +491,7 @@ components:
             trigger again. Default 300. 0 disables cooldown.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to watch events on. 0 = the aggregator's default chain (a workflow carries no chain).
+          description: Chain to watch events on. Required: a workflow carries no chain to inherit.
 
     # ---- Trigger union ----
 
@@ -591,7 +591,7 @@ components:
           description: Amount in wei (decimal string for big-int safety). Special value `max` withdraws the entire balance.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to execute on. 0 = the aggregator's default chain (a workflow carries no chain).
+          description: Chain to execute on. Required: a workflow carries no chain to inherit.
 
     ContractWriteNodeConfig:
       type: object
@@ -617,7 +617,7 @@ components:
           description: Custom gas limit (decimal string).
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to execute on. 0 = the aggregator's default chain (a workflow carries no chain).
+          description: Chain to execute on. Required: a workflow carries no chain to inherit.
 
     ContractReadNodeConfig:
       type: object
@@ -633,7 +633,7 @@ components:
           items: { $ref: '#/components/schemas/MethodCall' }
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to read from. 0 = the aggregator's default chain (a workflow carries no chain).
+          description: Chain to read from. Required: a workflow carries no chain to inherit.
 
     GraphQLQueryNodeConfig:
       type: object

--- a/core/taskengine/chain_per_part_test.go
+++ b/core/taskengine/chain_per_part_test.go
@@ -109,9 +109,11 @@ func TestValidateExplicitPartChains(t *testing.T) {
 		require.NoError(t, n.validateExplicitPartChains(task))
 	})
 
-	t.Run("chain_id 0 passes (resolves to aggregator default at execution)", func(t *testing.T) {
+	t.Run("chain_id 0 is rejected (explicit chain required)", func(t *testing.T) {
 		task := &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{cwNode(0)}}}
-		require.NoError(t, n.validateExplicitPartChains(task))
+		err := n.validateExplicitPartChains(task)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "explicit chain_id")
 	})
 
 	t.Run("unconfigured explicit node chain is rejected", func(t *testing.T) {

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -519,9 +519,8 @@ func (n *Engine) isChainConfigured(chainID int64) bool {
 
 // validateExplicitPartChains rejects, at create time, a task whose chain-aware
 // trigger or nodes either omit chain_id (<= 0) or name a chain the aggregator
-// isn't configured for. Post-G5 a task carries no chain; an omitted (0) chain resolves to the
-// aggregator default at execution, so only an explicit, unconfigured chain is
-// rejected here. Only enforced in gateway
+// isn't configured for. Post-G5 a task carries no chain, so every chain-aware part must name an
+// explicit, configured chain; chain_id 0 or an unconfigured chain is rejected. Only enforced in gateway
 // mode, where chainConfigs enumerates the served chains; single-chain mode has
 // one chain and nothing to validate against.
 func (n *Engine) validateExplicitPartChains(task *model.Workflow) error {
@@ -529,10 +528,13 @@ func (n *Engine) validateExplicitPartChains(task *model.Workflow) error {
 		return nil
 	}
 	check := func(kind string, chainID int64) error {
-		// chain_id 0 resolves to the aggregator default at execution (a task no
-		// longer provides a chain); only an explicit, unconfigured chain is a
-		// hard error here.
-		if chainID == 0 || n.isChainConfigured(chainID) {
+		// A task carries no chain, so every chain-aware part must name an
+		// explicit, configured chain — chain_id 0 is rejected at create.
+		if chainID <= 0 {
+			return status.Errorf(codes.InvalidArgument,
+				"%s requires an explicit chain_id (a task no longer provides a default chain)", kind)
+		}
+		if n.isChainConfigured(chainID) {
 			return nil
 		}
 		return status.Errorf(codes.InvalidArgument,

--- a/core/taskengine/execute_uniswap_approval_test.go
+++ b/core/taskengine/execute_uniswap_approval_test.go
@@ -160,6 +160,7 @@ func TestExecuteTask_UniswapApprovalAndSwap_DifferentApprovalAmounts_Sepolia(t *
 					TaskType: &avsproto.TaskNode_ContractWrite{
 						ContractWrite: &avsproto.ContractWriteNode{
 							Config: &avsproto.ContractWriteNode_Config{
+								ChainId:         11155111,                                 // explicit chain (strict)
 								ContractAddress: "{{settings.uniswap_v3_pool.token1.id}}", // USDC
 								ContractAbi: func() []*structpb.Value {
 									abi, _ := structpb.NewValue(map[string]interface{}{
@@ -195,6 +196,7 @@ func TestExecuteTask_UniswapApprovalAndSwap_DifferentApprovalAmounts_Sepolia(t *
 					TaskType: &avsproto.TaskNode_ContractWrite{
 						ContractWrite: &avsproto.ContractWriteNode{
 							Config: &avsproto.ContractWriteNode_Config{
+								ChainId:         11155111, // explicit chain (strict)
 								ContractAddress: "{{settings.uniswap_v3_contracts.quoterV2}}",
 								ContractAbi: func() []*structpb.Value {
 									abi, _ := structpb.NewValue(map[string]interface{}{
@@ -243,6 +245,7 @@ func TestExecuteTask_UniswapApprovalAndSwap_DifferentApprovalAmounts_Sepolia(t *
 					TaskType: &avsproto.TaskNode_ContractWrite{
 						ContractWrite: &avsproto.ContractWriteNode{
 							Config: &avsproto.ContractWriteNode_Config{
+								ChainId:         11155111, // explicit chain (strict)
 								ContractAddress: "{{settings.uniswap_v3_contracts.swapRouter02}}",
 								ContractAbi: func() []*structpb.Value {
 									abi, _ := structpb.NewValue(map[string]interface{}{

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -1489,11 +1489,13 @@ func (n *Engine) executeMethodCallForSimulation(ctx context.Context, methodCall 
 	// Get method params as strings (ContractReadNode expects []string)
 	methodParams := methodCall.GetMethodParams()
 
-	// Create a temporary contractRead node for execution (same as direct calls)
+	// Create a temporary contractRead node for execution (same as direct calls).
+	// chain_id is required (G5 strict) — carry the caller's chain onto the node.
 	contractReadNode := &avsproto.ContractReadNode{
 		Config: &avsproto.ContractReadNode_Config{
 			ContractAddress: contractAddressStr,
 			ContractAbi:     abiValues,
+			ChainId:         chainID,
 			MethodCalls: []*avsproto.ContractReadNode_MethodCall{
 				{
 					MethodName:   methodCall.GetMethodName(),

--- a/core/taskengine/run_node_immediately_missing_dependencies_test.go
+++ b/core/taskengine/run_node_immediately_missing_dependencies_test.go
@@ -64,6 +64,7 @@ func TestRunNodeImmediately_ContractWrite_MissingNodeDependency(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E", // Uniswap SwapRouter02
+			"chainId":         int64(11155111),                              // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{
@@ -150,6 +151,7 @@ func TestRunNodeImmediately_ContractWrite_MissingNodeDependency(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{
@@ -199,6 +201,7 @@ func TestRunNodeImmediately_ContractWrite_MissingNodeDependency(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{

--- a/core/taskengine/run_node_immediately_settings_test.go
+++ b/core/taskengine/run_node_immediately_settings_test.go
@@ -59,6 +59,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 		// Contract configuration for USDC approve
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b", // USDC Sepolia
+			"chainId":         int64(11155111),                              // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{
@@ -144,6 +145,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{
@@ -197,6 +199,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{
@@ -245,6 +248,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{

--- a/core/taskengine/run_node_immediately_tuple_test.go
+++ b/core/taskengine/run_node_immediately_tuple_test.go
@@ -95,6 +95,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3", // Sepolia QuoterV2
+			"chainId":         int64(11155111),                              // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{
@@ -218,6 +219,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{
@@ -304,6 +306,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     quoterV2ABI,
 			"methodCalls": []interface{}{
 				map[string]interface{}{
@@ -363,6 +366,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     quoterV2ABI,
 			"methodCalls": []interface{}{
 				map[string]interface{}{
@@ -433,6 +437,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", // USDC Sepolia
+			"chainId":         int64(11155111),                              // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"inputs": []interface{}{

--- a/core/taskengine/run_node_with_inputs_simulation_mode_test.go
+++ b/core/taskengine/run_node_with_inputs_simulation_mode_test.go
@@ -143,6 +143,7 @@ func TestRunNodeWithInputsRespectsIsSimulatedFlag(t *testing.T) {
 				TaskType: &avsproto.TaskNode_ContractWrite{
 					ContractWrite: &avsproto.ContractWriteNode{
 						Config: &avsproto.ContractWriteNode_Config{
+							ChainId:         11155111,                                     // explicit chain (strict)
 							ContractAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", // USDC on Sepolia
 							ContractAbi:     contractAbi,
 							MethodCalls: []*avsproto.ContractWriteNode_MethodCall{
@@ -161,7 +162,8 @@ func TestRunNodeWithInputsRespectsIsSimulatedFlag(t *testing.T) {
 
 			// Create protobuf request with the full TaskNode
 			req := &avsproto.RunNodeWithInputsReq{
-				Node: contractWriteNode,
+				ChainId: 11155111, // explicit chain (strict)
+				Node:    contractWriteNode,
 			}
 
 			// Settings for the workflow
@@ -307,6 +309,7 @@ func TestRunNodeWithInputsDefaultsToSimulation(t *testing.T) {
 		TaskType: &avsproto.TaskNode_ContractWrite{
 			ContractWrite: &avsproto.ContractWriteNode{
 				Config: &avsproto.ContractWriteNode_Config{
+					ChainId:         11155111, // explicit chain (strict)
 					ContractAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
 					ContractAbi:     contractAbi,
 					MethodCalls: []*avsproto.ContractWriteNode_MethodCall{
@@ -324,7 +327,8 @@ func TestRunNodeWithInputsDefaultsToSimulation(t *testing.T) {
 	}
 
 	req := &avsproto.RunNodeWithInputsReq{
-		Node: contractWriteNode,
+		ChainId: 11155111, // explicit chain (strict)
+		Node:    contractWriteNode,
 	}
 
 	settingsData := map[string]interface{}{

--- a/core/taskengine/tenderly_client_test.go
+++ b/core/taskengine/tenderly_client_test.go
@@ -2137,6 +2137,7 @@ func TestContractWrite_WETHDeposit_WithETHValue_Sepolia(t *testing.T) {
 		nodeType := "contractWrite"
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14", // WETH on Sepolia
+			"chainId":         int64(11155111),                              // explicit chain (strict)
 			"contractAbi": []interface{}{
 				map[string]interface{}{
 					"constant":        false,

--- a/core/taskengine/utils_calldata_test.go
+++ b/core/taskengine/utils_calldata_test.go
@@ -490,6 +490,7 @@ func TestContractRead_InvalidNumericValue_ResponseStructure(t *testing.T) {
 		TaskType: &avsproto.TaskNode_ContractRead{
 			ContractRead: &avsproto.ContractReadNode{
 				Config: &avsproto.ContractReadNode_Config{
+					ChainId:         11155111, // explicit chain (strict)
 					ContractAddress: "0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3",
 					ContractAbi:     contractAbi,
 					MethodCalls: []*avsproto.ContractReadNode_MethodCall{
@@ -506,7 +507,8 @@ func TestContractRead_InvalidNumericValue_ResponseStructure(t *testing.T) {
 	}
 
 	req := &avsproto.RunNodeWithInputsReq{
-		Node: contractReadNode,
+		ChainId: 11155111, // explicit chain (strict)
+		Node:    contractReadNode,
 		InputVariables: map[string]*structpb.Value{
 			"settings": structpb.NewStructValue(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -649,6 +651,7 @@ func TestContractWrite_InvalidNumericValue_ResponseStructure(t *testing.T) {
 		TaskType: &avsproto.TaskNode_ContractWrite{
 			ContractWrite: &avsproto.ContractWriteNode{
 				Config: &avsproto.ContractWriteNode_Config{
+					ChainId:         11155111, // explicit chain (strict)
 					ContractAddress: "0xA0b86a33E6441d0be3c7bb50e65Eb42d5E0b2b4b",
 					ContractAbi:     contractAbi,
 					MethodCalls: []*avsproto.ContractWriteNode_MethodCall{
@@ -667,7 +670,8 @@ func TestContractWrite_InvalidNumericValue_ResponseStructure(t *testing.T) {
 	}
 
 	req := &avsproto.RunNodeWithInputsReq{
-		Node: contractWriteNode,
+		ChainId: 11155111, // explicit chain (strict)
+		Node:    contractWriteNode,
 		InputVariables: map[string]*structpb.Value{
 			"settings": structpb.NewStructValue(&structpb.Struct{
 				Fields: map[string]*structpb.Value{

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -329,23 +329,27 @@ func (v *VM) WithChainConfigResolver(resolver func(chainID int64) *config.SmartW
 
 // resolveSmartWalletForNode picks the SmartWalletConfig a chain-aware node
 // should use. Post-G5 a task carries no chain, so the node's own chain_id is
-// authoritative — there is nothing to inherit:
-//   - An explicit node chain_id (> 0) is authoritative: in gateway mode it must
-//     resolve against the configured set, else error (no silent fallback — the
-//     Sentry EIGENLAYER-AVS-1N/1M footgun).
-//   - A 0 node chain_id resolves to the VM's default config — the request /
-//     aggregator chain. Deployed tasks SHOULD carry explicit per-node chains
-//     (enforced at create for gateway, see validateExplicitPartChains), but an
-//     isolated run (RunNodeImmediately / simulate) supplies the chain via the
-//     request, which is already baked into v.smartWalletConfig here.
+// REQUIRED — there is nothing to inherit and no default to fall back to:
+//   - chain_id <= 0 is a hard error in all modes. An isolated run
+//     (RunNodeImmediately / simulate) must supply the chain on the request,
+//     which is stamped onto the node before execution (stampNodeChainIfUnset).
+//   - Gateway mode: the chain must resolve against the configured set, else
+//     error (no silent fallback — the Sentry EIGENLAYER-AVS-1N/1M footgun).
+//   - Single-chain mode (no resolver): the sole smart_wallet config is used.
 func (v *VM) resolveSmartWalletForNode(nodeChainID int64) (*config.SmartWalletConfig, error) {
-	if v.chainConfigResolver != nil && nodeChainID > 0 {
+	if nodeChainID <= 0 {
+		return nil, fmt.Errorf("chain-aware node requires an explicit chain_id (got %d); a task no longer provides a default chain", nodeChainID)
+	}
+	if v.chainConfigResolver != nil {
 		if resolved := v.chainConfigResolver(nodeChainID); resolved != nil {
 			return resolved, nil
 		}
 		return nil, fmt.Errorf("chain_id %d is not configured on this aggregator", nodeChainID)
 	}
-	return v.smartWalletConfig, nil
+	if v.smartWalletConfig != nil {
+		return v.smartWalletConfig, nil
+	}
+	return nil, fmt.Errorf("no smart wallet config available for chain_id %d", nodeChainID)
 }
 
 // vmDefaultChainID returns the VM's default-config chain, used for

--- a/core/taskengine/vm_resolve_smart_wallet_test.go
+++ b/core/taskengine/vm_resolve_smart_wallet_test.go
@@ -58,8 +58,8 @@ func TestResolveSmartWalletForNode_TaskChainIDFallback(t *testing.T) {
 	}
 
 	// Post-G5: a task carries no chain, so there is no inheritance. A node's
-	// explicit chain resolves (or errors if unconfigured); a 0 node chain
-	// resolves to the VM default config (the request/aggregator chain).
+	// explicit chain resolves (or errors if unconfigured); a 0 node chain is a
+	// hard error (chain_id required on chain-aware nodes in all modes).
 	_ = sepoliaCfg
 	tests := []struct {
 		name        string
@@ -75,12 +75,11 @@ func TestResolveSmartWalletForNode_TaskChainIDFallback(t *testing.T) {
 			want:        baseCfg,
 		},
 		{
-			// A 0 node chain_id resolves to the VM default config (the
-			// request/aggregator chain) — there is no task chain to inherit.
-			name:        "node chain_id 0 uses the VM default config",
+			// A 0 node chain_id is a hard error (chain required, no inheritance).
+			name:        "node chain_id 0 errors",
 			nodeChainID: 0,
 			vmDefault:   mainnetCfg,
-			want:        mainnetCfg,
+			wantErr:     true,
 		},
 		{
 			name:        "explicit unknown node chain_id errors",
@@ -116,7 +115,7 @@ func TestResolveSmartWalletForNode_TaskChainIDFallback(t *testing.T) {
 
 // TestResolveSmartWalletForNode_NoResolver covers the single-chain
 // (non-gateway) shape: chainConfigResolver is nil, so the resolver returns
-// v.smartWalletConfig regardless of the node chain_id (including 0).
+// v.smartWalletConfig for an explicit (>0) node chain_id; 0 is a hard error.
 func TestResolveSmartWalletForNode_NoResolver(t *testing.T) {
 	defaultCfg := &config.SmartWalletConfig{ChainID: 1, EthRpcUrl: "https://default/rpc"}
 	vm := NewVM()
@@ -125,8 +124,8 @@ func TestResolveSmartWalletForNode_NoResolver(t *testing.T) {
 	if got, err := vm.resolveSmartWalletForNode(8453); err != nil || got != defaultCfg {
 		t.Fatalf("expected default config when chainConfigResolver is nil, got %v (err %v)", got, err)
 	}
-	if got, err := vm.resolveSmartWalletForNode(0); err != nil || got != defaultCfg {
-		t.Fatalf("expected default config for chain_id 0 when resolver is nil, got %v (err %v)", got, err)
+	if _, err := vm.resolveSmartWalletForNode(0); err == nil {
+		t.Fatalf("expected error for chain_id 0 (explicit chain required), got nil")
 	}
 }
 

--- a/core/taskengine/vm_runner_contract_write_data_priority_test.go
+++ b/core/taskengine/vm_runner_contract_write_data_priority_test.go
@@ -104,6 +104,7 @@ func TestContractWriteDataPriority(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": sepoliaUsdcAddress.Hex(),
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     contractAbi,
 			"methodCalls": []interface{}{
 				map[string]interface{}{
@@ -165,6 +166,7 @@ func TestContractWriteDataPriority(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": sepoliaUsdcAddress.Hex(),
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     contractAbi,
 			"methodCalls": []interface{}{
 				map[string]interface{}{
@@ -225,6 +227,7 @@ func TestContractWriteDataPriority(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": sepoliaUsdcAddress.Hex(),
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     contractAbi,
 			"methodCalls": []interface{}{
 				map[string]interface{}{
@@ -292,6 +295,7 @@ func TestContractWriteDataPriority(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": sepoliaUsdcAddress.Hex(),
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     contractAbi,
 			"methodCalls": []interface{}{
 				map[string]interface{}{

--- a/core/taskengine/vm_runner_contract_write_simulation_test.go
+++ b/core/taskengine/vm_runner_contract_write_simulation_test.go
@@ -77,7 +77,8 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		// Test run_node_immediately
 		nodeConfig := map[string]interface{}{
 			"contractAddress": sepoliaUsdcAddress.Hex(),
-			"contractAbi":     contractAbi, // Now using parsed array instead of JSON string
+			"chainId":         int64(11155111), // explicit chain (strict)
+			"contractAbi":     contractAbi,     // Now using parsed array instead of JSON string
 			"methodCalls": []interface{}{
 				map[string]interface{}{
 					"callData":   approveCallData,
@@ -190,6 +191,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		// Exact node config from client request
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     contractAbi,
 			"methodCalls": []interface{}{
 				map[string]interface{}{
@@ -319,6 +321,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 
 		nodeConfig := map[string]interface{}{
 			"contractAddress": "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238",
+			"chainId":         int64(11155111), // explicit chain (strict)
 			"contractAbi":     transferAbi,
 			"methodCalls": []interface{}{
 				map[string]interface{}{

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -7216,7 +7216,7 @@ func (x *CronTrigger_Output) GetData() *structpb.Value {
 type BlockTrigger_Config struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Interval int64                  `protobuf:"varint,1,opt,name=interval,proto3" json:"interval,omitempty"`
-	// Chain to watch blocks on. 0 = the aggregator's default chain (a task carries no chain).
+	// Chain to watch blocks on. Required: a task carries no chain to inherit.
 	ChainId       int64 `protobuf:"varint,2,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -7497,7 +7497,7 @@ type EventTrigger_Config struct {
 	// Default: 300 (5 minutes cooldown - prevents repeated firing when conditions remain true)
 	// Set to 0 to disable cooldown (triggers fire immediately when conditions match)
 	CooldownSeconds *uint32 `protobuf:"varint,2,opt,name=cooldown_seconds,json=cooldownSeconds,proto3,oneof" json:"cooldown_seconds,omitempty"`
-	// Chain to watch events on. 0 = the aggregator's default chain (a task carries no chain).
+	// Chain to watch events on. Required: a task carries no chain to inherit.
 	ChainId       int64 `protobuf:"varint,3,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -7720,7 +7720,7 @@ type ETHTransferNode_Config struct {
 	state       protoimpl.MessageState `protogen:"open.v1"`
 	Destination string                 `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
 	Amount      string                 `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount,omitempty"`
-	// Chain to execute the transfer on. 0 = the aggregator's default chain (a task carries no chain).
+	// Chain to execute the transfer on. Required: a task carries no chain to inherit.
 	ChainId       int64 `protobuf:"varint,3,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -7835,7 +7835,7 @@ type ContractWriteNode_Config struct {
 	Value *string `protobuf:"bytes,6,opt,name=value,proto3,oneof" json:"value,omitempty"`
 	// Custom gas limit for the transaction (as string to handle large numbers)
 	GasLimit *string `protobuf:"bytes,7,opt,name=gas_limit,json=gasLimit,proto3,oneof" json:"gas_limit,omitempty"`
-	// Chain to execute the write on. 0 = the aggregator's default chain (a task carries no chain).
+	// Chain to execute the write on. Required: a task carries no chain to inherit.
 	ChainId       int64 `protobuf:"varint,8,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -8208,7 +8208,7 @@ type ContractReadNode_Config struct {
 	ContractAbi []*structpb.Value `protobuf:"bytes,2,rep,name=contract_abi,json=contractAbi,proto3" json:"contract_abi,omitempty"`
 	// Array of method calls to execute serially
 	MethodCalls []*ContractReadNode_MethodCall `protobuf:"bytes,3,rep,name=method_calls,json=methodCalls,proto3" json:"method_calls,omitempty"`
-	// Chain to read state from. 0 = the aggregator's default chain (a task carries no chain).
+	// Chain to read state from. Required: a task carries no chain to inherit.
 	ChainId       int64 `protobuf:"varint,4,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -148,7 +148,7 @@ message CronTrigger {
 message BlockTrigger {
   message Config {
     int64 interval = 1;
-    // Chain to watch blocks on. 0 = the aggregator's default chain (a task carries no chain).
+    // Chain to watch blocks on. Required: a task carries no chain to inherit.
     int64 chain_id = 2;
   }
   
@@ -218,7 +218,7 @@ message EventTrigger {
     // Default: 300 (5 minutes cooldown - prevents repeated firing when conditions remain true)
     // Set to 0 to disable cooldown (triggers fire immediately when conditions match)
     optional uint32 cooldown_seconds = 2;
-    // Chain to watch events on. 0 = the aggregator's default chain (a task carries no chain).
+    // Chain to watch events on. Required: a task carries no chain to inherit.
     int64 chain_id = 3;
   }
 
@@ -380,7 +380,7 @@ message ETHTransferNode {
   message Config {
     string destination = 1;
     string amount = 2;
-    // Chain to execute the transfer on. 0 = the aggregator's default chain (a task carries no chain).
+    // Chain to execute the transfer on. Required: a task carries no chain to inherit.
     int64 chain_id = 3;
   }
 
@@ -406,7 +406,7 @@ message ContractWriteNode {
     optional string value = 6;
     // Custom gas limit for the transaction (as string to handle large numbers)
     optional string gas_limit = 7;
-    // Chain to execute the write on. 0 = the aggregator's default chain (a task carries no chain).
+    // Chain to execute the write on. Required: a task carries no chain to inherit.
     int64 chain_id = 8;
   }
 
@@ -451,7 +451,7 @@ message ContractReadNode {
     repeated google.protobuf.Value contract_abi = 2;
     // Array of method calls to execute serially
     repeated MethodCall method_calls = 3;
-    // Chain to read state from. 0 = the aggregator's default chain (a task carries no chain).
+    // Chain to read state from. Required: a task carries no chain to inherit.
     int64 chain_id = 4;
   }
 


### PR DESCRIPTION
## Summary

Completes the chain-decoupling model: a chain-aware part must **always** name an explicit chain — `chain_id <= 0` is invalid in all modes, with no aggregator-default fallback. Follows #631 (which removed the task-level chain but left `0` tolerant).

Per the team decision, the sole client (studio/SDK) is updated in lockstep to send explicit per-part chains, so the brief break-and-update window is accepted.

## Changes

- `resolveSmartWalletForNode` rejects `chain_id <= 0` (all modes); gateway still validates against the configured set.
- `validateExplicitPartChains` rejects `chain_id <= 0` at create.
- Integration / runNode / simulate tests now supply an explicit chain (config-map `chainId`, `RunNodeWithInputsReq.ChainId`, or proto node config). `RunNodeImmediately` propagates the request chain onto the node via `stampNodeChainIfUnset`.
- proto / OpenAPI `chain_id` docs restored to "required".

## Verification

Local suite green except the two pre-existing failures (`StopLoss_Sepolia` needs `OWNER_EOA`; `BalanceNode_MissingAPIKey` nil-config guard). The Tenderly/Sepolia integration tests are env-gated and only run in CI — **this PR relies on CI to confirm them**.

## Coordination

Lands together with the **ava-sdk-js + studio** change to always send per-part `chainId`. Do not merge ahead of the client update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)