### PR TITLE
feat: Await node + signal intake + API surface (durable execution step 2)

### DIFF
--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -16,9 +16,14 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for AwaitNodeType.
+const (
+	AwaitNodeTypeAwait AwaitNodeType = "await"
+)
+
 // Defines values for BalanceNodeType.
 const (
-	BalanceNodeTypeBalance BalanceNodeType = "balance"
+	Balance BalanceNodeType = "balance"
 )
 
 // Defines values for BlockTriggerType.
@@ -159,6 +164,7 @@ const (
 
 // Defines values for NodeType.
 const (
+	NodeTypeAwait         NodeType = "await"
 	NodeTypeBalance       NodeType = "balance"
 	NodeTypeBranch        NodeType = "branch"
 	NodeTypeContractRead  NodeType = "contractRead"
@@ -256,6 +262,33 @@ type AuthExchangeResponse struct {
 
 	// Token JWT bearer token.
 	Token string `json:"token"`
+}
+
+// AwaitNode defines model for AwaitNode.
+type AwaitNode struct {
+	// Config Pauses the workflow until a signal arrives (durable execution). v1 is the
+	// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+	Config *AwaitNodeConfig `json:"config,omitempty"`
+	Type   *AwaitNodeType   `json:"type,omitempty"`
+}
+
+// AwaitNodeType defines model for AwaitNode.Type.
+type AwaitNodeType string
+
+// AwaitNodeConfig Pauses the workflow until a signal arrives (durable execution). v1 is the
+// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+type AwaitNodeConfig struct {
+	// Approvers Authorized approver identities. Empty = the workflow owner.
+	Approvers *[]string `json:"approvers,omitempty"`
+
+	// Channel Signal channel: `telegram` or `api`.
+	Channel string `json:"channel"`
+
+	// Prompt Message shown to the approver.
+	Prompt *string `json:"prompt,omitempty"`
+
+	// TimeoutSeconds Safety bound; 0 = server default (the wait is never unbounded).
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
 
 // BalanceNode defines model for BalanceNode.
@@ -1972,6 +2005,36 @@ func (t *Node) MergeBalanceNode(v BalanceNode) error {
 	return err
 }
 
+// AsAwaitNode returns the union data inside the Node as a AwaitNode
+func (t Node) AsAwaitNode() (AwaitNode, error) {
+	var body AwaitNode
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAwaitNode overwrites any union data inside the Node as the provided AwaitNode
+func (t *Node) FromAwaitNode(v AwaitNode) error {
+	t.Type = "await"
+
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAwaitNode performs a merge with any union data inside the Node, using the provided AwaitNode
+func (t *Node) MergeAwaitNode(v AwaitNode) error {
+	t.Type = "await"
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t Node) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -1986,6 +2049,8 @@ func (t Node) ValueByDiscriminator() (interface{}, error) {
 		return nil, err
 	}
 	switch discriminator {
+	case "await":
+		return t.AsAwaitNode()
 	case "balance":
 		return t.AsBalanceNode()
 	case "branch":

--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -176,6 +176,18 @@ func OpenAPIToProtoNode(in generated.Node) (*avsproto.TaskNode, error) {
 		out.Type = avsproto.NodeType_NODE_TYPE_BALANCE
 		out.TaskType = &avsproto.TaskNode_Balance{Balance: &avsproto.BalanceNode{Config: cfg}}
 
+	case string(generated.NodeTypeAwait):
+		v, err := in.AsAwaitNode()
+		if err != nil {
+			return nil, fmt.Errorf("node %s: decode AwaitNode: %w", in.Id, err)
+		}
+		cfg := &avsproto.AwaitNode_Config{}
+		if err := jsonRetargetProto(v.Config, cfg); err != nil {
+			return nil, fmt.Errorf("node %s: %w", in.Id, err)
+		}
+		out.Type = avsproto.NodeType_NODE_TYPE_AWAIT
+		out.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: cfg}}
+
 	default:
 		return nil, fmt.Errorf("node %s: unknown type %q", in.Id, discriminator)
 	}
@@ -323,7 +335,7 @@ func ProtoToOpenAPINode(in *avsproto.TaskNode) (generated.Node, error) {
 		return out, out.FromCustomCodeNode(v)
 
 	case avsproto.NodeType_NODE_TYPE_BALANCE:
-		t := generated.BalanceNodeTypeBalance
+		t := generated.Balance
 		v := generated.BalanceNode{Type: &t}
 		v.Config = &generated.BalanceNodeConfig{}
 		if err := protoRetargetJSON(in.GetBalance().GetConfig(), v.Config); err != nil {
@@ -331,6 +343,16 @@ func ProtoToOpenAPINode(in *avsproto.TaskNode) (generated.Node, error) {
 		}
 		out.Type = generated.NodeTypeBalance
 		return out, out.FromBalanceNode(v)
+
+	case avsproto.NodeType_NODE_TYPE_AWAIT:
+		t := generated.AwaitNodeTypeAwait
+		v := generated.AwaitNode{Type: &t}
+		v.Config = &generated.AwaitNodeConfig{}
+		if err := protoRetargetJSON(in.GetAwait().GetConfig(), v.Config); err != nil {
+			return out, err
+		}
+		out.Type = generated.NodeTypeAwait
+		return out, out.FromAwaitNode(v)
 	}
 
 	return out, fmt.Errorf("node %s: unsupported proto type %v", in.GetId(), in.GetType())

--- a/aggregator/rest/mapping/node_test.go
+++ b/aggregator/rest/mapping/node_test.go
@@ -160,6 +160,42 @@ func TestNodeRoundTrip_PerNodeChainId(t *testing.T) {
 	})
 }
 
+// TestNodeRoundTrip_Await proves the Await node survives the create→render REST
+// round-trip (OpenAPI → proto → OpenAPI), so the SDK/studio can put it in a workflow.
+func TestNodeRoundTrip_Await(t *testing.T) {
+	typ := generated.AwaitNodeTypeAwait
+	approvers := []string{"0xowner"}
+	prompt := "approve the transfer?"
+	timeout := int64(3600)
+	inner := generated.AwaitNode{Type: &typ, Config: &generated.AwaitNodeConfig{
+		Channel:        "telegram",
+		Approvers:      &approvers,
+		Prompt:         &prompt,
+		TimeoutSeconds: &timeout,
+	}}
+	n := generated.Node{Id: "appr", Type: generated.NodeTypeAwait}
+	require.NoError(t, n.FromAwaitNode(inner))
+
+	// Inbound (CreateWorkflow path).
+	pn, err := OpenAPIToProtoNode(n)
+	require.NoError(t, err)
+	cfg := pn.GetAwait().GetConfig()
+	require.NotNil(t, cfg)
+	assert.Equal(t, "telegram", cfg.GetChannel())
+	assert.Equal(t, []string{"0xowner"}, cfg.GetApprovers())
+	assert.Equal(t, "approve the transfer?", cfg.GetPrompt())
+	assert.Equal(t, uint32(3600), cfg.GetTimeoutSeconds())
+
+	// Outbound (GET/list render).
+	rt, err := ProtoToOpenAPINode(pn)
+	require.NoError(t, err)
+	v, err := rt.AsAwaitNode()
+	require.NoError(t, err)
+	assert.Equal(t, "telegram", v.Config.Channel)
+	require.NotNil(t, v.Config.TimeoutSeconds)
+	assert.Equal(t, int64(3600), *v.Config.TimeoutSeconds)
+}
+
 func TestNodeRoundTrip_LoopWithCustomCodeRunner(t *testing.T) {
 	innerTyp := generated.CustomCode
 	runnerNode := generated.Node{Id: "inner", Type: generated.NodeTypeCustomCode}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -324,6 +324,7 @@ components:
         - filter
         - loop
         - balance
+        - await
       description: |
         Discriminator field for the Node union. Mirrors the proto
         `NodeType` enum but without the `NODE_TYPE_` prefix.
@@ -759,6 +760,28 @@ components:
           items: { $ref: '#/components/schemas/EthereumAddress' }
           description: Restrict to these tokens. Empty = fetch all.
 
+    AwaitNodeConfig:
+      type: object
+      description: |
+        Pauses the workflow until a signal arrives (durable execution). v1 is the
+        external-signal flavor (human approval — e.g. a Telegram approve/reject).
+      required: [channel]
+      properties:
+        channel:
+          type: string
+          description: 'Signal channel: `telegram` or `api`.'
+        approvers:
+          type: array
+          items: { type: string }
+          description: Authorized approver identities. Empty = the workflow owner.
+        prompt:
+          type: string
+          description: Message shown to the approver.
+        timeoutSeconds:
+          type: integer
+          format: int64
+          description: Safety bound; 0 = server default (the wait is never unbounded).
+
     # ---- Node union ----
 
     Node:
@@ -781,6 +804,7 @@ components:
           filter:        '#/components/schemas/FilterNode'
           loop:          '#/components/schemas/LoopNode'
           balance:       '#/components/schemas/BalanceNode'
+          await:         '#/components/schemas/AwaitNode'
       oneOf:
         - $ref: '#/components/schemas/ETHTransferNode'
         - $ref: '#/components/schemas/ContractWriteNode'
@@ -792,6 +816,7 @@ components:
         - $ref: '#/components/schemas/FilterNode'
         - $ref: '#/components/schemas/LoopNode'
         - $ref: '#/components/schemas/BalanceNode'
+        - $ref: '#/components/schemas/AwaitNode'
 
     ETHTransferNode:
       allOf:
@@ -862,6 +887,13 @@ components:
           properties:
             type: { type: string, enum: [balance] }
             config: { $ref: '#/components/schemas/BalanceNodeConfig' }
+
+    AwaitNode:
+      allOf:
+        - type: object
+          properties:
+            type: { type: string, enum: [await] }
+            config: { $ref: '#/components/schemas/AwaitNodeConfig' }
 
     # ---- Workflow envelope ----
 

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -386,6 +386,14 @@ func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription,
 	return out, nil
 }
 
+func loadWakeSubscription(db storage.Storage, execID string) (*WakeSubscription, error) {
+	b, err := db.GetKey(wakeSubscriptionKey(execID))
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalWake(b)
+}
+
 func deleteWakeSubscription(db storage.Storage, execID string) error {
 	return db.Delete(wakeSubscriptionKey(execID))
 }

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -869,6 +869,19 @@ func (x *WorkflowExecutor) DeliverSignal(task *model.Workflow, signal *Signal) (
 	if err := signal.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid signal: %w", err)
 	}
+	// Enforce the gate: a signal only counts against an actual pending wait whose
+	// kind it matches and which hasn't timed out. Otherwise resumption could be
+	// triggered with no wait outstanding (or with the wrong wake source).
+	wake, err := loadWakeSubscription(x.db, signal.ExecutionID)
+	if err != nil {
+		return nil, fmt.Errorf("no pending wait for execution %s: %w", signal.ExecutionID, err)
+	}
+	if signal.Kind != wake.Kind {
+		return nil, fmt.Errorf("signal kind %s does not match the pending wait (%s)", signal.Kind, wake.Kind)
+	}
+	if wake.TimeoutAt > 0 && time.Now().UnixMilli() > wake.TimeoutAt {
+		return nil, fmt.Errorf("the wait for execution %s has timed out", signal.ExecutionID)
+	}
 	return x.Advance(task, signal.ExecutionID, signal)
 }
 

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -861,6 +861,17 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	return execution, nil
 }
 
+// DeliverSignal is the signal-intake entrypoint: a gateway approve/reject endpoint
+// or operator internal-trigger calls this to wake a suspended execution. It
+// validates the signal and advances the execution. (Authorization of the signal
+// against the wait's approvers is a follow-up — see the approval security model.)
+func (x *WorkflowExecutor) DeliverSignal(task *model.Workflow, signal *Signal) (*avsproto.Execution, error) {
+	if err := signal.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid signal: %w", err)
+	}
+	return x.Advance(task, signal.ExecutionID, signal)
+}
+
 // Advance resumes a WAITING execution from storage. An optional signal's payload
 // becomes the suspended step's output (readable by downstream steps). Idempotent
 // (durable exactly-once, E8): a non-WAITING execution is a no-op, so a duplicate or

--- a/core/taskengine/node_types.go
+++ b/core/taskengine/node_types.go
@@ -27,6 +27,7 @@ const (
 	NodeTypeFilter        = "filter"
 	NodeTypeLoop          = "loop"
 	NodeTypeBalance       = "balance"
+	NodeTypeAwait         = "await"
 )
 
 // AllNodeTypes returns a slice of all supported node types

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -3321,6 +3321,28 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 				Config: balanceConfig,
 			},
 		}
+	case NodeTypeAwait:
+		node.Type = avsproto.NodeType_NODE_TYPE_AWAIT
+		awaitConfig := &avsproto.AwaitNode_Config{}
+		if channel, ok := config["channel"].(string); ok {
+			awaitConfig.Channel = channel
+		} else {
+			return nil, fmt.Errorf("await node requires 'channel' field")
+		}
+		if approvers, ok := config["approvers"].([]interface{}); ok {
+			for _, a := range approvers {
+				if s, ok := a.(string); ok {
+					awaitConfig.Approvers = append(awaitConfig.Approvers, s)
+				}
+			}
+		}
+		if prompt, ok := config["prompt"].(string); ok {
+			awaitConfig.Prompt = prompt
+		}
+		if timeout, ok := config["timeoutSeconds"].(float64); ok {
+			awaitConfig.TimeoutSeconds = uint32(timeout)
+		}
+		node.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: awaitConfig}}
 	default:
 		return nil, fmt.Errorf("unsupported node type for CreateNodeFromType: %s", nodeType)
 	}
@@ -3818,6 +3840,17 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 
 			// Clean up complex protobuf types before returning
 			return removeComplexProtobufTypes(config)
+		}
+
+	case *avsproto.TaskNode_Await:
+		await := taskNode.GetAwait()
+		if await != nil && await.Config != nil {
+			return map[string]interface{}{
+				"channel":        await.Config.Channel,
+				"approvers":      await.Config.Approvers,
+				"prompt":         await.Config.Prompt,
+				"timeoutSeconds": float64(await.Config.TimeoutSeconds),
+			}
 		}
 
 	case *avsproto.TaskNode_Branch:

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -3340,6 +3340,9 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 			awaitConfig.Prompt = prompt
 		}
 		if timeout, ok := config["timeoutSeconds"].(float64); ok {
+			if timeout < 0 || timeout > float64(^uint32(0)) {
+				return nil, fmt.Errorf("await node 'timeoutSeconds' out of range: %v", timeout)
+			}
 			awaitConfig.TimeoutSeconds = uint32(timeout)
 		}
 		node.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: awaitConfig}}
@@ -3845,9 +3848,13 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 	case *avsproto.TaskNode_Await:
 		await := taskNode.GetAwait()
 		if await != nil && await.Config != nil {
+			approvers := make([]interface{}, len(await.Config.Approvers))
+			for i, a := range await.Config.Approvers {
+				approvers[i] = a
+			}
 			return map[string]interface{}{
 				"channel":        await.Config.Channel,
-				"approvers":      await.Config.Approvers,
+				"approvers":      approvers, // []interface{} so structpb.NewValue accepts it
 				"prompt":         await.Config.Prompt,
 				"timeoutSeconds": float64(await.Config.TimeoutSeconds),
 			}

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1438,6 +1438,11 @@ func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
 		if executionLogForNode != nil {
 			v.addExecutionLog(executionLogForNode)
 		}
+	} else if node.GetAwait() != nil {
+		executionLogForNode, err = v.runAwait(node)
+		if executionLogForNode != nil {
+			v.addExecutionLog(executionLogForNode)
+		}
 	} else {
 		err = fmt.Errorf("unknown node type for node ID %s", node.Id)
 	}

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -329,7 +329,8 @@ func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// Leg 2 — deliver the approval signal; the execution resumes and runs cc2.
-	payload, _ := structpb.NewValue(map[string]any{"decision": "approve", "by": "0xowner"})
+	payload, err := structpb.NewValue(map[string]any{"decision": "approve", "by": "0xowner"})
+	require.NoError(t, err)
 	out, err := executor.DeliverSignal(task, &Signal{
 		ExecutionID: execID, Kind: WakeExternalSignal, Decision: "approve", Approver: "0xowner", Payload: payload,
 	})

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -7,12 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
+
+func customCodeNode(id string) *avsproto.TaskNode {
+	return &avsproto.TaskNode{
+		Id: id, Name: id,
+		TaskType: &avsproto.TaskNode_CustomCode{CustomCode: &avsproto.CustomCodeNode{
+			Config: &avsproto.CustomCodeNode_Config{Lang: avsproto.Lang_LANG_JAVASCRIPT, Source: "return { ok: true };"},
+		}},
+	}
+}
 
 // buildLinearCustomCodeVM builds trigger -> cc1 -> cc2 -> cc3 (all self-contained
 // CustomCode nodes, no cross-references), compiled and ready to Run.
@@ -272,6 +282,69 @@ func TestExecutor_Advance_ResumesAndFinalizes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, out.Status, again.Status)
 	assert.Len(t, again.Steps, 3, "no re-execution on a duplicate advance")
+}
+
+// TestAwaitNode_SuspendThenSignal_EndToEnd is the whole user-facing feature: a
+// workflow [cc1 -> await -> cc2] runs, the Await node suspends it, a delivered
+// approval signal (DeliverSignal) resumes it, and cc2 runs. The first real
+// Suspendable node, end-to-end through storage.
+func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "appr", Name: "appr", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", Approvers: []string{"0xowner"}, Prompt: "approve?", TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id:      "approval-wf",
+		Trigger: trigger,
+		Nodes:   []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"},
+			{Id: "e1", Source: "cc1", Target: "appr"},
+			{Id: "e2", Source: "appr", Target: "cc2"},
+		},
+	}}
+
+	// Leg 1 — run; the Await node suspends after cc1.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	assert.Equal(t, []string{"cc1", "appr"}, executedNodeIDs(vm1), "ran up to the Await, then suspended")
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+	assert.Equal(t, WakeExternalSignal, susp.Wake.Kind)
+	assert.Equal(t, "appr", susp.AwaitNodeID)
+	assert.Equal(t, "telegram", susp.Wake.External.Channel)
+
+	const execID = "exec-appr-1"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+
+	// Leg 2 — deliver the approval signal; the execution resumes and runs cc2.
+	payload, _ := structpb.NewValue(map[string]any{"decision": "approve", "by": "0xowner"})
+	out, err := executor.DeliverSignal(task, &Signal{
+		ExecutionID: execID, Kind: WakeExternalSignal, Decision: "approve", Approver: "0xowner", Payload: payload,
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status, "resumed to terminal")
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "appr", "cc2"}, ids, "signal resumed the workflow; cc2 ran")
+
+	// Durable state GC'd.
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID])
 }
 
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:

