### PR TITLE
feat: durable execution engine core — re-entrant scheduler, vars snapshot/restore, wake registry (step 1)

### DIFF
--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -156,19 +156,31 @@ func (s *Signal) Validate() error {
 	return nil
 }
 
+// reservedSystemVarNames are VM vars that hold system/secret context, re-injected
+// fresh on resume — never node outputs. A node whose (user-chosen) name collides
+// with one of these must NOT have its var snapshotted or restored: snapshotting
+// would persist secrets (apContext) to disk; restoring would clobber system state.
+var reservedSystemVarNames = map[string]bool{
+	"apContext":     true, // secrets / ap.* JS context
+	"settings":      true, // runner + chain_id
+	"aa_sender":     true, // smart-wallet address
+	"aa_salt":       true, // wallet salt
+	"triggerConfig": true, // trigger config
+}
+
 // snapshotNodeVars serializes only the per-node output vars (keyed by node name)
-// for a durable suspend. System/secret vars (settings, aa_*, apContext, trigger)
-// are deliberately excluded — they are re-injected fresh on resume, never
-// persisted (apContext carries secrets). This is the restorable slice of state
-// that lets a resumed leg reference prior steps' outputs ({{node.data.x}}).
+// for a durable suspend. System/secret vars are deliberately excluded — they are
+// re-injected fresh on resume, never persisted (apContext carries secrets). This
+// is the restorable slice of state that lets a resumed leg reference prior steps'
+// outputs ({{node.data.x}}).
 func (v *VM) snapshotNodeVars() ([]byte, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	out := make(map[string]any, len(v.TaskNodes))
 	for nodeID := range v.TaskNodes {
 		name := v.getNodeNameAsVarLocked(nodeID)
-		if name == "" {
-			continue
+		if name == "" || reservedSystemVarNames[name] {
+			continue // never persist a system/secret var, even if a node is named one
 		}
 		if val, ok := v.vars[name]; ok {
 			out[name] = val
@@ -196,6 +208,9 @@ func (v *VM) restoreNodeVars(snapshot []byte) error {
 		v.vars = make(map[string]any)
 	}
 	for k, val := range restored {
+		if reservedSystemVarNames[k] {
+			continue // defense-in-depth: a corrupt/tampered snapshot must not clobber system/secret vars
+		}
 		v.vars[k] = val
 	}
 	return nil
@@ -292,6 +307,11 @@ func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription,
 		sub, err := unmarshalWake(it.Value)
 		if err != nil {
 			return nil, fmt.Errorf("load wake %s: %w", execID, err)
+		}
+		// Re-validate on load: a corrupted or partially-written record gets a clear
+		// error path here rather than surfacing as hard-to-debug behavior later.
+		if err := sub.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid wake %s: %w", execID, err)
 		}
 		out[execID] = sub
 	}

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
 
 // Durable execution vocabulary (Level-3 engine — see PLAN_DURABLE_EXECUTION.md).
@@ -209,4 +212,92 @@ func completedNodeIDsFromSteps(steps []*avsproto.Execution_Step) map[string]bool
 		}
 	}
 	return out
