### PR TITLE
feat: gateway signal endpoint — human-approval transport (durable execution step 3)

### DIFF
--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -29,6 +29,9 @@ type ServerInterface interface {
 	// Get execution status (lightweight, no steps)
 	// (GET /executions/{id}:getStatus)
 	GetExecutionStatus(ctx echo.Context, id Ulid, params GetExecutionStatusParams) error
+	// Deliver an approval/external signal to a waiting execution
+	// (POST /executions/{id}:signal)
+	SignalExecution(ctx echo.Context, id Ulid, params SignalExecutionParams) error
 	// Stream execution status changes (Server-Sent Events)
 	// (GET /executions/{id}:stream)
 	StreamExecution(ctx echo.Context, id Ulid, params StreamExecutionParams) error
@@ -218,6 +221,33 @@ func (w *ServerInterfaceWrapper) GetExecutionStatus(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.GetExecutionStatus(ctx, id, params)
+	return err
+}
+
+// SignalExecution converts echo context to params.
+func (w *ServerInterfaceWrapper) SignalExecution(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id Ulid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params SignalExecutionParams
+	// ------------- Required query parameter "workflowId" -------------
+
+	err = runtime.BindQueryParameter("form", true, true, "workflowId", ctx.QueryParams(), &params.WorkflowId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workflowId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.SignalExecution(ctx, id, params)
 	return err
 }
 
@@ -820,6 +850,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/executions", wrapper.ListExecutions)
 	router.GET(baseURL+"/executions/:id", wrapper.GetExecution)
 	router.GET(baseURL+"/executions/:id:getStatus", wrapper.GetExecutionStatus)
+	router.POST(baseURL+"/executions/:id:signal", wrapper.SignalExecution)
 	router.GET(baseURL+"/executions/:id:stream", wrapper.StreamExecution)
 	router.GET(baseURL+"/executions:count", wrapper.CountExecutions)
 	router.GET(baseURL+"/executions:stats", wrapper.ExecutionStats)
@@ -1028,6 +1059,58 @@ type GetExecutionStatus404ApplicationProblemPlusJSONResponse struct {
 }
 
 func (response GetExecutionStatus404ApplicationProblemPlusJSONResponse) VisitGetExecutionStatusResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecutionRequestObject struct {
+	Id     Ulid `json:"id"`
+	Params SignalExecutionParams
+	Body   *SignalExecutionJSONRequestBody
+}
+
+type SignalExecutionResponseObject interface {
+	VisitSignalExecutionResponse(w http.ResponseWriter) error
+}
+
+type SignalExecution200JSONResponse Execution
+
+func (response SignalExecution200JSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecution400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response SignalExecution400ApplicationProblemPlusJSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecution401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response SignalExecution401ApplicationProblemPlusJSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecution404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response SignalExecution404ApplicationProblemPlusJSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(404)
 
@@ -2138,6 +2221,9 @@ type StrictServerInterface interface {
 	// Get execution status (lightweight, no steps)
 	// (GET /executions/{id}:getStatus)
 	GetExecutionStatus(ctx context.Context, request GetExecutionStatusRequestObject) (GetExecutionStatusResponseObject, error)
+	// Deliver an approval/external signal to a waiting execution
+	// (POST /executions/{id}:signal)
+	SignalExecution(ctx context.Context, request SignalExecutionRequestObject) (SignalExecutionResponseObject, error)
 	// Stream execution status changes (Server-Sent Events)
 	// (GET /executions/{id}:stream)
 	StreamExecution(ctx context.Context, request StreamExecutionRequestObject) (StreamExecutionResponseObject, error)
@@ -2333,6 +2419,38 @@ func (sh *strictHandler) GetExecutionStatus(ctx echo.Context, id Ulid, params Ge
 		return err
 	} else if validResponse, ok := response.(GetExecutionStatusResponseObject); ok {
 		return validResponse.VisitGetExecutionStatusResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// SignalExecution operation middleware
+func (sh *strictHandler) SignalExecution(ctx echo.Context, id Ulid, params SignalExecutionParams) error {
+	var request SignalExecutionRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	var body SignalExecutionJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.SignalExecution(ctx.Request().Context(), request.(SignalExecutionRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "SignalExecution")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(SignalExecutionResponseObject); ok {
+		return validResponse.VisitSignalExecutionResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -200,6 +200,12 @@ const (
 	SecretScopeWorkflow SecretScope = "workflow"
 )
 
+// Defines values for SignalExecutionRequestDecision.
+const (
+	Approve SignalExecutionRequestDecision = "approve"
+	Reject  SignalExecutionRequestDecision = "reject"
+)
+
 // Defines values for TokenMetadataResponseSource.
 const (
 	Cache     TokenMetadataResponseSource = "cache"
@@ -1193,6 +1199,18 @@ type SecretList struct {
 	PageInfo PageInfo `json:"pageInfo"`
 }
 
+// SignalExecutionRequest defines model for SignalExecutionRequest.
+type SignalExecutionRequest struct {
+	// Decision The approver's decision.
+	Decision SignalExecutionRequestDecision `json:"decision"`
+
+	// Payload Optional structured data delivered as the await step's output.
+	Payload *map[string]interface{} `json:"payload,omitempty"`
+}
+
+// SignalExecutionRequestDecision The approver's decision.
+type SignalExecutionRequestDecision string
+
 // SimulateWorkflowRequest defines model for SimulateWorkflowRequest.
 type SimulateWorkflowRequest struct {
 	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
@@ -1515,6 +1533,12 @@ type GetExecutionStatusParams struct {
 	WorkflowId Ulid `form:"workflowId" json:"workflowId"`
 }
 
+// SignalExecutionParams defines parameters for SignalExecution.
+type SignalExecutionParams struct {
+	// WorkflowId Workflow id the execution belongs to. See `getExecution`.
+	WorkflowId Ulid `form:"workflowId" json:"workflowId"`
+}
+
 // StreamExecutionParams defines parameters for StreamExecution.
 type StreamExecutionParams struct {
 	Interval *string `form:"interval,omitempty" json:"interval,omitempty"`
@@ -1606,6 +1630,9 @@ type CountWorkflowsParams struct {
 
 // AuthExchangeJSONRequestBody defines body for AuthExchange for application/json ContentType.
 type AuthExchangeJSONRequestBody = AuthExchangeRequest
+
+// SignalExecutionJSONRequestBody defines body for SignalExecution for application/json ContentType.
+type SignalExecutionJSONRequestBody = SignalExecutionRequest
 
 // RunNodeJSONRequestBody defines body for RunNode for application/json ContentType.
 type RunNodeJSONRequestBody = RunNodeRequest

--- a/aggregator/rest/handlers_executions.go
+++ b/aggregator/rest/handlers_executions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/mapping"
@@ -91,6 +92,40 @@ func (s *Server) GetExecution(ctx echo.Context, id generated.Ulid, params genera
 		TaskId:      workflowID,
 		ExecutionId: string(id),
 	})
+	if err != nil {
+		return notFoundOrError(err)
+	}
+	resp, err := mapping.ProtoToOpenAPIExecution(exec, workflowID)
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// SignalExecution — POST /api/v1/executions/{id}:signal
+//
+// Delivers an approval/external signal to a WAITING execution (durable execution).
+// The caller must own the workflow; the engine's gate (DeliverSignal) rejects a
+// signal with no pending wait, a mismatched kind, or one that has timed out.
+func (s *Server) SignalExecution(ctx echo.Context, id generated.Ulid, params generated.SignalExecutionParams) error {
+	user, err := s.requireUser(ctx)
+	if err != nil {
+		return err
+	}
+	var body generated.SignalExecutionRequest
+	if err := ctx.Bind(&body); err != nil {
+		return badRequest("SIGNAL_BAD_REQUEST", "Invalid request body", err.Error())
+	}
+	var payload *structpb.Value
+	if body.Payload != nil {
+		p, perr := structpb.NewValue(map[string]interface{}(*body.Payload))
+		if perr != nil {
+			return badRequest("SIGNAL_BAD_PAYLOAD", "Invalid payload", perr.Error())
+		}
+		payload = p
+	}
+	workflowID := string(params.WorkflowId)
+	exec, err := s.engine.SignalExecution(user, workflowID, string(id), string(body.Decision), payload)
 	if err != nil {
 		return notFoundOrError(err)
 	}

--- a/aggregator/rest/handlers_executions.go
+++ b/aggregator/rest/handlers_executions.go
@@ -127,7 +127,10 @@ func (s *Server) SignalExecution(ctx echo.Context, id generated.Ulid, params gen
 	workflowID := string(params.WorkflowId)
 	exec, err := s.engine.SignalExecution(user, workflowID, string(id), string(body.Decision), payload)
 	if err != nil {
-		return notFoundOrError(err)
+		// SignalExecution returns gRPC status errors (NotFound / InvalidArgument /
+		// FailedPrecondition); the central ProblemErrorHandler maps them to the right
+		// HTTP status (404 vs 400), so don't force a 404 here.
+		return err
 	}
 	resp, err := mapping.ProtoToOpenAPIExecution(exec, workflowID)
 	if err != nil {

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -782,6 +782,19 @@ components:
           format: int64
           description: Safety bound; 0 = server default (the wait is never unbounded).
 
+    SignalExecutionRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          type: string
+          enum: [approve, reject]
+          description: The approver's decision.
+        payload:
+          type: object
+          additionalProperties: true
+          description: Optional structured data delivered as the await step's output.
+
     # ---- Node union ----
 
     Node:
@@ -2035,6 +2048,41 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ExecutionStatusSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /executions/{id}:signal:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/Ulid' }
+      - name: workflowId
+        in: query
+        required: true
+        description: Workflow id the execution belongs to. See `getExecution`.
+        schema: { $ref: '#/components/schemas/Ulid' }
+    post:
+      tags: [Executions]
+      summary: Deliver an approval/external signal to a waiting execution
+      description: |
+        Resumes a WAITING execution (durable execution). The caller must own the
+        workflow; the signal only counts against an actual pending wait whose kind
+        it matches and which has not timed out. v1 is the external-signal (human
+        approval) flavor — e.g. a Telegram approve/reject for a money-moving step.
+      operationId: signalExecution
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SignalExecutionRequest' }
+      responses:
+        '200':
+          description: The resumed (terminal or still-waiting) execution.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Execution' }
+        '400': { $ref: '#/components/responses/BadRequest' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '404': { $ref: '#/components/responses/NotFound' }
 

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -4292,28 +4292,35 @@ func (n *Engine) getExecutionStatusFromQueue(task *model.Workflow, executionID s
 	return &statusValue, nil
 }
 
-// GetExecution for a given task id and execution id
 // SignalExecution delivers an external/approval signal to a WAITING execution
 // (durable execution — the human-approval transport). The authenticated user must
-// own the workflow (GetWorkflow enforces ownership); the executor's DeliverSignal
-// then enforces the gate (a matching, un-timed-out wait must exist). Decision is
-// "approve" | "reject".
+// own the workflow (GetWorkflow → NotFound otherwise); the decision is validated
+// (InvalidArgument); and a DeliverSignal gate failure (no pending wait / mismatched
+// kind / timed out) is mapped to FailedPrecondition, so the REST layer returns a
+// 4xx rather than a 500. Decision is "approve" | "reject".
 func (n *Engine) SignalExecution(user *model.User, workflowID, executionID, decision string, payload *structpb.Value) (*avsproto.Execution, error) {
+	if decision != "approve" && decision != "reject" {
+		return nil, status.Errorf(codes.InvalidArgument, "decision must be 'approve' or 'reject', got %q", decision)
+	}
 	task, err := n.GetWorkflow(user, workflowID)
 	if err != nil {
-		return nil, err
+		return nil, err // GetWorkflow returns codes.NotFound for a missing/non-owned workflow
 	}
 	executor := NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
-	signal := &Signal{
+	exec, err := executor.DeliverSignal(task, &Signal{
 		ExecutionID: executionID,
 		Kind:        WakeExternalSignal,
 		Decision:    decision,
 		Approver:    strings.ToLower(user.Address.Hex()),
 		Payload:     payload,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "deliver signal: %v", err)
 	}
-	return executor.DeliverSignal(task, signal)
+	return exec, nil
 }
 
+// GetExecution for a given task id and execution id
 func (n *Engine) GetExecution(user *model.User, payload *avsproto.ExecutionReq) (*avsproto.Execution, error) {
 	task, err := n.GetWorkflow(user, payload.TaskId)
 	if err != nil {

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -4293,6 +4293,27 @@ func (n *Engine) getExecutionStatusFromQueue(task *model.Workflow, executionID s
 }
 
 // GetExecution for a given task id and execution id
+// SignalExecution delivers an external/approval signal to a WAITING execution
+// (durable execution — the human-approval transport). The authenticated user must
+// own the workflow (GetWorkflow enforces ownership); the executor's DeliverSignal
+// then enforces the gate (a matching, un-timed-out wait must exist). Decision is
+// "approve" | "reject".
+func (n *Engine) SignalExecution(user *model.User, workflowID, executionID, decision string, payload *structpb.Value) (*avsproto.Execution, error) {
+	task, err := n.GetWorkflow(user, workflowID)
+	if err != nil {
+		return nil, err
+	}
+	executor := NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
+	signal := &Signal{
+		ExecutionID: executionID,
+		Kind:        WakeExternalSignal,
+		Decision:    decision,
+		Approver:    strings.ToLower(user.Address.Hex()),
+		Payload:     payload,
+	}
+	return executor.DeliverSignal(task, signal)
+}
+
 func (n *Engine) GetExecution(user *model.User, payload *avsproto.ExecutionReq) (*avsproto.Execution, error) {
 	task, err := n.GetWorkflow(user, payload.TaskId)
 	if err != nil {

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -348,6 +348,19 @@ func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
 	assert.Nil(t, wakes[execID])
 }
 
+// TestSignalExecution_RequiresOwnedWorkflow proves the engine-level transport gate:
+// SignalExecution resolves the workflow via GetWorkflow (ownership), so a signal for
+// a non-owned/non-existent workflow is rejected before any resume. The full
+// resume path is covered by TestAwaitNode_SuspendThenSignal_EndToEnd + Advance tests.
+func TestSignalExecution_RequiresOwnedWorkflow(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	_, err := n.SignalExecution(testutil.TestUser1(), "nonexistent-workflow", "exec-1", "approve", nil)
+	require.Error(t, err, "signaling a non-owned/non-existent workflow must be rejected")
+}
+
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:
 // a node literally named a system var (apContext) must not be snapshotted, or a
 // resume could persist secrets to disk.

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -348,17 +350,27 @@ func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
 	assert.Nil(t, wakes[execID])
 }
 
-// TestSignalExecution_RequiresOwnedWorkflow proves the engine-level transport gate:
-// SignalExecution resolves the workflow via GetWorkflow (ownership), so a signal for
-// a non-owned/non-existent workflow is rejected before any resume. The full
-// resume path is covered by TestAwaitNode_SuspendThenSignal_EndToEnd + Advance tests.
-func TestSignalExecution_RequiresOwnedWorkflow(t *testing.T) {
+// TestSignalExecution_AuthGates proves the engine-level transport gates map to the
+// right gRPC codes (so the REST layer returns 400 vs 404, not 500): an invalid
+// decision is InvalidArgument; a signal from a non-owner is NotFound (the ownership
+// gate — User2 cannot signal User1's workflow). The full suspend→signal→resume path
+// is covered by TestAwaitNode_SuspendThenSignal_EndToEnd + the Advance tests.
+func TestSignalExecution_AuthGates(t *testing.T) {
 	db := testutil.TestMustDB()
 	defer db.Close()
 	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
 
-	_, err := n.SignalExecution(testutil.TestUser1(), "nonexistent-workflow", "exec-1", "approve", nil)
-	require.Error(t, err, "signaling a non-owned/non-existent workflow must be rejected")
+	// Invalid decision is rejected up front, before any workflow lookup.
+	_, err := n.SignalExecution(testutil.TestUser1(), "any-workflow", "exec-1", "maybe", nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err), "invalid decision → InvalidArgument")
+
+	// User1 owns a workflow; User2 must not be able to signal it.
+	created, err := n.CreateWorkflow(testutil.TestUser1(), testutil.RestTask())
+	require.NoError(t, err)
+	_, err = n.SignalExecution(testutil.TestUser2(), created.Id, "exec-1", "approve", nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err), "non-owner signal → NotFound (ownership gate)")
 }
 
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:


### PR DESCRIPTION
**Draft / WIP** — the human-approval transport for durable execution (design: `PLAN_DURABLE_EXECUTION.md`; builds on the `Await` node + `DeliverSignal` in #645). This is the HTTP endpoint a Telegram bot (or API client) hits to approve/reject a paused workflow, completing the priority flow: a money-moving step gated behind human approval.

## The flow (now end-to-end over HTTP)
Create a workflow with an `Await` node → it **suspends** at the gated step → the owner POSTs an approve → the workflow **resumes** and executes.

## What's here
- **OpenAPI:** `POST /executions/{id}:signal` (`operationId: signalExecution`) + `SignalExecutionRequest` schema (`decision: approve|reject`, optional `payload`). `make rest-gen`.
- **Handler `SignalExecution`:** `requireUser` → bind body → `engine.SignalExecution`.
- **`Engine.SignalExecution(user, workflowId, executionId, decision, payload)`:** `GetWorkflow` enforces **ownership** (only the owner can signal), builds an executor, and calls `DeliverSignal`, which enforces the **wait gate** (a matching, un-timed-out wait must exist).

## Gates
- **Ownership** — `GetWorkflow(user, workflowId)`; a non-owned/non-existent workflow is rejected.
- **Wait gate** (from #645) — the signal only counts against an actual pending wait whose kind it matches and which hasn't timed out.

## Proof
- `SignalExecution` rejects a non-owned/non-existent workflow (ownership gate test).
- The full suspend→signal→resume path is covered by the `Await` end-to-end + `Advance` tests in #645.
- aggregator + taskengine suites green (110s); fresh-run parity held.

## Not in this PR (the last transport item)
- **Operator internal-trigger** for chain-event `Await` (cross-chain wake) — the operator-side registry sync + `AggregateChecksResultWithState` routing.
- Finer **approver-list / Telegram-binding** authorization (v1 = the workflow owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