--- a/core/taskengine/vm_runner_await.go
+++ b/core/taskengine/vm_runner_await.go
@@ -18,13 +18,20 @@ const defaultAwaitTimeoutSeconds = 86400 // 24h
 // as this node's output.
 func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error) {
 	t0 := time.Now()
-	cfg := node.GetAwait().GetConfig()
-
 	step := &avsproto.Execution_Step{
 		Id:      node.Id,
 		Type:    avsproto.NodeType_NODE_TYPE_AWAIT.String(),
 		Name:    node.Name,
 		StartAt: t0.UnixMilli(),
+	}
+
+	cfg := node.GetAwait().GetConfig()
+	if cfg == nil {
+		err := fmt.Errorf("await node %s has no config", node.Id)
+		step.Success = false
+		step.Error = err.Error()
+		step.EndAt = time.Now().UnixMilli()
+		return step, err
 	}
 
 	timeoutSec := int64(cfg.GetTimeoutSeconds())

--- a/core/taskengine/vm_runner_await.go
+++ b/core/taskengine/vm_runner_await.go
@@ -1,0 +1,57 @@
+package taskengine
+
+import (
+	"fmt"
+	"time"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// defaultAwaitTimeoutSeconds bounds an Await with no explicit timeout. Every wait
+// is bounded — an unbounded human-approval gate would park funds forever.
+const defaultAwaitTimeoutSeconds = 86400 // 24h
+
+// runAwait executes an Await node: it builds the wake subscription from config and
+// requests suspension (the scheduler then stops; the executor checkpoints +
+// registers the wake). The runner runs exactly once, on the suspend pass — on
+// resume the node is in resumeCompleted and Advance injects the delivered signal
+// as this node's output.
+func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error) {
+	t0 := time.Now()
+	cfg := node.GetAwait().GetConfig()
+
+	step := &avsproto.Execution_Step{
+		Id:      node.Id,
+		Type:    avsproto.NodeType_NODE_TYPE_AWAIT.String(),
+		Name:    node.Name,
+		StartAt: t0.UnixMilli(),
+	}
+
+	timeoutSec := int64(cfg.GetTimeoutSeconds())
+	if timeoutSec <= 0 {
+		timeoutSec = defaultAwaitTimeoutSeconds
+	}
+	wake := &WakeSubscription{
+		Kind: WakeExternalSignal,
+		External: &ExternalSignalSpec{
+			Channel:   cfg.GetChannel(),
+			Approvers: cfg.GetApprovers(),
+			Prompt:    cfg.GetPrompt(),
+		},
+		TimeoutAt: t0.Add(time.Duration(timeoutSec) * time.Second).UnixMilli(),
+	}
+	if err := wake.Validate(); err != nil {
+		// A misconfigured Await fails the step rather than suspending.
+		step.Success = false
+		step.Error = err.Error()
+		step.EndAt = time.Now().UnixMilli()
+		return step, err
+	}
+
+	v.requestSuspend(node.Id, wake)
+
+	step.Success = true
+	step.Log = fmt.Sprintf("awaiting external signal on channel %q", cfg.GetChannel())
+	step.EndAt = time.Now().UnixMilli()
+	return step, nil
+}

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -1556,7 +1556,6 @@ func (x *BalanceNode) GetConfig() *BalanceNode_Config {
 type AwaitNode struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Config        *AwaitNode_Config      `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
-	Output        *AwaitNode_Output      `protobuf:"bytes,2,opt,name=output,proto3" json:"output,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1594,13 +1593,6 @@ func (*AwaitNode) Descriptor() ([]byte, []int) {
 func (x *AwaitNode) GetConfig() *AwaitNode_Config {
 	if x != nil {
 		return x.Config
-	}
-	return nil
-}
-
-func (x *AwaitNode) GetOutput() *AwaitNode_Output {
-	if x != nil {
-		return x.Output
 	}
 	return nil
 }
@@ -10169,10 +10161,9 @@ const file_avs_proto_rawDesc = "" +
 	"\x13min_usd_value_cents\x18\x05 \x01(\x03R\x10minUsdValueCents\x12'\n" +
 	"\x0ftoken_addresses\x18\x06 \x03(\tR\x0etokenAddresses\x1a4\n" +
 	"\x06Output\x12*\n" +
-	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xb1\x02\n" +
+	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xfb\x01\n" +
 	"\tAwaitNode\x124\n" +
-	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x124\n" +
-	"\x06output\x18\x02 \x01(\v2\x1c.aggregator.AwaitNode.OutputR\x06output\x1a\x81\x01\n" +
+	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x1a\x81\x01\n" +
 	"\x06Config\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1c\n" +
 	"\tapprovers\x18\x02 \x03(\tR\tapprovers\x12\x16\n" +
@@ -10993,177 +10984,176 @@ var file_avs_proto_depIdxs = []int32{
 	124, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
 	126, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
 	128, // 19: aggregator.AwaitNode.config:type_name -> aggregator.AwaitNode.Config
-	129, // 20: aggregator.AwaitNode.output:type_name -> aggregator.AwaitNode.Output
-	131, // 21: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
-	133, // 22: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
-	18,  // 23: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
-	19,  // 24: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
-	20,  // 25: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
-	21,  // 26: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
-	22,  // 27: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
-	23,  // 28: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
-	135, // 29: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
-	1,   // 30: aggregator.TaskNode.type:type_name -> aggregator.NodeType
-	18,  // 31: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
-	19,  // 32: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
-	20,  // 33: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
-	21,  // 34: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
-	22,  // 35: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
-	26,  // 36: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
-	27,  // 37: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
-	28,  // 38: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
-	23,  // 39: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
-	24,  // 40: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
-	25,  // 41: aggregator.TaskNode.await:type_name -> aggregator.AwaitNode
-	7,   // 42: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
-	86,  // 43: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
-	88,  // 44: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
-	89,  // 45: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
-	137, // 46: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
-	6,   // 47: aggregator.Task.status:type_name -> aggregator.TaskStatus
-	17,  // 48: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
-	30,  // 49: aggregator.Task.nodes:type_name -> aggregator.TaskNode
-	29,  // 50: aggregator.Task.edges:type_name -> aggregator.TaskEdge
-	138, // 51: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
-	17,  // 52: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	30,  // 53: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
-	29,  // 54: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
-	139, // 55: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
-	38,  // 56: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
-	32,  // 57: aggregator.ListTasksResp.items:type_name -> aggregator.Task
-	57,  // 58: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
-	31,  // 59: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
-	57,  // 60: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
-	7,   // 61: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
-	0,   // 62: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
-	98,  // 63: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	94,  // 64: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	96,  // 65: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	102, // 66: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
-	104, // 67: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	140, // 68: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
-	7,   // 69: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
-	137, // 70: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
-	58,  // 71: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
-	57,  // 72: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
-	30,  // 73: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
-	141, // 74: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	76,  // 75: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
-	145, // 76: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
-	145, // 77: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 78: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
-	108, // 79: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	119, // 80: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	116, // 81: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
-	111, // 82: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	125, // 83: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	122, // 84: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
-	132, // 85: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
-	134, // 86: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
-	136, // 87: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
-	127, // 88: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
-	17,  // 89: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
-	142, // 90: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
-	145, // 91: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
-	145, // 92: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 93: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
-	98,  // 94: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	94,  // 95: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	96,  // 96: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	102, // 97: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
-	104, // 98: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	17,  // 99: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	30,  // 100: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
-	29,  // 101: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
-	143, // 102: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
-	17,  // 103: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
-	30,  // 104: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
-	29,  // 105: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
-	144, // 106: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
-	82,  // 107: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
-	84,  // 108: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
-	82,  // 109: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
-	82,  // 110: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
-	82,  // 111: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
-	86,  // 112: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
-	86,  // 113: aggregator.ValueFee.fee:type_name -> aggregator.Fee
-	2,   // 114: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
-	86,  // 115: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
-	5,   // 116: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
-	87,  // 117: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
-	86,  // 118: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
-	88,  // 119: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
-	89,  // 120: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
-	90,  // 121: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
-	145, // 122: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
-	145, // 123: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
-	145, // 124: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
-	145, // 125: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
-	92,  // 126: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
-	100, // 127: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
-	99,  // 128: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
-	145, // 129: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
-	145, // 130: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
-	105, // 131: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
-	106, // 132: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
-	4,   // 133: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
-	145, // 134: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
-	145, // 135: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
-	145, // 136: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
-	110, // 137: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
-	145, // 138: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
-	145, // 139: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
-	145, // 140: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
-	145, // 141: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
-	145, // 142: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
-	113, // 143: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
-	117, // 144: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
-	145, // 145: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
-	120, // 146: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
-	145, // 147: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
-	123, // 148: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
-	145, // 149: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
-	145, // 150: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
-	4,   // 151: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
-	145, // 152: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
-	145, // 153: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
-	145, // 154: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
-	130, // 155: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	145, // 156: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	145, // 157: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	3,   // 158: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	145, // 159: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	5,   // 160: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
-	145, // 161: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	145, // 162: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	145, // 163: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	98,  // 164: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	94,  // 165: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	96,  // 166: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	102, // 167: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	104, // 168: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	108, // 169: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	119, // 170: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	116, // 171: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	111, // 172: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	125, // 173: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	122, // 174: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	132, // 175: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	134, // 176: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	136, // 177: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	127, // 178: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
-	145, // 179: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 180: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 181: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	145, // 182: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 183: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	145, // 184: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 185: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	186, // [186:186] is the sub-list for method output_type
-	186, // [186:186] is the sub-list for method input_type
-	186, // [186:186] is the sub-list for extension type_name
-	186, // [186:186] is the sub-list for extension extendee
-	0,   // [0:186] is the sub-list for field type_name
+	131, // 20: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
+	133, // 21: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
+	18,  // 22: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
+	19,  // 23: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
+	20,  // 24: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
+	21,  // 25: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
+	22,  // 26: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
+	23,  // 27: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
+	135, // 28: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
+	1,   // 29: aggregator.TaskNode.type:type_name -> aggregator.NodeType
+	18,  // 30: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
+	19,  // 31: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
+	20,  // 32: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
+	21,  // 33: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
+	22,  // 34: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
+	26,  // 35: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
+	27,  // 36: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
+	28,  // 37: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
+	23,  // 38: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
+	24,  // 39: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
+	25,  // 40: aggregator.TaskNode.await:type_name -> aggregator.AwaitNode
+	7,   // 41: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
+	86,  // 42: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
+	88,  // 43: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
+	89,  // 44: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
+	137, // 45: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
+	6,   // 46: aggregator.Task.status:type_name -> aggregator.TaskStatus
+	17,  // 47: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 48: aggregator.Task.nodes:type_name -> aggregator.TaskNode
+	29,  // 49: aggregator.Task.edges:type_name -> aggregator.TaskEdge
+	138, // 50: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
+	17,  // 51: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 52: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 53: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
+	139, // 54: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
+	38,  // 55: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
+	32,  // 56: aggregator.ListTasksResp.items:type_name -> aggregator.Task
+	57,  // 57: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
+	31,  // 58: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
+	57,  // 59: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
+	7,   // 60: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
+	0,   // 61: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
+	98,  // 62: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 63: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 64: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 65: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 66: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	140, // 67: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
+	7,   // 68: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
+	137, // 69: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
+	58,  // 70: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
+	57,  // 71: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
+	30,  // 72: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
+	141, // 73: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	76,  // 74: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
+	145, // 75: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
+	145, // 76: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 77: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
+	108, // 78: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 79: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 80: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 81: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 82: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 83: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 84: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
+	134, // 85: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
+	136, // 86: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
+	127, // 87: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
+	17,  // 88: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
+	142, // 89: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
+	145, // 90: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
+	145, // 91: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 92: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
+	98,  // 93: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 94: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 95: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 96: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 97: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	17,  // 98: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 99: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 100: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
+	143, // 101: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
+	17,  // 102: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 103: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 104: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
+	144, // 105: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
+	82,  // 106: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
+	84,  // 107: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
+	82,  // 108: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
+	82,  // 109: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
+	82,  // 110: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
+	86,  // 111: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
+	86,  // 112: aggregator.ValueFee.fee:type_name -> aggregator.Fee
+	2,   // 113: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
+	86,  // 114: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
+	5,   // 115: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
+	87,  // 116: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
+	86,  // 117: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
+	88,  // 118: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
+	89,  // 119: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
+	90,  // 120: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
+	145, // 121: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 122: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 123: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 124: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
+	92,  // 125: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
+	100, // 126: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
+	99,  // 127: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
+	145, // 128: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 129: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
+	105, // 130: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
+	106, // 131: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
+	4,   // 132: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
+	145, // 133: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 134: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
+	145, // 135: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
+	110, // 136: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
+	145, // 137: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
+	145, // 138: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
+	145, // 139: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
+	145, // 140: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
+	145, // 141: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
+	113, // 142: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
+	117, // 143: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
+	145, // 144: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
+	120, // 145: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
+	145, // 146: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
+	123, // 147: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
+	145, // 148: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
+	145, // 149: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
+	4,   // 150: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
+	145, // 151: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
+	145, // 152: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
+	145, // 153: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
+	130, // 154: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	145, // 155: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	145, // 156: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	3,   // 157: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	145, // 158: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	5,   // 159: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
+	145, // 160: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	145, // 161: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	145, // 162: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	98,  // 163: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 164: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 165: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 166: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 167: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	108, // 168: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 169: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 170: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 171: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 172: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 173: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 174: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	134, // 175: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	136, // 176: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	127, // 177: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
+	145, // 178: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 179: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 180: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 181: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 182: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 183: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 184: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	185, // [185:185] is the sub-list for method output_type
+	185, // [185:185] is the sub-list for method input_type
+	185, // [185:185] is the sub-list for extension type_name
+	185, // [185:185] is the sub-list for extension extendee
+	0,   // [0:185] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -98,6 +98,7 @@ const (
 	NodeType_NODE_TYPE_FILTER         NodeType = 8  // Filter node
 	NodeType_NODE_TYPE_LOOP           NodeType = 9  // Loop node
 	NodeType_NODE_TYPE_BALANCE        NodeType = 10 // Balance node for retrieving wallet token balances
+	NodeType_NODE_TYPE_AWAIT          NodeType = 11 // Suspendable node: pause until a signal arrives (durable execution)
 )
 
 // Enum value maps for NodeType.
@@ -114,6 +115,7 @@ var (
 		8:  "NODE_TYPE_FILTER",
 		9:  "NODE_TYPE_LOOP",
 		10: "NODE_TYPE_BALANCE",
+		11: "NODE_TYPE_AWAIT",
 	}
 	NodeType_value = map[string]int32{
 		"NODE_TYPE_UNSPECIFIED":    0,
@@ -127,6 +129,7 @@ var (
 		"NODE_TYPE_FILTER":         8,
 		"NODE_TYPE_LOOP":           9,
 		"NODE_TYPE_BALANCE":        10,
+		"NODE_TYPE_AWAIT":          11,
 	}
 )
 
@@ -1546,6 +1549,62 @@ func (x *BalanceNode) GetConfig() *BalanceNode_Config {
 	return nil
 }
 
+// AwaitNode pauses the workflow until a signal arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
+// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
+// (cross-chain Await) and timer wakes follow.
+type AwaitNode struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Config        *AwaitNode_Config      `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	Output        *AwaitNode_Output      `protobuf:"bytes,2,opt,name=output,proto3" json:"output,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AwaitNode) Reset() {
+	*x = AwaitNode{}
+	mi := &file_avs_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AwaitNode) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AwaitNode) ProtoMessage() {}
+
+func (x *AwaitNode) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AwaitNode.ProtoReflect.Descriptor instead.
+func (*AwaitNode) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *AwaitNode) GetConfig() *AwaitNode_Config {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *AwaitNode) GetOutput() *AwaitNode_Output {
+	if x != nil {
+		return x.Output
+	}
+	return nil
+}
+
 type BranchNode struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Include Config as field