+}
+
+// ---- Durable wake registry (key: wake:<execId>) ------------------------------
+//
+// The persisted set of pending waits. It is the source of truth for restart
+// durability: on boot, loadAllWakeSubscriptions rebuilds the in-memory registry,
+// which the engine then re-arms to operators (chain), reloads timers, and GCs
+// against execution status. New key template — additive, no migration.
+
+const wakeSubscriptionPrefix = "wake:"
+
+func wakeSubscriptionKey(execID string) []byte {
+	return []byte(wakeSubscriptionPrefix + execID)
+}
+
+// persistedWake is the on-disk shape. ChainEvent is stored as protojson so its
+// proto oneofs / well-known types (structpb.Value in contract_abi) round-trip
+// faithfully — plain encoding/json cannot serialize those.
+type persistedWake struct {
+	Kind       WakeKind            `json:"kind"`
+	ChainEvent json.RawMessage     `json:"chainEvent,omitempty"`
+	External   *ExternalSignalSpec `json:"external,omitempty"`
+	TimeoutAt  int64               `json:"timeoutAt"`
+}
+
+func marshalWake(sub *WakeSubscription) ([]byte, error) {
+	rec := persistedWake{Kind: sub.Kind, External: sub.External, TimeoutAt: sub.TimeoutAt}
+	if sub.ChainEvent != nil {
+		b, err := protojson.Marshal(sub.ChainEvent)
+		if err != nil {
+			return nil, fmt.Errorf("marshal wake chain event: %w", err)
+		}
+		rec.ChainEvent = b
+	}
+	return json.Marshal(rec)
+}
+
+func unmarshalWake(b []byte) (*WakeSubscription, error) {
+	var rec persistedWake
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return nil, err
+	}
+	sub := &WakeSubscription{Kind: rec.Kind, External: rec.External, TimeoutAt: rec.TimeoutAt}
+	if len(rec.ChainEvent) > 0 {
+		cfg := &avsproto.EventTrigger_Config{}
+		if err := protojson.Unmarshal(rec.ChainEvent, cfg); err != nil {
+			return nil, fmt.Errorf("unmarshal wake chain event: %w", err)
+		}
+		sub.ChainEvent = cfg
+	}
+	return sub, nil
+}
+
+// persistWakeSubscription writes the wait for execID. Validated first so we never
+// persist an inconsistent subscription.
+func persistWakeSubscription(db storage.Storage, execID string, sub *WakeSubscription) error {
+	if err := sub.Validate(); err != nil {
+		return err
+	}
+	b, err := marshalWake(sub)
+	if err != nil {
+		return err
+	}
+	return db.Set(wakeSubscriptionKey(execID), b)
+}
+
+// loadAllWakeSubscriptions scans the registry — the boot re-arm entrypoint. The
+// engine uses the result to re-register chain waits to operators, reload timers,
+// and GC entries whose execution is no longer WAITING.
+func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription, error) {
+	items, err := db.GetByPrefix([]byte(wakeSubscriptionPrefix))
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]*WakeSubscription, len(items))
+	for _, it := range items {
+		execID := strings.TrimPrefix(string(it.Key), wakeSubscriptionPrefix)
+		sub, err := unmarshalWake(it.Value)
+		if err != nil {
+			return nil, fmt.Errorf("load wake %s: %w", execID, err)
+		}
+		out[execID] = sub
+	}
+	return out, nil
+}
+
+func deleteWakeSubscription(db storage.Storage, execID string) error {
+	return db.Delete(wakeSubscriptionKey(execID))
 }

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -1,0 +1,152 @@
+package taskengine
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// Durable execution vocabulary (Level-3 engine — see PLAN_DURABLE_EXECUTION.md).
+//
+// These are pure type definitions: the foundation the re-entrant executor
+// (advance) and the suspendable steps (Await, HumanApproval) build on. Nothing
+// wires them yet — increment 2 establishes the vocabulary; later increments use it.
+
+// RunDisposition is what the executor should do after a step's run returns. The
+// core of the durable model is that any step may ask to suspend, not just fail or
+// continue.
+type RunDisposition int
+
+const (
+	RunContinue RunDisposition = iota // normal completion; schedule successors
+	RunSuspend                        // pause: persist WAITING + register the wake subscription
+	RunFail                           // fatal: terminate the execution as FAILED
+)
+
+func (d RunDisposition) String() string {
+	switch d {
+	case RunContinue:
+		return "continue"
+	case RunSuspend:
+		return "suspend"
+	case RunFail:
+		return "fail"
+	default:
+		return fmt.Sprintf("RunDisposition(%d)", int(d))
+	}
+}
+
+// WakeKind identifies which signal source can advance a suspended execution.
+type WakeKind int
+
+const (
+	WakeChainEvent     WakeKind = iota // operator-watched event on a chain (cross-chain Await)
+	WakeExternalSignal                 // gateway-received signal (Telegram approval, webhook)
+	WakeTimer                          // scheduler due-time (delay, approval timeout)
+)
+
+func (k WakeKind) String() string {
+	switch k {
+	case WakeChainEvent:
+		return "chain_event"
+	case WakeExternalSignal:
+		return "external_signal"
+	case WakeTimer:
+		return "timer"
+	default:
+		return fmt.Sprintf("WakeKind(%d)", int(k))
+	}
+}
+
+// WakeSubscription is what a suspended execution is waiting for. Exactly one
+// source field is populated, matching Kind. Persisted (key wake:<execId>) while
+// the execution is WAITING, and matched by an inbound Signal to advance it.
+type WakeSubscription struct {
+	Kind WakeKind `json:"kind"`
+
+	// ChainEvent is the event filter the operator watches (chain = ChainEvent's
+	// chain_id). Set iff Kind == WakeChainEvent. Reuses the existing event-trigger
+	// config so the operator watches it with no new logic.
+	ChainEvent *avsproto.EventTrigger_Config `json:"chainEvent,omitempty"`
+
+	// External describes who/what may deliver the wake. Set iff Kind == WakeExternalSignal.
+	External *ExternalSignalSpec `json:"external,omitempty"`
+
+	// TimeoutAt bounds every wait (unix ms). For Kind == WakeTimer it is the fire
+	// time; for the other kinds it is the hard timeout after which the wait expires.
+	TimeoutAt int64 `json:"timeoutAt"`
+}
+
+// ExternalSignalSpec describes an externally-delivered wake (human approval, webhook).
+// Authorization is anchored on the deploy-time EOA signature (the bounded envelope);
+// the signal just provides the go/no-go within it. See the approval security model
+// in PLAN_DURABLE_EXECUTION.md.
+type ExternalSignalSpec struct {
+	Channel   string   `json:"channel"`             // "telegram" | "api"
+	Approvers []string `json:"approvers,omitempty"` // authorized parties; empty ⇒ the workflow owner
+	Prompt    string   `json:"prompt,omitempty"`
+}
+
+// Validate asserts the subscription is internally consistent: exactly the source
+// field matching Kind is populated, and a timeout is set.
+func (w *WakeSubscription) Validate() error {
+	if w == nil {
+		return fmt.Errorf("nil wake subscription")
+	}
+	switch w.Kind {
+	case WakeChainEvent:
+		if w.ChainEvent == nil {
+			return fmt.Errorf("chain-event wake requires ChainEvent config")
+		}
+		if w.External != nil {
+			return fmt.Errorf("chain-event wake must not set External")
+		}
+	case WakeExternalSignal:
+		if w.External == nil || w.External.Channel == "" {
+			return fmt.Errorf("external-signal wake requires External with a channel")
+		}
+		if w.ChainEvent != nil {
+			return fmt.Errorf("external-signal wake must not set ChainEvent")
+		}
+	case WakeTimer:
+		if w.ChainEvent != nil || w.External != nil {
+			return fmt.Errorf("timer wake must not set ChainEvent/External")
+		}
+	default:
+		return fmt.Errorf("unknown wake kind %d", int(w.Kind))
+	}
+	if w.TimeoutAt <= 0 {
+		return fmt.Errorf("wake subscription requires a positive TimeoutAt (every wait is bounded)")
+	}
+	return nil
+}
+
+// Signal is an inbound wake delivered to one waiting execution via
+// advance(executionId, signal). Its Payload becomes the suspended step's output.
+type Signal struct {
+	ExecutionID string    `json:"executionId"`
+	Kind        WakeKind  `json:"kind"`
+	// Decision is set for external/approval signals: "approve" | "reject".
+	Decision string `json:"decision,omitempty"`
+	// Approver identifies who delivered an external signal (audit + authorization).
+	Approver string `json:"approver,omitempty"`
+	// Payload carries the wake event (e.g. the matched chain log) as structured data
+	// that becomes the suspended step's output, readable by downstream steps.
+	Payload *structpb.Value `json:"-"`
+}
+
+// Validate asserts the signal can be routed to a waiting execution.
+func (s *Signal) Validate() error {
+	if s == nil {
+		return fmt.Errorf("nil signal")
+	}
+	if s.ExecutionID == "" {
+		return fmt.Errorf("signal requires an executionId")
+	}
+	if s.Kind == WakeExternalSignal && s.Decision == "" {
+		return fmt.Errorf("external signal requires a decision")
+	}
+	return nil
+}

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -1,6 +1,8 @@
 package taskengine
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -149,4 +151,62 @@ func (s *Signal) Validate() error {
 		return fmt.Errorf("external signal requires a decision")
 	}
 	return nil
