### PR TITLE
feat: durable execution suspend/resume — checkpoint + Advance() cycle (step 2)

### DIFF
--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -210,7 +210,7 @@ var reservedSystemVarNames = map[string]bool{
 func (v *VM) snapshotNodeVars() ([]byte, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	out := make(map[string]any, len(v.TaskNodes))
+	out := make(map[string]any, len(v.TaskNodes)+1)
 	for nodeID := range v.TaskNodes {
 		name := v.getNodeNameAsVarLocked(nodeID)
 		if name == "" || reservedSystemVarNames[name] {
@@ -218,6 +218,16 @@ func (v *VM) snapshotNodeVars() ([]byte, error) {
 		}
 		if val, ok := v.vars[name]; ok {
 			out[name] = val
+		}
+	}
+	// Include the trigger's output var too (keyed by sanitized trigger name) so a
+	// resumed leg can still reference {{trigger.data.x}}.
+	if v.task != nil && v.task.Trigger != nil {
+		tname := sanitizeTriggerNameForJS(v.task.Trigger.GetName())
+		if tname != "" && !reservedSystemVarNames[tname] {
+			if val, ok := v.vars[tname]; ok {
+				out[tname] = val
+			}
 		}
 	}
 	return json.Marshal(out)

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -263,6 +263,30 @@ func completedNodeIDsFromSteps(steps []*avsproto.Execution_Step) map[string]bool
 	return out
 }
 
+// ---- Durable checkpoint (key: ckpt:<execId>) ---------------------------------
+//
+// The resumable vars snapshot for a suspended execution (snapshotNodeVars output).
+// Paired with the WAITING execution record (which carries the completed steps) and
+// the wake subscription. New key template — additive, no migration.
+
+const checkpointPrefix = "ckpt:"
+
+func checkpointKey(execID string) []byte {
+	return []byte(checkpointPrefix + execID)
+}
+
+func persistCheckpoint(db storage.Storage, execID string, varsSnapshot []byte) error {
+	return db.Set(checkpointKey(execID), varsSnapshot)
+}
+
+func loadCheckpoint(db storage.Storage, execID string) ([]byte, error) {
+	return db.GetKey(checkpointKey(execID))
+}
+
+func deleteCheckpoint(db storage.Storage, execID string) error {
+	return db.Delete(checkpointKey(execID))
+}
+
 // ---- Durable wake registry (key: wake:<execId>) ------------------------------
 //
 // The persisted set of pending waits. It is the source of truth for restart

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -43,6 +43,40 @@ func (d RunDisposition) String() string {
 	}
 }
 
+// SuspendRequest is recorded by a Suspendable step's runner (Await, HumanApproval)
+// to pause the execution. The scheduler stops scheduling new work; the executor
+// then checkpoints the run (snapshot vars + status WAITING) and registers Wake in
+// the durable registry. AwaitNodeID is the step that suspended.
+type SuspendRequest struct {
+	AwaitNodeID string
+	Wake        *WakeSubscription
+}
+
+// requestSuspend records a suspension (called by a step runner during executeNode).
+// First-writer-wins: once a step has asked to suspend, later requests are ignored.
+func (v *VM) requestSuspend(nodeID string, wake *WakeSubscription) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.suspend == nil {
+		v.suspend = &SuspendRequest{AwaitNodeID: nodeID, Wake: wake}
+	}
+}
+
+// isSuspendRequested reports whether a step asked the execution to suspend.
+func (v *VM) isSuspendRequested() bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.suspend != nil
+}
+
+// PendingSuspend returns the recorded suspension after a Run (nil if the run
+// completed normally). The executor consumes this to decide checkpoint vs. finish.
+func (v *VM) PendingSuspend() *SuspendRequest {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.suspend
+}
+
 // WakeKind identifies which signal source can advance a suspended execution.
 type WakeKind int
 

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -861,6 +861,106 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	return execution, nil
 }
 