@@ -1556,7 +1615,7 @@ type BranchNode struct {
 
 func (x *BranchNode) Reset() {
 	*x = BranchNode{}
-	mi := &file_avs_proto_msgTypes[17]
+	mi := &file_avs_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1568,7 +1627,7 @@ func (x *BranchNode) String() string {
 func (*BranchNode) ProtoMessage() {}
 
 func (x *BranchNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[17]
+	mi := &file_avs_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1581,7 +1640,7 @@ func (x *BranchNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode.ProtoReflect.Descriptor instead.
 func (*BranchNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17}
+	return file_avs_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *BranchNode) GetConfig() *BranchNode_Config {
@@ -1601,7 +1660,7 @@ type FilterNode struct {
 
 func (x *FilterNode) Reset() {
 	*x = FilterNode{}
-	mi := &file_avs_proto_msgTypes[18]
+	mi := &file_avs_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1613,7 +1672,7 @@ func (x *FilterNode) String() string {
 func (*FilterNode) ProtoMessage() {}
 
 func (x *FilterNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[18]
+	mi := &file_avs_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1626,7 +1685,7 @@ func (x *FilterNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterNode.ProtoReflect.Descriptor instead.
 func (*FilterNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{18}
+	return file_avs_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *FilterNode) GetConfig() *FilterNode_Config {
@@ -1658,7 +1717,7 @@ type LoopNode struct {
 
 func (x *LoopNode) Reset() {
 	*x = LoopNode{}
-	mi := &file_avs_proto_msgTypes[19]
+	mi := &file_avs_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1670,7 +1729,7 @@ func (x *LoopNode) String() string {
 func (*LoopNode) ProtoMessage() {}
 
 func (x *LoopNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[19]
+	mi := &file_avs_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1683,7 +1742,7 @@ func (x *LoopNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoopNode.ProtoReflect.Descriptor instead.
 func (*LoopNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{19}
+	return file_avs_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *LoopNode) GetRunner() isLoopNode_Runner {
@@ -1812,7 +1871,7 @@ type TaskEdge struct {
 
 func (x *TaskEdge) Reset() {
 	*x = TaskEdge{}
-	mi := &file_avs_proto_msgTypes[20]
+	mi := &file_avs_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1824,7 +1883,7 @@ func (x *TaskEdge) String() string {
 func (*TaskEdge) ProtoMessage() {}
 
 func (x *TaskEdge) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[20]
+	mi := &file_avs_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1837,7 +1896,7 @@ func (x *TaskEdge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskEdge.ProtoReflect.Descriptor instead.
 func (*TaskEdge) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{20}
+	return file_avs_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TaskEdge) GetId() string {
@@ -1881,6 +1940,7 @@ type TaskNode struct {
 	//	*TaskNode_Loop
 	//	*TaskNode_CustomCode
 	//	*TaskNode_Balance
+	//	*TaskNode_Await
 	TaskType      isTaskNode_TaskType `protobuf_oneof:"task_type"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1888,7 +1948,7 @@ type TaskNode struct {
 
 func (x *TaskNode) Reset() {
 	*x = TaskNode{}
-	mi := &file_avs_proto_msgTypes[21]
+	mi := &file_avs_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1900,7 +1960,7 @@ func (x *TaskNode) String() string {
 func (*TaskNode) ProtoMessage() {}
 
 func (x *TaskNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[21]
+	mi := &file_avs_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1913,7 +1973,7 @@ func (x *TaskNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskNode.ProtoReflect.Descriptor instead.
 func (*TaskNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{21}
+	return file_avs_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TaskNode) GetId() string {
@@ -2034,6 +2094,15 @@ func (x *TaskNode) GetBalance() *BalanceNode {
 	return nil
 }
 
+func (x *TaskNode) GetAwait() *AwaitNode {
+	if x != nil {
+		if x, ok := x.TaskType.(*TaskNode_Await); ok {
+			return x.Await
+		}
+	}
+	return nil
+}
+
 type isTaskNode_TaskType interface {
 	isTaskNode_TaskType()
 }
@@ -2086,6 +2155,11 @@ type TaskNode_Balance struct {
 	Balance *BalanceNode `protobuf:"bytes,19,opt,name=balance,proto3,oneof"`
 }
 
+type TaskNode_Await struct {
+	// Pause until a signal arrives (durable execution)
+	Await *AwaitNode `protobuf:"bytes,20,opt,name=await,proto3,oneof"`
+}
+
 func (*TaskNode_EthTransfer) isTaskNode_TaskType() {}
 
 func (*TaskNode_ContractWrite) isTaskNode_TaskType() {}
@@ -2105,6 +2179,8 @@ func (*TaskNode_Loop) isTaskNode_TaskType() {}
 func (*TaskNode_CustomCode) isTaskNode_TaskType() {}
 
 func (*TaskNode_Balance) isTaskNode_TaskType() {}
+
+func (*TaskNode_Await) isTaskNode_TaskType() {}
 
 type Execution struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
@@ -2133,7 +2209,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_avs_proto_msgTypes[22]
+	mi := &file_avs_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2145,7 +2221,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[22]
+	mi := &file_avs_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2158,7 +2234,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{22}
+	return file_avs_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Execution) GetId() string {
@@ -2290,7 +2366,7 @@ type Task struct {
 
 func (x *Task) Reset() {
 	*x = Task{}
-	mi := &file_avs_proto_msgTypes[23]
+	mi := &file_avs_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2302,7 +2378,7 @@ func (x *Task) String() string {
 func (*Task) ProtoMessage() {}
 
 func (x *Task) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[23]
+	mi := &file_avs_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2315,7 +2391,7 @@ func (x *Task) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Task.ProtoReflect.Descriptor instead.
 func (*Task) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{23}
+	return file_avs_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Task) GetId() string {
@@ -2459,7 +2535,7 @@ type CreateTaskReq struct {
 
 func (x *CreateTaskReq) Reset() {
 	*x = CreateTaskReq{}
-	mi := &file_avs_proto_msgTypes[24]
+	mi := &file_avs_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2471,7 +2547,7 @@ func (x *CreateTaskReq) String() string {
 func (*CreateTaskReq) ProtoMessage() {}
 
 func (x *CreateTaskReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[24]
+	mi := &file_avs_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2484,7 +2560,7 @@ func (x *CreateTaskReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskReq.ProtoReflect.Descriptor instead.
 func (*CreateTaskReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{24}
+	return file_avs_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CreateTaskReq) GetTrigger() *TaskTrigger {
@@ -2559,7 +2635,7 @@ type CreateTaskResp struct {
 
 func (x *CreateTaskResp) Reset() {
 	*x = CreateTaskResp{}
-	mi := &file_avs_proto_msgTypes[25]
+	mi := &file_avs_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2571,7 +2647,7 @@ func (x *CreateTaskResp) String() string {
 func (*CreateTaskResp) ProtoMessage() {}
 
 func (x *CreateTaskResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[25]
+	mi := &file_avs_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2584,7 +2660,7 @@ func (x *CreateTaskResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskResp.ProtoReflect.Descriptor instead.
 func (*CreateTaskResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{25}
+	return file_avs_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *CreateTaskResp) GetId() string {
@@ -2603,7 +2679,7 @@ type NonceRequest struct {
 
 func (x *NonceRequest) Reset() {
 	*x = NonceRequest{}
-	mi := &file_avs_proto_msgTypes[26]
+	mi := &file_avs_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2615,7 +2691,7 @@ func (x *NonceRequest) String() string {
 func (*NonceRequest) ProtoMessage() {}
 
 func (x *NonceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[26]
+	mi := &file_avs_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2628,7 +2704,7 @@ func (x *NonceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NonceRequest.ProtoReflect.Descriptor instead.
 func (*NonceRequest) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{26}
+	return file_avs_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *NonceRequest) GetOwner() string {
@@ -2647,7 +2723,7 @@ type NonceResp struct {
 
 func (x *NonceResp) Reset() {
 	*x = NonceResp{}
-	mi := &file_avs_proto_msgTypes[27]
+	mi := &file_avs_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2659,7 +2735,7 @@ func (x *NonceResp) String() string {
 func (*NonceResp) ProtoMessage() {}
 
 func (x *NonceResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[27]
+	mi := &file_avs_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2672,7 +2748,7 @@ func (x *NonceResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NonceResp.ProtoReflect.Descriptor instead.
 func (*NonceResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{27}
+	return file_avs_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *NonceResp) GetNonce() string {
@@ -2694,7 +2770,7 @@ type ListWalletReq struct {
 
 func (x *ListWalletReq) Reset() {
 	*x = ListWalletReq{}
-	mi := &file_avs_proto_msgTypes[28]
+	mi := &file_avs_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2706,7 +2782,7 @@ func (x *ListWalletReq) String() string {
 func (*ListWalletReq) ProtoMessage() {}
 
 func (x *ListWalletReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[28]
+	mi := &file_avs_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2719,7 +2795,7 @@ func (x *ListWalletReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletReq.ProtoReflect.Descriptor instead.
 func (*ListWalletReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{28}
+	return file_avs_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListWalletReq) GetFactoryAddress() string {
@@ -2748,7 +2824,7 @@ type SmartWallet struct {
 
 func (x *SmartWallet) Reset() {
 	*x = SmartWallet{}
-	mi := &file_avs_proto_msgTypes[29]
+	mi := &file_avs_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2760,7 +2836,7 @@ func (x *SmartWallet) String() string {
 func (*SmartWallet) ProtoMessage() {}
 
 func (x *SmartWallet) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[29]
+	mi := &file_avs_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2773,7 +2849,7 @@ func (x *SmartWallet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SmartWallet.ProtoReflect.Descriptor instead.
 func (*SmartWallet) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{29}
+	return file_avs_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SmartWallet) GetAddress() string {
@@ -2813,7 +2889,7 @@ type ListWalletResp struct {
 
 func (x *ListWalletResp) Reset() {
 	*x = ListWalletResp{}
-	mi := &file_avs_proto_msgTypes[30]
+	mi := &file_avs_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2825,7 +2901,7 @@ func (x *ListWalletResp) String() string {
 func (*ListWalletResp) ProtoMessage() {}
 
 func (x *ListWalletResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[30]
+	mi := &file_avs_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2838,7 +2914,7 @@ func (x *ListWalletResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletResp.ProtoReflect.Descriptor instead.
 func (*ListWalletResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{30}
+	return file_avs_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListWalletResp) GetItems() []*SmartWallet {
@@ -2866,7 +2942,7 @@ type ListTasksReq struct {
 
 func (x *ListTasksReq) Reset() {
 	*x = ListTasksReq{}
-	mi := &file_avs_proto_msgTypes[31]
+	mi := &file_avs_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2878,7 +2954,7 @@ func (x *ListTasksReq) String() string {
 func (*ListTasksReq) ProtoMessage() {}
 
 func (x *ListTasksReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[31]
+	mi := &file_avs_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2891,7 +2967,7 @@ func (x *ListTasksReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksReq.ProtoReflect.Descriptor instead.
 func (*ListTasksReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{31}
+	return file_avs_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListTasksReq) GetSmartWalletAddress() []string {
@@ -2946,7 +3022,7 @@ type ListTasksResp struct {
 
 func (x *ListTasksResp) Reset() {
 	*x = ListTasksResp{}
-	mi := &file_avs_proto_msgTypes[32]
+	mi := &file_avs_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2958,7 +3034,7 @@ func (x *ListTasksResp) String() string {
 func (*ListTasksResp) ProtoMessage() {}
 
 func (x *ListTasksResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[32]
+	mi := &file_avs_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2971,7 +3047,7 @@ func (x *ListTasksResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksResp.ProtoReflect.Descriptor instead.
 func (*ListTasksResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{32}
+	return file_avs_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListTasksResp) GetItems() []*Task {
@@ -3002,7 +3078,7 @@ type ListExecutionsReq struct {
 
 func (x *ListExecutionsReq) Reset() {
 	*x = ListExecutionsReq{}
-	mi := &file_avs_proto_msgTypes[33]
+	mi := &file_avs_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3014,7 +3090,7 @@ func (x *ListExecutionsReq) String() string {
 func (*ListExecutionsReq) ProtoMessage() {}
 
 func (x *ListExecutionsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[33]
+	mi := &file_avs_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3027,7 +3103,7 @@ func (x *ListExecutionsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsReq.ProtoReflect.Descriptor instead.
 func (*ListExecutionsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{33}
+	return file_avs_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListExecutionsReq) GetTaskIds() []string {
@@ -3068,7 +3144,7 @@ type ListExecutionsResp struct {
 
 func (x *ListExecutionsResp) Reset() {
 	*x = ListExecutionsResp{}
-	mi := &file_avs_proto_msgTypes[34]
+	mi := &file_avs_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3080,7 +3156,7 @@ func (x *ListExecutionsResp) String() string {
 func (*ListExecutionsResp) ProtoMessage() {}
 
 func (x *ListExecutionsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[34]
+	mi := &file_avs_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3093,7 +3169,7 @@ func (x *ListExecutionsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsResp.ProtoReflect.Descriptor instead.
 func (*ListExecutionsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{34}
+	return file_avs_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListExecutionsResp) GetItems() []*Execution {
@@ -3120,7 +3196,7 @@ type ExecutionReq struct {
 
 func (x *ExecutionReq) Reset() {
 	*x = ExecutionReq{}
-	mi := &file_avs_proto_msgTypes[35]
+	mi := &file_avs_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3132,7 +3208,7 @@ func (x *ExecutionReq) String() string {
 func (*ExecutionReq) ProtoMessage() {}
 
 func (x *ExecutionReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[35]
+	mi := &file_avs_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3145,7 +3221,7 @@ func (x *ExecutionReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionReq.ProtoReflect.Descriptor instead.
 func (*ExecutionReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{35}
+	return file_avs_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ExecutionReq) GetTaskId() string {
@@ -3171,7 +3247,7 @@ type ExecutionStatusResp struct {
 
 func (x *ExecutionStatusResp) Reset() {
 	*x = ExecutionStatusResp{}
-	mi := &file_avs_proto_msgTypes[36]
+	mi := &file_avs_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3183,7 +3259,7 @@ func (x *ExecutionStatusResp) String() string {
 func (*ExecutionStatusResp) ProtoMessage() {}
 
 func (x *ExecutionStatusResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[36]
+	mi := &file_avs_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3196,7 +3272,7 @@ func (x *ExecutionStatusResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStatusResp.ProtoReflect.Descriptor instead.
 func (*ExecutionStatusResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{36}
+	return file_avs_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ExecutionStatusResp) GetStatus() ExecutionStatus {
@@ -3218,7 +3294,7 @@ type GetKeyReq struct {
 
 func (x *GetKeyReq) Reset() {
 	*x = GetKeyReq{}
-	mi := &file_avs_proto_msgTypes[37]
+	mi := &file_avs_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3230,7 +3306,7 @@ func (x *GetKeyReq) String() string {
 func (*GetKeyReq) ProtoMessage() {}
 
 func (x *GetKeyReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[37]
+	mi := &file_avs_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3243,7 +3319,7 @@ func (x *GetKeyReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetKeyReq.ProtoReflect.Descriptor instead.
 func (*GetKeyReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{37}
+	return file_avs_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetKeyReq) GetMessage() string {
@@ -3276,7 +3352,7 @@ type KeyResp struct {
 
 func (x *KeyResp) Reset() {
 	*x = KeyResp{}
-	mi := &file_avs_proto_msgTypes[38]
+	mi := &file_avs_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3288,7 +3364,7 @@ func (x *KeyResp) String() string {
 func (*KeyResp) ProtoMessage() {}
 
 func (x *KeyResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[38]
+	mi := &file_avs_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3301,7 +3377,7 @@ func (x *KeyResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyResp.ProtoReflect.Descriptor instead.
 func (*KeyResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{38}
+	return file_avs_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *KeyResp) GetAddress() string {
@@ -3343,7 +3419,7 @@ type GetWalletReq struct {
 
 func (x *GetWalletReq) Reset() {
 	*x = GetWalletReq{}
-	mi := &file_avs_proto_msgTypes[39]
+	mi := &file_avs_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3355,7 +3431,7 @@ func (x *GetWalletReq) String() string {
 func (*GetWalletReq) ProtoMessage() {}
 
 func (x *GetWalletReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[39]
+	mi := &file_avs_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3368,7 +3444,7 @@ func (x *GetWalletReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletReq.ProtoReflect.Descriptor instead.
 func (*GetWalletReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{39}
+	return file_avs_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetWalletReq) GetSalt() string {
@@ -3402,7 +3478,7 @@ type GetWalletResp struct {
 
 func (x *GetWalletResp) Reset() {
 	*x = GetWalletResp{}
-	mi := &file_avs_proto_msgTypes[40]
+	mi := &file_avs_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3414,7 +3490,7 @@ func (x *GetWalletResp) String() string {
 func (*GetWalletResp) ProtoMessage() {}
 
 func (x *GetWalletResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[40]
+	mi := &file_avs_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3427,7 +3503,7 @@ func (x *GetWalletResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletResp.ProtoReflect.Descriptor instead.
 func (*GetWalletResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{40}
+	return file_avs_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetWalletResp) GetAddress() string {
@@ -3506,7 +3582,7 @@ type SetWalletReq struct {
 
 func (x *SetWalletReq) Reset() {
 	*x = SetWalletReq{}
-	mi := &file_avs_proto_msgTypes[41]
+	mi := &file_avs_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3518,7 +3594,7 @@ func (x *SetWalletReq) String() string {
 func (*SetWalletReq) ProtoMessage() {}
 
 func (x *SetWalletReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[41]
+	mi := &file_avs_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3531,7 +3607,7 @@ func (x *SetWalletReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetWalletReq.ProtoReflect.Descriptor instead.
 func (*SetWalletReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{41}
+	return file_avs_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SetWalletReq) GetSalt() string {
@@ -3575,7 +3651,7 @@ type WithdrawFundsReq struct {
 
 func (x *WithdrawFundsReq) Reset() {
 	*x = WithdrawFundsReq{}
-	mi := &file_avs_proto_msgTypes[42]
+	mi := &file_avs_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3587,7 +3663,7 @@ func (x *WithdrawFundsReq) String() string {
 func (*WithdrawFundsReq) ProtoMessage() {}
 
 func (x *WithdrawFundsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[42]
+	mi := &file_avs_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3600,7 +3676,7 @@ func (x *WithdrawFundsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawFundsReq.ProtoReflect.Descriptor instead.
 func (*WithdrawFundsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{42}
+	return file_avs_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *WithdrawFundsReq) GetRecipientAddress() string {
@@ -3657,7 +3733,7 @@ type WithdrawFundsResp struct {
 
 func (x *WithdrawFundsResp) Reset() {
 	*x = WithdrawFundsResp{}
-	mi := &file_avs_proto_msgTypes[43]
+	mi := &file_avs_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3669,7 +3745,7 @@ func (x *WithdrawFundsResp) String() string {
 func (*WithdrawFundsResp) ProtoMessage() {}
 
 func (x *WithdrawFundsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[43]
+	mi := &file_avs_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3682,7 +3758,7 @@ func (x *WithdrawFundsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawFundsResp.ProtoReflect.Descriptor instead.
 func (*WithdrawFundsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{43}
+	return file_avs_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *WithdrawFundsResp) GetSuccess() bool {
@@ -3785,7 +3861,7 @@ type TriggerTaskReq struct {
 
 func (x *TriggerTaskReq) Reset() {
 	*x = TriggerTaskReq{}
-	mi := &file_avs_proto_msgTypes[44]
+	mi := &file_avs_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3797,7 +3873,7 @@ func (x *TriggerTaskReq) String() string {
 func (*TriggerTaskReq) ProtoMessage() {}
 
 func (x *TriggerTaskReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[44]
+	mi := &file_avs_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3810,7 +3886,7 @@ func (x *TriggerTaskReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTaskReq.ProtoReflect.Descriptor instead.
 func (*TriggerTaskReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{44}
+	return file_avs_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *TriggerTaskReq) GetTaskId() string {
@@ -3956,7 +4032,7 @@ type TriggerTaskResp struct {
 
 func (x *TriggerTaskResp) Reset() {
 	*x = TriggerTaskResp{}
-	mi := &file_avs_proto_msgTypes[45]
+	mi := &file_avs_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3968,7 +4044,7 @@ func (x *TriggerTaskResp) String() string {
 func (*TriggerTaskResp) ProtoMessage() {}
 
 func (x *TriggerTaskResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[45]
+	mi := &file_avs_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3981,7 +4057,7 @@ func (x *TriggerTaskResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTaskResp.ProtoReflect.Descriptor instead.
 func (*TriggerTaskResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{45}
+	return file_avs_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *TriggerTaskResp) GetExecutionId() string {
@@ -4052,7 +4128,7 @@ type CreateOrUpdateSecretReq struct {
 
 func (x *CreateOrUpdateSecretReq) Reset() {
 	*x = CreateOrUpdateSecretReq{}
-	mi := &file_avs_proto_msgTypes[46]
+	mi := &file_avs_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4064,7 +4140,7 @@ func (x *CreateOrUpdateSecretReq) String() string {
 func (*CreateOrUpdateSecretReq) ProtoMessage() {}
 
 func (x *CreateOrUpdateSecretReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[46]
+	mi := &file_avs_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4077,7 +4153,7 @@ func (x *CreateOrUpdateSecretReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOrUpdateSecretReq.ProtoReflect.Descriptor instead.
 func (*CreateOrUpdateSecretReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{46}
+	return file_avs_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CreateOrUpdateSecretReq) GetName() string {
@@ -4126,7 +4202,7 @@ type ListSecretsReq struct {
 
 func (x *ListSecretsReq) Reset() {
 	*x = ListSecretsReq{}
-	mi := &file_avs_proto_msgTypes[47]
+	mi := &file_avs_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4138,7 +4214,7 @@ func (x *ListSecretsReq) String() string {
 func (*ListSecretsReq) ProtoMessage() {}
 
 func (x *ListSecretsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[47]
+	mi := &file_avs_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4151,7 +4227,7 @@ func (x *ListSecretsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretsReq.ProtoReflect.Descriptor instead.
 func (*ListSecretsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{47}
+	return file_avs_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ListSecretsReq) GetWorkflowId() string {
@@ -4216,7 +4292,7 @@ type PageInfo struct {
 
 func (x *PageInfo) Reset() {
 	*x = PageInfo{}
-	mi := &file_avs_proto_msgTypes[48]
+	mi := &file_avs_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4228,7 +4304,7 @@ func (x *PageInfo) String() string {
 func (*PageInfo) ProtoMessage() {}
 
 func (x *PageInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[48]
+	mi := &file_avs_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4241,7 +4317,7 @@ func (x *PageInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PageInfo.ProtoReflect.Descriptor instead.
 func (*PageInfo) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{48}
+	return file_avs_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *PageInfo) GetStartCursor() string {
@@ -4291,7 +4367,7 @@ type Secret struct {
 
 func (x *Secret) Reset() {
 	*x = Secret{}
-	mi := &file_avs_proto_msgTypes[49]
+	mi := &file_avs_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4303,7 +4379,7 @@ func (x *Secret) String() string {
 func (*Secret) ProtoMessage() {}
 
 func (x *Secret) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[49]
+	mi := &file_avs_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4316,7 +4392,7 @@ func (x *Secret) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Secret.ProtoReflect.Descriptor instead.
 func (*Secret) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{49}
+	return file_avs_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *Secret) GetName() string {
@@ -4385,7 +4461,7 @@ type ListSecretsResp struct {
 
 func (x *ListSecretsResp) Reset() {
 	*x = ListSecretsResp{}
-	mi := &file_avs_proto_msgTypes[50]
+	mi := &file_avs_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4397,7 +4473,7 @@ func (x *ListSecretsResp) String() string {
 func (*ListSecretsResp) ProtoMessage() {}
 
 func (x *ListSecretsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[50]
+	mi := &file_avs_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4410,7 +4486,7 @@ func (x *ListSecretsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretsResp.ProtoReflect.Descriptor instead.
 func (*ListSecretsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{50}
+	return file_avs_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ListSecretsResp) GetItems() []*Secret {
@@ -4440,7 +4516,7 @@ type DeleteSecretReq struct {
 
 func (x *DeleteSecretReq) Reset() {
 	*x = DeleteSecretReq{}
-	mi := &file_avs_proto_msgTypes[51]
+	mi := &file_avs_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4452,7 +4528,7 @@ func (x *DeleteSecretReq) String() string {
 func (*DeleteSecretReq) ProtoMessage() {}
 
 func (x *DeleteSecretReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[51]
+	mi := &file_avs_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4465,7 +4541,7 @@ func (x *DeleteSecretReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSecretReq.ProtoReflect.Descriptor instead.
 func (*DeleteSecretReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{51}
+	return file_avs_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DeleteSecretReq) GetName() string {
@@ -4504,7 +4580,7 @@ type DeleteSecretResp struct {
 
 func (x *DeleteSecretResp) Reset() {
 	*x = DeleteSecretResp{}
-	mi := &file_avs_proto_msgTypes[52]
+	mi := &file_avs_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4516,7 +4592,7 @@ func (x *DeleteSecretResp) String() string {
 func (*DeleteSecretResp) ProtoMessage() {}
 
 func (x *DeleteSecretResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[52]
+	mi := &file_avs_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4529,7 +4605,7 @@ func (x *DeleteSecretResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSecretResp.ProtoReflect.Descriptor instead.
 func (*DeleteSecretResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{52}
+	return file_avs_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *DeleteSecretResp) GetSuccess() bool {
@@ -4584,7 +4660,7 @@ type GetSignatureFormatReq struct {
 
 func (x *GetSignatureFormatReq) Reset() {
 	*x = GetSignatureFormatReq{}
-	mi := &file_avs_proto_msgTypes[53]
+	mi := &file_avs_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4596,7 +4672,7 @@ func (x *GetSignatureFormatReq) String() string {
 func (*GetSignatureFormatReq) ProtoMessage() {}
 
 func (x *GetSignatureFormatReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[53]
+	mi := &file_avs_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4609,7 +4685,7 @@ func (x *GetSignatureFormatReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSignatureFormatReq.ProtoReflect.Descriptor instead.
 func (*GetSignatureFormatReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{53}
+	return file_avs_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetSignatureFormatReq) GetWallet() string {
@@ -4629,7 +4705,7 @@ type GetSignatureFormatResp struct {
 
 func (x *GetSignatureFormatResp) Reset() {
 	*x = GetSignatureFormatResp{}
-	mi := &file_avs_proto_msgTypes[54]
+	mi := &file_avs_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4641,7 +4717,7 @@ func (x *GetSignatureFormatResp) String() string {
 func (*GetSignatureFormatResp) ProtoMessage() {}
 
 func (x *GetSignatureFormatResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[54]
+	mi := &file_avs_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4654,7 +4730,7 @@ func (x *GetSignatureFormatResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSignatureFormatResp.ProtoReflect.Descriptor instead.
 func (*GetSignatureFormatResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{54}
+	return file_avs_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetSignatureFormatResp) GetMessage() string {
@@ -4679,7 +4755,7 @@ type CreateSecretResp struct {
 
 func (x *CreateSecretResp) Reset() {
 	*x = CreateSecretResp{}
-	mi := &file_avs_proto_msgTypes[55]
+	mi := &file_avs_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4691,7 +4767,7 @@ func (x *CreateSecretResp) String() string {
 func (*CreateSecretResp) ProtoMessage() {}
 
 func (x *CreateSecretResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[55]
+	mi := &file_avs_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4704,7 +4780,7 @@ func (x *CreateSecretResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSecretResp.ProtoReflect.Descriptor instead.
 func (*CreateSecretResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{55}
+	return file_avs_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *CreateSecretResp) GetSuccess() bool {
@@ -4764,7 +4840,7 @@ type UpdateSecretResp struct {
 
 func (x *UpdateSecretResp) Reset() {
 	*x = UpdateSecretResp{}
-	mi := &file_avs_proto_msgTypes[56]
+	mi := &file_avs_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4776,7 +4852,7 @@ func (x *UpdateSecretResp) String() string {
 func (*UpdateSecretResp) ProtoMessage() {}
 
 func (x *UpdateSecretResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[56]
+	mi := &file_avs_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4789,7 +4865,7 @@ func (x *UpdateSecretResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSecretResp.ProtoReflect.Descriptor instead.
 func (*UpdateSecretResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{56}
+	return file_avs_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *UpdateSecretResp) GetSuccess() bool {
@@ -4849,7 +4925,7 @@ type DeleteTaskResp struct {
 
 func (x *DeleteTaskResp) Reset() {
 	*x = DeleteTaskResp{}
-	mi := &file_avs_proto_msgTypes[57]
+	mi := &file_avs_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4861,7 +4937,7 @@ func (x *DeleteTaskResp) String() string {
 func (*DeleteTaskResp) ProtoMessage() {}
 
 func (x *DeleteTaskResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[57]
+	mi := &file_avs_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4874,7 +4950,7 @@ func (x *DeleteTaskResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTaskResp.ProtoReflect.Descriptor instead.
 func (*DeleteTaskResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{57}
+	return file_avs_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *DeleteTaskResp) GetSuccess() bool {
@@ -4930,7 +5006,7 @@ type SetTaskEnabledReq struct {
 
 func (x *SetTaskEnabledReq) Reset() {
 	*x = SetTaskEnabledReq{}
-	mi := &file_avs_proto_msgTypes[58]
+	mi := &file_avs_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4942,7 +5018,7 @@ func (x *SetTaskEnabledReq) String() string {
 func (*SetTaskEnabledReq) ProtoMessage() {}
 
 func (x *SetTaskEnabledReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[58]
+	mi := &file_avs_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4955,7 +5031,7 @@ func (x *SetTaskEnabledReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTaskEnabledReq.ProtoReflect.Descriptor instead.
 func (*SetTaskEnabledReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{58}
+	return file_avs_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *SetTaskEnabledReq) GetId() string {
@@ -4986,7 +5062,7 @@ type SetTaskEnabledResp struct {
 
 func (x *SetTaskEnabledResp) Reset() {
 	*x = SetTaskEnabledResp{}
-	mi := &file_avs_proto_msgTypes[59]
+	mi := &file_avs_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4998,7 +5074,7 @@ func (x *SetTaskEnabledResp) String() string {
 func (*SetTaskEnabledResp) ProtoMessage() {}
 
 func (x *SetTaskEnabledResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[59]
+	mi := &file_avs_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5011,7 +5087,7 @@ func (x *SetTaskEnabledResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTaskEnabledResp.ProtoReflect.Descriptor instead.
 func (*SetTaskEnabledResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{59}
+	return file_avs_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *SetTaskEnabledResp) GetSuccess() bool {
@@ -5066,7 +5142,7 @@ type GetWorkflowCountReq struct {
 
 func (x *GetWorkflowCountReq) Reset() {
 	*x = GetWorkflowCountReq{}
-	mi := &file_avs_proto_msgTypes[60]
+	mi := &file_avs_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5078,7 +5154,7 @@ func (x *GetWorkflowCountReq) String() string {
 func (*GetWorkflowCountReq) ProtoMessage() {}
 
 func (x *GetWorkflowCountReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[60]
+	mi := &file_avs_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5091,7 +5167,7 @@ func (x *GetWorkflowCountReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkflowCountReq.ProtoReflect.Descriptor instead.
 func (*GetWorkflowCountReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{60}
+	return file_avs_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetWorkflowCountReq) GetAddresses() []string {
@@ -5112,7 +5188,7 @@ type GetWorkflowCountResp struct {
 
 func (x *GetWorkflowCountResp) Reset() {
 	*x = GetWorkflowCountResp{}
-	mi := &file_avs_proto_msgTypes[61]
+	mi := &file_avs_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5124,7 +5200,7 @@ func (x *GetWorkflowCountResp) String() string {
 func (*GetWorkflowCountResp) ProtoMessage() {}
 
 func (x *GetWorkflowCountResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[61]
+	mi := &file_avs_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5137,7 +5213,7 @@ func (x *GetWorkflowCountResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkflowCountResp.ProtoReflect.Descriptor instead.
 func (*GetWorkflowCountResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{61}
+	return file_avs_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetWorkflowCountResp) GetTotal() int64 {
@@ -5156,7 +5232,7 @@ type GetExecutionCountReq struct {
 
 func (x *GetExecutionCountReq) Reset() {
 	*x = GetExecutionCountReq{}
-	mi := &file_avs_proto_msgTypes[62]
+	mi := &file_avs_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5168,7 +5244,7 @@ func (x *GetExecutionCountReq) String() string {
 func (*GetExecutionCountReq) ProtoMessage() {}
 
 func (x *GetExecutionCountReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[62]
+	mi := &file_avs_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5181,7 +5257,7 @@ func (x *GetExecutionCountReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionCountReq.ProtoReflect.Descriptor instead.
 func (*GetExecutionCountReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{62}
+	return file_avs_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetExecutionCountReq) GetWorkflowIds() []string {
@@ -5202,7 +5278,7 @@ type GetExecutionCountResp struct {
 
 func (x *GetExecutionCountResp) Reset() {
 	*x = GetExecutionCountResp{}
-	mi := &file_avs_proto_msgTypes[63]
+	mi := &file_avs_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5214,7 +5290,7 @@ func (x *GetExecutionCountResp) String() string {
 func (*GetExecutionCountResp) ProtoMessage() {}
 
 func (x *GetExecutionCountResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[63]
+	mi := &file_avs_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5227,7 +5303,7 @@ func (x *GetExecutionCountResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionCountResp.ProtoReflect.Descriptor instead.
 func (*GetExecutionCountResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{63}
+	return file_avs_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetExecutionCountResp) GetTotal() int64 {
@@ -5248,7 +5324,7 @@ type GetExecutionStatsReq struct {
 
 func (x *GetExecutionStatsReq) Reset() {
 	*x = GetExecutionStatsReq{}
-	mi := &file_avs_proto_msgTypes[64]
+	mi := &file_avs_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5260,7 +5336,7 @@ func (x *GetExecutionStatsReq) String() string {
 func (*GetExecutionStatsReq) ProtoMessage() {}
 
 func (x *GetExecutionStatsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[64]
+	mi := &file_avs_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5273,7 +5349,7 @@ func (x *GetExecutionStatsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionStatsReq.ProtoReflect.Descriptor instead.
 func (*GetExecutionStatsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{64}
+	return file_avs_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetExecutionStatsReq) GetWorkflowIds() []string {
@@ -5303,7 +5379,7 @@ type GetExecutionStatsResp struct {
 
 func (x *GetExecutionStatsResp) Reset() {
 	*x = GetExecutionStatsResp{}
-	mi := &file_avs_proto_msgTypes[65]
+	mi := &file_avs_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5315,7 +5391,7 @@ func (x *GetExecutionStatsResp) String() string {
 func (*GetExecutionStatsResp) ProtoMessage() {}
 
 func (x *GetExecutionStatsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[65]
+	mi := &file_avs_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5328,7 +5404,7 @@ func (x *GetExecutionStatsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionStatsResp.ProtoReflect.Descriptor instead.
 func (*GetExecutionStatsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{65}
+	return file_avs_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *GetExecutionStatsResp) GetTotal() int64 {
@@ -5382,7 +5458,7 @@ type RunNodeWithInputsReq struct {
 
 func (x *RunNodeWithInputsReq) Reset() {
 	*x = RunNodeWithInputsReq{}
-	mi := &file_avs_proto_msgTypes[66]
+	mi := &file_avs_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5394,7 +5470,7 @@ func (x *RunNodeWithInputsReq) String() string {
 func (*RunNodeWithInputsReq) ProtoMessage() {}
 
 func (x *RunNodeWithInputsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[66]
+	mi := &file_avs_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5407,7 +5483,7 @@ func (x *RunNodeWithInputsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunNodeWithInputsReq.ProtoReflect.Descriptor instead.
 func (*RunNodeWithInputsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{66}
+	return file_avs_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *RunNodeWithInputsReq) GetNode() *TaskNode {
@@ -5458,7 +5534,7 @@ type ERC20StateOverride struct {
 
 func (x *ERC20StateOverride) Reset() {
 	*x = ERC20StateOverride{}
-	mi := &file_avs_proto_msgTypes[67]
+	mi := &file_avs_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5470,7 +5546,7 @@ func (x *ERC20StateOverride) String() string {
 func (*ERC20StateOverride) ProtoMessage() {}
 
 func (x *ERC20StateOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[67]
+	mi := &file_avs_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5483,7 +5559,7 @@ func (x *ERC20StateOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ERC20StateOverride.ProtoReflect.Descriptor instead.
 func (*ERC20StateOverride) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{67}
+	return file_avs_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ERC20StateOverride) GetTokenAddress() string {
@@ -5566,7 +5642,7 @@ type RunNodeWithInputsResp struct {
 
 func (x *RunNodeWithInputsResp) Reset() {
 	*x = RunNodeWithInputsResp{}
-	mi := &file_avs_proto_msgTypes[68]
+	mi := &file_avs_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5578,7 +5654,7 @@ func (x *RunNodeWithInputsResp) String() string {
 func (*RunNodeWithInputsResp) ProtoMessage() {}
 
 func (x *RunNodeWithInputsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[68]
+	mi := &file_avs_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5591,7 +5667,7 @@ func (x *RunNodeWithInputsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunNodeWithInputsResp.ProtoReflect.Descriptor instead.
 func (*RunNodeWithInputsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{68}
+	return file_avs_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *RunNodeWithInputsResp) GetSuccess() bool {
@@ -5803,7 +5879,7 @@ type RunTriggerReq struct {
 
 func (x *RunTriggerReq) Reset() {
 	*x = RunTriggerReq{}
-	mi := &file_avs_proto_msgTypes[69]
+	mi := &file_avs_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5815,7 +5891,7 @@ func (x *RunTriggerReq) String() string {
 func (*RunTriggerReq) ProtoMessage() {}
 
 func (x *RunTriggerReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[69]
+	mi := &file_avs_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5828,7 +5904,7 @@ func (x *RunTriggerReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTriggerReq.ProtoReflect.Descriptor instead.
 func (*RunTriggerReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{69}
+	return file_avs_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *RunTriggerReq) GetTrigger() *TaskTrigger {
@@ -5871,7 +5947,7 @@ type RunTriggerResp struct {
 
 func (x *RunTriggerResp) Reset() {
 	*x = RunTriggerResp{}
-	mi := &file_avs_proto_msgTypes[70]
+	mi := &file_avs_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5883,7 +5959,7 @@ func (x *RunTriggerResp) String() string {
 func (*RunTriggerResp) ProtoMessage() {}
 
 func (x *RunTriggerResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[70]
+	mi := &file_avs_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5896,7 +5972,7 @@ func (x *RunTriggerResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTriggerResp.ProtoReflect.Descriptor instead.
 func (*RunTriggerResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{70}
+	return file_avs_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *RunTriggerResp) GetSuccess() bool {
@@ -6037,7 +6113,7 @@ type SimulateTaskReq struct {
 
 func (x *SimulateTaskReq) Reset() {
 	*x = SimulateTaskReq{}
-	mi := &file_avs_proto_msgTypes[71]
+	mi := &file_avs_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6049,7 +6125,7 @@ func (x *SimulateTaskReq) String() string {
 func (*SimulateTaskReq) ProtoMessage() {}
 
 func (x *SimulateTaskReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[71]
+	mi := &file_avs_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6062,7 +6138,7 @@ func (x *SimulateTaskReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SimulateTaskReq.ProtoReflect.Descriptor instead.
 func (*SimulateTaskReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{71}
+	return file_avs_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *SimulateTaskReq) GetTrigger() *TaskTrigger {
@@ -6124,7 +6200,7 @@ type EstimateFeesReq struct {
 
 func (x *EstimateFeesReq) Reset() {
 	*x = EstimateFeesReq{}
-	mi := &file_avs_proto_msgTypes[72]
+	mi := &file_avs_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6136,7 +6212,7 @@ func (x *EstimateFeesReq) String() string {
 func (*EstimateFeesReq) ProtoMessage() {}
 
 func (x *EstimateFeesReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[72]
+	mi := &file_avs_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6149,7 +6225,7 @@ func (x *EstimateFeesReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeesReq.ProtoReflect.Descriptor instead.
 func (*EstimateFeesReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{72}
+	return file_avs_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *EstimateFeesReq) GetTrigger() *TaskTrigger {
@@ -6228,7 +6304,7 @@ type FeeAmount struct {
 
 func (x *FeeAmount) Reset() {
 	*x = FeeAmount{}
-	mi := &file_avs_proto_msgTypes[73]
+	mi := &file_avs_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6240,7 +6316,7 @@ func (x *FeeAmount) String() string {
 func (*FeeAmount) ProtoMessage() {}
 
 func (x *FeeAmount) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[73]
+	mi := &file_avs_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6253,7 +6329,7 @@ func (x *FeeAmount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeAmount.ProtoReflect.Descriptor instead.
 func (*FeeAmount) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{73}
+	return file_avs_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *FeeAmount) GetNativeTokenAmount() string {
@@ -6301,7 +6377,7 @@ type GasFeeBreakdown struct {
 
 func (x *GasFeeBreakdown) Reset() {
 	*x = GasFeeBreakdown{}
-	mi := &file_avs_proto_msgTypes[74]
+	mi := &file_avs_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6313,7 +6389,7 @@ func (x *GasFeeBreakdown) String() string {
 func (*GasFeeBreakdown) ProtoMessage() {}
 
 func (x *GasFeeBreakdown) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[74]
+	mi := &file_avs_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6326,7 +6402,7 @@ func (x *GasFeeBreakdown) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GasFeeBreakdown.ProtoReflect.Descriptor instead.
 func (*GasFeeBreakdown) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{74}
+	return file_avs_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GasFeeBreakdown) GetTotalGasFees() *FeeAmount {
@@ -6385,7 +6461,7 @@ type GasOperationFee struct {
 
 func (x *GasOperationFee) Reset() {
 	*x = GasOperationFee{}
-	mi := &file_avs_proto_msgTypes[75]
+	mi := &file_avs_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6397,7 +6473,7 @@ func (x *GasOperationFee) String() string {
 func (*GasOperationFee) ProtoMessage() {}
 
 func (x *GasOperationFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[75]
+	mi := &file_avs_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6410,7 +6486,7 @@ func (x *GasOperationFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GasOperationFee.ProtoReflect.Descriptor instead.
 func (*GasOperationFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{75}
+	return file_avs_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GasOperationFee) GetOperationType() string {
@@ -6461,7 +6537,7 @@ type SmartWalletCreationFee struct {
 
 func (x *SmartWalletCreationFee) Reset() {
 	*x = SmartWalletCreationFee{}
-	mi := &file_avs_proto_msgTypes[76]
+	mi := &file_avs_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6473,7 +6549,7 @@ func (x *SmartWalletCreationFee) String() string {
 func (*SmartWalletCreationFee) ProtoMessage() {}
 
 func (x *SmartWalletCreationFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[76]
+	mi := &file_avs_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6486,7 +6562,7 @@ func (x *SmartWalletCreationFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SmartWalletCreationFee.ProtoReflect.Descriptor instead.
 func (*SmartWalletCreationFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{76}
+	return file_avs_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *SmartWalletCreationFee) GetCreationRequired() bool {
@@ -6529,7 +6605,7 @@ type Fee struct {
 
 func (x *Fee) Reset() {
 	*x = Fee{}
-	mi := &file_avs_proto_msgTypes[77]
+	mi := &file_avs_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6541,7 +6617,7 @@ func (x *Fee) String() string {
 func (*Fee) ProtoMessage() {}
 
 func (x *Fee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[77]
+	mi := &file_avs_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6554,7 +6630,7 @@ func (x *Fee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Fee.ProtoReflect.Descriptor instead.
 func (*Fee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{77}
+	return file_avs_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *Fee) GetAmount() string {
@@ -6582,7 +6658,7 @@ type NativeToken struct {
 
 func (x *NativeToken) Reset() {
 	*x = NativeToken{}
-	mi := &file_avs_proto_msgTypes[78]
+	mi := &file_avs_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6594,7 +6670,7 @@ func (x *NativeToken) String() string {
 func (*NativeToken) ProtoMessage() {}
 
 func (x *NativeToken) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[78]
+	mi := &file_avs_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6607,7 +6683,7 @@ func (x *NativeToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NativeToken.ProtoReflect.Descriptor instead.
 func (*NativeToken) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{78}
+	return file_avs_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *NativeToken) GetSymbol() string {
@@ -6637,7 +6713,7 @@ type NodeCOGS struct {
 
 func (x *NodeCOGS) Reset() {
 	*x = NodeCOGS{}
-	mi := &file_avs_proto_msgTypes[79]
+	mi := &file_avs_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6649,7 +6725,7 @@ func (x *NodeCOGS) String() string {
 func (*NodeCOGS) ProtoMessage() {}
 
 func (x *NodeCOGS) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[79]
+	mi := &file_avs_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6662,7 +6738,7 @@ func (x *NodeCOGS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeCOGS.ProtoReflect.Descriptor instead.
 func (*NodeCOGS) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{79}
+	return file_avs_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *NodeCOGS) GetNodeId() string {
@@ -6709,7 +6785,7 @@ type ValueFee struct {
 
 func (x *ValueFee) Reset() {
 	*x = ValueFee{}
-	mi := &file_avs_proto_msgTypes[80]
+	mi := &file_avs_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6721,7 +6797,7 @@ func (x *ValueFee) String() string {
 func (*ValueFee) ProtoMessage() {}
 
 func (x *ValueFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[80]
+	mi := &file_avs_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6734,7 +6810,7 @@ func (x *ValueFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValueFee.ProtoReflect.Descriptor instead.
 func (*ValueFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{80}
+	return file_avs_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ValueFee) GetFee() *Fee {
@@ -6793,7 +6869,7 @@ type FeeDiscount struct {
 
 func (x *FeeDiscount) Reset() {
 	*x = FeeDiscount{}
-	mi := &file_avs_proto_msgTypes[81]
+	mi := &file_avs_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6805,7 +6881,7 @@ func (x *FeeDiscount) String() string {
 func (*FeeDiscount) ProtoMessage() {}
 
 func (x *FeeDiscount) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[81]
+	mi := &file_avs_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6818,7 +6894,7 @@ func (x *FeeDiscount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeDiscount.ProtoReflect.Descriptor instead.
 func (*FeeDiscount) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{81}
+	return file_avs_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *FeeDiscount) GetDiscountType() string {
@@ -6884,7 +6960,7 @@ type EstimateFeesResp struct {
 
 func (x *EstimateFeesResp) Reset() {
 	*x = EstimateFeesResp{}
-	mi := &file_avs_proto_msgTypes[82]
+	mi := &file_avs_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6896,7 +6972,7 @@ func (x *EstimateFeesResp) String() string {
 func (*EstimateFeesResp) ProtoMessage() {}
 
 func (x *EstimateFeesResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[82]
+	mi := &file_avs_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6909,7 +6985,7 @@ func (x *EstimateFeesResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeesResp.ProtoReflect.Descriptor instead.
 func (*EstimateFeesResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{82}
+	return file_avs_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *EstimateFeesResp) GetSuccess() bool {
@@ -7006,7 +7082,7 @@ type EventCondition struct {
 
 func (x *EventCondition) Reset() {
 	*x = EventCondition{}
-	mi := &file_avs_proto_msgTypes[83]
+	mi := &file_avs_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7018,7 +7094,7 @@ func (x *EventCondition) String() string {
 func (*EventCondition) ProtoMessage() {}
 
 func (x *EventCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[83]
+	mi := &file_avs_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7031,7 +7107,7 @@ func (x *EventCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventCondition.ProtoReflect.Descriptor instead.
 func (*EventCondition) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{83}
+	return file_avs_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *EventCondition) GetFieldName() string {
@@ -7071,7 +7147,7 @@ type FixedTimeTrigger_Config struct {
 
 func (x *FixedTimeTrigger_Config) Reset() {
 	*x = FixedTimeTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[84]
+	mi := &file_avs_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7083,7 +7159,7 @@ func (x *FixedTimeTrigger_Config) String() string {
 func (*FixedTimeTrigger_Config) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[84]
+	mi := &file_avs_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7115,7 +7191,7 @@ type FixedTimeTrigger_Output struct {
 
 func (x *FixedTimeTrigger_Output) Reset() {
 	*x = FixedTimeTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7127,7 +7203,7 @@ func (x *FixedTimeTrigger_Output) String() string {
 func (*FixedTimeTrigger_Output) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7159,7 +7235,7 @@ type CronTrigger_Config struct {
 
 func (x *CronTrigger_Config) Reset() {
 	*x = CronTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7171,7 +7247,7 @@ func (x *CronTrigger_Config) String() string {
 func (*CronTrigger_Config) ProtoMessage() {}
 
 func (x *CronTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7203,7 +7279,7 @@ type CronTrigger_Output struct {
 
 func (x *CronTrigger_Output) Reset() {
 	*x = CronTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7215,7 +7291,7 @@ func (x *CronTrigger_Output) String() string {
 func (*CronTrigger_Output) ProtoMessage() {}
 
 func (x *CronTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7249,7 +7325,7 @@ type BlockTrigger_Config struct {
 
 func (x *BlockTrigger_Config) Reset() {
 	*x = BlockTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7261,7 +7337,7 @@ func (x *BlockTrigger_Config) String() string {
 func (*BlockTrigger_Config) ProtoMessage() {}
 
 func (x *BlockTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7300,7 +7376,7 @@ type BlockTrigger_Output struct {
 
 func (x *BlockTrigger_Output) Reset() {
 	*x = BlockTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7312,7 +7388,7 @@ func (x *BlockTrigger_Output) String() string {
 func (*BlockTrigger_Output) ProtoMessage() {}
 
 func (x *BlockTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7372,7 +7448,7 @@ type EventTrigger_Query struct {
 
 func (x *EventTrigger_Query) Reset() {
 	*x = EventTrigger_Query{}
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7384,7 +7460,7 @@ func (x *EventTrigger_Query) String() string {
 func (*EventTrigger_Query) ProtoMessage() {}
 
 func (x *EventTrigger_Query) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7455,7 +7531,7 @@ type EventTrigger_MethodCall struct {
 
 func (x *EventTrigger_MethodCall) Reset() {
 	*x = EventTrigger_MethodCall{}
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7467,7 +7543,7 @@ func (x *EventTrigger_MethodCall) String() string {
 func (*EventTrigger_MethodCall) ProtoMessage() {}
 
 func (x *EventTrigger_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7530,7 +7606,7 @@ type EventTrigger_Config struct {
 
 func (x *EventTrigger_Config) Reset() {
 	*x = EventTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7542,7 +7618,7 @@ func (x *EventTrigger_Config) String() string {
 func (*EventTrigger_Config) ProtoMessage() {}
 
 func (x *EventTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7588,7 +7664,7 @@ type EventTrigger_Output struct {
 
 func (x *EventTrigger_Output) Reset() {
 	*x = EventTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7600,7 +7676,7 @@ func (x *EventTrigger_Output) String() string {
 func (*EventTrigger_Output) ProtoMessage() {}
 
 func (x *EventTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7640,7 +7716,7 @@ type ManualTrigger_Config struct {
 
 func (x *ManualTrigger_Config) Reset() {
 	*x = ManualTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7652,7 +7728,7 @@ func (x *ManualTrigger_Config) String() string {
 func (*ManualTrigger_Config) ProtoMessage() {}
 
 func (x *ManualTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7706,7 +7782,7 @@ type ManualTrigger_Output struct {
 
 func (x *ManualTrigger_Output) Reset() {
 	*x = ManualTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[95]
+	mi := &file_avs_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7718,7 +7794,7 @@ func (x *ManualTrigger_Output) String() string {
 func (*ManualTrigger_Output) ProtoMessage() {}
 
 func (x *ManualTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[95]
+	mi := &file_avs_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7753,7 +7829,7 @@ type ETHTransferNode_Config struct {
 
 func (x *ETHTransferNode_Config) Reset() {
 	*x = ETHTransferNode_Config{}
-	mi := &file_avs_proto_msgTypes[98]
+	mi := &file_avs_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7765,7 +7841,7 @@ func (x *ETHTransferNode_Config) String() string {
 func (*ETHTransferNode_Config) ProtoMessage() {}
 
 func (x *ETHTransferNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[98]
+	mi := &file_avs_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7811,7 +7887,7 @@ type ETHTransferNode_Output struct {
 
 func (x *ETHTransferNode_Output) Reset() {
 	*x = ETHTransferNode_Output{}
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7823,7 +7899,7 @@ func (x *ETHTransferNode_Output) String() string {
 func (*ETHTransferNode_Output) ProtoMessage() {}
 
 func (x *ETHTransferNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7868,7 +7944,7 @@ type ContractWriteNode_Config struct {
 
 func (x *ContractWriteNode_Config) Reset() {
 	*x = ContractWriteNode_Config{}
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7880,7 +7956,7 @@ func (x *ContractWriteNode_Config) String() string {
 func (*ContractWriteNode_Config) ProtoMessage() {}
 
 func (x *ContractWriteNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7964,7 +8040,7 @@ type ContractWriteNode_MethodCall struct {
 
 func (x *ContractWriteNode_MethodCall) Reset() {
 	*x = ContractWriteNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7976,7 +8052,7 @@ func (x *ContractWriteNode_MethodCall) String() string {
 func (*ContractWriteNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8031,7 +8107,7 @@ type ContractWriteNode_Output struct {
 
 func (x *ContractWriteNode_Output) Reset() {
 	*x = ContractWriteNode_Output{}
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8043,7 +8119,7 @@ func (x *ContractWriteNode_Output) String() string {
 func (*ContractWriteNode_Output) ProtoMessage() {}
 
 func (x *ContractWriteNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8081,7 +8157,7 @@ type ContractWriteNode_MethodResult struct {
 
 func (x *ContractWriteNode_MethodResult) Reset() {
 	*x = ContractWriteNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8093,7 +8169,7 @@ func (x *ContractWriteNode_MethodResult) String() string {
 func (*ContractWriteNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8170,7 +8246,7 @@ type ContractReadNode_MethodCall struct {
 
 func (x *ContractReadNode_MethodCall) Reset() {
 	*x = ContractReadNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8182,7 +8258,7 @@ func (x *ContractReadNode_MethodCall) String() string {
 func (*ContractReadNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8241,7 +8317,7 @@ type ContractReadNode_Config struct {
 
 func (x *ContractReadNode_Config) Reset() {
 	*x = ContractReadNode_Config{}
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8253,7 +8329,7 @@ func (x *ContractReadNode_Config) String() string {
 func (*ContractReadNode_Config) ProtoMessage() {}
 
 func (x *ContractReadNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8310,7 +8386,7 @@ type ContractReadNode_MethodResult struct {
 
 func (x *ContractReadNode_MethodResult) Reset() {
 	*x = ContractReadNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8322,7 +8398,7 @@ func (x *ContractReadNode_MethodResult) String() string {
 func (*ContractReadNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8377,7 +8453,7 @@ type ContractReadNode_Output struct {
 
 func (x *ContractReadNode_Output) Reset() {
 	*x = ContractReadNode_Output{}
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8389,7 +8465,7 @@ func (x *ContractReadNode_Output) String() string {
 func (*ContractReadNode_Output) ProtoMessage() {}
 
 func (x *ContractReadNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8424,7 +8500,7 @@ type ContractReadNode_MethodResult_StructuredField struct {
 
 func (x *ContractReadNode_MethodResult_StructuredField) Reset() {
 	*x = ContractReadNode_MethodResult_StructuredField{}
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8436,7 +8512,7 @@ func (x *ContractReadNode_MethodResult_StructuredField) String() string {
 func (*ContractReadNode_MethodResult_StructuredField) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult_StructuredField) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8485,7 +8561,7 @@ type GraphQLQueryNode_Config struct {
 
 func (x *GraphQLQueryNode_Config) Reset() {
 	*x = GraphQLQueryNode_Config{}
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8497,7 +8573,7 @@ func (x *GraphQLQueryNode_Config) String() string {
 func (*GraphQLQueryNode_Config) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8545,7 +8621,7 @@ type GraphQLQueryNode_Output struct {
 
 func (x *GraphQLQueryNode_Output) Reset() {
 	*x = GraphQLQueryNode_Output{}
-	mi := &file_avs_proto_msgTypes[110]
+	mi := &file_avs_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8557,7 +8633,7 @@ func (x *GraphQLQueryNode_Output) String() string {
 func (*GraphQLQueryNode_Output) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[110]
+	mi := &file_avs_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8594,7 +8670,7 @@ type RestAPINode_Config struct {
 
 func (x *RestAPINode_Config) Reset() {
 	*x = RestAPINode_Config{}
-	mi := &file_avs_proto_msgTypes[112]
+	mi := &file_avs_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8606,7 +8682,7 @@ func (x *RestAPINode_Config) String() string {
 func (*RestAPINode_Config) ProtoMessage() {}
 
 func (x *RestAPINode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[112]
+	mi := &file_avs_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8667,7 +8743,7 @@ type RestAPINode_Output struct {
 
 func (x *RestAPINode_Output) Reset() {
 	*x = RestAPINode_Output{}
-	mi := &file_avs_proto_msgTypes[113]
+	mi := &file_avs_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8679,7 +8755,7 @@ func (x *RestAPINode_Output) String() string {
 func (*RestAPINode_Output) ProtoMessage() {}
 
 func (x *RestAPINode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[113]
+	mi := &file_avs_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8712,7 +8788,7 @@ type CustomCodeNode_Config struct {
 
 func (x *CustomCodeNode_Config) Reset() {
 	*x = CustomCodeNode_Config{}
-	mi := &file_avs_proto_msgTypes[115]
+	mi := &file_avs_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8724,7 +8800,7 @@ func (x *CustomCodeNode_Config) String() string {
 func (*CustomCodeNode_Config) ProtoMessage() {}
 
 func (x *CustomCodeNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[115]
+	mi := &file_avs_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8764,7 +8840,7 @@ type CustomCodeNode_Output struct {
 
 func (x *CustomCodeNode_Output) Reset() {
 	*x = CustomCodeNode_Output{}
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8776,7 +8852,7 @@ func (x *CustomCodeNode_Output) String() string {
 func (*CustomCodeNode_Output) ProtoMessage() {}
 
 func (x *CustomCodeNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8841,7 +8917,7 @@ type BalanceNode_Config struct {
 
 func (x *BalanceNode_Config) Reset() {
 	*x = BalanceNode_Config{}
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8853,7 +8929,7 @@ func (x *BalanceNode_Config) String() string {
 func (*BalanceNode_Config) ProtoMessage() {}
 
 func (x *BalanceNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8924,7 +9000,7 @@ type BalanceNode_Output struct {
 
 func (x *BalanceNode_Output) Reset() {
 	*x = BalanceNode_Output{}
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8936,7 +9012,7 @@ func (x *BalanceNode_Output) String() string {
 func (*BalanceNode_Output) ProtoMessage() {}
 
 func (x *BalanceNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8959,6 +9035,120 @@ func (x *BalanceNode_Output) GetData() *structpb.Value {
 	return nil
 }
 
+type AwaitNode_Config struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// External-signal wake parameters.
+	Channel        string   `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`                                      // "telegram" | "api"
+	Approvers      []string `protobuf:"bytes,2,rep,name=approvers,proto3" json:"approvers,omitempty"`                                  // authorized parties; empty ⇒ the workflow owner
+	Prompt         string   `protobuf:"bytes,3,opt,name=prompt,proto3" json:"prompt,omitempty"`                                        // shown to the approver
+	TimeoutSeconds uint32   `protobuf:"varint,4,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"` // safety bound; 0 ⇒ server default (never an unbounded wait)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AwaitNode_Config) Reset() {
+	*x = AwaitNode_Config{}
+	mi := &file_avs_proto_msgTypes[120]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AwaitNode_Config) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AwaitNode_Config) ProtoMessage() {}
+
+func (x *AwaitNode_Config) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[120]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AwaitNode_Config.ProtoReflect.Descriptor instead.
+func (*AwaitNode_Config) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{17, 0}
+}
+
+func (x *AwaitNode_Config) GetChannel() string {
+	if x != nil {
+		return x.Channel
+	}
+	return ""
+}
+
+func (x *AwaitNode_Config) GetApprovers() []string {
+	if x != nil {
+		return x.Approvers
+	}
+	return nil
+}
+
+func (x *AwaitNode_Config) GetPrompt() string {
+	if x != nil {
+		return x.Prompt
+	}
+	return ""
+}
+
+func (x *AwaitNode_Config) GetTimeoutSeconds() uint32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+type AwaitNode_Output struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The delivered signal (decision + payload), readable by downstream steps.
+	Data          *structpb.Value `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AwaitNode_Output) Reset() {
+	*x = AwaitNode_Output{}
+	mi := &file_avs_proto_msgTypes[121]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AwaitNode_Output) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AwaitNode_Output) ProtoMessage() {}
+
+func (x *AwaitNode_Output) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[121]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AwaitNode_Output.ProtoReflect.Descriptor instead.
+func (*AwaitNode_Output) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{17, 1}
+}
+
+func (x *AwaitNode_Output) GetData() *structpb.Value {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 type BranchNode_Condition struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -8970,7 +9160,7 @@ type BranchNode_Condition struct {
 
 func (x *BranchNode_Condition) Reset() {
 	*x = BranchNode_Condition{}
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8982,7 +9172,7 @@ func (x *BranchNode_Condition) String() string {
 func (*BranchNode_Condition) ProtoMessage() {}
 
 func (x *BranchNode_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8995,7 +9185,7 @@ func (x *BranchNode_Condition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode_Condition.ProtoReflect.Descriptor instead.
 func (*BranchNode_Condition) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17, 0}
+	return file_avs_proto_rawDescGZIP(), []int{18, 0}
 }
 
 func (x *BranchNode_Condition) GetId() string {
@@ -9028,7 +9218,7 @@ type BranchNode_Config struct {
 
 func (x *BranchNode_Config) Reset() {
 	*x = BranchNode_Config{}
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9040,7 +9230,7 @@ func (x *BranchNode_Config) String() string {
 func (*BranchNode_Config) ProtoMessage() {}
 
 func (x *BranchNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9053,7 +9243,7 @@ func (x *BranchNode_Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode_Config.ProtoReflect.Descriptor instead.
 func (*BranchNode_Config) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17, 1}
+	return file_avs_proto_rawDescGZIP(), []int{18, 1}
 }
 
 func (x *BranchNode_Config) GetConditions() []*BranchNode_Condition {
@@ -9075,7 +9265,7 @@ type BranchNode_Output struct {
 
 func (x *BranchNode_Output) Reset() {
 	*x = BranchNode_Output{}
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9087,7 +9277,7 @@ func (x *BranchNode_Output) String() string {
 func (*BranchNode_Output) ProtoMessage() {}
 
 func (x *BranchNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9100,7 +9290,7 @@ func (x *BranchNode_Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode_Output.ProtoReflect.Descriptor instead.
 func (*BranchNode_Output) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17, 2}
+	return file_avs_proto_rawDescGZIP(), []int{18, 2}
 }
 
 func (x *BranchNode_Output) GetData() *structpb.Value {
@@ -9123,7 +9313,7 @@ type FilterNode_Config struct {
 
 func (x *FilterNode_Config) Reset() {
 	*x = FilterNode_Config{}
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9135,7 +9325,7 @@ func (x *FilterNode_Config) String() string {
 func (*FilterNode_Config) ProtoMessage() {}
 
 func (x *FilterNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9148,7 +9338,7 @@ func (x *FilterNode_Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterNode_Config.ProtoReflect.Descriptor instead.
 func (*FilterNode_Config) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{18, 0}
+	return file_avs_proto_rawDescGZIP(), []int{19, 0}
 }
 
 func (x *FilterNode_Config) GetExpression() string {
@@ -9175,7 +9365,7 @@ type FilterNode_Output struct {
 
 func (x *FilterNode_Output) Reset() {
 	*x = FilterNode_Output{}
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9187,7 +9377,7 @@ func (x *FilterNode_Output) String() string {
 func (*FilterNode_Output) ProtoMessage() {}
 
 func (x *FilterNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9200,7 +9390,7 @@ func (x *FilterNode_Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterNode_Output.ProtoReflect.Descriptor instead.
 func (*FilterNode_Output) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{18, 1}
+	return file_avs_proto_rawDescGZIP(), []int{19, 1}
 }
 
 func (x *FilterNode_Output) GetData() *structpb.Value {
@@ -9231,7 +9421,7 @@ type LoopNode_Config struct {
 
 func (x *LoopNode_Config) Reset() {
 	*x = LoopNode_Config{}
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9243,7 +9433,7 @@ func (x *LoopNode_Config) String() string {
 func (*LoopNode_Config) ProtoMessage() {}
 
 func (x *LoopNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9256,7 +9446,7 @@ func (x *LoopNode_Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoopNode_Config.ProtoReflect.Descriptor instead.
 func (*LoopNode_Config) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{19, 0}
+	return file_avs_proto_rawDescGZIP(), []int{20, 0}
 }
 
 func (x *LoopNode_Config) GetInputVariable() string {
@@ -9303,7 +9493,7 @@ type LoopNode_Output struct {
 
 func (x *LoopNode_Output) Reset() {
 	*x = LoopNode_Output{}
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9315,7 +9505,7 @@ func (x *LoopNode_Output) String() string {
 func (*LoopNode_Output) ProtoMessage() {}
 
 func (x *LoopNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9328,7 +9518,7 @@ func (x *LoopNode_Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoopNode_Output.ProtoReflect.Descriptor instead.
 func (*LoopNode_Output) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{19, 1}
+	return file_avs_proto_rawDescGZIP(), []int{20, 1}
 }
 
 func (x *LoopNode_Output) GetData() *structpb.Value {
@@ -9390,7 +9580,7 @@ type Execution_Step struct {
 
 func (x *Execution_Step) Reset() {
 	*x = Execution_Step{}
-	mi := &file_avs_proto_msgTypes[126]
+	mi := &file_avs_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9402,7 +9592,7 @@ func (x *Execution_Step) String() string {
 func (*Execution_Step) ProtoMessage() {}
 
 func (x *Execution_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[126]
+	mi := &file_avs_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9415,7 +9605,7 @@ func (x *Execution_Step) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution_Step.ProtoReflect.Descriptor instead.
 func (*Execution_Step) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{22, 0}
+	return file_avs_proto_rawDescGZIP(), []int{23, 0}
 }
 
 func (x *Execution_Step) GetId() string {
@@ -9979,6 +10169,16 @@ const file_avs_proto_rawDesc = "" +
 	"\x13min_usd_value_cents\x18\x05 \x01(\x03R\x10minUsdValueCents\x12'\n" +
 	"\x0ftoken_addresses\x18\x06 \x03(\tR\x0etokenAddresses\x1a4\n" +
 	"\x06Output\x12*\n" +
+	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xb1\x02\n" +
+	"\tAwaitNode\x124\n" +
+	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x124\n" +
+	"\x06output\x18\x02 \x01(\v2\x1c.aggregator.AwaitNode.OutputR\x06output\x1a\x81\x01\n" +
+	"\x06Config\x12\x18\n" +
+	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1c\n" +
+	"\tapprovers\x18\x02 \x03(\tR\tapprovers\x12\x16\n" +
+	"\x06prompt\x18\x03 \x01(\tR\x06prompt\x12'\n" +
+	"\x0ftimeout_seconds\x18\x04 \x01(\rR\x0etimeoutSeconds\x1a4\n" +
+	"\x06Output\x12*\n" +
 	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\x96\x02\n" +
 	"\n" +
 	"BranchNode\x125\n" +
@@ -10027,7 +10227,7 @@ const file_avs_proto_rawDesc = "" +
 	"\bTaskEdge\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06source\x18\x02 \x01(\tR\x06source\x12\x16\n" +
-	"\x06target\x18\x03 \x01(\tR\x06target\"\xb3\x05\n" +
+	"\x06target\x18\x03 \x01(\tR\x06target\"\xe2\x05\n" +
 	"\bTaskNode\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12(\n" +
@@ -10043,7 +10243,8 @@ const file_avs_proto_rawDesc = "" +
 	"\x04loop\x18\x11 \x01(\v2\x14.aggregator.LoopNodeH\x00R\x04loop\x12=\n" +
 	"\vcustom_code\x18\x12 \x01(\v2\x1a.aggregator.CustomCodeNodeH\x00R\n" +
 	"customCode\x123\n" +
-	"\abalance\x18\x13 \x01(\v2\x17.aggregator.BalanceNodeH\x00R\abalanceB\v\n" +
+	"\abalance\x18\x13 \x01(\v2\x17.aggregator.BalanceNodeH\x00R\abalance\x12-\n" +
+	"\x05await\x18\x14 \x01(\v2\x15.aggregator.AwaitNodeH\x00R\x05awaitB\v\n" +
 	"\ttask_type\"\xd1\x0f\n" +
 	"\tExecution\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
@@ -10522,7 +10723,7 @@ const file_avs_proto_rawDesc = "" +
 	"\x17TRIGGER_TYPE_FIXED_TIME\x10\x02\x12\x15\n" +
 	"\x11TRIGGER_TYPE_CRON\x10\x03\x12\x16\n" +
 	"\x12TRIGGER_TYPE_BLOCK\x10\x04\x12\x16\n" +
-	"\x12TRIGGER_TYPE_EVENT\x10\x05*\xa3\x02\n" +
+	"\x12TRIGGER_TYPE_EVENT\x10\x05*\xb8\x02\n" +
 	"\bNodeType\x12\x19\n" +
 	"\x15NODE_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16NODE_TYPE_ETH_TRANSFER\x10\x01\x12\x1c\n" +
@@ -10535,7 +10736,8 @@ const file_avs_proto_rawDesc = "" +
 	"\x10NODE_TYPE_FILTER\x10\b\x12\x12\n" +
 	"\x0eNODE_TYPE_LOOP\x10\t\x12\x15\n" +
 	"\x11NODE_TYPE_BALANCE\x10\n" +
-	"*q\n" +
+	"\x12\x13\n" +
+	"\x0fNODE_TYPE_AWAIT\x10\v*q\n" +
 	"\rExecutionTier\x12\x1e\n" +
 	"\x1aEXECUTION_TIER_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10EXECUTION_TIER_1\x10\x01\x12\x14\n" +
@@ -10621,7 +10823,7 @@ func file_avs_proto_rawDescGZIP() []byte {
 }
 
 var file_avs_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 134)
+var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 137)
 var file_avs_proto_goTypes = []any{
 	(TriggerType)(0),                                      // 0: aggregator.TriggerType
 	(NodeType)(0),                                         // 1: aggregator.NodeType
@@ -10648,313 +10850,320 @@ var file_avs_proto_goTypes = []any{
 	(*RestAPINode)(nil),                                   // 22: aggregator.RestAPINode
 	(*CustomCodeNode)(nil),                                // 23: aggregator.CustomCodeNode
 	(*BalanceNode)(nil),                                   // 24: aggregator.BalanceNode
-	(*BranchNode)(nil),                                    // 25: aggregator.BranchNode
-	(*FilterNode)(nil),                                    // 26: aggregator.FilterNode
-	(*LoopNode)(nil),                                      // 27: aggregator.LoopNode
-	(*TaskEdge)(nil),                                      // 28: aggregator.TaskEdge
-	(*TaskNode)(nil),                                      // 29: aggregator.TaskNode
-	(*Execution)(nil),                                     // 30: aggregator.Execution
-	(*Task)(nil),                                          // 31: aggregator.Task
-	(*CreateTaskReq)(nil),                                 // 32: aggregator.CreateTaskReq
-	(*CreateTaskResp)(nil),                                // 33: aggregator.CreateTaskResp
-	(*NonceRequest)(nil),                                  // 34: aggregator.NonceRequest
-	(*NonceResp)(nil),                                     // 35: aggregator.NonceResp
-	(*ListWalletReq)(nil),                                 // 36: aggregator.ListWalletReq
-	(*SmartWallet)(nil),                                   // 37: aggregator.SmartWallet
-	(*ListWalletResp)(nil),                                // 38: aggregator.ListWalletResp
-	(*ListTasksReq)(nil),                                  // 39: aggregator.ListTasksReq
-	(*ListTasksResp)(nil),                                 // 40: aggregator.ListTasksResp
-	(*ListExecutionsReq)(nil),                             // 41: aggregator.ListExecutionsReq
-	(*ListExecutionsResp)(nil),                            // 42: aggregator.ListExecutionsResp
-	(*ExecutionReq)(nil),                                  // 43: aggregator.ExecutionReq
-	(*ExecutionStatusResp)(nil),                           // 44: aggregator.ExecutionStatusResp
-	(*GetKeyReq)(nil),                                     // 45: aggregator.GetKeyReq
-	(*KeyResp)(nil),                                       // 46: aggregator.KeyResp
-	(*GetWalletReq)(nil),                                  // 47: aggregator.GetWalletReq
-	(*GetWalletResp)(nil),                                 // 48: aggregator.GetWalletResp
-	(*SetWalletReq)(nil),                                  // 49: aggregator.SetWalletReq
-	(*WithdrawFundsReq)(nil),                              // 50: aggregator.WithdrawFundsReq
-	(*WithdrawFundsResp)(nil),                             // 51: aggregator.WithdrawFundsResp
-	(*TriggerTaskReq)(nil),                                // 52: aggregator.TriggerTaskReq
-	(*TriggerTaskResp)(nil),                               // 53: aggregator.TriggerTaskResp
-	(*CreateOrUpdateSecretReq)(nil),                       // 54: aggregator.CreateOrUpdateSecretReq
-	(*ListSecretsReq)(nil),                                // 55: aggregator.ListSecretsReq
-	(*PageInfo)(nil),                                      // 56: aggregator.PageInfo
-	(*Secret)(nil),                                        // 57: aggregator.Secret
-	(*ListSecretsResp)(nil),                               // 58: aggregator.ListSecretsResp
-	(*DeleteSecretReq)(nil),                               // 59: aggregator.DeleteSecretReq
-	(*DeleteSecretResp)(nil),                              // 60: aggregator.DeleteSecretResp
-	(*GetSignatureFormatReq)(nil),                         // 61: aggregator.GetSignatureFormatReq
-	(*GetSignatureFormatResp)(nil),                        // 62: aggregator.GetSignatureFormatResp
-	(*CreateSecretResp)(nil),                              // 63: aggregator.CreateSecretResp
-	(*UpdateSecretResp)(nil),                              // 64: aggregator.UpdateSecretResp
-	(*DeleteTaskResp)(nil),                                // 65: aggregator.DeleteTaskResp
-	(*SetTaskEnabledReq)(nil),                             // 66: aggregator.SetTaskEnabledReq
-	(*SetTaskEnabledResp)(nil),                            // 67: aggregator.SetTaskEnabledResp
-	(*GetWorkflowCountReq)(nil),                           // 68: aggregator.GetWorkflowCountReq
-	(*GetWorkflowCountResp)(nil),                          // 69: aggregator.GetWorkflowCountResp
-	(*GetExecutionCountReq)(nil),                          // 70: aggregator.GetExecutionCountReq
-	(*GetExecutionCountResp)(nil),                         // 71: aggregator.GetExecutionCountResp
-	(*GetExecutionStatsReq)(nil),                          // 72: aggregator.GetExecutionStatsReq
-	(*GetExecutionStatsResp)(nil),                         // 73: aggregator.GetExecutionStatsResp
-	(*RunNodeWithInputsReq)(nil),                          // 74: aggregator.RunNodeWithInputsReq
-	(*ERC20StateOverride)(nil),                            // 75: aggregator.ERC20StateOverride
-	(*RunNodeWithInputsResp)(nil),                         // 76: aggregator.RunNodeWithInputsResp
-	(*RunTriggerReq)(nil),                                 // 77: aggregator.RunTriggerReq
-	(*RunTriggerResp)(nil),                                // 78: aggregator.RunTriggerResp
-	(*SimulateTaskReq)(nil),                               // 79: aggregator.SimulateTaskReq
-	(*EstimateFeesReq)(nil),                               // 80: aggregator.EstimateFeesReq
-	(*FeeAmount)(nil),                                     // 81: aggregator.FeeAmount
-	(*GasFeeBreakdown)(nil),                               // 82: aggregator.GasFeeBreakdown
-	(*GasOperationFee)(nil),                               // 83: aggregator.GasOperationFee
-	(*SmartWalletCreationFee)(nil),                        // 84: aggregator.SmartWalletCreationFee
-	(*Fee)(nil),                                           // 85: aggregator.Fee
-	(*NativeToken)(nil),                                   // 86: aggregator.NativeToken
-	(*NodeCOGS)(nil),                                      // 87: aggregator.NodeCOGS
-	(*ValueFee)(nil),                                      // 88: aggregator.ValueFee
-	(*FeeDiscount)(nil),                                   // 89: aggregator.FeeDiscount
-	(*EstimateFeesResp)(nil),                              // 90: aggregator.EstimateFeesResp
-	(*EventCondition)(nil),                                // 91: aggregator.EventCondition
-	(*FixedTimeTrigger_Config)(nil),                       // 92: aggregator.FixedTimeTrigger.Config
-	(*FixedTimeTrigger_Output)(nil),                       // 93: aggregator.FixedTimeTrigger.Output
-	(*CronTrigger_Config)(nil),                            // 94: aggregator.CronTrigger.Config
-	(*CronTrigger_Output)(nil),                            // 95: aggregator.CronTrigger.Output
-	(*BlockTrigger_Config)(nil),                           // 96: aggregator.BlockTrigger.Config
-	(*BlockTrigger_Output)(nil),                           // 97: aggregator.BlockTrigger.Output
-	(*EventTrigger_Query)(nil),                            // 98: aggregator.EventTrigger.Query
-	(*EventTrigger_MethodCall)(nil),                       // 99: aggregator.EventTrigger.MethodCall
-	(*EventTrigger_Config)(nil),                           // 100: aggregator.EventTrigger.Config
-	(*EventTrigger_Output)(nil),                           // 101: aggregator.EventTrigger.Output
-	(*ManualTrigger_Config)(nil),                          // 102: aggregator.ManualTrigger.Config
-	(*ManualTrigger_Output)(nil),                          // 103: aggregator.ManualTrigger.Output
-	nil,                                                   // 104: aggregator.ManualTrigger.Config.HeadersEntry
-	nil,                                                   // 105: aggregator.ManualTrigger.Config.PathParamsEntry
-	(*ETHTransferNode_Config)(nil),                        // 106: aggregator.ETHTransferNode.Config
-	(*ETHTransferNode_Output)(nil),                        // 107: aggregator.ETHTransferNode.Output
-	(*ContractWriteNode_Config)(nil),                      // 108: aggregator.ContractWriteNode.Config
-	(*ContractWriteNode_MethodCall)(nil),                  // 109: aggregator.ContractWriteNode.MethodCall
-	(*ContractWriteNode_Output)(nil),                      // 110: aggregator.ContractWriteNode.Output
-	(*ContractWriteNode_MethodResult)(nil),                // 111: aggregator.ContractWriteNode.MethodResult
-	(*ContractReadNode_MethodCall)(nil),                   // 112: aggregator.ContractReadNode.MethodCall
-	(*ContractReadNode_Config)(nil),                       // 113: aggregator.ContractReadNode.Config
-	(*ContractReadNode_MethodResult)(nil),                 // 114: aggregator.ContractReadNode.MethodResult
-	(*ContractReadNode_Output)(nil),                       // 115: aggregator.ContractReadNode.Output
-	(*ContractReadNode_MethodResult_StructuredField)(nil), // 116: aggregator.ContractReadNode.MethodResult.StructuredField
-	(*GraphQLQueryNode_Config)(nil),                       // 117: aggregator.GraphQLQueryNode.Config
-	(*GraphQLQueryNode_Output)(nil),                       // 118: aggregator.GraphQLQueryNode.Output
-	nil,                                                   // 119: aggregator.GraphQLQueryNode.Config.VariablesEntry
-	(*RestAPINode_Config)(nil),                            // 120: aggregator.RestAPINode.Config
-	(*RestAPINode_Output)(nil),                            // 121: aggregator.RestAPINode.Output
-	nil,                                                   // 122: aggregator.RestAPINode.Config.HeadersEntry
-	(*CustomCodeNode_Config)(nil),                         // 123: aggregator.CustomCodeNode.Config
-	(*CustomCodeNode_Output)(nil),                         // 124: aggregator.CustomCodeNode.Output
-	(*BalanceNode_Config)(nil),                            // 125: aggregator.BalanceNode.Config
-	(*BalanceNode_Output)(nil),                            // 126: aggregator.BalanceNode.Output
-	(*BranchNode_Condition)(nil),                          // 127: aggregator.BranchNode.Condition
-	(*BranchNode_Config)(nil),                             // 128: aggregator.BranchNode.Config
-	(*BranchNode_Output)(nil),                             // 129: aggregator.BranchNode.Output
-	(*FilterNode_Config)(nil),                             // 130: aggregator.FilterNode.Config
-	(*FilterNode_Output)(nil),                             // 131: aggregator.FilterNode.Output
-	(*LoopNode_Config)(nil),                               // 132: aggregator.LoopNode.Config
-	(*LoopNode_Output)(nil),                               // 133: aggregator.LoopNode.Output
-	(*Execution_Step)(nil),                                // 134: aggregator.Execution.Step
-	nil,                                                   // 135: aggregator.Task.InputVariablesEntry
-	nil,                                                   // 136: aggregator.CreateTaskReq.InputVariablesEntry
-	nil,                                                   // 137: aggregator.TriggerTaskReq.TriggerInputEntry
-	nil,                                                   // 138: aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	nil,                                                   // 139: aggregator.RunTriggerReq.TriggerInputEntry
-	nil,                                                   // 140: aggregator.SimulateTaskReq.InputVariablesEntry
-	nil,                                                   // 141: aggregator.EstimateFeesReq.InputVariablesEntry
-	(*structpb.Value)(nil),                                // 142: google.protobuf.Value
+	(*AwaitNode)(nil),                                     // 25: aggregator.AwaitNode
+	(*BranchNode)(nil),                                    // 26: aggregator.BranchNode
+	(*FilterNode)(nil),                                    // 27: aggregator.FilterNode
+	(*LoopNode)(nil),                                      // 28: aggregator.LoopNode
+	(*TaskEdge)(nil),                                      // 29: aggregator.TaskEdge
+	(*TaskNode)(nil),                                      // 30: aggregator.TaskNode
+	(*Execution)(nil),                                     // 31: aggregator.Execution
+	(*Task)(nil),                                          // 32: aggregator.Task
+	(*CreateTaskReq)(nil),                                 // 33: aggregator.CreateTaskReq
+	(*CreateTaskResp)(nil),                                // 34: aggregator.CreateTaskResp
+	(*NonceRequest)(nil),                                  // 35: aggregator.NonceRequest
+	(*NonceResp)(nil),                                     // 36: aggregator.NonceResp
+	(*ListWalletReq)(nil),                                 // 37: aggregator.ListWalletReq
+	(*SmartWallet)(nil),                                   // 38: aggregator.SmartWallet
+	(*ListWalletResp)(nil),                                // 39: aggregator.ListWalletResp
+	(*ListTasksReq)(nil),                                  // 40: aggregator.ListTasksReq
+	(*ListTasksResp)(nil),                                 // 41: aggregator.ListTasksResp
+	(*ListExecutionsReq)(nil),                             // 42: aggregator.ListExecutionsReq
+	(*ListExecutionsResp)(nil),                            // 43: aggregator.ListExecutionsResp
+	(*ExecutionReq)(nil),                                  // 44: aggregator.ExecutionReq
+	(*ExecutionStatusResp)(nil),                           // 45: aggregator.ExecutionStatusResp
+	(*GetKeyReq)(nil),                                     // 46: aggregator.GetKeyReq
+	(*KeyResp)(nil),                                       // 47: aggregator.KeyResp
+	(*GetWalletReq)(nil),                                  // 48: aggregator.GetWalletReq
+	(*GetWalletResp)(nil),                                 // 49: aggregator.GetWalletResp
+	(*SetWalletReq)(nil),                                  // 50: aggregator.SetWalletReq
+	(*WithdrawFundsReq)(nil),                              // 51: aggregator.WithdrawFundsReq
+	(*WithdrawFundsResp)(nil),                             // 52: aggregator.WithdrawFundsResp
+	(*TriggerTaskReq)(nil),                                // 53: aggregator.TriggerTaskReq
+	(*TriggerTaskResp)(nil),                               // 54: aggregator.TriggerTaskResp
+	(*CreateOrUpdateSecretReq)(nil),                       // 55: aggregator.CreateOrUpdateSecretReq
+	(*ListSecretsReq)(nil),                                // 56: aggregator.ListSecretsReq
+	(*PageInfo)(nil),                                      // 57: aggregator.PageInfo
+	(*Secret)(nil),                                        // 58: aggregator.Secret
+	(*ListSecretsResp)(nil),                               // 59: aggregator.ListSecretsResp
+	(*DeleteSecretReq)(nil),                               // 60: aggregator.DeleteSecretReq
+	(*DeleteSecretResp)(nil),                              // 61: aggregator.DeleteSecretResp
+	(*GetSignatureFormatReq)(nil),                         // 62: aggregator.GetSignatureFormatReq
+	(*GetSignatureFormatResp)(nil),                        // 63: aggregator.GetSignatureFormatResp
+	(*CreateSecretResp)(nil),                              // 64: aggregator.CreateSecretResp
+	(*UpdateSecretResp)(nil),                              // 65: aggregator.UpdateSecretResp
+	(*DeleteTaskResp)(nil),                                // 66: aggregator.DeleteTaskResp
+	(*SetTaskEnabledReq)(nil),                             // 67: aggregator.SetTaskEnabledReq
+	(*SetTaskEnabledResp)(nil),                            // 68: aggregator.SetTaskEnabledResp
+	(*GetWorkflowCountReq)(nil),                           // 69: aggregator.GetWorkflowCountReq
+	(*GetWorkflowCountResp)(nil),                          // 70: aggregator.GetWorkflowCountResp
+	(*GetExecutionCountReq)(nil),                          // 71: aggregator.GetExecutionCountReq
+	(*GetExecutionCountResp)(nil),                         // 72: aggregator.GetExecutionCountResp
+	(*GetExecutionStatsReq)(nil),                          // 73: aggregator.GetExecutionStatsReq
+	(*GetExecutionStatsResp)(nil),                         // 74: aggregator.GetExecutionStatsResp
+	(*RunNodeWithInputsReq)(nil),                          // 75: aggregator.RunNodeWithInputsReq
+	(*ERC20StateOverride)(nil),                            // 76: aggregator.ERC20StateOverride
+	(*RunNodeWithInputsResp)(nil),                         // 77: aggregator.RunNodeWithInputsResp
+	(*RunTriggerReq)(nil),                                 // 78: aggregator.RunTriggerReq
+	(*RunTriggerResp)(nil),                                // 79: aggregator.RunTriggerResp
+	(*SimulateTaskReq)(nil),                               // 80: aggregator.SimulateTaskReq
+	(*EstimateFeesReq)(nil),                               // 81: aggregator.EstimateFeesReq
+	(*FeeAmount)(nil),                                     // 82: aggregator.FeeAmount
+	(*GasFeeBreakdown)(nil),                               // 83: aggregator.GasFeeBreakdown
+	(*GasOperationFee)(nil),                               // 84: aggregator.GasOperationFee
+	(*SmartWalletCreationFee)(nil),                        // 85: aggregator.SmartWalletCreationFee
+	(*Fee)(nil),                                           // 86: aggregator.Fee
+	(*NativeToken)(nil),                                   // 87: aggregator.NativeToken
+	(*NodeCOGS)(nil),                                      // 88: aggregator.NodeCOGS
+	(*ValueFee)(nil),                                      // 89: aggregator.ValueFee
+	(*FeeDiscount)(nil),                                   // 90: aggregator.FeeDiscount
+	(*EstimateFeesResp)(nil),                              // 91: aggregator.EstimateFeesResp
+	(*EventCondition)(nil),                                // 92: aggregator.EventCondition
+	(*FixedTimeTrigger_Config)(nil),                       // 93: aggregator.FixedTimeTrigger.Config
+	(*FixedTimeTrigger_Output)(nil),                       // 94: aggregator.FixedTimeTrigger.Output
+	(*CronTrigger_Config)(nil),                            // 95: aggregator.CronTrigger.Config
+	(*CronTrigger_Output)(nil),                            // 96: aggregator.CronTrigger.Output
+	(*BlockTrigger_Config)(nil),                           // 97: aggregator.BlockTrigger.Config
+	(*BlockTrigger_Output)(nil),                           // 98: aggregator.BlockTrigger.Output
+	(*EventTrigger_Query)(nil),                            // 99: aggregator.EventTrigger.Query
+	(*EventTrigger_MethodCall)(nil),                       // 100: aggregator.EventTrigger.MethodCall
+	(*EventTrigger_Config)(nil),                           // 101: aggregator.EventTrigger.Config
+	(*EventTrigger_Output)(nil),                           // 102: aggregator.EventTrigger.Output
+	(*ManualTrigger_Config)(nil),                          // 103: aggregator.ManualTrigger.Config
+	(*ManualTrigger_Output)(nil),                          // 104: aggregator.ManualTrigger.Output
+	nil,                                                   // 105: aggregator.ManualTrigger.Config.HeadersEntry
+	nil,                                                   // 106: aggregator.ManualTrigger.Config.PathParamsEntry
+	(*ETHTransferNode_Config)(nil),                        // 107: aggregator.ETHTransferNode.Config
+	(*ETHTransferNode_Output)(nil),                        // 108: aggregator.ETHTransferNode.Output
+	(*ContractWriteNode_Config)(nil),                      // 109: aggregator.ContractWriteNode.Config
+	(*ContractWriteNode_MethodCall)(nil),                  // 110: aggregator.ContractWriteNode.MethodCall
+	(*ContractWriteNode_Output)(nil),                      // 111: aggregator.ContractWriteNode.Output
+	(*ContractWriteNode_MethodResult)(nil),                // 112: aggregator.ContractWriteNode.MethodResult
+	(*ContractReadNode_MethodCall)(nil),                   // 113: aggregator.ContractReadNode.MethodCall
+	(*ContractReadNode_Config)(nil),                       // 114: aggregator.ContractReadNode.Config
+	(*ContractReadNode_MethodResult)(nil),                 // 115: aggregator.ContractReadNode.MethodResult
+	(*ContractReadNode_Output)(nil),                       // 116: aggregator.ContractReadNode.Output
+	(*ContractReadNode_MethodResult_StructuredField)(nil), // 117: aggregator.ContractReadNode.MethodResult.StructuredField
+	(*GraphQLQueryNode_Config)(nil),                       // 118: aggregator.GraphQLQueryNode.Config
+	(*GraphQLQueryNode_Output)(nil),                       // 119: aggregator.GraphQLQueryNode.Output
+	nil,                                                   // 120: aggregator.GraphQLQueryNode.Config.VariablesEntry
+	(*RestAPINode_Config)(nil),                            // 121: aggregator.RestAPINode.Config
+	(*RestAPINode_Output)(nil),                            // 122: aggregator.RestAPINode.Output
+	nil,                                                   // 123: aggregator.RestAPINode.Config.HeadersEntry
+	(*CustomCodeNode_Config)(nil),                         // 124: aggregator.CustomCodeNode.Config
+	(*CustomCodeNode_Output)(nil),                         // 125: aggregator.CustomCodeNode.Output
+	(*BalanceNode_Config)(nil),                            // 126: aggregator.BalanceNode.Config
+	(*BalanceNode_Output)(nil),                            // 127: aggregator.BalanceNode.Output
+	(*AwaitNode_Config)(nil),                              // 128: aggregator.AwaitNode.Config
+	(*AwaitNode_Output)(nil),                              // 129: aggregator.AwaitNode.Output
+	(*BranchNode_Condition)(nil),                          // 130: aggregator.BranchNode.Condition
+	(*BranchNode_Config)(nil),                             // 131: aggregator.BranchNode.Config
+	(*BranchNode_Output)(nil),                             // 132: aggregator.BranchNode.Output
+	(*FilterNode_Config)(nil),                             // 133: aggregator.FilterNode.Config
+	(*FilterNode_Output)(nil),                             // 134: aggregator.FilterNode.Output
+	(*LoopNode_Config)(nil),                               // 135: aggregator.LoopNode.Config
+	(*LoopNode_Output)(nil),                               // 136: aggregator.LoopNode.Output
+	(*Execution_Step)(nil),                                // 137: aggregator.Execution.Step
+	nil,                                                   // 138: aggregator.Task.InputVariablesEntry
+	nil,                                                   // 139: aggregator.CreateTaskReq.InputVariablesEntry
+	nil,                                                   // 140: aggregator.TriggerTaskReq.TriggerInputEntry
+	nil,                                                   // 141: aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	nil,                                                   // 142: aggregator.RunTriggerReq.TriggerInputEntry
+	nil,                                                   // 143: aggregator.SimulateTaskReq.InputVariablesEntry
+	nil,                                                   // 144: aggregator.EstimateFeesReq.InputVariablesEntry
+	(*structpb.Value)(nil),                                // 145: google.protobuf.Value
 }
 var file_avs_proto_depIdxs = []int32{
 	8,   // 0: aggregator.GetTokenMetadataResp.token:type_name -> aggregator.TokenMetadata
-	92,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
-	94,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
-	96,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
-	100, // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
-	102, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
+	93,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
+	95,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
+	97,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
+	101, // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
+	103, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
 	0,   // 6: aggregator.TaskTrigger.type:type_name -> aggregator.TriggerType
 	16,  // 7: aggregator.TaskTrigger.manual:type_name -> aggregator.ManualTrigger
 	12,  // 8: aggregator.TaskTrigger.fixed_time:type_name -> aggregator.FixedTimeTrigger
 	13,  // 9: aggregator.TaskTrigger.cron:type_name -> aggregator.CronTrigger
 	14,  // 10: aggregator.TaskTrigger.block:type_name -> aggregator.BlockTrigger
 	15,  // 11: aggregator.TaskTrigger.event:type_name -> aggregator.EventTrigger
-	106, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
-	108, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
-	113, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
-	117, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
-	120, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
-	123, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
-	125, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
-	128, // 19: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
-	130, // 20: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
-	18,  // 21: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
-	19,  // 22: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
-	20,  // 23: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
-	21,  // 24: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
-	22,  // 25: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
-	23,  // 26: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
-	132, // 27: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
-	1,   // 28: aggregator.TaskNode.type:type_name -> aggregator.NodeType
-	18,  // 29: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
-	19,  // 30: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
-	20,  // 31: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
-	21,  // 32: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
-	22,  // 33: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
-	25,  // 34: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
-	26,  // 35: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
-	27,  // 36: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
-	23,  // 37: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
-	24,  // 38: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
-	7,   // 39: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
-	85,  // 40: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
-	87,  // 41: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
-	88,  // 42: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
-	134, // 43: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
-	6,   // 44: aggregator.Task.status:type_name -> aggregator.TaskStatus
-	17,  // 45: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 46: aggregator.Task.nodes:type_name -> aggregator.TaskNode
-	28,  // 47: aggregator.Task.edges:type_name -> aggregator.TaskEdge
-	135, // 48: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
-	17,  // 49: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 50: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 51: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
-	136, // 52: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
-	37,  // 53: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
-	31,  // 54: aggregator.ListTasksResp.items:type_name -> aggregator.Task
-	56,  // 55: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
-	30,  // 56: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
-	56,  // 57: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
-	7,   // 58: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
-	0,   // 59: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
-	97,  // 60: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	93,  // 61: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	95,  // 62: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	101, // 63: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
-	103, // 64: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	137, // 65: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
-	7,   // 66: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
-	134, // 67: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
-	57,  // 68: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
-	56,  // 69: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
-	29,  // 70: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
-	138, // 71: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	75,  // 72: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
-	142, // 73: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
-	142, // 74: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 75: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
-	107, // 76: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	118, // 77: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	115, // 78: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
-	110, // 79: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	124, // 80: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	121, // 81: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
-	129, // 82: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
-	131, // 83: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
-	133, // 84: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
-	126, // 85: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
-	17,  // 86: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
-	139, // 87: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
-	142, // 88: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
-	142, // 89: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 90: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
-	97,  // 91: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	93,  // 92: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	95,  // 93: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	101, // 94: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
-	103, // 95: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	17,  // 96: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 97: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 98: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
-	140, // 99: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
-	17,  // 100: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 101: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 102: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
-	141, // 103: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
-	81,  // 104: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
-	83,  // 105: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
-	81,  // 106: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
-	81,  // 107: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
-	81,  // 108: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
-	85,  // 109: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
-	85,  // 110: aggregator.ValueFee.fee:type_name -> aggregator.Fee
-	2,   // 111: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
-	85,  // 112: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
-	5,   // 113: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
-	86,  // 114: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
-	85,  // 115: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
-	87,  // 116: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
-	88,  // 117: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
-	89,  // 118: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
-	142, // 119: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 120: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 121: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 122: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
-	91,  // 123: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
-	99,  // 124: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
-	98,  // 125: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
-	142, // 126: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 127: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
-	104, // 128: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
-	105, // 129: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
-	4,   // 130: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
-	142, // 131: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 132: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
-	142, // 133: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
-	109, // 134: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
-	142, // 135: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
-	142, // 136: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
-	142, // 137: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
-	142, // 138: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
-	142, // 139: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
-	112, // 140: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
-	116, // 141: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
-	142, // 142: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
-	119, // 143: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
-	142, // 144: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
-	122, // 145: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
-	142, // 146: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
-	142, // 147: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
-	4,   // 148: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
-	142, // 149: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
-	142, // 150: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
-	127, // 151: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	142, // 152: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	142, // 153: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	3,   // 154: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	142, // 155: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	5,   // 156: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
-	142, // 157: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	142, // 158: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	142, // 159: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	97,  // 160: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	93,  // 161: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	95,  // 162: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	101, // 163: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	103, // 164: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	107, // 165: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	118, // 166: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	115, // 167: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	110, // 168: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	124, // 169: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	121, // 170: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	129, // 171: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	131, // 172: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	133, // 173: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	126, // 174: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
-	142, // 175: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 176: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 177: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	142, // 178: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 179: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	142, // 180: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 181: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	182, // [182:182] is the sub-list for method output_type
-	182, // [182:182] is the sub-list for method input_type
-	182, // [182:182] is the sub-list for extension type_name
-	182, // [182:182] is the sub-list for extension extendee
-	0,   // [0:182] is the sub-list for field type_name
+	107, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
+	109, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
+	114, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
+	118, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
+	121, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
+	124, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
+	126, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
+	128, // 19: aggregator.AwaitNode.config:type_name -> aggregator.AwaitNode.Config
+	129, // 20: aggregator.AwaitNode.output:type_name -> aggregator.AwaitNode.Output
+	131, // 21: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
+	133, // 22: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
+	18,  // 23: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
+	19,  // 24: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
+	20,  // 25: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
+	21,  // 26: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
+	22,  // 27: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
+	23,  // 28: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
+	135, // 29: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
+	1,   // 30: aggregator.TaskNode.type:type_name -> aggregator.NodeType
+	18,  // 31: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
+	19,  // 32: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
+	20,  // 33: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
+	21,  // 34: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
+	22,  // 35: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
+	26,  // 36: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
+	27,  // 37: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
+	28,  // 38: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
+	23,  // 39: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
+	24,  // 40: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
+	25,  // 41: aggregator.TaskNode.await:type_name -> aggregator.AwaitNode
+	7,   // 42: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
+	86,  // 43: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
+	88,  // 44: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
+	89,  // 45: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
+	137, // 46: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
+	6,   // 47: aggregator.Task.status:type_name -> aggregator.TaskStatus
+	17,  // 48: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 49: aggregator.Task.nodes:type_name -> aggregator.TaskNode
+	29,  // 50: aggregator.Task.edges:type_name -> aggregator.TaskEdge
+	138, // 51: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
+	17,  // 52: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 53: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 54: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
+	139, // 55: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
+	38,  // 56: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
+	32,  // 57: aggregator.ListTasksResp.items:type_name -> aggregator.Task
+	57,  // 58: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
+	31,  // 59: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
+	57,  // 60: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
+	7,   // 61: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
+	0,   // 62: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
+	98,  // 63: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 64: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 65: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 66: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 67: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	140, // 68: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
+	7,   // 69: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
+	137, // 70: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
+	58,  // 71: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
+	57,  // 72: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
+	30,  // 73: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
+	141, // 74: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	76,  // 75: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
+	145, // 76: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
+	145, // 77: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 78: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
+	108, // 79: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 80: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 81: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 82: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 83: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 84: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 85: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
+	134, // 86: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
+	136, // 87: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
+	127, // 88: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
+	17,  // 89: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
+	142, // 90: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
+	145, // 91: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
+	145, // 92: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 93: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
+	98,  // 94: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 95: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 96: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 97: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 98: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	17,  // 99: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 100: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 101: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
+	143, // 102: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
+	17,  // 103: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 104: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 105: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
+	144, // 106: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
+	82,  // 107: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
+	84,  // 108: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
+	82,  // 109: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
+	82,  // 110: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
+	82,  // 111: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
+	86,  // 112: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
+	86,  // 113: aggregator.ValueFee.fee:type_name -> aggregator.Fee
+	2,   // 114: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
+	86,  // 115: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
+	5,   // 116: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
+	87,  // 117: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
+	86,  // 118: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
+	88,  // 119: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
+	89,  // 120: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
+	90,  // 121: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
+	145, // 122: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 123: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 124: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 125: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
+	92,  // 126: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
+	100, // 127: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
+	99,  // 128: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
+	145, // 129: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 130: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
+	105, // 131: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
+	106, // 132: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
+	4,   // 133: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
+	145, // 134: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 135: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
+	145, // 136: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
+	110, // 137: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
+	145, // 138: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
+	145, // 139: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
+	145, // 140: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
+	145, // 141: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
+	145, // 142: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
+	113, // 143: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
+	117, // 144: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
+	145, // 145: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
+	120, // 146: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
+	145, // 147: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
+	123, // 148: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
+	145, // 149: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
+	145, // 150: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
+	4,   // 151: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
+	145, // 152: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
+	145, // 153: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
+	145, // 154: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
+	130, // 155: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	145, // 156: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	145, // 157: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	3,   // 158: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	145, // 159: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	5,   // 160: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
+	145, // 161: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	145, // 162: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	145, // 163: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	98,  // 164: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 165: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 166: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 167: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 168: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	108, // 169: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 170: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 171: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 172: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 173: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 174: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 175: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	134, // 176: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	136, // 177: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	127, // 178: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
+	145, // 179: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 180: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 181: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 182: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 183: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 184: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 185: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	186, // [186:186] is the sub-list for method output_type
+	186, // [186:186] is the sub-list for method input_type
+	186, // [186:186] is the sub-list for extension type_name
+	186, // [186:186] is the sub-list for extension extendee
+	0,   // [0:186] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }
@@ -10969,7 +11178,7 @@ func file_avs_proto_init() {
 		(*TaskTrigger_Block)(nil),
 		(*TaskTrigger_Event)(nil),
 	}
-	file_avs_proto_msgTypes[19].OneofWrappers = []any{
+	file_avs_proto_msgTypes[20].OneofWrappers = []any{
 		(*LoopNode_EthTransfer)(nil),
 		(*LoopNode_ContractWrite)(nil),
 		(*LoopNode_ContractRead)(nil),
@@ -10977,7 +11186,7 @@ func file_avs_proto_init() {
 		(*LoopNode_RestApi)(nil),
 		(*LoopNode_CustomCode)(nil),
 	}
-	file_avs_proto_msgTypes[21].OneofWrappers = []any{
+	file_avs_proto_msgTypes[22].OneofWrappers = []any{
 		(*TaskNode_EthTransfer)(nil),
 		(*TaskNode_ContractWrite)(nil),
 		(*TaskNode_ContractRead)(nil),
@@ -10988,17 +11197,18 @@ func file_avs_proto_init() {
 		(*TaskNode_Loop)(nil),
 		(*TaskNode_CustomCode)(nil),
 		(*TaskNode_Balance)(nil),
+		(*TaskNode_Await)(nil),
 	}
-	file_avs_proto_msgTypes[44].OneofWrappers = []any{
+	file_avs_proto_msgTypes[45].OneofWrappers = []any{
 		(*TriggerTaskReq_BlockTrigger)(nil),
 		(*TriggerTaskReq_FixedTimeTrigger)(nil),
 		(*TriggerTaskReq_CronTrigger)(nil),
 		(*TriggerTaskReq_EventTrigger)(nil),
 		(*TriggerTaskReq_ManualTrigger)(nil),
 	}
-	file_avs_proto_msgTypes[45].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[67].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[68].OneofWrappers = []any{
+	file_avs_proto_msgTypes[46].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[68].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[69].OneofWrappers = []any{
 		(*RunNodeWithInputsResp_EthTransfer)(nil),
 		(*RunNodeWithInputsResp_Graphql)(nil),
 		(*RunNodeWithInputsResp_ContractRead)(nil),
@@ -11010,22 +11220,22 @@ func file_avs_proto_init() {
 		(*RunNodeWithInputsResp_Loop)(nil),
 		(*RunNodeWithInputsResp_Balance)(nil),
 	}
-	file_avs_proto_msgTypes[70].OneofWrappers = []any{
+	file_avs_proto_msgTypes[71].OneofWrappers = []any{
 		(*RunTriggerResp_BlockTrigger)(nil),
 		(*RunTriggerResp_FixedTimeTrigger)(nil),
 		(*RunTriggerResp_CronTrigger)(nil),
 		(*RunTriggerResp_EventTrigger)(nil),
 		(*RunTriggerResp_ManualTrigger)(nil),
 	}
-	file_avs_proto_msgTypes[90].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[91].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[92].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[100].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[93].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[101].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[103].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[102].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[104].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[112].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[126].OneofWrappers = []any{
+	file_avs_proto_msgTypes[105].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[113].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[129].OneofWrappers = []any{
 		(*Execution_Step_BlockTrigger)(nil),
 		(*Execution_Step_FixedTimeTrigger)(nil),
 		(*Execution_Step_CronTrigger)(nil),
@@ -11048,7 +11258,7 @@ func file_avs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_avs_proto_rawDesc), len(file_avs_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   134,
+			NumMessages:   137,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -34,6 +34,7 @@ enum NodeType {
   NODE_TYPE_FILTER = 8;          // Filter node
   NODE_TYPE_LOOP = 9;            // Loop node
   NODE_TYPE_BALANCE = 10;        // Balance node for retrieving wallet token balances
+  NODE_TYPE_AWAIT = 11;          // Suspendable node: pause until a signal arrives (durable execution)
 }
 
 // ExecutionTier defines value-capture pricing groups for on-chain execution nodes.
@@ -584,8 +585,28 @@ message BalanceNode {
     google.protobuf.Value data = 1;
   }
 
-  // Include Config as field 
+  // Include Config as field
   Config config = 1;
+}
+
+// AwaitNode pauses the workflow until a signal arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
+// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
+// (cross-chain Await) and timer wakes follow.
+message AwaitNode {
+  message Config {
+    // External-signal wake parameters.
+    string channel = 1;             // "telegram" | "api"
+    repeated string approvers = 2;  // authorized parties; empty ⇒ the workflow owner
+    string prompt = 3;              // shown to the approver
+    uint32 timeout_seconds = 4;     // safety bound; 0 ⇒ server default (never an unbounded wait)
+  }
+  message Output {
+    // The delivered signal (decision + payload), readable by downstream steps.
+    google.protobuf.Value data = 1;
+  }
+  Config config = 1;
+  Output output = 2;
 }
 
 message BranchNode {
@@ -707,6 +728,8 @@ message TaskNode {
     CustomCodeNode    custom_code = 18;
     // Get token balances for a wallet address
     BalanceNode       balance = 19;
+    // Pause until a signal arrives (durable execution)
+    AwaitNode         await = 20;
   }
 }
 

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -606,7 +606,6 @@ message AwaitNode {
     google.protobuf.Value data = 1;
   }
   Config config = 1;
-  Output output = 2;
 }
 
 message BranchNode {


### PR DESCRIPTION
**Draft / WIP** — the first `Suspendable` node and its full API surface (design: `PLAN_DURABLE_EXECUTION.md`; builds on the durable engine in #643 + #644). This turns the durable machinery into a **usable, API-creatable feature**: a workflow can pause at an `Await` node and resume when a signal arrives — the human-approval gate for money-moving steps.

## What's here
**The node + intake (engine):**
- `AwaitNode` proto (`NODE_TYPE_AWAIT=11`, oneof `await=20`) — v1 external-signal flavor (human approval: `channel`/`approvers`/`prompt`/`timeoutSeconds`). chain-event + timer wakes follow.
- `vm_runner_await.go` — builds a `WakeSubscription` from config and `requestSuspend`; runs once on the suspend pass; bounded by `timeout` (default 24h, never unbounded). Wired into `executeNode`.
- `DeliverSignal(task, signal)` — the intake entrypoint a gateway approve/reject endpoint (or operator) calls → validate → `Advance()`.

**The API surface (so the SDK/studio can use it):**
- OpenAPI: `AwaitNode` + `AwaitNodeConfig` schemas; added to the Node union (discriminator + oneOf) and the `NodeType` enum. `make rest-gen`.
- REST mapping: `OpenAPIToProtoNode` (CreateWorkflow) + `ProtoToOpenAPINode` (GET/list render).
- `CreateNodeFromType` + `ExtractNodeConfiguration` (run-node/simulate path).

## Proof
- **End-to-end:** `[cc1 → await → cc2]` runs, the `Await` suspends after cc1, `DeliverSignal(approve)` resumes it through BadgerDB, cc2 runs, durable state GC'd.
- **API round-trip:** OpenAPI → proto → OpenAPI preserves the await config (channel/approvers/prompt/timeout).
- aggregator + taskengine suites green (122s); fresh-run parity held.

## Regen note
Adding the `await` enum value shifted oapi-codegen's naming of the single-value `BalanceNodeType` constant (`BalanceNodeTypeBalance` → `Balance`); its one reference in `node.go` was updated. Deterministic, not a toolchain bump.

## Not in this PR (next unit)
The signal **transport**: the gateway approve/reject HTTP endpoint (Telegram bot → `DeliverSignal`), the operator internal-trigger for chain-event `Await`, and approver **authorization** against the deploy-time binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