+}
+
+// snapshotNodeVars serializes only the per-node output vars (keyed by node name)
+// for a durable suspend. System/secret vars (settings, aa_*, apContext, trigger)
+// are deliberately excluded — they are re-injected fresh on resume, never
+// persisted (apContext carries secrets). This is the restorable slice of state
+// that lets a resumed leg reference prior steps' outputs ({{node.data.x}}).
+func (v *VM) snapshotNodeVars() ([]byte, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make(map[string]any, len(v.TaskNodes))
+	for nodeID := range v.TaskNodes {
+		name := v.getNodeNameAsVarLocked(nodeID)
+		if name == "" {
+			continue
+		}
+		if val, ok := v.vars[name]; ok {
+			out[name] = val
+		}
+	}
+	return json.Marshal(out)
+}
+
+// restoreNodeVars overlays a snapshot from snapshotNodeVars back onto the VM's
+// vars, so resumed nodes resolve prior steps' outputs. UseNumber keeps integers
+// from being silently coerced to float64, preserving template-render fidelity.
+func (v *VM) restoreNodeVars(snapshot []byte) error {
+	if len(snapshot) == 0 {
+		return nil
+	}
+	var restored map[string]any
+	dec := json.NewDecoder(bytes.NewReader(snapshot))
+	dec.UseNumber()
+	if err := dec.Decode(&restored); err != nil {
+		return fmt.Errorf("restore node vars: %w", err)
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.vars == nil {
+		v.vars = make(map[string]any)
+	}
+	for k, val := range restored {
+		v.vars[k] = val
+	}
+	return nil
+}
+
+// completedNodeIDsFromSteps derives the resume completion set from a prior leg's
+// persisted execution steps (each executed node appended one step). This is the
+// resumeCompleted the re-entrant scheduler consumes.
+func completedNodeIDsFromSteps(steps []*avsproto.Execution_Step) map[string]bool {
+	out := make(map[string]bool, len(steps))
+	for _, s := range steps {
+		if s != nil && s.Id != "" {
+			out[s.Id] = true
+		}
+	}
+	return out
 }

--- a/core/taskengine/durable_test.go
+++ b/core/taskengine/durable_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
 
@@ -75,4 +76,59 @@ func TestEnumStrings(t *testing.T) {
 	assert.Equal(t, "chain_event", WakeChainEvent.String())
 	assert.Equal(t, "external_signal", WakeExternalSignal.String())
 	assert.Equal(t, "timer", WakeTimer.String())
+}
+
+// TestWakeRegistry_RoundTrip proves the durable wake registry: persist (chain +
+// external), scan/load (the boot re-arm entrypoint) with faithful round-trip
+// including the proto chain-event, and GC. Restart durability rides on this.
+func TestWakeRegistry_RoundTrip(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	chainSub := &WakeSubscription{
+		Kind: WakeChainEvent,
+		ChainEvent: &avsproto.EventTrigger_Config{
+			ChainId: 84532,
+			Queries: []*avsproto.EventTrigger_Query{{
+				Addresses: []string{"0xbridge"},
+				Topics:    []string{"0xdeadbeef"},
+			}},
+		},
+		TimeoutAt: 1234,
+	}
+	extSub := &WakeSubscription{
+		Kind:      WakeExternalSignal,
+		External:  &ExternalSignalSpec{Channel: "telegram", Approvers: []string{"0xowner"}, Prompt: "approve?"},
+		TimeoutAt: 5678,
+	}
+
+	require.NoError(t, persistWakeSubscription(db, "exec-A", chainSub))
+	require.NoError(t, persistWakeSubscription(db, "exec-B", extSub))
+
+	all, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	// Chain-event survived the protojson round-trip (chain_id + topics + addresses).
+	a := all["exec-A"]
+	require.NotNil(t, a)
+	assert.Equal(t, WakeChainEvent, a.Kind)
+	assert.Equal(t, int64(84532), a.ChainEvent.GetChainId())
+	require.Len(t, a.ChainEvent.GetQueries(), 1)
+	assert.Equal(t, []string{"0xdeadbeef"}, a.ChainEvent.GetQueries()[0].GetTopics())
+	assert.Equal(t, []string{"0xbridge"}, a.ChainEvent.GetQueries()[0].GetAddresses())
+
+	b := all["exec-B"]
+	require.NotNil(t, b)
+	assert.Equal(t, "telegram", b.External.Channel)
+	assert.Equal(t, []string{"0xowner"}, b.External.Approvers)
+	assert.Equal(t, int64(5678), b.TimeoutAt)
+
+	// GC one; the scan reflects it.
+	require.NoError(t, deleteWakeSubscription(db, "exec-A"))
+	all, err = loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Nil(t, all["exec-A"])
+	assert.NotNil(t, all["exec-B"])
 }

--- a/core/taskengine/durable_test.go
+++ b/core/taskengine/durable_test.go
@@ -1,0 +1,78 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+func TestWakeSubscription_Validate(t *testing.T) {
+	cases := []struct {
+		name string
+		sub  WakeSubscription
+		ok   bool
+	}{
+		{
+			name: "chain event valid",
+			sub:  WakeSubscription{Kind: WakeChainEvent, ChainEvent: &avsproto.EventTrigger_Config{ChainId: 84532}, TimeoutAt: 1},
+			ok:   true,
+		},
+		{
+			name: "chain event missing config",
+			sub:  WakeSubscription{Kind: WakeChainEvent, TimeoutAt: 1},
+			ok:   false,
+		},
+		{
+			name: "external valid",
+			sub:  WakeSubscription{Kind: WakeExternalSignal, External: &ExternalSignalSpec{Channel: "telegram"}, TimeoutAt: 1},
+			ok:   true,
+		},
+		{
+			name: "external missing channel",
+			sub:  WakeSubscription{Kind: WakeExternalSignal, External: &ExternalSignalSpec{}, TimeoutAt: 1},
+			ok:   false,
+		},
+		{
+			name: "external must not set chain event",
+			sub:  WakeSubscription{Kind: WakeExternalSignal, External: &ExternalSignalSpec{Channel: "api"}, ChainEvent: &avsproto.EventTrigger_Config{}, TimeoutAt: 1},
+			ok:   false,
+		},
+		{
+			name: "timer valid",
+			sub:  WakeSubscription{Kind: WakeTimer, TimeoutAt: 1},
+			ok:   true,
+		},
+		{
+			name: "every wait must be bounded",
+			sub:  WakeSubscription{Kind: WakeTimer, TimeoutAt: 0},
+			ok:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.sub.Validate()
+			if tc.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestSignal_Validate(t *testing.T) {
+	require.Error(t, (&Signal{}).Validate(), "missing executionId")
+	require.Error(t, (&Signal{ExecutionID: "e1", Kind: WakeExternalSignal}).Validate(), "approval needs a decision")
+	require.NoError(t, (&Signal{ExecutionID: "e1", Kind: WakeChainEvent}).Validate())
+	require.NoError(t, (&Signal{ExecutionID: "e1", Kind: WakeExternalSignal, Decision: "approve", Approver: "0xowner"}).Validate())
+}
+
+func TestEnumStrings(t *testing.T) {
+	assert.Equal(t, "suspend", RunSuspend.String())
+	assert.Equal(t, "chain_event", WakeChainEvent.String())
+	assert.Equal(t, "external_signal", WakeExternalSignal.String())
+	assert.Equal(t, "timer", WakeTimer.String())
+}

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -266,6 +266,14 @@ type VM struct {
 	// per-node chain_id overrides. When nil or called with 0, callers fall back to
 	// v.smartWalletConfig. Set via WithChainConfigResolver after construction.
 	chainConfigResolver func(chainID int64) *config.SmartWalletConfig
+
+	// resumeCompleted marks nodes that completed in a prior leg of a durable
+	// execution (PLAN_DURABLE_EXECUTION.md). nil/empty for a fresh run — in which
+	// case the scheduler behaves exactly as before. When set, the scheduler
+	// fast-forwards these nodes (applies their completion to downstream predCounts)
+	// without re-executing them, so it resumes from where execution left off.
+	// Set once before Run(); read-only during the run.
+	resumeCompleted map[string]bool
 }
 
 func NewVM() *VM {
@@ -957,6 +965,7 @@ func (v *VM) runKahnScheduler() error {
 	}
 	trigger := v.task.Trigger
 	edges := v.task.Edges
+	completed := v.resumeCompleted // nil for a fresh run; read-only during the run
 	v.mu.Unlock()
 
 	for _, e := range edges {
@@ -1034,15 +1043,43 @@ func (v *VM) runKahnScheduler() error {
 		}
 	}
 
+	// Seed the initial ready frontier. For a fresh run (completed nil/empty) this is
+	// every predCount==0 non-branch node — identical to the original seed. For a
+	// resume, the already-completed prefix is "fast-forwarded" (its successors are
+	// decremented as if it had run, without executing it), so the frontier becomes the
+	// not-yet-completed nodes that have become ready — i.e. where execution left off.
+	// See PLAN_DURABLE_EXECUTION.md (Appendix A.3).
+	seedQueue := make([]string, 0, len(predCount))
 	for nodeID, c := range predCount {
-		if c == 0 {
-			if branchTargets[nodeID] {
-				continue // still gated by branch until a condition is selected
-			}
-			ready <- nodeID
-			scheduled[nodeID] = true
-			scheduledCount++
+		if c == 0 && !branchTargets[nodeID] {
+			seedQueue = append(seedQueue, nodeID)
 		}
+	}
+	seedVisited := make(map[string]bool)
+	for len(seedQueue) > 0 {
+		nodeID := seedQueue[0]
+		seedQueue = seedQueue[1:]
+		if seedVisited[nodeID] {
+			continue
+		}
+		seedVisited[nodeID] = true
+		if completed[nodeID] {
+			// Already ran in a prior leg: apply its completion to downstream predCounts
+			// without executing it. Counts as done; NOT added to scheduledCount.
+			scheduled[nodeID] = true
+			for _, succ := range adj[nodeID] {
+				if _, exists := predCount[succ]; exists {
+					predCount[succ]--
+					if predCount[succ] == 0 && !branchTargets[succ] {
+						seedQueue = append(seedQueue, succ)
+					}
+				}
+			}
+			continue
+		}
+		ready <- nodeID
+		scheduled[nodeID] = true
+		scheduledCount++
 	}
 
 	var processed int64

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1082,6 +1082,14 @@ func (v *VM) runKahnScheduler() error {
 		scheduledCount++
 	}
 
+	// Empty frontier — e.g. a resume where every node already completed, or a graph
+	// with no runnable roots. Nothing will be processed, so the termination check
+	// inside the worker loop is never reached; return now instead of spawning
+	// workers that would block forever on an unclosed, empty channel.
+	if scheduledCount == 0 {
+		return nil
+	}
+
 	var processed int64
 	var mu sync.Mutex
 	workers := len(nodes)

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -2,6 +2,7 @@ package taskengine
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,51 @@ func TestVM_SnapshotRestoreNodeVars_Fidelity(t *testing.T) {
 func TestCompletedNodeIDsFromSteps(t *testing.T) {
 	steps := []*avsproto.Execution_Step{{Id: "a"}, {Id: "b"}, nil, {Id: ""}}
 	assert.Equal(t, map[string]bool{"a": true, "b": true}, completedNodeIDsFromSteps(steps))
+}
+
+// TestScheduler_Resume_AllCompleted_Terminates guards the empty-frontier case
+// (every node already completed). Without the early return it would hang on an
+// unclosed channel; the timeout fails fast rather than wedging the suite.
+func TestScheduler_Resume_AllCompleted_Terminates(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	vm.resumeCompleted = map[string]bool{ids[0]: true, ids[1]: true, ids[2]: true}
+
+	done := make(chan error, 1)
+	go func() { done <- vm.Run() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler hung on an all-completed (empty frontier) resume")
+	}
+	assert.Empty(t, executedNodeIDs(vm), "no nodes execute when all are completed")
+}
+
+// TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:
+// a node literally named a system var (apContext) must not be snapshotted, or a
+// resume could persist secrets to disk.
+func TestSnapshotNodeVars_ExcludesReservedNames(t *testing.T) {
+	node := &avsproto.TaskNode{
+		Id: "apContext", Name: "apContext",
+		TaskType: &avsproto.TaskNode_CustomCode{CustomCode: &avsproto.CustomCodeNode{
+			Config: &avsproto.CustomCodeNode_Config{Lang: avsproto.Lang_LANG_JAVASCRIPT, Source: "return {};"},
+		}},
+	}
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "x", Nodes: []*avsproto.TaskNode{node}, Trigger: trigger,
+		Edges: []*avsproto.TaskEdge{{Id: "e", Source: "t", Target: "apContext"}},
+	}}
+	vm, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+
+	proc := &CommonProcessor{vm: vm}
+	proc.SetOutputVarForStep("apContext", map[string]any{"data": map[string]any{"secret": "leak"}})
+
+	snap, err := vm.snapshotNodeVars()
+	require.NoError(t, err)
+	assert.NotContains(t, string(snap), "leak", "a node named apContext must not be snapshotted")
+	assert.Equal(t, "{}", string(snap), "snapshot is empty — the only node collides with a reserved name")
 }
 
 // TestResume_RestoredVarsUsableByFrontier ties it together: restore a prior leg's

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -1,0 +1,86 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// buildLinearCustomCodeVM builds trigger -> cc1 -> cc2 -> cc3 (all self-contained
+// CustomCode nodes, no cross-references), compiled and ready to Run.
+func buildLinearCustomCodeVM(t *testing.T) (*VM, []string) {
+	t.Helper()
+	ids := []string{"cc1", "cc2", "cc3"}
+	nodes := make([]*avsproto.TaskNode, len(ids))
+	for i, id := range ids {
+		nodes[i] = &avsproto.TaskNode{
+			Id:   id,
+			Name: id,
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{
+						Lang:   avsproto.Lang_LANG_JAVASCRIPT,
+						Source: "return { ok: true };",
+					},
+				},
+			},
+		}
+	}
+	trigger := &avsproto.TaskTrigger{Id: "trig", Name: "trig", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	edges := []*avsproto.TaskEdge{
+		{Id: "e0", Source: trigger.Id, Target: "cc1"},
+		{Id: "e1", Source: "cc1", Target: "cc2"},
+		{Id: "e2", Source: "cc2", Target: "cc3"},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{Id: "resume-test", Nodes: nodes, Edges: edges, Trigger: trigger}}
+
+	vm, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm.WithLogger(testutil.GetLogger())
+	require.NoError(t, vm.Compile())
+	return vm, ids
+}
+
+func executedNodeIDs(vm *VM) []string {
+	out := []string{}
+	for _, step := range vm.ExecutionLogs {
+		out = append(out, step.Id)
+	}
+	return out
+}
+
+// TestScheduler_FreshRun_RunsAllNodes is the parity baseline: with no resume state,
+// every node executes (the dry-replay seed degenerates to the original behavior).
+func TestScheduler_FreshRun_RunsAllNodes(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm.Run())
+	assert.ElementsMatch(t, ids, executedNodeIDs(vm), "fresh run executes every node")
+}
+
+// TestScheduler_Resume_SkipsCompletedNodes proves the re-entrant scheduler:
+// marking cc1+cc2 completed makes the resumed run execute ONLY cc3 (the frontier).
+// Covers E4 (completed nodes don't re-run) and E5 (resumed run terminates).
+func TestScheduler_Resume_SkipsCompletedNodes(t *testing.T) {
+	vm, _ := buildLinearCustomCodeVM(t)
+	vm.resumeCompleted = map[string]bool{"cc1": true, "cc2": true}
+
+	require.NoError(t, vm.Run(), "resumed run must terminate, not hang (E5)")
+
+	executed := executedNodeIDs(vm)
+	assert.Equal(t, []string{"cc3"}, executed, "resume executes only the frontier; cc1/cc2 are not re-run (E4)")
+}
+
+// TestScheduler_Resume_EmptyCompletedEqualsFresh asserts the gate: an empty
+// resumeCompleted map behaves exactly like a fresh run.
+func TestScheduler_Resume_EmptyCompletedEqualsFresh(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	vm.resumeCompleted = map[string]bool{} // empty, not nil
+	require.NoError(t, vm.Run())
+	assert.ElementsMatch(t, ids, executedNodeIDs(vm), "empty completed == fresh run")
+}

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -84,3 +84,64 @@ func TestScheduler_Resume_EmptyCompletedEqualsFresh(t *testing.T) {
 	require.NoError(t, vm.Run())
 	assert.ElementsMatch(t, ids, executedNodeIDs(vm), "empty completed == fresh run")
 }
+
+// TestVM_SnapshotRestoreNodeVars_Fidelity is the fidelity-critical proof for
+// increment 4: a node's output survives a snapshot → restore (into a fresh VM)
+// such that template resolution is byte-identical — so a resumed leg can read
+// {{prior.data.x}}. Also asserts secrets/system vars are NOT snapshotted.
+func TestVM_SnapshotRestoreNodeVars_Fidelity(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	cc1 := ids[0]
+
+	proc := &CommonProcessor{vm: vm}
+	proc.SetOutputVarForStep(cc1, map[string]any{"data": map[string]any{
+		"value":  42,
+		"msg":    "hi",
+		"amount": "1000000000000000000",
+	}})
+
+	name := vm.GetNodeNameAsVar(cc1)
+	tmpl := "{{" + name + ".data.value}}|{{" + name + ".data.msg}}|{{" + name + ".data.amount}}"
+	before := vm.preprocessText(tmpl)
+	require.Equal(t, "42|hi|1000000000000000000", before, "sanity: original resolution")
+
+	snap, err := vm.snapshotNodeVars()
+	require.NoError(t, err)
+	require.Contains(t, string(snap), name, "snapshot includes the node output")
+	require.NotContains(t, string(snap), "apContext", "snapshot excludes system/secret vars")
+
+	// Restore into a fresh VM (same task) and assert identical resolution.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(snap))
+	after := vm2.preprocessText(tmpl)
+	assert.Equal(t, before, after, "template resolution must be identical after snapshot/restore")
+}
+
+func TestCompletedNodeIDsFromSteps(t *testing.T) {
+	steps := []*avsproto.Execution_Step{{Id: "a"}, {Id: "b"}, nil, {Id: ""}}
+	assert.Equal(t, map[string]bool{"a": true, "b": true}, completedNodeIDsFromSteps(steps))
+}
+
+// TestResume_RestoredVarsUsableByFrontier ties it together: restore a prior leg's
+// node vars into a fresh VM, mark them completed, and run — the frontier node
+// executes (only it) with the restored vars available. This is the in-memory
+// shape of advance(); the storage-backed wiring is the remaining step.
+func TestResume_RestoredVarsUsableByFrontier(t *testing.T) {
+	// Leg 1: run fully, snapshot the node vars.
+	vm1, ids := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm1.Run())
+	require.Len(t, executedNodeIDs(vm1), 3)
+	snap, err := vm1.snapshotNodeVars()
+	require.NoError(t, err)
+
+	// Leg 2 (resume): fresh VM, restore vars, mark cc1+cc2 done, run.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(snap))
+	vm2.resumeCompleted = completedNodeIDsFromSteps([]*avsproto.Execution_Step{{Id: ids[0]}, {Id: ids[1]}})
+	require.NoError(t, vm2.Run())
+
+	assert.Equal(t, []string{ids[2]}, executedNodeIDs(vm2), "only the frontier runs on resume")
+	// The restored prior output is present and resolvable.
+	assert.Contains(t, vm2.preprocessText("{{"+vm2.GetNodeNameAsVar(ids[0])+".data.ok}}"), "true",
+		"restored prior-node output is readable by the resumed leg")
+}

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -562,6 +562,9 @@ const (
 	ExecutionStatus_EXECUTION_STATUS_SUCCESS     ExecutionStatus = 2
 	ExecutionStatus_EXECUTION_STATUS_FAILED      ExecutionStatus = 3
 	ExecutionStatus_EXECUTION_STATUS_ERROR       ExecutionStatus = 5
+	// Durable execution: the execution is suspended mid-workflow, waiting for a
+	// signal (chain event, external approval, or timer) to advance. Non-terminal.
+	ExecutionStatus_EXECUTION_STATUS_WAITING ExecutionStatus = 6
 )
 
 // Enum value maps for ExecutionStatus.
@@ -572,6 +575,7 @@ var (
 		2: "EXECUTION_STATUS_SUCCESS",
 		3: "EXECUTION_STATUS_FAILED",
 		5: "EXECUTION_STATUS_ERROR",
+		6: "EXECUTION_STATUS_WAITING",
 	}
 	ExecutionStatus_value = map[string]int32{
 		"EXECUTION_STATUS_UNSPECIFIED": 0,
@@ -579,6 +583,7 @@ var (
 		"EXECUTION_STATUS_SUCCESS":     2,
 		"EXECUTION_STATUS_FAILED":      3,
 		"EXECUTION_STATUS_ERROR":       5,
+		"EXECUTION_STATUS_WAITING":     6,
 	}
 )
 
@@ -2112,9 +2117,15 @@ type Execution struct {
 	// This helps clients understand execution order without calculating based on timestamps
 	Index int64 `protobuf:"varint,6,opt,name=index,proto3" json:"index,omitempty"`
 	// Fees actually charged for this execution (matches EstimateFeesResp format)
-	ExecutionFee  *Fee              `protobuf:"bytes,7,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"` // Flat platform fee charged {amount, unit: "USD"}
-	Cogs          []*NodeCOGS       `protobuf:"bytes,9,rep,name=cogs,proto3" json:"cogs,omitempty"`                                     // Per-node actual gas/API costs {fee: {amount, unit: "WEI"}}
-	ValueFee      *ValueFee         `protobuf:"bytes,10,opt,name=value_fee,json=valueFee,proto3" json:"value_fee,omitempty"`            // Value-capture fee charged (post-paid) {fee: {amount, unit: "PERCENTAGE"}}
+	ExecutionFee *Fee        `protobuf:"bytes,7,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"` // Flat platform fee charged {amount, unit: "USD"}
+	Cogs         []*NodeCOGS `protobuf:"bytes,9,rep,name=cogs,proto3" json:"cogs,omitempty"`                                     // Per-node actual gas/API costs {fee: {amount, unit: "WEI"}}
+	ValueFee     *ValueFee   `protobuf:"bytes,10,opt,name=value_fee,json=valueFee,proto3" json:"value_fee,omitempty"`            // Value-capture fee charged (post-paid) {fee: {amount, unit: "PERCENTAGE"}}
+	// Durable execution (suspend/resume). Set only while status == WAITING; cleared
+	// on resume to a terminal status. The accumulated `steps` above carry each
+	// completed step's output, so they are the resumable state — these fields just
+	// mark where/why the execution is parked.
+	ResumeNodeId  string            `protobuf:"bytes,11,opt,name=resume_node_id,json=resumeNodeId,proto3" json:"resume_node_id,omitempty"` // the suspended step; execution resumes at its successors
+	WaitReason    string            `protobuf:"bytes,12,opt,name=wait_reason,json=waitReason,proto3" json:"wait_reason,omitempty"`         // debug/human label for why it is waiting
 	Steps         []*Execution_Step `protobuf:"bytes,8,rep,name=steps,proto3" json:"steps,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2211,6 +2222,20 @@ func (x *Execution) GetValueFee() *ValueFee {
 		return x.ValueFee
 	}
 	return nil
+}
+
+func (x *Execution) GetResumeNodeId() string {
+	if x != nil {
+		return x.ResumeNodeId
+	}
+	return ""
+}
+
+func (x *Execution) GetWaitReason() string {
+	if x != nil {
+		return x.WaitReason
+	}
+	return ""
 }
 
 func (x *Execution) GetSteps() []*Execution_Step {
@@ -10019,7 +10044,7 @@ const file_avs_proto_rawDesc = "" +
 	"\vcustom_code\x18\x12 \x01(\v2\x1a.aggregator.CustomCodeNodeH\x00R\n" +
 	"customCode\x123\n" +
 	"\abalance\x18\x13 \x01(\v2\x17.aggregator.BalanceNodeH\x00R\abalanceB\v\n" +
-	"\ttask_type\"\x8a\x0f\n" +
+	"\ttask_type\"\xd1\x0f\n" +
 	"\tExecution\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
 	"\bstart_at\x18\x02 \x01(\x03R\astartAt\x12\x15\n" +
@@ -10030,7 +10055,10 @@ const file_avs_proto_rawDesc = "" +
 	"\rexecution_fee\x18\a \x01(\v2\x0f.aggregator.FeeR\fexecutionFee\x12(\n" +
 	"\x04cogs\x18\t \x03(\v2\x14.aggregator.NodeCOGSR\x04cogs\x121\n" +
 	"\tvalue_fee\x18\n" +
-	" \x01(\v2\x14.aggregator.ValueFeeR\bvalueFee\x120\n" +
+	" \x01(\v2\x14.aggregator.ValueFeeR\bvalueFee\x12$\n" +
+	"\x0eresume_node_id\x18\v \x01(\tR\fresumeNodeId\x12\x1f\n" +
+	"\vwait_reason\x18\f \x01(\tR\n" +
+	"waitReason\x120\n" +
 	"\x05steps\x18\b \x03(\v2\x1a.aggregator.Execution.StepR\x05steps\x1a\x94\f\n" +
 	"\x04Step\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -10570,13 +10598,14 @@ const file_avs_proto_rawDesc = "" +
 	"\n" +
 	"\x06Failed\x10\x02\x12\v\n" +
 	"\aRunning\x10\x04\x12\f\n" +
-	"\bDisabled\x10\x05*\xd0\x01\n" +
+	"\bDisabled\x10\x05*\xee\x01\n" +
 	"\x0fExecutionStatus\x12 \n" +
 	"\x1cEXECUTION_STATUS_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18EXECUTION_STATUS_PENDING\x10\x01\x12\x1c\n" +
 	"\x18EXECUTION_STATUS_SUCCESS\x10\x02\x12\x1b\n" +
 	"\x17EXECUTION_STATUS_FAILED\x10\x03\x12\x1a\n" +
-	"\x16EXECUTION_STATUS_ERROR\x10\x05\"\x04\b\x04\x10\x04* EXECUTION_STATUS_PARTIAL_SUCCESSB\fZ\n" +
+	"\x16EXECUTION_STATUS_ERROR\x10\x05\x12\x1c\n" +
+	"\x18EXECUTION_STATUS_WAITING\x10\x06\"\x04\b\x04\x10\x04* EXECUTION_STATUS_PARTIAL_SUCCESSB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -370,6 +370,9 @@ enum ExecutionStatus {
   reserved 4;
   reserved "EXECUTION_STATUS_PARTIAL_SUCCESS";
   EXECUTION_STATUS_ERROR = 5;
+  // Durable execution: the execution is suspended mid-workflow, waiting for a
+  // signal (chain event, external approval, or timer) to advance. Non-terminal.
+  EXECUTION_STATUS_WAITING = 6;
 }
 
 
@@ -723,6 +726,13 @@ message Execution {
   Fee execution_fee = 7;            // Flat platform fee charged {amount, unit: "USD"}
   repeated NodeCOGS cogs = 9;      // Per-node actual gas/API costs {fee: {amount, unit: "WEI"}}
   ValueFee value_fee = 10;         // Value-capture fee charged (post-paid) {fee: {amount, unit: "PERCENTAGE"}}
+
+  // Durable execution (suspend/resume). Set only while status == WAITING; cleared
+  // on resume to a terminal status. The accumulated `steps` above carry each
+  // completed step's output, so they are the resumable state — these fields just
+  // mark where/why the execution is parked.
+  string resume_node_id = 11;  // the suspended step; execution resumes at its successors
+  string wait_reason    = 12;  // debug/human label for why it is waiting
 
   message Step {
     string id = 1;


### PR DESCRIPTION
**Draft / WIP** — landing-step 1 of the durable execution engine (design: `PLAN_DURABLE_EXECUTION.md`). This builds and **independently proves** the load-bearing pieces of a re-entrant, checkpoint-based executor. It is **additive and inert**: nothing sets `WAITING` or calls the new paths yet, so existing behavior is unchanged — the next step assembles these into the live executor (`RunTask → advance()`).

## Why
The current executor is synchronous and single-pass — it cannot suspend mid-workflow and resume later. That blocks **cross-chain sequencing** (bridge on A → wait for arrival on B → continue) and **human-approval gates** (a money-moving `contractWrite` waits for a Telegram green-light). Both are the same shape: run → suspend on a condition → resume on a signal. This PR is the engine core both ride on.

## What's here (6 commits, each tested)
| Increment | What | Proof |
|---|---|---|
| 1 | `EXECUTION_STATUS_WAITING` (=6; slot 4 is reserved) + `Execution.resume_node_id`/`wait_reason` | additive proto |
| 2 | durable vocabulary — `RunDisposition`, `WakeSubscription`, `Signal` (+ `Validate`) | unit tests |
| 3 | **re-entrant scheduler** — `runKahnScheduler` resumes from a `completed` set (dry-replay), gated so empty ⇒ byte-identical fresh run | **full taskengine suite parity** + resume tests (E4 completed-not-re-run, E5 terminates) |
| 4 | **vars snapshot/restore** — node outputs survive resume with byte-identical template resolution; system/secret vars excluded | fidelity + in-memory advance tests |
| 5 | **durable wake registry** (`wake:<execId>`) + boot re-arm entrypoint | protojson round-trip + GC test |

## Safety / blast radius
- **Fresh-run parity is the gate:** the entire taskengine suite stays green (the only 2 failures are the known pre-existing `OWNER_EOA` / `Balance-nil-config` ones). The scheduler change is byte-identical when `resumeCompleted` is empty/nil.
- **Additive proto + new key templates** (`wake:`) ⇒ `storage-check` clean, no migration.
- **Secrets never persisted:** `snapshotNodeVars` deliberately excludes `apContext`/`aa_*`/`settings` (re-injected fresh on resume).

## Not in this PR (next steps)
- Storage-backed `advance()` (load `Execution` from BadgerDB + per-step persist) — thin layer over the proven in-memory core.
- The `Await` + `HumanApproval` nodes and signal intake (operator internal-trigger + gateway approve/reject endpoint) — landing-step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