+// Advance resumes a WAITING execution from storage. An optional signal's payload
+// becomes the suspended step's output (readable by downstream steps). Idempotent
+// (durable exactly-once, E8): a non-WAITING execution is a no-op, so a duplicate or
+// post-restart signal resumes at most once. On a terminal finish it persists the
+// final record and GCs the checkpoint + wake; if the run suspends again it
+// re-checkpoints.
+//
+// Reconstructs node + trigger output vars from the checkpoint; faithful
+// reconstruction of arbitrary input variables is a follow-up.
+func (x *WorkflowExecutor) Advance(task *model.Workflow, executionID string, signal *Signal) (*avsproto.Execution, error) {
+	raw, err := x.db.GetKey(TaskExecutionKey(task, executionID))
+	if err != nil {
+		return nil, fmt.Errorf("load execution %s: %w", executionID, err)
+	}
+	execution := &avsproto.Execution{}
+	if err := protojson.Unmarshal(raw, execution); err != nil {
+		return nil, fmt.Errorf("unmarshal execution %s: %w", executionID, err)
+	}
+	// Only a WAITING execution resumes (exactly-once across a duplicate / post-restart signal).
+	if execution.Status != avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING {
+		return execution, nil
+	}
+
+	// Rebuild the VM (mirror RunTask's construction).
+	secrets, secErr := LoadSecretForTask(x.db, task)
+	if secErr != nil {
+		secrets = map[string]string{}
+	}
+	vm, err := NewVMWithData(task, nil, x.smartWalletConfig, secrets)
+	if err != nil {
+		return nil, fmt.Errorf("rebuild vm on resume: %w", err)
+	}
+	vm.WithDb(x.db).WithLogger(x.logger)
+	if x.engine != nil {
+		vm.WithChainConfigResolver(x.engine.ResolveSmartWalletConfig)
+	}
+	if err := vm.Compile(); err != nil {
+		return nil, fmt.Errorf("compile on resume: %w", err)
+	}
+
+	// Restore prior-leg vars.
+	if ckpt, lErr := loadCheckpoint(x.db, executionID); lErr == nil && len(ckpt) > 0 {
+		if err := vm.restoreNodeVars(ckpt); err != nil {
+			return nil, fmt.Errorf("restore vars on resume: %w", err)
+		}
+	}
+
+	// The wake delivers the suspended step's output.
+	if signal != nil && signal.Payload != nil && execution.ResumeNodeId != "" {
+		(&CommonProcessor{vm: vm}).SetOutputVarForStep(execution.ResumeNodeId,
+			map[string]any{"data": signal.Payload.AsInterface()})
+	}
+
+	// Resume state: skip the completed prefix, keep its steps in the final record.
+	vm.resumeCompleted = completedNodeIDsFromSteps(execution.Steps)
+	vm.ExecutionLogs = append([]*avsproto.Execution_Step{}, execution.Steps...)
+
+	runErr := vm.Run()
+
+	// Suspended again — re-checkpoint and stay WAITING.
+	if susp := vm.PendingSuspend(); susp != nil {
+		return x.checkpointSuspendedExecution(task, execution, vm, susp)
+	}
+
+	// Terminal — finalize and GC the durable state.
+	executionError, _, resultStatus := vm.AnalyzeExecutionResult()
+	execution.Steps = vm.ExecutionLogs
+	execution.Status = convertToExecutionStatus(resultStatus)
+	execution.Error = executionError
+	execution.EndAt = time.Now().UnixMilli()
+	if runErr != nil {
+		execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR
+		if execution.Error == "" {
+			execution.Error = fmt.Sprintf("VM execution error: %s", runErr.Error())
+		}
+	}
+	execution.ResumeNodeId = ""
+	execution.WaitReason = ""
+	sanitizeExecutionForPersistence(execution)
+
+	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	execBytes, err := mo.Marshal(execution)
+	if err != nil {
+		return nil, fmt.Errorf("marshal resumed execution: %w", err)
+	}
+	if err := x.db.BatchWrite(map[string][]byte{
+		string(TaskExecutionKey(task, executionID)): execBytes,
+	}); err != nil {
+		return nil, fmt.Errorf("persist resumed execution: %w", err)
+	}
+	_ = deleteCheckpoint(x.db, executionID)
+	_ = deleteWakeSubscription(x.db, executionID)
+
+	if x.logger != nil {
+		x.logger.Info("execution resumed to terminal",
+			"task_id", task.Id, "execution_id", executionID, "status", execution.Status.String())
+	}
+	return execution, nil
+}
+
 // sanitizeExecutionForPersistence walks execution steps and replaces any NaN/Inf float
 // occurrences inside step output/config/metadata with safe JSON values (nil or 0).
 // NOTE: This function does NOT redact sensitive data - it only handles NaN/Inf for JSON compatibility.

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -676,6 +676,13 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 		runTaskErr = vm.Run()
 	}
 
