### PR TITLE
fix: render int64 chainId on create/get/list (protojson vs encoding/json) — closes #639

### DIFF
--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -391,12 +391,19 @@ func unquoteProtoInt64Strings(tree map[string]interface{}, md protoreflect.Messa
 		switch {
 		case fd.IsMap():
 			vDesc := fd.MapValue()
-			if vDesc.Kind() == protoreflect.MessageKind && !isWellKnownProto(vDesc.Message()) {
-				if m, ok := val.(map[string]interface{}); ok {
-					for _, mv := range m {
-						if sub, ok := mv.(map[string]interface{}); ok {
-							unquoteProtoInt64Strings(sub, vDesc.Message())
-						}
+			m, _ := val.(map[string]interface{})
+			switch {
+			case vDesc.Kind() == protoreflect.MessageKind && !isWellKnownProto(vDesc.Message()):
+				for _, mv := range m {
+					if sub, ok := mv.(map[string]interface{}); ok {
+						unquoteProtoInt64Strings(sub, vDesc.Message())
+					}
+				}
+			case is64BitIntKind(vDesc.Kind()):
+				// map<_, int64> values are protojson-encoded as strings too.
+				for k, mv := range m {
+					if s, ok := mv.(string); ok {
+						m[k] = json.Number(s)
 					}
 				}
 			}

--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -1,11 +1,14 @@
 package mapping
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
@@ -336,15 +339,108 @@ func ProtoToOpenAPINode(in *avsproto.TaskNode) (generated.Node, error) {
 // protoRetargetJSON serializes a proto message via protojson (camelCase)
 // and unmarshals it into the supplied Go struct. Inverse of
 // jsonRetargetProto.
+//
+// protojson encodes 64-bit integer fields (int64/uint64/sint64/fixed64/sfixed64)
+// as JSON *strings* per the proto3-JSON spec, but the generated REST structs type
+// them as plain int64 with no `,string` tag — so encoding/json rejects the string
+// ("cannot unmarshal string into ... of type int64"). Since chainId became a
+// required int64 on every chain-aware config, that broke proto→OpenAPI rendering
+// on create/get/list. We rewrite exactly those fields back to JSON numbers,
+// identifying them via the proto descriptor so genuine string fields (e.g. an
+// ethTransfer Amount) are never touched. See issue #639.
 func protoRetargetJSON(in proto.Message, out interface{}) error {
 	raw, err := (protojson.MarshalOptions{EmitUnpopulated: false}).Marshal(in)
 	if err != nil {
 		return fmt.Errorf("marshal proto config: %w", err)
 	}
+
+	desc := in.ProtoReflect().Descriptor()
+	// Well-known types (Timestamp, Duration, Struct, Value, ...) protojson-encode
+	// to non-object JSON and carry no plain int64 struct fields — decode directly.
+	if !isWellKnownProto(desc) {
+		var tree map[string]interface{}
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.UseNumber()
+		if decErr := dec.Decode(&tree); decErr == nil {
+			unquoteProtoInt64Strings(tree, desc)
+			if normalized, mErr := json.Marshal(tree); mErr == nil {
+				raw = normalized
+			}
+		}
+	}
+
 	if err := json.Unmarshal(raw, out); err != nil {
 		return fmt.Errorf("unmarshal config into Go struct: %w", err)
 	}
 	return nil
+}
+
+// unquoteProtoInt64Strings walks a protojson-decoded JSON tree alongside the
+// proto descriptor and converts the string-encoded 64-bit integer fields back to
+// JSON numbers (json.Number), recursing into nested (non-well-known) messages,
+// repeated values, and map values. Driven by the descriptor so only true int64
+// fields are touched — never string fields that merely contain digits.
+func unquoteProtoInt64Strings(tree map[string]interface{}, md protoreflect.MessageDescriptor) {
+	fields := md.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+		val, ok := tree[fd.JSONName()]
+		if !ok {
+			continue
+		}
+		switch {
+		case fd.IsMap():
+			vDesc := fd.MapValue()
+			if vDesc.Kind() == protoreflect.MessageKind && !isWellKnownProto(vDesc.Message()) {
+				if m, ok := val.(map[string]interface{}); ok {
+					for _, mv := range m {
+						if sub, ok := mv.(map[string]interface{}); ok {
+							unquoteProtoInt64Strings(sub, vDesc.Message())
+						}
+					}
+				}
+			}
+		case fd.IsList():
+			list, _ := val.([]interface{})
+			if is64BitIntKind(fd.Kind()) {
+				for j, item := range list {
+					if s, ok := item.(string); ok {
+						list[j] = json.Number(s)
+					}
+				}
+			} else if fd.Kind() == protoreflect.MessageKind && !isWellKnownProto(fd.Message()) {
+				for _, item := range list {
+					if sub, ok := item.(map[string]interface{}); ok {
+						unquoteProtoInt64Strings(sub, fd.Message())
+					}
+				}
+			}
+		case fd.Kind() == protoreflect.MessageKind:
+			if !isWellKnownProto(fd.Message()) {
+				if sub, ok := val.(map[string]interface{}); ok {
+					unquoteProtoInt64Strings(sub, fd.Message())
+				}
+			}
+		case is64BitIntKind(fd.Kind()):
+			if s, ok := val.(string); ok {
+				tree[fd.JSONName()] = json.Number(s)
+			}
+		}
+	}
+}
+
+func is64BitIntKind(k protoreflect.Kind) bool {
+	switch k {
+	case protoreflect.Int64Kind, protoreflect.Uint64Kind, protoreflect.Sint64Kind,
+		protoreflect.Fixed64Kind, protoreflect.Sfixed64Kind:
+		return true
+	default:
+		return false
+	}
+}
+
+func isWellKnownProto(md protoreflect.MessageDescriptor) bool {
+	return strings.HasPrefix(string(md.FullName()), "google.protobuf.")
 }
 
 // protoLoopRunnerToOpenAPI converts the proto LoopNode.Runner oneof back

--- a/aggregator/rest/mapping/node_chainid_outbound_test.go
+++ b/aggregator/rest/mapping/node_chainid_outbound_test.go
@@ -1,0 +1,96 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestProtoToOpenAPINode_PerNodeChainId covers the proto→OpenAPI render path
+// (ProtoToOpenAPINode → protoRetargetJSON) that create/get/list use to return a
+// persisted node to clients. protojson encodes the int64 chainId as a quoted
+// string ("11155111"); without the descriptor-driven unquote (issue #639) the
+// generated struct's plain int64 ChainId field rejects it and the whole render
+// fails. #633 only exercised the inbound (OpenAPIToProtoNode) direction, which is
+// lenient via protojson.Unmarshal, so it stayed green while this path was broken.
+func TestProtoToOpenAPINode_PerNodeChainId(t *testing.T) {
+	const chainID = int64(11155111)
+	const addr = "0x1234567890123456789012345678901234567890"
+
+	t.Run("contractRead", func(t *testing.T) {
+		pn := &avsproto.TaskNode{Id: "cr1", Type: avsproto.NodeType_NODE_TYPE_CONTRACT_READ, TaskType: &avsproto.TaskNode_ContractRead{
+			ContractRead: &avsproto.ContractReadNode{Config: &avsproto.ContractReadNode_Config{
+				ContractAddress: addr,
+				ChainId:         chainID,
+			}},
+		}}
+		out, err := ProtoToOpenAPINode(pn)
+		require.NoError(t, err)
+		v, err := out.AsContractReadNode()
+		require.NoError(t, err)
+		assert.Equal(t, chainID, int64(v.Config.ChainId))
+	})
+
+	t.Run("contractWrite", func(t *testing.T) {
+		pn := &avsproto.TaskNode{Id: "cw1", Type: avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE, TaskType: &avsproto.TaskNode_ContractWrite{
+			ContractWrite: &avsproto.ContractWriteNode{Config: &avsproto.ContractWriteNode_Config{
+				ContractAddress: addr,
+				ChainId:         chainID,
+			}},
+		}}
+		out, err := ProtoToOpenAPINode(pn)
+		require.NoError(t, err)
+		v, err := out.AsContractWriteNode()
+		require.NoError(t, err)
+		assert.Equal(t, chainID, int64(v.Config.ChainId))
+	})
+
+	// ethTransfer doubles as the corruption guard: Amount is a digit-only *string*
+	// field. A blind unquote would turn "1000000000000000" into a number and break
+	// it — the descriptor-driven approach must leave it a string while still
+	// unquoting the int64 chainId sitting right next to it.
+	t.Run("ethTransfer: chainId unquoted, Amount string preserved", func(t *testing.T) {
+		pn := &avsproto.TaskNode{Id: "et1", Type: avsproto.NodeType_NODE_TYPE_ETH_TRANSFER, TaskType: &avsproto.TaskNode_EthTransfer{
+			EthTransfer: &avsproto.ETHTransferNode{Config: &avsproto.ETHTransferNode_Config{
+				Destination: addr,
+				Amount:      "1000000000000000",
+				ChainId:     chainID,
+			}},
+		}}
+		out, err := ProtoToOpenAPINode(pn)
+		require.NoError(t, err)
+		v, err := out.AsETHTransferNode()
+		require.NoError(t, err)
+		assert.Equal(t, chainID, int64(v.Config.ChainId), "int64 chainId must survive the protojson string round-trip")
+		assert.Equal(t, "1000000000000000", v.Config.Amount, "digit-only Amount string must NOT be unquoted to a number")
+	})
+}
+
+// TestNodeRoundTrip_PerNodeChainId_FullCycle proves the complete create-render
+// cycle a client sees: OpenAPI (chainId as a JSON number) → proto → OpenAPI,
+// i.e. OpenAPIToProtoNode + ProtoToOpenAPINode chained — what CreateWorkflow then
+// a subsequent GET exercise.
+func TestNodeRoundTrip_PerNodeChainId_FullCycle(t *testing.T) {
+	const chainID = int64(8453)
+	typ := generated.ContractRead
+	inner := generated.ContractReadNode{Type: &typ, Config: &generated.ContractReadNodeConfig{
+		ContractAddress: generated.EthereumAddress("0x1234567890123456789012345678901234567890"),
+		ChainId:         generated.ChainId(chainID),
+	}}
+	n := generated.Node{Id: "cr1", Type: generated.NodeTypeContractRead}
+	require.NoError(t, n.FromContractReadNode(inner))
+
+	pn, err := OpenAPIToProtoNode(n)
+	require.NoError(t, err)
+	require.Equal(t, chainID, pn.GetContractRead().GetConfig().GetChainId())
+
+	rt, err := ProtoToOpenAPINode(pn)
+	require.NoError(t, err)
+	v, err := rt.AsContractReadNode()
+	require.NoError(t, err)
+	assert.Equal(t, chainID, int64(v.Config.ChainId))
+}


### PR DESCRIPTION
Closes #639.

`protoRetargetJSON` (proto→OpenAPI) did `protojson.Marshal` → `encoding/json.Unmarshal`. protojson encodes 64-bit ints as JSON **strings** (proto3-JSON spec), but the generated structs type `chainId` as plain `int64` (no `,string`), so create/get/list failed to re-render every chain-aware node once #634 made `chainId` **required** (always emitted). simulate/runNode never re-render node config, so they stayed green — and #633 only tested the inbound direction.

**Fix:** walk the protojson output alongside the **proto descriptor** and unquote exactly the 64-bit int fields (recursing into nested messages/lists/maps, skipping well-known types). Descriptor-driven so genuine string fields — e.g. an ethTransfer `Amount` of `"1000000000000000"` — are never corrupted. No wire-contract or generated-type change; `chainId` stays an integer on the wire (matches the spec + shipped SDK).

**Tests:** `TestProtoToOpenAPINode_PerNodeChainId` (outbound render for contractRead/Write/ethTransfer + Amount-string-preserved guard) and `TestNodeRoundTrip_PerNodeChainId_FullCycle` (full OpenAPI→proto→OpenAPI cycle). Full mapping + aggregator suites green.

Unblocks the SDK's `PER_NODE_CHAIN_READY=1 … multichain-per-part-chain.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)