### PR TITLE
fix: cross-chain wallet/salt/fee validation at execution (#636 review)

### DIFF
--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -586,6 +586,10 @@ func checkNodeChain(node *avsproto.TaskNode, check func(string, int64) error) er
 			return check("loop eth transfer runner", et.Config.GetChainId())
 		}
 	}
+	// NOTE: chain-aware nodes nested inside a Branch node's conditional paths are
+	// not validated here — they fall through to the strict resolveSmartWalletForNode
+	// check at execution time instead of being rejected at create time. If Branch
+	// gains nested chain-aware runners, add a case here (mirroring Loop above).
 	return nil
 }
 
@@ -688,12 +692,13 @@ func chainNeedsOperatorMonitoring(tt avsproto.TriggerType) bool {
 // triggerMonitoringChainID returns the chain an operator must subscribe to in
 // order to watch this task's trigger fire (G2). For chain-watching triggers
 // (event/block) it is the trigger's OWN configured chain — so a workflow can
-// watch chain X while its nodes act on chain Y. A 0 on the trigger means
-// "inherit", so we fall back to the task chain (legacy, until G5 removes the
-// task chain). Non-chain triggers (cron/fixedtime/manual) carry the fallback
-// through unchanged — the operator's TimeTrigger is chain-agnostic and ignores
-// it. Proto getters are nil-safe, so the GetEvent()/GetBlock() chain reads are
-// safe for any trigger type.
+// watch chain X while its nodes act on chain Y. Post-G5 there is no task-level
+// chain: every caller passes fallbackChainID=0, and strict create-time validation
+// already rejects a chain-watching trigger with chain_id<=0, so a 0 trigger chain
+// here only occurs for non-chain triggers (cron/fixedtime/manual), which carry the
+// fallback through unchanged — the operator's TimeTrigger is chain-agnostic and
+// ignores it. Proto getters are nil-safe, so the GetEvent()/GetBlock() chain reads
+// are safe for any trigger type.
 func triggerMonitoringChainID(trigger *avsproto.TaskTrigger, fallbackChainID int64) int64 {
 	if cid := trigger.GetEvent().GetConfig().GetChainId(); cid != 0 {
 		return cid

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -451,6 +451,16 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 
 		// Enhanced wallet validation that handles any legitimately derived wallet
 		isValid, err := x.validateWalletOwnership(ctx, x.engine.defaultChainID(), user, smartWalletAddr)
+		if err == nil && !isValid {
+			// The smart-wallet runner address is chain-invariant across configured
+			// chains, but its ownership record (w:<chain>:...) may have been written
+			// under a different chain than the gateway default. Mirror the create-time
+			// cross-chain check (userOwnsWalletOnAnyChain) so a wallet registered on a
+			// non-default chain isn't spuriously rejected at execution → auto-disabled.
+			if ok, ownErr := x.engine.userOwnsWalletOnAnyChain(user, smartWalletAddr); ownErr == nil && ok {
+				isValid = true
+			}
+		}
 		if err != nil {
 			execution.EndAt = time.Now().UnixMilli()
 			execution.Error = fmt.Sprintf("failed to validate wallet ownership for owner %s: %v", owner.Hex(), err)
@@ -470,12 +480,19 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 			x.logger.Info("Executor: AA sender resolved", "sender", task.SmartWalletAddress)
 		}
 
-		// Look up the wallet's salt from DB for auto-deployment of non-salt-0 wallets
+		// Look up the wallet's salt from DB for auto-deployment of non-salt-0 wallets.
+		// The salt is chain-invariant (same salt derives the same address on every
+		// configured chain), but the record (w:<chain>:...) is keyed by the chain it
+		// was registered on, which may differ from the gateway default. Scan all
+		// configured chains so the salt isn't missed → wallet auto-deployed wrong.
 		if x.db != nil {
-			if wallet, walletErr := GetWallet(x.db, x.engine.defaultChainID(), owner, task.SmartWalletAddress); walletErr == nil && wallet != nil && wallet.Salt != nil {
-				vm.AddVar("aa_salt", wallet.Salt)
-				if x.logger != nil {
-					x.logger.Info("Executor: AA salt resolved from wallet DB", "salt", wallet.Salt.String(), "wallet", task.SmartWalletAddress)
+			for _, walletChainID := range x.engine.knownChainIDs() {
+				if wallet, walletErr := GetWallet(x.db, walletChainID, owner, task.SmartWalletAddress); walletErr == nil && wallet != nil && wallet.Salt != nil {
+					vm.AddVar("aa_salt", wallet.Salt)
+					if x.logger != nil {
+						x.logger.Info("Executor: AA salt resolved from wallet DB", "salt", wallet.Salt.String(), "wallet", task.SmartWalletAddress, "chain_id", walletChainID)
+					}
+					break
 				}
 			}
 		}
@@ -533,15 +550,23 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 
 		if creditLimitWei != nil {
 			taskOwner := common.HexToAddress(task.Owner)
-			withinLimit, outstanding, checkErr := x.feeLedger.CheckCreditLimit(x.engine.defaultChainID(), taskOwner, creditLimitWei)
-			if checkErr != nil {
-				x.logger.Warn("Fee ledger check failed, proceeding with execution", "error", checkErr)
-			} else if !withinLimit {
-				execution.EndAt = time.Now().UnixMilli()
-				execution.Error = fmt.Sprintf("[INSUFFICIENT_CREDIT] outstanding value fees (%s wei) exceed credit limit", outstanding.String())
-				execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED
-				x.persistFailedExecution(task, execution, initialTaskStatus)
-				return execution, nil
+			// Value fees accrue per execution chain (fl:<chain>:<owner>) and a task's
+			// nodes can act on different chains, so an outstanding balance may sit on a
+			// non-default chain. Gate against every configured chain rather than just
+			// the gateway default, so credit limits can't be bypassed cross-chain.
+			for _, feeChainID := range x.engine.knownChainIDs() {
+				withinLimit, outstanding, checkErr := x.feeLedger.CheckCreditLimit(feeChainID, taskOwner, creditLimitWei)
+				if checkErr != nil {
+					x.logger.Warn("Fee ledger check failed, proceeding with execution", "chain_id", feeChainID, "error", checkErr)
+					continue
+				}
+				if !withinLimit {
+					execution.EndAt = time.Now().UnixMilli()
+					execution.Error = fmt.Sprintf("[INSUFFICIENT_CREDIT] outstanding value fees (%s wei) exceed credit limit", outstanding.String())
+					execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED
+					x.persistFailedExecution(task, execution, initialTaskStatus)
+					return execution, nil
+				}
 			}
 		}
 	}

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -46,6 +46,19 @@ func stampNodeChainIfUnset(node *avsproto.TaskNode, chainID int64) {
 	if et := node.GetEthTransfer(); et != nil && et.Config != nil && et.Config.ChainId == 0 {
 		et.Config.ChainId = chainID
 	}
+	// Loop node's inner runner is itself chain-aware — stamp it too, so a directly
+	// constructed (test/SDK) Loop whose runner has chain_id=0 still resolves.
+	if loop := node.GetLoop(); loop != nil {
+		if cw := loop.GetContractWrite(); cw != nil && cw.Config != nil && cw.Config.ChainId == 0 {
+			cw.Config.ChainId = chainID
+		}
+		if cr := loop.GetContractRead(); cr != nil && cr.Config != nil && cr.Config.ChainId == 0 {
+			cr.Config.ChainId = chainID
+		}
+		if et := loop.GetEthTransfer(); et != nil && et.Config != nil && et.Config.ChainId == 0 {
+			et.Config.ChainId = chainID
+		}
+	}
 }
 
 func getRealisticBlockNumberForChain(chainID int64) uint64 {

--- a/core/taskengine/stamp_node_chain_test.go
+++ b/core/taskengine/stamp_node_chain_test.go
@@ -1,0 +1,65 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestStampNodeChainIfUnset covers the chain stamping used by RunNodeImmediately,
+// including the Loop inner-runner path (regression: the runner was previously not
+// stamped, so a Loop with a chain_id=0 contractWrite/Read/ethTransfer runner failed
+// resolveSmartWalletForNode at execution).
+func TestStampNodeChainIfUnset(t *testing.T) {
+	const chainID = int64(11155111)
+
+	t.Run("top-level chain-aware nodes get stamped", func(t *testing.T) {
+		cw := &avsproto.TaskNode{TaskType: &avsproto.TaskNode_ContractWrite{
+			ContractWrite: &avsproto.ContractWriteNode{Config: &avsproto.ContractWriteNode_Config{}},
+		}}
+		stampNodeChainIfUnset(cw, chainID)
+		assert.Equal(t, chainID, cw.GetContractWrite().GetConfig().GetChainId())
+
+		cr := &avsproto.TaskNode{TaskType: &avsproto.TaskNode_ContractRead{
+			ContractRead: &avsproto.ContractReadNode{Config: &avsproto.ContractReadNode_Config{}},
+		}}
+		stampNodeChainIfUnset(cr, chainID)
+		assert.Equal(t, chainID, cr.GetContractRead().GetConfig().GetChainId())
+
+		et := &avsproto.TaskNode{TaskType: &avsproto.TaskNode_EthTransfer{
+			EthTransfer: &avsproto.ETHTransferNode{Config: &avsproto.ETHTransferNode_Config{}},
+		}}
+		stampNodeChainIfUnset(et, chainID)
+		assert.Equal(t, chainID, et.GetEthTransfer().GetConfig().GetChainId())
+	})
+
+	t.Run("loop inner runner gets stamped", func(t *testing.T) {
+		loop := &avsproto.TaskNode{TaskType: &avsproto.TaskNode_Loop{
+			Loop: &avsproto.LoopNode{Runner: &avsproto.LoopNode_ContractWrite{
+				ContractWrite: &avsproto.ContractWriteNode{Config: &avsproto.ContractWriteNode_Config{}},
+			}},
+		}}
+		stampNodeChainIfUnset(loop, chainID)
+		assert.Equal(t, chainID, loop.GetLoop().GetContractWrite().GetConfig().GetChainId(),
+			"loop runner chain_id should be stamped")
+	})
+
+	t.Run("already-set chain_id is not overwritten", func(t *testing.T) {
+		const explicit = int64(8453)
+		cw := &avsproto.TaskNode{TaskType: &avsproto.TaskNode_ContractWrite{
+			ContractWrite: &avsproto.ContractWriteNode{Config: &avsproto.ContractWriteNode_Config{ChainId: explicit}},
+		}}
+		stampNodeChainIfUnset(cw, chainID)
+		assert.Equal(t, explicit, cw.GetContractWrite().GetConfig().GetChainId())
+	})
+
+	t.Run("zero stamp chainID is a no-op", func(t *testing.T) {
+		cw := &avsproto.TaskNode{TaskType: &avsproto.TaskNode_ContractWrite{
+			ContractWrite: &avsproto.ContractWriteNode{Config: &avsproto.ContractWriteNode_Config{}},
+		}}
+		stampNodeChainIfUnset(cw, 0)
+		assert.Equal(t, int64(0), cw.GetContractWrite().GetConfig().GetChainId())
+	})
+}


### PR DESCRIPTION
Addresses the @claude review on the release PR #636 — the executor validated the runner wallet against `defaultChainID()` while create-time uses the cross-chain `userOwnsWalletOnAnyChain`. In a multi-chain gateway, a wallet/salt/credit registered on a non-default chain passed *create* then failed *execution* → task auto-disabled on first run.

## Fixes
| Site | Before | After |
|---|---|---|
| Ownership (`executor.go`) | `validateWalletOwnership(defaultChainID())` only | on miss, fall back to cross-chain `userOwnsWalletOnAnyChain` |
| Salt lookup | `GetWallet(defaultChainID())` | scan all configured chains (salt is chain-invariant) |
| Fee credit limit | `CheckCreditLimit(defaultChainID())` | gate against every chain's `fl:<chain>:<owner>` ledger |

The wallet address is chain-invariant (identical factory across the 4 core chains), so derivation on the default chain is fine — only the **chain-keyed DB records** (`w:`, `fl:`) needed cross-chain lookups.

## Minor (also from the review)
- `stampNodeChainIfUnset` now stamps **Loop inner runners** (+ unit test `TestStampNodeChainIfUnset`).
- Dropped the stale "inherit/legacy task chain" comment in `triggerMonitoringChainID`.
- Noted that **Branch**-nested chain-aware nodes are validated at run time, not create time, in `checkNodeChain`.

Build + targeted taskengine suites green. Merges into staging ahead of the held release #636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)