### PR TITLE
fix: render per-node chainId on create/get/list (#639) + local dev-stack tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ build:
 gateway: build
 	@echo "🚀 Starting local-dev gateway (config/gateway.yaml)..."
 	@echo "📝 Logs will be written to gateway.log"
-	./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway.log
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; ./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway.log
 
 # Legacy per-chain aggregator targets retained as redirects so muscle
 # memory and old runbooks still work. They print a deprecation notice
@@ -270,34 +270,32 @@ operator-default: build
 	./out/ap operator --config=config/operator.yaml 2>&1 | tee operator-default.log
 
 
-## dev-gateway: run the dev gateway (REST 8080, gRPC 2206)
+## run-*: BUILD-FREE pure-exec targets — the single source of truth for each
+## local-dev process's command (config + .env.local). studio/scripts/start.sh
+## (tmux panes) and `make dev-stack` both invoke these, so config paths / ports /
+## env can't drift between them. Build-free so callers that already ran
+## `make build` don't fire concurrent go builds racing on ./out/ap. Output goes
+## to the caller's terminal/pane; callers that want files redirect (dev-stack →
+## logs/, start.sh → tee). Each sources .env.local so the
+## ${SEPOLIA_BUNDLER_URL} / ${BASE_SEPOLIA_BUNDLER_URL} refs in the YAML resolve.
+.PHONY: run-gateway run-worker-sepolia run-worker-base-sepolia run-operator-sepolia
+run-gateway:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap aggregator --config=config/gateway.yaml
+run-worker-sepolia:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-sepolia.yaml
+run-worker-base-sepolia:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base-sepolia.yaml
+run-operator-sepolia:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap operator --config=config/operator-sepolia.yaml
+
+## dev-gateway / dev-worker-* / dev-operator-sepolia: build once, then run a single
+## process in the foreground (standalone use). For a file log, pipe it yourself:
+##   make run-gateway 2>&1 | tee logs/gateway.log
 .PHONY: dev-gateway dev-worker-sepolia dev-worker-base-sepolia dev-operator-sepolia
-dev-gateway: build
-	@mkdir -p logs
-	@echo "🚀 Starting gateway (dev) — REST :8080, gRPC :2206"
-	@echo "📝 Logs: logs/gateway.log"
-	./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee logs/gateway.log
-
-## dev-worker-sepolia: run the sepolia chain worker (gRPC 50051)
-dev-worker-sepolia: build
-	@mkdir -p logs
-	@echo "🛠  Starting worker:sepolia (dev) — gRPC :50051"
-	@echo "📝 Logs: logs/worker-sepolia.log"
-	./out/ap worker --config=config/worker-sepolia.yaml 2>&1 | tee logs/worker-sepolia.log
-
-## dev-worker-base-sepolia: run the base-sepolia chain worker (gRPC 50052)
-dev-worker-base-sepolia: build
-	@mkdir -p logs
-	@echo "🛠  Starting worker:base-sepolia (dev) — gRPC :50052"
-	@echo "📝 Logs: logs/worker-base-sepolia.log"
-	./out/ap worker --config=config/worker-base-sepolia.yaml 2>&1 | tee logs/worker-base-sepolia.log
-
-## dev-operator-sepolia: run the sepolia operator pointed at the dev gateway
-dev-operator-sepolia: build
-	@mkdir -p logs
-	@echo "🔧 Starting operator:sepolia (dev) — aggregator: 127.0.0.1:2206"
-	@echo "📝 Logs: logs/operator-sepolia.log"
-	./out/ap operator --config=config/operator-sepolia.yaml 2>&1 | tee logs/operator-sepolia.log
+dev-gateway: build run-gateway
+dev-worker-sepolia: build run-worker-sepolia
+dev-worker-base-sepolia: build run-worker-base-sepolia
+dev-operator-sepolia: build run-operator-sepolia
 
 ## dev-stack: run gateway + sepolia worker + base-sepolia worker + sepolia operator together (Ctrl-C stops all)
 ##
@@ -318,14 +316,19 @@ dev-stack: build
 	@echo "   Tail with:  tail -f logs/*.log"
 	@echo "   Stop with:  Ctrl-C  (kills the whole stack)"
 	@echo ""
-	@set -m; \
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; \
+		if [ -z "$$SEPOLIA_BUNDLER_URL" ] || [ -z "$$BASE_SEPOLIA_BUNDLER_URL" ]; then \
+			echo "❌ Missing SEPOLIA_BUNDLER_URL / BASE_SEPOLIA_BUNDLER_URL — add them to .env.local (pull from Railway)"; \
+			exit 1; \
+		fi; \
+		set -m; \
 		trap 'echo; echo "🛑 Stopping dev stack..."; kill 0 2>/dev/null; exit 0' INT TERM; \
-		./out/ap worker --config=config/worker-sepolia.yaml      > logs/worker-sepolia.log      2>&1 & \
-		./out/ap worker --config=config/worker-base-sepolia.yaml > logs/worker-base-sepolia.log 2>&1 & \
+		$(MAKE) run-worker-sepolia      > logs/worker-sepolia.log      2>&1 & \
+		$(MAKE) run-worker-base-sepolia > logs/worker-base-sepolia.log 2>&1 & \
 		sleep 1; \
-		./out/ap aggregator --config=config/gateway.yaml         > logs/gateway.log             2>&1 & \
+		$(MAKE) run-gateway             > logs/gateway.log             2>&1 & \
 		sleep 3; \
-		./out/ap operator   --config=config/operator-sepolia.yaml    > logs/operator-sepolia.log    2>&1 & \
+		$(MAKE) run-operator-sepolia    > logs/operator-sepolia.log    2>&1 & \
 		wait
 
 ## clean: cleanup storage data

--- a/Makefile
+++ b/Makefile
@@ -289,13 +289,22 @@ run-operator-sepolia:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap operator --config=config/operator-sepolia.yaml
 
 ## dev-gateway / dev-worker-* / dev-operator-sepolia: build once, then run a single
-## process in the foreground (standalone use). For a file log, pipe it yourself:
-##   make run-gateway 2>&1 | tee logs/gateway.log
+## process in the foreground (standalone use), streaming to logs/<svc>.log.
+## Depends on `build` only and invokes run-* in the recipe so the binary is built
+## before it runs even under `make -j` (a `build run-*` prereq list could race).
 .PHONY: dev-gateway dev-worker-sepolia dev-worker-base-sepolia dev-operator-sepolia
-dev-gateway: build run-gateway
-dev-worker-sepolia: build run-worker-sepolia
-dev-worker-base-sepolia: build run-worker-base-sepolia
-dev-operator-sepolia: build run-operator-sepolia
+dev-gateway: build
+	@mkdir -p logs
+	@$(MAKE) --no-print-directory run-gateway 2>&1 | tee logs/gateway.log
+dev-worker-sepolia: build
+	@mkdir -p logs
+	@$(MAKE) --no-print-directory run-worker-sepolia 2>&1 | tee logs/worker-sepolia.log
+dev-worker-base-sepolia: build
+	@mkdir -p logs
+	@$(MAKE) --no-print-directory run-worker-base-sepolia 2>&1 | tee logs/worker-base-sepolia.log
+dev-operator-sepolia: build
+	@mkdir -p logs
+	@$(MAKE) --no-print-directory run-operator-sepolia 2>&1 | tee logs/operator-sepolia.log
 
 ## dev-stack: run gateway + sepolia worker + base-sepolia worker + sepolia operator together (Ctrl-C stops all)
 ##
@@ -323,12 +332,12 @@ dev-stack: build
 		fi; \
 		set -m; \
 		trap 'echo; echo "🛑 Stopping dev stack..."; kill 0 2>/dev/null; exit 0' INT TERM; \
-		$(MAKE) run-worker-sepolia      > logs/worker-sepolia.log      2>&1 & \
-		$(MAKE) run-worker-base-sepolia > logs/worker-base-sepolia.log 2>&1 & \
+		$(MAKE) --no-print-directory run-worker-sepolia      > logs/worker-sepolia.log      2>&1 & \
+		$(MAKE) --no-print-directory run-worker-base-sepolia > logs/worker-base-sepolia.log 2>&1 & \
 		sleep 1; \
-		$(MAKE) run-gateway             > logs/gateway.log             2>&1 & \
+		$(MAKE) --no-print-directory run-gateway             > logs/gateway.log             2>&1 & \
 		sleep 3; \
-		$(MAKE) run-operator-sepolia    > logs/operator-sepolia.log    2>&1 & \
+		$(MAKE) --no-print-directory run-operator-sepolia    > logs/operator-sepolia.log    2>&1 & \
 		wait
 
 ## clean: cleanup storage data

--- a/PLAN_CHAIN_DECOUPLING.md
+++ b/PLAN_CHAIN_DECOUPLING.md
@@ -32,23 +32,23 @@ Backend gaps (this repo):
 - [x] **Strict reject-0** — `chain_id <= 0` invalid in all modes (resolver + create validator); no default fallback — **merged #632**
 - [x] **Create-path verification** — `TestNodeRoundTrip_PerNodeChainId` proves the persisted create path decodes per-node `chainId` — **merged #633**
 - [x] **OpenAPI renovation** — removed `Workflow.chainId` / `CreateWorkflowRequest.chainId` + the `ChainIdQuery` param on list/count/executions; per-part config `chainId` now `required` — **merged #634**
+- [x] **Executor cross-chain wallet/salt/fee** — execution-time wallet ownership/salt/credit checks scan all configured chains (mirror create-time), not the gateway default — **merged #637**
+- [x] **proto→OpenAPI int64 render fix** — `protoRetargetJSON` unquotes protojson's string-encoded `int64` (chainId) so create/get/list render chain-aware nodes; descriptor-driven so string fields (Amount) are untouched — **merged #640 (closes #639)**
 
-**Backend chain decoupling is complete on `staging`.** Wallet/exec defaults (decided): wallet-ownership
+**Backend chain decoupling is complete.** Wallet/exec defaults (decided): wallet-ownership
 checks across all configured chains (`userOwnsWalletOnAnyChain`); VM-default config = aggregator default;
 salt is chain-invariant. ✅ done.
 
-Client (separate repos — backend spec on `staging` now unblocks them):
+Client (separate repos — backend spec on `main` now unblocks them):
 
-- [ ] **`ava-sdk-js`** — **handed off to the SDK project.** Regen types (`openapi-download`+`types-gen` off the
-      renovated staging spec), make builder `chainId` required, drop list/count/executions `chainId` params, fix the
-      stale chain-resolution doc, flip the `PER_NODE_CHAIN_READY` tests. Contract: `## Client contract` below.
-- [ ] **studio** — Phase 3: per-part chains in the canvas; drop workflow-level `chainId`; chain-agnostic workflow list
+- [x] **`ava-sdk-js`** — **done.** Types regenerated off the renovated spec, builders require `chainId`, list/count/executions
+      `chainId` dropped; `PER_NODE_CHAIN_READY` multichain e2e **passes** against a local gateway.
+- [ ] **studio** — Phase 3: per-part chains in the canvas; drop workflow-level `chainId`; chain-agnostic workflow list (separate repo; not gated on the backend)
 
 Release / ops (this repo):
 
-- [ ] **staging → main** promotion: confirm the `wipe-chain-bucketed-task-keys` migration runs at boot;
-      `make storage-check` will flag the breaking proto + key-template change (expected — the migration is the handler).
-      Coordinate with the SDK/studio client update so chain-less calls aren't in flight when strict prod goes live.
+- [x] **staging → main** promotion (chain decoupling, incl. executor cross-chain fix #637): **merged #636**; `wipe-chain-bucketed-task-keys` migration runs at boot after a DB backup.
+- [ ] **staging → main** follow-up promotion: ship the #639 render fix (#640) + dev tooling to `main`. `make storage-check` clean (no new migration). *(SDK lockstep satisfied — e2e green; main currently carries the chain decoupling WITH the #639 render bug until this lands.)*
 
 Future (not started):
 

--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -1,11 +1,14 @@
 package mapping
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
@@ -336,15 +339,115 @@ func ProtoToOpenAPINode(in *avsproto.TaskNode) (generated.Node, error) {
 // protoRetargetJSON serializes a proto message via protojson (camelCase)
 // and unmarshals it into the supplied Go struct. Inverse of
 // jsonRetargetProto.
+//
+// protojson encodes 64-bit integer fields (int64/uint64/sint64/fixed64/sfixed64)
+// as JSON *strings* per the proto3-JSON spec, but the generated REST structs type
+// them as plain int64 with no `,string` tag — so encoding/json rejects the string
+// ("cannot unmarshal string into ... of type int64"). Since chainId became a
+// required int64 on every chain-aware config, that broke proto→OpenAPI rendering
+// on create/get/list. We rewrite exactly those fields back to JSON numbers,
+// identifying them via the proto descriptor so genuine string fields (e.g. an
+// ethTransfer Amount) are never touched. See issue #639.
 func protoRetargetJSON(in proto.Message, out interface{}) error {
 	raw, err := (protojson.MarshalOptions{EmitUnpopulated: false}).Marshal(in)
 	if err != nil {
 		return fmt.Errorf("marshal proto config: %w", err)
 	}
+
+	desc := in.ProtoReflect().Descriptor()
+	// Well-known types (Timestamp, Duration, Struct, Value, ...) protojson-encode
+	// to non-object JSON and carry no plain int64 struct fields — decode directly.
+	if !isWellKnownProto(desc) {
+		var tree map[string]interface{}
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.UseNumber()
+		if decErr := dec.Decode(&tree); decErr == nil {
+			unquoteProtoInt64Strings(tree, desc)
+			if normalized, mErr := json.Marshal(tree); mErr == nil {
+				raw = normalized
+			}
+		}
+	}
+
 	if err := json.Unmarshal(raw, out); err != nil {
 		return fmt.Errorf("unmarshal config into Go struct: %w", err)
 	}
 	return nil
+}
+
+// unquoteProtoInt64Strings walks a protojson-decoded JSON tree alongside the
+// proto descriptor and converts the string-encoded 64-bit integer fields back to
+// JSON numbers (json.Number), recursing into nested (non-well-known) messages,
+// repeated values, and map values. Driven by the descriptor so only true int64
+// fields are touched — never string fields that merely contain digits.
+func unquoteProtoInt64Strings(tree map[string]interface{}, md protoreflect.MessageDescriptor) {
+	fields := md.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+		val, ok := tree[fd.JSONName()]
+		if !ok {
+			continue
+		}
+		switch {
+		case fd.IsMap():
+			vDesc := fd.MapValue()
+			m, _ := val.(map[string]interface{})
+			switch {
+			case vDesc.Kind() == protoreflect.MessageKind && !isWellKnownProto(vDesc.Message()):
+				for _, mv := range m {
+					if sub, ok := mv.(map[string]interface{}); ok {
+						unquoteProtoInt64Strings(sub, vDesc.Message())
+					}
+				}
+			case is64BitIntKind(vDesc.Kind()):
+				// map<_, int64> values are protojson-encoded as strings too.
+				for k, mv := range m {
+					if s, ok := mv.(string); ok {
+						m[k] = json.Number(s)
+					}
+				}
+			}
+		case fd.IsList():
+			list, _ := val.([]interface{})
+			if is64BitIntKind(fd.Kind()) {
+				for j, item := range list {
+					if s, ok := item.(string); ok {
+						list[j] = json.Number(s)
+					}
+				}
+			} else if fd.Kind() == protoreflect.MessageKind && !isWellKnownProto(fd.Message()) {
+				for _, item := range list {
+					if sub, ok := item.(map[string]interface{}); ok {
+						unquoteProtoInt64Strings(sub, fd.Message())
+					}
+				}
+			}
+		case fd.Kind() == protoreflect.MessageKind:
+			if !isWellKnownProto(fd.Message()) {
+				if sub, ok := val.(map[string]interface{}); ok {
+					unquoteProtoInt64Strings(sub, fd.Message())
+				}
+			}
+		case is64BitIntKind(fd.Kind()):
+			if s, ok := val.(string); ok {
+				tree[fd.JSONName()] = json.Number(s)
+			}
+		}
+	}
+}
+
+func is64BitIntKind(k protoreflect.Kind) bool {
+	switch k {
+	case protoreflect.Int64Kind, protoreflect.Uint64Kind, protoreflect.Sint64Kind,
+		protoreflect.Fixed64Kind, protoreflect.Sfixed64Kind:
+		return true
+	default:
+		return false
+	}
+}
+
+func isWellKnownProto(md protoreflect.MessageDescriptor) bool {
+	return strings.HasPrefix(string(md.FullName()), "google.protobuf.")
 }
 
 // protoLoopRunnerToOpenAPI converts the proto LoopNode.Runner oneof back

--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -354,25 +354,63 @@ func protoRetargetJSON(in proto.Message, out interface{}) error {
 		return fmt.Errorf("marshal proto config: %w", err)
 	}
 
+	// Only pay for the unquote round-trip when the message actually carries a
+	// 64-bit int field (most node configs don't). Well-known types (Timestamp,
+	// Duration, Struct, ...) protojson-encode to non-object JSON, so skip them too.
 	desc := in.ProtoReflect().Descriptor()
-	// Well-known types (Timestamp, Duration, Struct, Value, ...) protojson-encode
-	// to non-object JSON and carry no plain int64 struct fields — decode directly.
-	if !isWellKnownProto(desc) {
+	if !isWellKnownProto(desc) && messageHas64BitInt(desc, map[protoreflect.FullName]bool{}) {
 		var tree map[string]interface{}
 		dec := json.NewDecoder(bytes.NewReader(raw))
 		dec.UseNumber()
-		if decErr := dec.Decode(&tree); decErr == nil {
-			unquoteProtoInt64Strings(tree, desc)
-			if normalized, mErr := json.Marshal(tree); mErr == nil {
-				raw = normalized
-			}
+		if decErr := dec.Decode(&tree); decErr != nil {
+			return fmt.Errorf("decode protojson intermediate: %w", decErr)
 		}
+		unquoteProtoInt64Strings(tree, desc)
+		normalized, mErr := json.Marshal(tree)
+		if mErr != nil {
+			return fmt.Errorf("re-marshal normalized config: %w", mErr)
+		}
+		raw = normalized
 	}
 
 	if err := json.Unmarshal(raw, out); err != nil {
 		return fmt.Errorf("unmarshal config into Go struct: %w", err)
 	}
 	return nil
+}
+
+// messageHas64BitInt reports whether md — or any nested non-well-known message it
+// contains — declares a 64-bit integer field (the only fields protojson encodes
+// as strings that the unquote pass must repair). Lets protoRetargetJSON skip the
+// tree round-trip for the common int64-free config. `seen` guards recursive types.
+// (Map *keys* typed as int64 are not considered: encoding/json natively parses
+// string JSON object keys into integer map-key types, so they never need fixing.)
+func messageHas64BitInt(md protoreflect.MessageDescriptor, seen map[protoreflect.FullName]bool) bool {
+	if seen[md.FullName()] {
+		return false
+	}
+	seen[md.FullName()] = true
+	fields := md.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+		if is64BitIntKind(fd.Kind()) {
+			return true
+		}
+		if fd.IsMap() {
+			vDesc := fd.MapValue()
+			if is64BitIntKind(vDesc.Kind()) {
+				return true
+			}
+			if vDesc.Kind() == protoreflect.MessageKind && !isWellKnownProto(vDesc.Message()) && messageHas64BitInt(vDesc.Message(), seen) {
+				return true
+			}
+			continue
+		}
+		if fd.Kind() == protoreflect.MessageKind && !isWellKnownProto(fd.Message()) && messageHas64BitInt(fd.Message(), seen) {
+			return true
+		}
+	}
+	return false
 }
 
 // unquoteProtoInt64Strings walks a protojson-decoded JSON tree alongside the

--- a/aggregator/rest/mapping/node_chainid_outbound_test.go
+++ b/aggregator/rest/mapping/node_chainid_outbound_test.go
@@ -1,0 +1,96 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestProtoToOpenAPINode_PerNodeChainId covers the proto→OpenAPI render path
+// (ProtoToOpenAPINode → protoRetargetJSON) that create/get/list use to return a
+// persisted node to clients. protojson encodes the int64 chainId as a quoted
+// string ("11155111"); without the descriptor-driven unquote (issue #639) the
+// generated struct's plain int64 ChainId field rejects it and the whole render
+// fails. #633 only exercised the inbound (OpenAPIToProtoNode) direction, which is
+// lenient via protojson.Unmarshal, so it stayed green while this path was broken.
+func TestProtoToOpenAPINode_PerNodeChainId(t *testing.T) {
+	const chainID = int64(11155111)
+	const addr = "0x1234567890123456789012345678901234567890"
+
+	t.Run("contractRead", func(t *testing.T) {
+		pn := &avsproto.TaskNode{Id: "cr1", Type: avsproto.NodeType_NODE_TYPE_CONTRACT_READ, TaskType: &avsproto.TaskNode_ContractRead{
+			ContractRead: &avsproto.ContractReadNode{Config: &avsproto.ContractReadNode_Config{
+				ContractAddress: addr,
+				ChainId:         chainID,
+			}},
+		}}
+		out, err := ProtoToOpenAPINode(pn)
+		require.NoError(t, err)
+		v, err := out.AsContractReadNode()
+		require.NoError(t, err)
+		assert.Equal(t, chainID, int64(v.Config.ChainId))
+	})
+
+	t.Run("contractWrite", func(t *testing.T) {
+		pn := &avsproto.TaskNode{Id: "cw1", Type: avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE, TaskType: &avsproto.TaskNode_ContractWrite{
+			ContractWrite: &avsproto.ContractWriteNode{Config: &avsproto.ContractWriteNode_Config{
+				ContractAddress: addr,
+				ChainId:         chainID,
+			}},
+		}}
+		out, err := ProtoToOpenAPINode(pn)
+		require.NoError(t, err)
+		v, err := out.AsContractWriteNode()
+		require.NoError(t, err)
+		assert.Equal(t, chainID, int64(v.Config.ChainId))
+	})
+
+	// ethTransfer doubles as the corruption guard: Amount is a digit-only *string*
+	// field. A blind unquote would turn "1000000000000000" into a number and break
+	// it — the descriptor-driven approach must leave it a string while still
+	// unquoting the int64 chainId sitting right next to it.
+	t.Run("ethTransfer: chainId unquoted, Amount string preserved", func(t *testing.T) {
+		pn := &avsproto.TaskNode{Id: "et1", Type: avsproto.NodeType_NODE_TYPE_ETH_TRANSFER, TaskType: &avsproto.TaskNode_EthTransfer{
+			EthTransfer: &avsproto.ETHTransferNode{Config: &avsproto.ETHTransferNode_Config{
+				Destination: addr,
+				Amount:      "1000000000000000",
+				ChainId:     chainID,
+			}},
+		}}
+		out, err := ProtoToOpenAPINode(pn)
+		require.NoError(t, err)
+		v, err := out.AsETHTransferNode()
+		require.NoError(t, err)
+		assert.Equal(t, chainID, int64(v.Config.ChainId), "int64 chainId must survive the protojson string round-trip")
+		assert.Equal(t, "1000000000000000", v.Config.Amount, "digit-only Amount string must NOT be unquoted to a number")
+	})
+}
+
+// TestNodeRoundTrip_PerNodeChainId_FullCycle proves the complete create-render
+// cycle a client sees: OpenAPI (chainId as a JSON number) → proto → OpenAPI,
+// i.e. OpenAPIToProtoNode + ProtoToOpenAPINode chained — what CreateWorkflow then
+// a subsequent GET exercise.
+func TestNodeRoundTrip_PerNodeChainId_FullCycle(t *testing.T) {
+	const chainID = int64(8453)
+	typ := generated.ContractRead
+	inner := generated.ContractReadNode{Type: &typ, Config: &generated.ContractReadNodeConfig{
+		ContractAddress: generated.EthereumAddress("0x1234567890123456789012345678901234567890"),
+		ChainId:         generated.ChainId(chainID),
+	}}
+	n := generated.Node{Id: "cr1", Type: generated.NodeTypeContractRead}
+	require.NoError(t, n.FromContractReadNode(inner))
+
+	pn, err := OpenAPIToProtoNode(n)
+	require.NoError(t, err)
+	require.Equal(t, chainID, pn.GetContractRead().GetConfig().GetChainId())
+
+	rt, err := ProtoToOpenAPINode(pn)
+	require.NoError(t, err)
+	v, err := rt.AsContractReadNode()
+	require.NoError(t, err)
+	assert.Equal(t, chainID, int64(v.Config.ChainId))
+}

--- a/config/worker-base-sepolia.example.yaml
+++ b/config/worker-base-sepolia.example.yaml
@@ -24,7 +24,7 @@ health_address: "0.0.0.0:8091"
 gateway_address: "127.0.0.1:2206"
 
 # Chain RPC endpoints (Base Sepolia). Public RPC works for low-volume dev.
-eth_rpc_url: https://sepolia.base.org
+eth_rpc_url: https://base-sepolia-rpc.publicnode.com
 eth_ws_url:  wss://base-sepolia-rpc.publicnode.com
 
 # Third-party bundler endpoint (no self-hosted bundler).


### PR DESCRIPTION
Follow-up promotion after #636 (the chain-decoupling release). **`main` currently carries the chain decoupling *with* the #639 render bug** — create/get/list of any chain-aware workflow fails to render — so this is a correctness fix, not just tooling.

## Bundle (staging → main)
- **`fix:` #640 (closes #639)** — `protoRetargetJSON` unquotes protojson's string-encoded `int64` (chainId) so create/get/list render chain-aware nodes. Descriptor-driven, so genuine string fields (e.g. ethTransfer `Amount`) are untouched. Outbound + full-cycle round-trip tests added (the direction #633 missed).
- **`refactor:`** build-free `run-*` make targets as the single source of truth for the local stack (shared by `make dev-stack` and studio `start.sh`).
- **`chore:`** base-sepolia worker example RPC parity + plan-doc status.

## Release gates
- ✅ `make storage-check` clean — **no new migration** (the `wipe-chain-bucketed-task-keys` migration already shipped with #636).
- ✅ SDK lockstep satisfied — `ava-sdk-js` `PER_NODE_CHAIN_READY` multichain e2e **passes** against a local gateway built from this code.
- ✅ Full unit-test matrix green on the bundled commits.

Title is `fix:` (highest-impact in the bundle) → patch release via go-semantic-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