+	// Durable execution: a Suspendable step (Await / HumanApproval) may have paused
+	// the run. Checkpoint and return WAITING instead of finalizing. Inert today — no
+	// current node calls requestSuspend, so PendingSuspend is always nil.
+	if susp := vm.PendingSuspend(); susp != nil {
+		return x.checkpointSuspendedExecution(task, execution, vm, susp)
+	}
+
 	t1 := time.Now()
 
 	// when MaxExecution is 0, it means unlimited run until cancel
@@ -802,6 +809,55 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 		x.logger.Warn("task execution completed with step failures", "task_id", task.Id, "failed_steps", failedStepCount, "triggermark", queueData)
 	}
 
+	return execution, nil
+}
+
+// checkpointSuspendedExecution persists a paused execution so it can resume later
+// (PLAN_DURABLE_EXECUTION.md). It writes, in crash-safe order (Appendix C.3): the
+// resume DATA (vars snapshot) first, then the armed markers (wake subscription +
+// the WAITING execution record whose `steps` carry the completed-node outputs).
+// The task's own status row is untouched — the task stays Enabled; only this
+// execution is WAITING.
+func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, execution *avsproto.Execution, vm *VM, susp *SuspendRequest) (*avsproto.Execution, error) {
+	execution.Steps = vm.ExecutionLogs
+	execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING
+	execution.ResumeNodeId = susp.AwaitNodeID
+	if susp.Wake != nil {
+		execution.WaitReason = "waiting on " + susp.Wake.Kind.String()
+	}
+	// EndAt intentionally left unset — the execution has not finished.
+	sanitizeExecutionForPersistence(execution)
+
+	// 1. Resume data first.
+	snapshot, err := vm.snapshotNodeVars()
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint snapshot vars: %w", err)
+	}
+	if err := persistCheckpoint(x.db, execution.Id, snapshot); err != nil {
+		return nil, fmt.Errorf("persist checkpoint: %w", err)
+	}
+	// 2. Armed markers: the wake subscription...
+	if susp.Wake != nil {
+		if err := persistWakeSubscription(x.db, execution.Id, susp.Wake); err != nil {
+			return nil, fmt.Errorf("persist wake: %w", err)
+		}
+	}
+	// ...and the WAITING execution record.
+	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	execBytes, err := mo.Marshal(execution)
+	if err != nil {
+		return nil, fmt.Errorf("marshal suspended execution: %w", err)
+	}
+	if err := x.db.BatchWrite(map[string][]byte{
+		string(TaskExecutionKey(task, execution.Id)): execBytes,
+	}); err != nil {
+		return nil, fmt.Errorf("persist suspended execution: %w", err)
+	}
+
+	if x.logger != nil {
+		x.logger.Info("execution suspended (durable)",
+			"task_id", task.Id, "execution_id", execution.Id, "resume_node", susp.AwaitNodeID)
+	}
 	return execution, nil
 }
 

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -879,17 +879,26 @@ func (x *WorkflowExecutor) Advance(task *model.Workflow, executionID string, sig
 	if err := protojson.Unmarshal(raw, execution); err != nil {
 		return nil, fmt.Errorf("unmarshal execution %s: %w", executionID, err)
 	}
-	// Only a WAITING execution resumes (exactly-once across a duplicate / post-restart signal).
+	// Only a WAITING execution resumes (exactly-once across a duplicate / post-restart
+	// signal). On the no-op path, still best-effort GC any orphaned durable state in
+	// case a prior finalize crashed between persisting the terminal record and cleanup.
 	if execution.Status != avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING {
+		_ = deleteCheckpoint(x.db, executionID)
+		_ = deleteWakeSubscription(x.db, executionID)
 		return execution, nil
 	}
 
-	// Rebuild the VM (mirror RunTask's construction).
+	// Rebuild the VM, mirroring RunTask's swConfig resolution so the resumed leg uses
+	// the same wallet/chain settings as the initial leg.
 	secrets, secErr := LoadSecretForTask(x.db, task)
 	if secErr != nil {
 		secrets = map[string]string{}
 	}
-	vm, err := NewVMWithData(task, nil, x.smartWalletConfig, secrets)
+	swConfig := x.smartWalletConfig
+	if x.engine != nil {
+		swConfig = x.engine.ResolveSmartWalletConfig(x.engine.defaultChainID())
+	}
+	vm, err := NewVMWithData(task, nil, swConfig, secrets)
 	if err != nil {
 		return nil, fmt.Errorf("rebuild vm on resume: %w", err)
 	}
@@ -901,11 +910,15 @@ func (x *WorkflowExecutor) Advance(task *model.Workflow, executionID string, sig
 		return nil, fmt.Errorf("compile on resume: %w", err)
 	}
 
-	// Restore prior-leg vars.
-	if ckpt, lErr := loadCheckpoint(x.db, executionID); lErr == nil && len(ckpt) > 0 {
-		if err := vm.restoreNodeVars(ckpt); err != nil {
-			return nil, fmt.Errorf("restore vars on resume: %w", err)
-		}
+	// Restore prior-leg vars. A WAITING execution always has a checkpoint (written
+	// at suspend); a missing/unreadable one is corruption — fail rather than resume
+	// with partial state.
+	ckpt, lErr := loadCheckpoint(x.db, executionID)
+	if lErr != nil {
+		return nil, fmt.Errorf("load checkpoint for WAITING execution %s: %w", executionID, lErr)
+	}
+	if err := vm.restoreNodeVars(ckpt); err != nil {
+		return nil, fmt.Errorf("restore vars on resume: %w", err)
 	}
 
 	// The wake delivers the suspended step's output.

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -274,6 +274,12 @@ type VM struct {
 	// without re-executing them, so it resumes from where execution left off.
 	// Set once before Run(); read-only during the run.
 	resumeCompleted map[string]bool
+
+	// suspend is set by a Suspendable step's runner (via requestSuspend) to pause
+	// the execution mid-run. The scheduler stops scheduling new work; after Run()
+	// the executor reads PendingSuspend() to checkpoint + register the wake instead
+	// of finishing. nil for a normal run.
+	suspend *SuspendRequest
 }
 
 func NewVM() *VM {
@@ -1100,6 +1106,7 @@ func (v *VM) runKahnScheduler() error {
 	wg.Add(workers)
 
 	var closeOnce sync.Once
+	var suspended bool // guarded by mu; set when a Suspendable step pauses the run
 	worker := func() {
 		defer wg.Done()
 		for id := range ready {
@@ -1119,8 +1126,28 @@ func (v *VM) runKahnScheduler() error {
 				}
 			}
 
-			// On completion, decrement successors
+			// On completion (or suspension), update scheduling state.
 			mu.Lock()
+			if suspended {
+				// Another worker already suspended the run; stop scheduling. (An
+				// in-flight node still finishes its executeNode above, but schedules
+				// nothing further.)
+				processed++
+				mu.Unlock()
+				continue
+			}
+			if v.isSuspendRequested() {
+				// A Suspendable step (Await/HumanApproval) asked to pause. Stop
+				// scheduling new work and wind the run down; the executor will then
+				// checkpoint + register the wake. Successors are NOT scheduled.
+				suspended = true
+				closeOnce.Do(func() { close(ready) })
+				processed++
+				mu.Unlock()
+				continue
+			}
+
+			// Schedule successors.
 			for _, succ := range adj[id] {
 				if _, exists := predCount[succ]; exists {
 					predCount[succ]--

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
@@ -176,6 +177,62 @@ func TestSuspendThenResume_EndToEnd(t *testing.T) {
 	vm2.resumeCompleted = map[string]bool{"cc1": true}
 	require.NoError(t, vm2.Run())
 	assert.Equal(t, []string{"cc2", "cc3"}, executedNodeIDs(vm2), "resume runs exactly the remaining steps")
+}
+
+// TestExecutor_CheckpointAndResume_DBBacked is the storage-backed proof: the real
+// executor method checkpoints a suspended run to BadgerDB (WAITING execution +
+// vars checkpoint + wake), then a fresh VM reloads it and resumes to completion.
+func TestExecutor_CheckpointAndResume_DBBacked(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	// Minimal executor — checkpointSuspendedExecution only needs db + logger (no
+	// engine/RPC), so avoid NewExecutorForTesting which dials an RPC.
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger()}
+
+	// Leg 1 — run, suspend after cc1.
+	vm1, _ := buildLinearCustomCodeVM(t)
+	vm1.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 999})
+	require.NoError(t, vm1.Run())
+	require.Equal(t, []string{"cc1"}, executedNodeIDs(vm1))
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+
+	const execID = "exec-durable-1"
+	out, err := executor.checkpointSuspendedExecution(vm1.task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status)
+
+	// Persisted: the WAITING execution record (with its one completed step)...
+	raw, err := db.GetKey(TaskExecutionKey(vm1.task, execID))
+	require.NoError(t, err)
+	loaded := &avsproto.Execution{}
+	require.NoError(t, protojson.Unmarshal(raw, loaded))
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, loaded.Status)
+	assert.Equal(t, "cc1", loaded.ResumeNodeId)
+	require.Len(t, loaded.Steps, 1)
+	// ...the vars checkpoint...
+	ckpt, err := loadCheckpoint(db, execID)
+	require.NoError(t, err)
+	require.NotEmpty(t, ckpt)
+	// ...and the wake subscription.
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.NotNil(t, wakes[execID])
+
+	// Leg 2 — resume from storage: fresh VM, restore the checkpoint, completed from
+	// the persisted steps, run the rest.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(ckpt))
+	vm2.resumeCompleted = completedNodeIDsFromSteps(loaded.Steps)
+	require.NoError(t, vm2.Run())
+	assert.Equal(t, []string{"cc2", "cc3"}, executedNodeIDs(vm2), "resumed from storage, runs the remaining steps")
+
+	// Terminal cleanup (what advance() does on completion).
+	require.NoError(t, deleteCheckpoint(db, execID))
+	require.NoError(t, deleteWakeSubscription(db, execID))
+	gone, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, gone[execID])
 }
 
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -141,6 +141,43 @@ func TestScheduler_Resume_AllCompleted_Terminates(t *testing.T) {
 	assert.Empty(t, executedNodeIDs(vm), "no nodes execute when all are completed")
 }
 
+// TestScheduler_Suspend_StopsAfterCurrentNode proves the suspend path: a step that
+// requests suspension (simulated via requestSuspend on cc1) runs, then the scheduler
+// stops — cc2/cc3 are never scheduled — and the suspension is available to the
+// executor via PendingSuspend.
+func TestScheduler_Suspend_StopsAfterCurrentNode(t *testing.T) {
+	vm, _ := buildLinearCustomCodeVM(t)
+	vm.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 1})
+
+	require.NoError(t, vm.Run())
+
+	assert.Equal(t, []string{"cc1"}, executedNodeIDs(vm), "run stops after the suspending step")
+	susp := vm.PendingSuspend()
+	require.NotNil(t, susp, "executor can see the pending suspension")
+	assert.Equal(t, "cc1", susp.AwaitNodeID)
+}
+
+// TestSuspendThenResume_EndToEnd is the in-memory shape of the whole feature
+// (minus storage + real signals): leg 1 runs and suspends after cc1; leg 2 restores
+// its vars, marks cc1 completed, and resumes — running exactly cc2+cc3.
+func TestSuspendThenResume_EndToEnd(t *testing.T) {
+	// Leg 1 — run, suspend after cc1, snapshot.
+	vm1, _ := buildLinearCustomCodeVM(t)
+	vm1.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 1})
+	require.NoError(t, vm1.Run())
+	require.Equal(t, []string{"cc1"}, executedNodeIDs(vm1))
+	require.NotNil(t, vm1.PendingSuspend())
+	snap, err := vm1.snapshotNodeVars()
+	require.NoError(t, err)
+
+	// Leg 2 — resume: restore vars, mark cc1 done, run the rest.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(snap))
+	vm2.resumeCompleted = map[string]bool{"cc1": true}
+	require.NoError(t, vm2.Run())
+	assert.Equal(t, []string{"cc2", "cc3"}, executedNodeIDs(vm2), "resume runs exactly the remaining steps")
+}
+
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:
 // a node literally named a system var (apContext) must not be snapshotted, or a
 // resume could persist secrets to disk.

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -235,6 +235,45 @@ func TestExecutor_CheckpointAndResume_DBBacked(t *testing.T) {
 	assert.Nil(t, gone[execID])
 }
 
