### PR TITLE
chore: finish OpenAPI G5 renovation — remove workflow-level chainId (unblocks SDK regen)

### DIFF
--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -141,13 +141,6 @@ func (w *ServerInterfaceWrapper) ListExecutions(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workflowId: %s", err))
 	}
 
-	// ------------- Optional query parameter "chainId" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
-	}
-
 	// ------------- Optional query parameter "before" -------------
 
 	err = runtime.BindQueryParameter("form", true, false, "before", ctx.QueryParams(), &params.Before)
@@ -277,13 +270,6 @@ func (w *ServerInterfaceWrapper) CountExecutions(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workflowId: %s", err))
 	}
 
-	// ------------- Optional query parameter "chainId" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
-	}
-
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.CountExecutions(ctx, params)
 	return err
@@ -302,13 +288,6 @@ func (w *ServerInterfaceWrapper) ExecutionStats(ctx echo.Context) error {
 	err = runtime.BindQueryParameter("form", true, false, "workflowId", ctx.QueryParams(), &params.WorkflowId)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workflowId: %s", err))
-	}
-
-	// ------------- Optional query parameter "chainId" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
@@ -592,13 +571,6 @@ func (w *ServerInterfaceWrapper) ListWorkflows(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter status: %s", err))
 	}
 
-	// ------------- Optional query parameter "chainId" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
-	}
-
 	// ------------- Optional query parameter "before" -------------
 
 	err = runtime.BindQueryParameter("form", true, false, "before", ctx.QueryParams(), &params.Before)