+// TestExecutor_Advance_ResumesAndFinalizes exercises the production resume
+// entrypoint: a stored WAITING execution → Advance() rebuilds the VM, restores,
+// runs the rest to a terminal status, and GCs the durable state. Plus idempotency.
+func TestExecutor_Advance_ResumesAndFinalizes(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	// Arrange a WAITING execution: run+suspend after cc1, then checkpoint it.
+	vm1, _ := buildLinearCustomCodeVM(t)
+	vm1.WithDb(db)
+	vm1.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 999})
+	require.NoError(t, vm1.Run())
+	const execID = "exec-advance-1"
+	_, err := executor.checkpointSuspendedExecution(vm1.task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+
+	// Act: advance (resume).
+	out, err := executor.Advance(vm1.task, execID, nil)
+	require.NoError(t, err)
+
+	// Resumed to a terminal status, ran the remaining steps, durable state GC'd.
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status)
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "cc2", "cc3"}, ids, "resume appended the remaining steps to the record")
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID], "wake GC'd on terminal finish")
+
+	// Idempotent: advancing a now-terminal execution is a no-op (E8).
+	again, err := executor.Advance(vm1.task, execID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, out.Status, again.Status)
+	assert.Len(t, again.Steps, 3, "no re-execution on a duplicate advance")
+}
+
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:
 // a node literally named a system var (apContext) must not be snapshotted, or a
 // resume could persist secrets to disk.