@@ -787,13 +759,6 @@ func (w *ServerInterfaceWrapper) CountWorkflows(ctx echo.Context) error {
 	err = runtime.BindQueryParameter("form", true, false, "status", ctx.QueryParams(), &params.Status)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter status: %s", err))
-	}
-
-	// ------------- Optional query parameter "chainId" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -407,12 +407,8 @@ type CreateWalletRequest struct {
 
 // CreateWorkflowRequest defines model for CreateWorkflowRequest.
 type CreateWorkflowRequest struct {
-	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
-	// chain-aware trigger/node configs this is required and must be a
-	// configured chain; on query/filter params it is optional.
-	ChainId   *ChainId `json:"chainId,omitempty"`
-	Edges     *[]Edge  `json:"edges,omitempty"`
-	ExpiredAt *int64   `json:"expiredAt,omitempty"`
+	Edges     *[]Edge `json:"edges,omitempty"`
+	ExpiredAt *int64  `json:"expiredAt,omitempty"`
 
 	// InputVariables Free-form key-value bag of values used to resolve `{{variable.path}}`
 	// template references inside trigger and node configs. Conventional
@@ -1345,11 +1341,6 @@ type WithdrawResponseStatus string
 
 // Workflow defines model for Workflow.
 type Workflow struct {
-	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
-	// chain-aware trigger/node configs this is required and must be a
-	// configured chain; on query/filter params it is optional.
-	ChainId *ChainId `json:"chainId,omitempty"`
-
 	// CompletedAt Unix-epoch milliseconds — when the workflow reached a terminal state.
 	CompletedAt *int64 `json:"completedAt,omitempty"`
 
@@ -1463,10 +1454,6 @@ type ListExecutionsParams struct {
 	// WorkflowId Filter by workflow ID. Repeat to OR multiple workflows.
 	WorkflowId *[]Ulid `form:"workflowId,omitempty" json:"workflowId,omitempty"`
 
-	// ChainId Chain ID filter. Omit to use the aggregator default chain. Repeat
-	// the parameter to filter by multiple chains.
-	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
-
 	// Before Cursor — return items immediately before this position (backward pagination).
 	Before *PageBefore `form:"before,omitempty" json:"before,omitempty"`
 
@@ -1504,19 +1491,11 @@ type StreamExecutionParams struct {
 // CountExecutionsParams defines parameters for CountExecutions.
 type CountExecutionsParams struct {
 	WorkflowId *[]Ulid `form:"workflowId,omitempty" json:"workflowId,omitempty"`
-
-	// ChainId Chain ID filter. Omit to use the aggregator default chain. Repeat
-	// the parameter to filter by multiple chains.
-	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 
 // ExecutionStatsParams defines parameters for ExecutionStats.
 type ExecutionStatsParams struct {
 	WorkflowId *[]Ulid `form:"workflowId,omitempty" json:"workflowId,omitempty"`
-
-	// ChainId Chain ID filter. Omit to use the aggregator default chain. Repeat
-	// the parameter to filter by multiple chains.
-	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 
 // ListSecretsParams defines parameters for ListSecrets.
@@ -1562,10 +1541,6 @@ type ListWorkflowsParams struct {
 	// Status Filter by status. Repeat to OR multiple statuses.
 	Status *[]WorkflowStatus `form:"status,omitempty" json:"status,omitempty"`
 
-	// ChainId Chain ID filter. Omit to use the aggregator default chain. Repeat
-	// the parameter to filter by multiple chains.
-	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
-
 	// Before Cursor — return items immediately before this position (backward pagination).
 	Before *PageBefore `form:"before,omitempty" json:"before,omitempty"`
 
@@ -1592,10 +1567,6 @@ type ListExecutionsForWorkflowParams struct {
 type CountWorkflowsParams struct {
 	SmartWalletAddress *[]EthereumAddress `form:"smartWalletAddress,omitempty" json:"smartWalletAddress,omitempty"`
 	Status             *[]WorkflowStatus  `form:"status,omitempty" json:"status,omitempty"`
-
-	// ChainId Chain ID filter. Omit to use the aggregator default chain. Repeat
-	// the parameter to filter by multiple chains.
-	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 
 // AuthExchangeJSONRequestBody defines body for AuthExchange for application/json ContentType.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -894,9 +894,6 @@ components:
         name: { type: string }
         owner: { $ref: '#/components/schemas/EthereumAddress' }
         smartWalletAddress: { $ref: '#/components/schemas/EthereumAddress' }
-        chainId:
-          $ref: '#/components/schemas/ChainId'
-          description: Workflow-level default chain. Triggers and nodes may override.
         trigger: { $ref: '#/components/schemas/Trigger' }
         nodes:
           type: array
@@ -939,11 +936,6 @@ components:
       properties:
         name: { type: string }
         smartWalletAddress: { $ref: '#/components/schemas/EthereumAddress' }
-        chainId:
-          $ref: '#/components/schemas/ChainId'
-          description: >-
-            Deprecated and ignored (G5): a workflow no longer has a chain. Set
-            chain_id on each chain-aware trigger/node instead.
         trigger: { $ref: '#/components/schemas/Trigger' }
         nodes:
           type: array
@@ -1704,7 +1696,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/WorkflowStatus' }
-        - $ref: '#/components/parameters/ChainIdQuery'
         - $ref: '#/components/parameters/PageBefore'
         - $ref: '#/components/parameters/PageAfter'
         - $ref: '#/components/parameters/PageLimit'
@@ -1902,7 +1893,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/WorkflowStatus' }
-        - $ref: '#/components/parameters/ChainIdQuery'
       responses:
         '200':
           description: Workflow count for the filter set.
@@ -1927,7 +1917,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/Ulid' }
-        - $ref: '#/components/parameters/ChainIdQuery'
         - $ref: '#/components/parameters/PageBefore'
         - $ref: '#/components/parameters/PageAfter'
         - $ref: '#/components/parameters/PageLimit'
@@ -2065,7 +2054,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/Ulid' }
-        - $ref: '#/components/parameters/ChainIdQuery'
       responses:
         '200':
           description: Execution count.
@@ -2085,7 +2073,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/Ulid' }
-        - $ref: '#/components/parameters/ChainIdQuery'
       responses:
         '200':
           description: Execution stats.


### PR DESCRIPTION
Finishes the spec side of G5 so the SDK's `openapi-download && types-gen` produces clean types.

**Removed (workflow-level chain):**
- `Workflow.chainId` and `CreateWorkflowRequest.chainId` schemas
- `ChainIdQuery` param from listWorkflows / countWorkflows / listExecutions / countExecutions / executionStats (chain-agnostic now)

**Kept:**
- per-part config `chainId` (required: BlockTrigger/EventTrigger/ContractWrite/ContractRead/ETHTransfer)
- request-level `chainId` on simulate / estimateFees / runNode / createWallet / withdraw / getToken

Regenerated REST types/server; no Go changes needed (#631 already stopped reading these); aggregator suite green.

Once merged to staging, the SDK can regenerate — the workflow-level chainId will be gone from `openapi.gen.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)