@@ -258,8 +297,8 @@ func TestSnapshotNodeVars_ExcludesReservedNames(t *testing.T) {
 
 	snap, err := vm.snapshotNodeVars()
 	require.NoError(t, err)
-	assert.NotContains(t, string(snap), "leak", "a node named apContext must not be snapshotted")
-	assert.Equal(t, "{}", string(snap), "snapshot is empty — the only node collides with a reserved name")
+	assert.NotContains(t, string(snap), "leak", "the apContext node's secret value must not be snapshotted")
+	assert.NotContains(t, string(snap), "apContext", "a node named apContext must be excluded from the snapshot")
 }
 
 // TestResume_RestoredVarsUsableByFrontier ties it together: restore a prior leg's


### PR DESCRIPTION
**Draft / WIP** — step 2 of the durable execution engine (design: `PLAN_DURABLE_EXECUTION.md`; builds on the step-1 core merged in #643). This completes the **suspend → checkpoint → resume → finalize** cycle end-to-end through BadgerDB. It is **inert in production**: no node calls `requestSuspend` yet, so the `RunTask` checkpoint branch is never taken and existing behavior is unchanged.

## What's here (4 commits, each DB-backed-tested)
| Step | What | Proof |
|---|---|---|
| 2.1 | **suspend path** — a `SuspendRequest` (`VM.requestSuspend`) makes the scheduler stop scheduling and drain; `PendingSuspend()` exposes it | scheduler + end-to-end suspend→resume tests |
| 2.2 | **checkpoint** — `checkpointSuspendedExecution` persists `{vars snapshot (ckpt:), wake (wake:), WAITING execution}` in crash-safe order; `RunTask` branches to it after `vm.Run()` | DB round-trip test |
| 2.3 | **`Advance()`** — load the WAITING execution, rebuild the VM (secrets/swConfig/resolver), restore vars, deliver the signal payload as the suspended step's output, run the rest, finalize (+GC) or re-checkpoint | DB-backed resume + idempotency tests |

## Properties
- **Exactly-once (E8):** `Advance` no-ops on a non-WAITING execution, so a duplicate or post-restart signal resumes at most once.
- **Fidelity:** node outputs *and* the trigger output var are snapshot/restored, so a resumed leg resolves `{{prior.data.x}}` and `{{trigger.data.x}}` identically; secrets/system vars are never persisted.
- **Inert + parity-preserving:** the suspend branch only fires when a step suspends (none do yet); the scheduler resume seed is byte-identical when nothing is completed. Full taskengine suite stays green (90s).
- **Additive storage:** new key templates `ckpt:` / `wake:` ⇒ `storage-check` clean, no migration.

## Not in this PR (next step)
- The first `Suspendable` node (`Await` / `HumanApproval`) — turns the checkpoint branch live.
- Signal intake — operator internal-trigger (chain) + the gateway approve/reject endpoint (Telegram) delivering a `Signal` → `Advance()`.
- The `Advance` VM rebuild reconstructs node + trigger vars; faithful reconstruction of arbitrary input variables is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
