### PR TITLE
feat: cross-chain Await — chain-event wake + operator internal-trigger + hardening

### DIFF
--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -272,8 +272,11 @@ type AuthExchangeResponse struct {
 
 // AwaitNode defines model for AwaitNode.
 type AwaitNode struct {
-	// Config Pauses the workflow until a signal arrives (durable execution). v1 is the
-	// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+	// Config Pauses the workflow until a wake arrives (durable execution). Two mutually
+	// exclusive flavors: the external-signal flavor (human approval — set `channel`,
+	// e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+	// `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+	// bridge arrival on another chain). Exactly one flavor must be configured.
 	Config *AwaitNodeConfig `json:"config,omitempty"`
 	Type   *AwaitNodeType   `json:"type,omitempty"`
 }
@@ -281,16 +284,24 @@ type AwaitNode struct {
 // AwaitNodeType defines model for AwaitNode.Type.
 type AwaitNodeType string
 
-// AwaitNodeConfig Pauses the workflow until a signal arrives (durable execution). v1 is the
-// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+// AwaitNodeConfig Pauses the workflow until a wake arrives (durable execution). Two mutually
+// exclusive flavors: the external-signal flavor (human approval — set `channel`,
+// e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+// `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+// bridge arrival on another chain). Exactly one flavor must be configured.
 type AwaitNodeConfig struct {
-	// Approvers Authorized approver identities. Empty = the workflow owner.
+	// Approvers External-signal flavor — authorized approver identities. Empty = the workflow owner.
 	Approvers *[]string `json:"approvers,omitempty"`
 
-	// Channel Signal channel: `telegram` or `api`.
-	Channel string `json:"channel"`
+	// ChainEvent Chain-event flavor — the on-chain event to wait for (a mid-workflow
+	// EventTrigger). An operator covering `chainEvent.chainId` watches it and
+	// resumes the execution when it fires. Mutually exclusive with `channel`.
+	ChainEvent *EventTriggerConfig `json:"chainEvent,omitempty"`
 
-	// Prompt Message shown to the approver.
+	// Channel External-signal flavor — signal channel: `telegram` or `api`.
+	Channel *string `json:"channel,omitempty"`
+
+	// Prompt External-signal flavor — message shown to the approver.
 	Prompt *string `json:"prompt,omitempty"`
 
 	// TimeoutSeconds Safety bound; 0 = server default (the wait is never unbounded).

--- a/aggregator/rest/mapping/node_test.go
+++ b/aggregator/rest/mapping/node_test.go
@@ -164,11 +164,12 @@ func TestNodeRoundTrip_PerNodeChainId(t *testing.T) {
 // round-trip (OpenAPI → proto → OpenAPI), so the SDK/studio can put it in a workflow.
 func TestNodeRoundTrip_Await(t *testing.T) {
 	typ := generated.AwaitNodeTypeAwait
+	channel := "telegram"
 	approvers := []string{"0xowner"}
 	prompt := "approve the transfer?"
 	timeout := int64(3600)
 	inner := generated.AwaitNode{Type: &typ, Config: &generated.AwaitNodeConfig{
-		Channel:        "telegram",
+		Channel:        &channel,
 		Approvers:      &approvers,
 		Prompt:         &prompt,
 		TimeoutSeconds: &timeout,
@@ -191,9 +192,47 @@ func TestNodeRoundTrip_Await(t *testing.T) {
 	require.NoError(t, err)
 	v, err := rt.AsAwaitNode()
 	require.NoError(t, err)
-	assert.Equal(t, "telegram", v.Config.Channel)
+	require.NotNil(t, v.Config.Channel)
+	assert.Equal(t, "telegram", *v.Config.Channel)
 	require.NotNil(t, v.Config.TimeoutSeconds)
 	assert.Equal(t, int64(3600), *v.Config.TimeoutSeconds)
+}
+
+// TestNodeRoundTrip_AwaitChainEvent proves the cross-chain (chain-event) flavor of
+// Await survives OpenAPI → proto → OpenAPI, including the nested EventTrigger config.
+func TestNodeRoundTrip_AwaitChainEvent(t *testing.T) {
+	typ := generated.AwaitNodeTypeAwait
+	timeout := int64(7200)
+	addrs := []generated.EthereumAddress{"0xbridge0000000000000000000000000000000000"}
+	topics := []string{"0xMessageReceived00000000000000000000000000000000000000000000000000"}
+	inner := generated.AwaitNode{Type: &typ, Config: &generated.AwaitNodeConfig{
+		TimeoutSeconds: &timeout,
+		ChainEvent: &generated.EventTriggerConfig{
+			ChainId: generated.ChainId(8453),
+			Queries: []generated.EventTriggerQuery{{Addresses: &addrs, Topics: &topics}},
+		},
+	}}
+	n := generated.Node{Id: "wait", Type: generated.NodeTypeAwait}
+	require.NoError(t, n.FromAwaitNode(inner))
+
+	// Inbound (CreateWorkflow path) — the chain-event config retargets into the proto.
+	pn, err := OpenAPIToProtoNode(n)
+	require.NoError(t, err)
+	cfg := pn.GetAwait().GetConfig()
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg.GetChannel(), "chain-event flavor has no channel")
+	require.NotNil(t, cfg.GetChainEvent())
+	assert.Equal(t, int64(8453), cfg.GetChainEvent().GetChainId())
+	require.Len(t, cfg.GetChainEvent().GetQueries(), 1)
+	assert.Equal(t, []string{"0xbridge0000000000000000000000000000000000"}, cfg.GetChainEvent().GetQueries()[0].GetAddresses())
+
+	// Outbound (GET/list render).
+	rt, err := ProtoToOpenAPINode(pn)
+	require.NoError(t, err)
+	v, err := rt.AsAwaitNode()
+	require.NoError(t, err)
+	require.NotNil(t, v.Config.ChainEvent)
+	assert.Equal(t, generated.ChainId(8453), v.Config.ChainEvent.ChainId)
 }
 
 func TestNodeRoundTrip_LoopWithCustomCodeRunner(t *testing.T) {

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -763,20 +763,28 @@ components:
     AwaitNodeConfig:
       type: object
       description: |
-        Pauses the workflow until a signal arrives (durable execution). v1 is the
-        external-signal flavor (human approval — e.g. a Telegram approve/reject).
-      required: [channel]
+        Pauses the workflow until a wake arrives (durable execution). Two mutually
+        exclusive flavors: the external-signal flavor (human approval — set `channel`,
+        e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+        `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+        bridge arrival on another chain). Exactly one flavor must be configured.
       properties:
         channel:
           type: string
-          description: 'Signal channel: `telegram` or `api`.'
+          description: 'External-signal flavor — signal channel: `telegram` or `api`.'
         approvers:
           type: array
           items: { type: string }
-          description: Authorized approver identities. Empty = the workflow owner.
+          description: External-signal flavor — authorized approver identities. Empty = the workflow owner.
         prompt:
           type: string
-          description: Message shown to the approver.
+          description: External-signal flavor — message shown to the approver.
+        chainEvent:
+          allOf: [{ $ref: '#/components/schemas/EventTriggerConfig' }]
+          description: |
+            Chain-event flavor — the on-chain event to wait for (a mid-workflow
+            EventTrigger). An operator covering `chainEvent.chainId` watches it and
+            resumes the execution when it fires. Mutually exclusive with `channel`.
         timeoutSeconds:
           type: integer
           format: int64

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -105,6 +105,12 @@ func (k WakeKind) String() string {
 type WakeSubscription struct {
 	Kind WakeKind `json:"kind"`
 
+	// TaskID is the workflow that owns the suspended execution. Carried here because
+	// executions are stored task-scoped (TaskExecutionKey) and there is no global
+	// exec→task index, so resuming from a wake (a chain-event notify or boot re-arm)
+	// needs the task to load the execution.
+	TaskID string `json:"taskId"`
+
 	// ChainEvent is the event filter the operator watches (chain = ChainEvent's
 	// chain_id). Set iff Kind == WakeChainEvent. Reuses the existing event-trigger
 	// config so the operator watches it with no new logic.
@@ -315,13 +321,14 @@ func wakeSubscriptionKey(execID string) []byte {
 // faithfully — plain encoding/json cannot serialize those.
 type persistedWake struct {
 	Kind       WakeKind            `json:"kind"`
+	TaskID     string              `json:"taskId"`
 	ChainEvent json.RawMessage     `json:"chainEvent,omitempty"`
 	External   *ExternalSignalSpec `json:"external,omitempty"`
 	TimeoutAt  int64               `json:"timeoutAt"`
 }
 
 func marshalWake(sub *WakeSubscription) ([]byte, error) {
-	rec := persistedWake{Kind: sub.Kind, External: sub.External, TimeoutAt: sub.TimeoutAt}
+	rec := persistedWake{Kind: sub.Kind, TaskID: sub.TaskID, External: sub.External, TimeoutAt: sub.TimeoutAt}
 	if sub.ChainEvent != nil {
 		b, err := protojson.Marshal(sub.ChainEvent)
 		if err != nil {
@@ -337,7 +344,7 @@ func unmarshalWake(b []byte) (*WakeSubscription, error) {
 	if err := json.Unmarshal(b, &rec); err != nil {
 		return nil, err
 	}
-	sub := &WakeSubscription{Kind: rec.Kind, External: rec.External, TimeoutAt: rec.TimeoutAt}
+	sub := &WakeSubscription{Kind: rec.Kind, TaskID: rec.TaskID, External: rec.External, TimeoutAt: rec.TimeoutAt}
 	if len(rec.ChainEvent) > 0 {
 		cfg := &avsproto.EventTrigger_Config{}
 		if err := protojson.Unmarshal(rec.ChainEvent, cfg); err != nil {

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -2231,6 +2231,23 @@ func (n *Engine) StreamCheckToOperator(payload *avsproto.SyncMessagesReq, srv av
 			tasksByTriggerType[triggerTypeName]++
 		}
 
+		// Internal triggers: synthetic single-shot event-watches standing in for
+		// WAITING executions' chain-event waits (cross-chain Await). Unlike user tasks
+		// (single-operator assignment), these BROADCAST to every operator covering the
+		// chain — any one firing resumes the execution and the aggregator dedups the
+		// rest. They flow through the same tracked-task + send path, so a boot or
+		// operator reconnect re-arms every live wait automatically.
+		for _, itrigger := range n.pendingChainEventTriggers() {
+			if _, ok := tracked[itrigger.Id]; ok {
+				continue
+			}
+			if !n.supportsTaskTrigger(address, itrigger) || !n.supportsTaskChain(address, itrigger) {
+				continue
+			}
+			tasksToStream = append(tasksToStream, itrigger)
+			tasksByTriggerType[itrigger.Trigger.String()]++
+		}
+
 		// Log task processing results
 		n.logger.Debug("🔍 Task processing completed for operator",
 			"operator", address,
@@ -2636,6 +2653,14 @@ func (n *Engine) AggregateChecksResultWithState(address string, payload *avsprot
 	// Update operator task tracking
 	if state, exists := n.trackSyncedTasks[address]; exists {
 		state.TaskID[payload.TaskId] = true
+	}
+
+	// Internal trigger (itrig_<execId>): an operator-watched chain event standing in
+	// for a suspended execution's chain-event wake. Route it to resume that execution
+	// rather than the normal task-execution path (it has no user workflow to enqueue).
+	if executionID, ok := parseInternalTriggerTaskID(payload.TaskId); ok {
+		n.lock.Unlock()
+		return n.deliverChainEventWake(executionID, payload)
 	}
 
 	// Get task information to determine execution state

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -575,6 +575,12 @@ func checkNodeChain(node *avsproto.TaskNode, check func(string, int64) error) er
 	if et := node.GetEthTransfer(); et != nil && et.Config != nil {
 		return check("eth transfer node", et.Config.GetChainId())
 	}
+	if await := node.GetAwait(); await != nil && await.Config != nil {
+		// Only the chain-event flavor is chain-aware; external-signal Awaits have no chain.
+		if ce := await.Config.GetChainEvent(); ce != nil {
+			return check("await node chain event", ce.GetChainId())
+		}
+	}
 	if loop := node.GetLoop(); loop != nil {
 		if cw := loop.GetContractWrite(); cw != nil && cw.Config != nil {
 			return check("loop contract write runner", cw.Config.GetChainId())
@@ -987,6 +993,7 @@ func (n *Engine) runOrphanScanLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			n.scanOrphanedTasks()
+			n.sweepExpiredWaits()
 		}
 	}
 }
@@ -1777,6 +1784,12 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 
 	// Reject chain-aware parts that name an explicit, unconfigured chain (G4).
 	if err := n.validateExplicitPartChains(task); err != nil {
+		return nil, err
+	}
+
+	// Reject a chain-event Await whose chain no operator currently covers — a wait
+	// that nothing could ever fire would never resume.
+	if err := n.validateAwaitOperatorCoverage(task); err != nil {
 		return nil, err
 	}
 

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -1001,6 +1001,53 @@ func (x *WorkflowExecutor) Advance(task *model.Workflow, executionID string, sig
 	return execution, nil
 }
 
+// ExpireWait fails a WAITING execution whose wake timed out, writing a terminal
+// (FAILED) record and GC'ing the durable state. Idempotent: a non-WAITING execution
+// just GCs any orphaned state. Mirrors Advance's finalize without running the VM —
+// nothing resumes, the wait simply expires.
+func (x *WorkflowExecutor) ExpireWait(task *model.Workflow, executionID string) (*avsproto.Execution, error) {
+	raw, err := x.db.GetKey(TaskExecutionKey(task, executionID))
+	if err != nil {
+		_ = deleteCheckpoint(x.db, executionID)
+		_ = deleteWakeSubscription(x.db, executionID)
+		return nil, fmt.Errorf("load execution %s: %w", executionID, err)
+	}
+	execution := &avsproto.Execution{}
+	if err := protojson.Unmarshal(raw, execution); err != nil {
+		return nil, fmt.Errorf("unmarshal execution %s: %w", executionID, err)
+	}
+	// Only a still-WAITING execution expires; otherwise just GC (a resume may have
+	// raced the sweep) and return the record as-is.
+	if execution.Status != avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING {
+		_ = deleteCheckpoint(x.db, executionID)
+		_ = deleteWakeSubscription(x.db, executionID)
+		return execution, nil
+	}
+
+	execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED
+	if execution.Error == "" {
+		execution.Error = "await timed out before a wake arrived"
+	}
+	execution.EndAt = time.Now().UnixMilli()
+	execution.ResumeNodeId = ""
+	execution.WaitReason = ""
+	sanitizeExecutionForPersistence(execution)
+
+	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	execBytes, err := mo.Marshal(execution)
+	if err != nil {
+		return nil, fmt.Errorf("marshal expired execution: %w", err)
+	}
+	if err := x.db.BatchWrite(map[string][]byte{
+		string(TaskExecutionKey(task, executionID)): execBytes,
+	}); err != nil {
+		return nil, fmt.Errorf("persist expired execution: %w", err)
+	}
+	_ = deleteCheckpoint(x.db, executionID)
+	_ = deleteWakeSubscription(x.db, executionID)
+	return execution, nil
+}
+
 // sanitizeExecutionForPersistence walks execution steps and replaces any NaN/Inf float
 // occurrences inside step output/config/metadata with safe JSON values (nil or 0).
 // NOTE: This function does NOT redact sensitive data - it only handles NaN/Inf for JSON compatibility.

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -838,6 +838,9 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	}
 	// 2. Armed markers: the wake subscription...
 	if susp.Wake != nil {
+		// Bind the wake to its task so a chain-event notify / boot re-arm can resolve
+		// the task (executions are stored task-scoped; no global exec→task index).
+		susp.Wake.TaskID = task.Id
 		if err := persistWakeSubscription(x.db, execution.Id, susp.Wake); err != nil {
 			return nil, fmt.Errorf("persist wake: %w", err)
 		}

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -28,7 +28,11 @@ func (n *Engine) validateAwaitOperatorCoverage(task *model.Workflow) error {
 		if ce == nil {
 			continue // external-signal flavor needs no operator
 		}
-		if len(n.operatorsCoveringChain(ce.GetChainId())) == 0 {
+		// operatorsCoveringChain reads trackSyncedTasks and requires n.lock.
+		n.lock.Lock()
+		covered := len(n.operatorsCoveringChain(ce.GetChainId()))
+		n.lock.Unlock()
+		if covered == 0 {
 			return status.Errorf(codes.FailedPrecondition,
 				"await node waits on chain_id=%d but no operator currently covers it; the wait could never fire", ce.GetChainId())
 		}
@@ -60,9 +64,14 @@ func (n *Engine) sweepExpiredWaits() {
 		}
 		task, err := n.GetWorkflowByID(wake.TaskID)
 		if err != nil {
-			// Task gone — GC the orphaned durable state and move on.
-			_ = deleteCheckpoint(n.db, executionID)
-			_ = deleteWakeSubscription(n.db, executionID)
+			// Only GC when the task is genuinely gone. On a corrupted/transient error,
+			// preserve the durable state so the problem stays diagnosable + recoverable.
+			if status.Code(err) == codes.NotFound {
+				_ = deleteCheckpoint(n.db, executionID)
+				_ = deleteWakeSubscription(n.db, executionID)
+			} else {
+				n.logger.Error("sweep expired waits: load task", "task_id", wake.TaskID, "execution_id", executionID, "error", err)
+			}
 			continue
 		}
 		if executor == nil {
@@ -72,7 +81,10 @@ func (n *Engine) sweepExpiredWaits() {
 			n.logger.Error("sweep expired waits: expire", "execution_id", executionID, "error", err)
 			continue
 		}
-		n.deregisterInternalTrigger(executionID)
+		// Deregistration only applies to chain-event waits (operator-watched triggers).
+		if wake.Kind == WakeChainEvent {
+			n.deregisterInternalTrigger(executionID)
+		}
 		n.logger.Info("expired timed-out wait", "execution_id", executionID, "task_id", wake.TaskID)
 	}
 }

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -1,0 +1,96 @@
+package taskengine
+
+import (
+	"strings"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// internalTriggerPrefix namespaces the synthetic task IDs that stand in for a
+// suspended execution's chain-event wake. Real task IDs are ULIDs (base32, no
+// underscore), so this prefix can never collide with a user workflow ID — and it
+// lets the notify path tell an internal-trigger notification apart from a normal
+// task one by the ID alone.
+const internalTriggerPrefix = "itrig_"
+
+// internalTriggerTaskID is the synthetic task ID an operator watches for a
+// chain-event wake. The execution ID is embedded so the operator's NotifyTriggers
+// round-trips straight back to the waiting execution.
+func internalTriggerTaskID(executionID string) string {
+	return internalTriggerPrefix + executionID
+}
+
+// parseInternalTriggerTaskID reports whether taskID is an internal-trigger ID and,
+// if so, returns the execution ID it carries.
+func parseInternalTriggerTaskID(taskID string) (executionID string, ok bool) {
+	if strings.HasPrefix(taskID, internalTriggerPrefix) {
+		return strings.TrimPrefix(taskID, internalTriggerPrefix), true
+	}
+	return "", false
+}
+
+// pendingChainEventTriggers builds one synthetic, single-shot EventTrigger "task"
+// per WAITING execution that is waiting on a chain event. They are streamed to
+// operators through the very same sync path as user tasks, so the operator watches
+// them with zero new transport. Re-derived from storage on every sync, so a boot or
+// operator reconnect re-arms every live wait for free.
+func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
+	wakes, err := loadAllWakeSubscriptions(n.db)
+	if err != nil {
+		n.logger.Error("internal-trigger sync: load wake subscriptions", "error", err)
+		return nil
+	}
+	out := make([]*model.Workflow, 0, len(wakes))
+	for executionID, wake := range wakes {
+		if wake.Kind != WakeChainEvent || wake.ChainEvent == nil {
+			continue
+		}
+		id := internalTriggerTaskID(executionID)
+		out = append(out, &model.Workflow{Task: &avsproto.Task{
+			Id:           id,
+			Status:       avsproto.TaskStatus_Enabled,
+			MaxExecution: 1,
+			ExpiredAt:    wake.TimeoutAt, // operator stops watching past the wait's timeout
+			Trigger: &avsproto.TaskTrigger{
+				Id:   id,
+				Name: "await",
+				TriggerType: &avsproto.TaskTrigger_Event{
+					Event: &avsproto.EventTrigger{Config: wake.ChainEvent},
+				},
+			},
+		}})
+	}
+	return out
+}
+
+// deliverChainEventWake routes an operator's notification for an internal trigger
+// (itrig_<execId>) to its suspended execution: resolve the task from the wake, build
+// a chain-event Signal from the matched event output, and advance the execution.
+// A duplicate or late fire is a safe no-op — the wake is gone once resumed, and
+// Advance only acts on a still-WAITING execution.
+func (n *Engine) deliverChainEventWake(executionID string, payload *avsproto.NotifyTriggersReq) (*ExecutionState, error) {
+	wake, err := loadWakeSubscription(n.db, executionID)
+	if err != nil {
+		// No pending wait — already resumed, timed out, or GC'd. Nothing to do.
+		return &ExecutionState{Status: "not_found", Message: "no pending wait for " + executionID}, nil
+	}
+	task, err := n.GetWorkflowByID(wake.TaskID)
+	if err != nil {
+		return &ExecutionState{Status: "not_found", Message: "task " + wake.TaskID + " for wake " + executionID + " not found"}, nil
+	}
+
+	var eventOutput *structpb.Value
+	if out, ok := ExtractTriggerOutput(payload.TriggerOutput).(*avsproto.EventTrigger_Output); ok && out != nil {
+		eventOutput = out.GetData()
+	}
+
+	executor := NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
+	signal := &Signal{ExecutionID: executionID, Kind: WakeChainEvent, Payload: eventOutput}
+	if _, err := executor.DeliverSignal(task, signal); err != nil {
+		n.logger.Error("internal-trigger wake: deliver signal", "execution_id", executionID, "error", err)
+		return &ExecutionState{Status: "error", Message: err.Error()}, err
+	}
+	return &ExecutionState{Status: "wake_delivered", TaskStillEnabled: true, Message: "resumed execution " + executionID}, nil
+}

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -2,11 +2,80 @@ package taskengine
 
 import (
 	"strings"
+	"time"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+// validateAwaitOperatorCoverage rejects, at create time, a chain-event Await whose
+// chain no operator currently covers — the wait could never be observed, so it would
+// never resume. Gateway-only (where operators advertise chain coverage); a transient
+// FailedPrecondition, not a malformed request, since coverage is connection state.
+func (n *Engine) validateAwaitOperatorCoverage(task *model.Workflow) error {
+	if n.config == nil || !n.config.IsGateway || task == nil {
+		return nil
+	}
+	for _, node := range task.Nodes {
+		await := node.GetAwait()
+		if await == nil || await.Config == nil {
+			continue
+		}
+		ce := await.Config.GetChainEvent()
+		if ce == nil {
+			continue // external-signal flavor needs no operator
+		}
+		if len(n.operatorsCoveringChain(ce.GetChainId())) == 0 {
+			return status.Errorf(codes.FailedPrecondition,
+				"await node waits on chain_id=%d but no operator currently covers it; the wait could never fire", ce.GetChainId())
+		}
+	}
+	return nil
+}
+
+// deregisterInternalTrigger tells operators to stop watching a consumed internal
+// trigger (the wake it stood for is gone). If the execution re-suspended on a new
+// chain-event wake, the next sync re-registers it (DeleteTask also untracks it).
+func (n *Engine) deregisterInternalTrigger(executionID string) {
+	n.notifyOperatorsTaskOperation(internalTriggerTaskID(executionID), avsproto.MessageOp_DeleteTask)
+}
+
+// sweepExpiredWaits fails WAITING executions whose wake timed out (a stuck bridge, an
+// approver who never responded) and GCs their durable state. Runs on the periodic
+// scan loop, so a wait whose timeout passed while no operator was up still resolves.
+func (n *Engine) sweepExpiredWaits() {
+	wakes, err := loadAllWakeSubscriptions(n.db)
+	if err != nil {
+		n.logger.Error("sweep expired waits: load wakes", "error", err)
+		return
+	}
+	now := time.Now().UnixMilli()
+	var executor *WorkflowExecutor
+	for executionID, wake := range wakes {
+		if wake.TimeoutAt <= 0 || wake.TimeoutAt > now {
+			continue
+		}
+		task, err := n.GetWorkflowByID(wake.TaskID)
+		if err != nil {
+			// Task gone — GC the orphaned durable state and move on.
+			_ = deleteCheckpoint(n.db, executionID)
+			_ = deleteWakeSubscription(n.db, executionID)
+			continue
+		}
+		if executor == nil {
+			executor = NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
+		}
+		if _, err := executor.ExpireWait(task, executionID); err != nil {
+			n.logger.Error("sweep expired waits: expire", "execution_id", executionID, "error", err)
+			continue
+		}
+		n.deregisterInternalTrigger(executionID)
+		n.logger.Info("expired timed-out wait", "execution_id", executionID, "task_id", wake.TaskID)
+	}
+}
 
 // internalTriggerPrefix namespaces the synthetic task IDs that stand in for a
 // suspended execution's chain-event wake. Real task IDs are ULIDs (base32, no
@@ -92,5 +161,8 @@ func (n *Engine) deliverChainEventWake(executionID string, payload *avsproto.Not
 		n.logger.Error("internal-trigger wake: deliver signal", "execution_id", executionID, "error", err)
 		return &ExecutionState{Status: "error", Message: err.Error()}, err
 	}
+	// The wake it watched is consumed — tell operators to stop. A re-suspend on a new
+	// chain-event wake re-registers via the next sync.
+	n.deregisterInternalTrigger(executionID)
 	return &ExecutionState{Status: "wake_delivered", TaskStillEnabled: true, Message: "resumed execution " + executionID}, nil
 }

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -3357,7 +3357,11 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 			}
 			awaitConfig.ChainEvent = eventConfig
 		}
-		if awaitConfig.Channel == "" && awaitConfig.ChainEvent == nil {
+		hasExternal := awaitConfig.Channel != "" || len(awaitConfig.Approvers) > 0 || awaitConfig.Prompt != ""
+		if awaitConfig.ChainEvent != nil && hasExternal {
+			return nil, fmt.Errorf("await node sets both 'chainEvent' and external-signal fields; they are mutually exclusive")
+		}
+		if !hasExternal && awaitConfig.ChainEvent == nil {
 			return nil, fmt.Errorf("await node requires either 'channel' (external signal) or 'chainEvent' (chain event)")
 		}
 		node.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: awaitConfig}}
@@ -3863,25 +3867,28 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 	case *avsproto.TaskNode_Await:
 		await := taskNode.GetAwait()
 		if await != nil && await.Config != nil {
-			approvers := make([]interface{}, len(await.Config.Approvers))
-			for i, a := range await.Config.Approvers {
-				approvers[i] = a
-			}
 			result := map[string]interface{}{
-				"channel":        await.Config.Channel,
-				"approvers":      approvers, // []interface{} so structpb.NewValue accepts it
-				"prompt":         await.Config.Prompt,
 				"timeoutSeconds": float64(await.Config.TimeoutSeconds),
 			}
-			// Chain-event flavor — re-encode via protojson so the nested config (and
-			// its well-known types) round-trips as clean JSON map types.
+			// Emit only the active flavor's fields (they are mutually exclusive), so
+			// the serialized config isn't a confusing mix of channel:"" + chainEvent.
 			if await.Config.ChainEvent != nil {
+				// Re-encode via protojson so the nested config (and its well-known
+				// types) round-trips as clean JSON map types.
 				if raw, err := protojson.Marshal(await.Config.ChainEvent); err == nil {
 					var chainEvent map[string]interface{}
 					if json.Unmarshal(raw, &chainEvent) == nil {
 						result["chainEvent"] = chainEvent
 					}
 				}
+			} else {
+				approvers := make([]interface{}, len(await.Config.Approvers))
+				for i, a := range await.Config.Approvers {
+					approvers[i] = a // []interface{} so structpb.NewValue accepts it
+				}
+				result["channel"] = await.Config.Channel
+				result["approvers"] = approvers
+				result["prompt"] = await.Config.Prompt
 			}
 			return result
 		}

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
@@ -3326,8 +3327,6 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 		awaitConfig := &avsproto.AwaitNode_Config{}
 		if channel, ok := config["channel"].(string); ok {
 			awaitConfig.Channel = channel
-		} else {
-			return nil, fmt.Errorf("await node requires 'channel' field")
 		}
 		if approvers, ok := config["approvers"].([]interface{}); ok {
 			for _, a := range approvers {
@@ -3344,6 +3343,22 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 				return nil, fmt.Errorf("await node 'timeoutSeconds' out of range: %v", timeout)
 			}
 			awaitConfig.TimeoutSeconds = uint32(timeout)
+		}
+		// Chain-event flavor — a nested EventTrigger config. protojson handles its
+		// well-known types (e.g. structpb in contract_abi) that plain decoding can't.
+		if chainEvent, ok := config["chainEvent"].(map[string]interface{}); ok {
+			raw, err := json.Marshal(chainEvent)
+			if err != nil {
+				return nil, fmt.Errorf("await node: marshal chainEvent: %w", err)
+			}
+			eventConfig := &avsproto.EventTrigger_Config{}
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(raw, eventConfig); err != nil {
+				return nil, fmt.Errorf("await node: invalid chainEvent: %w", err)
+			}
+			awaitConfig.ChainEvent = eventConfig
+		}
+		if awaitConfig.Channel == "" && awaitConfig.ChainEvent == nil {
+			return nil, fmt.Errorf("await node requires either 'channel' (external signal) or 'chainEvent' (chain event)")
 		}
 		node.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: awaitConfig}}
 	default:
@@ -3852,12 +3867,23 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 			for i, a := range await.Config.Approvers {
 				approvers[i] = a
 			}
-			return map[string]interface{}{
+			result := map[string]interface{}{
 				"channel":        await.Config.Channel,
 				"approvers":      approvers, // []interface{} so structpb.NewValue accepts it
 				"prompt":         await.Config.Prompt,
 				"timeoutSeconds": float64(await.Config.TimeoutSeconds),
 			}
+			// Chain-event flavor — re-encode via protojson so the nested config (and
+			// its well-known types) round-trips as clean JSON map types.
+			if await.Config.ChainEvent != nil {
+				if raw, err := protojson.Marshal(await.Config.ChainEvent); err == nil {
+					var chainEvent map[string]interface{}
+					if json.Unmarshal(raw, &chainEvent) == nil {
+						result["chainEvent"] = chainEvent
+					}
+				}
+			}
+			return result
 		}
 
 	case *avsproto.TaskNode_Branch:

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -350,6 +350,124 @@ func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
 	assert.Nil(t, wakes[execID])
 }
 
+// chainEventConfig is a small EventTrigger.Config fixture for chain-event Await tests.
+func chainEventConfig(chainID int64) *avsproto.EventTrigger_Config {
+	return &avsproto.EventTrigger_Config{
+		ChainId: chainID,
+		Queries: []*avsproto.EventTrigger_Query{{
+			Addresses: []string{"0xbridge0000000000000000000000000000000000"},
+			Topics:    []string{"0xMessageReceived00000000000000000000000000000000000000000000000000"},
+		}},
+	}
+}
+
+// TestAwaitNode_ChainEvent_SuspendThenResume proves the cross-chain flavor: an Await
+// with a chain_event config suspends with a WakeChainEvent subscription (carrying the
+// task id + event filter), and a chain-event Signal (the matched log) resumes it.
+func TestAwaitNode_ChainEvent_SuspendThenResume(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453), TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id:      "bridge-wf",
+		Trigger: trigger,
+		Nodes:   []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"},
+			{Id: "e1", Source: "cc1", Target: "wait"},
+			{Id: "e2", Source: "wait", Target: "cc2"},
+		},
+	}}
+
+	// Leg 1 — runs to the Await, then suspends on the chain event.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+	assert.Equal(t, WakeChainEvent, susp.Wake.Kind)
+	require.NotNil(t, susp.Wake.ChainEvent)
+	assert.Equal(t, int64(8453), susp.Wake.ChainEvent.GetChainId())
+
+	const execID = "exec-bridge-1"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+
+	// The persisted wake carries its task id (so a notify can resolve the task) + the event filter.
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.NotNil(t, wakes[execID])
+	assert.Equal(t, "bridge-wf", wakes[execID].TaskID)
+	assert.Equal(t, WakeChainEvent, wakes[execID].Kind)
+	require.NotNil(t, wakes[execID].ChainEvent)
+
+	// Leg 2 — the matched chain log arrives as a chain-event signal; the execution resumes.
+	eventData, err := structpb.NewValue(map[string]any{"amount": "1000", "messageId": "0xabc"})
+	require.NoError(t, err)
+	out, err := executor.DeliverSignal(task, &Signal{ExecutionID: execID, Kind: WakeChainEvent, Payload: eventData})
+	require.NoError(t, err)
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status, "resumed to terminal")
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "wait", "cc2"}, ids, "chain event resumed the workflow; cc2 ran")
+
+	wakes, err = loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID], "wake GC'd after resume")
+}
+
+// TestInternalTrigger_SyncAndRoute proves the operator-transport seam: a chain-event
+// wake surfaces as a synthetic event-trigger "task" (pendingChainEventTriggers) that
+// the operator sync streams, and an internal-trigger id round-trips so the notify
+// path can route it back. A notify with no live wake is a safe no-op.
+func TestInternalTrigger_SyncAndRoute(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	// id round-trip; a real ULID-style id is not mistaken for an internal trigger.
+	const execID = "exec-itrig-1"
+	id := internalTriggerTaskID(execID)
+	got, ok := parseInternalTriggerTaskID(id)
+	require.True(t, ok)
+	assert.Equal(t, execID, got)
+	_, ok = parseInternalTriggerTaskID("01HZY8M0000000000000000000")
+	assert.False(t, ok, "a normal task id is not an internal trigger")
+
+	// A persisted chain-event wake surfaces as a synthetic single-shot event trigger.
+	require.NoError(t, persistWakeSubscription(db, execID, &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "wf-1", ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
+	}))
+	// An external-signal wake must NOT surface (it's not operator-watched).
+	require.NoError(t, persistWakeSubscription(db, "exec-ext-1", &WakeSubscription{
+		Kind: WakeExternalSignal, TaskID: "wf-2", External: &ExternalSignalSpec{Channel: "telegram"}, TimeoutAt: 1 << 40,
+	}))
+
+	triggers := n.pendingChainEventTriggers()
+	require.Len(t, triggers, 1, "only the chain-event wake yields an internal trigger")
+	syn := triggers[0]
+	assert.Equal(t, id, syn.Id)
+	assert.Equal(t, int64(8453), syn.Trigger.GetEvent().GetConfig().GetChainId())
+	assert.Equal(t, int64(1<<40), syn.ExpiredAt)
+
+	// A notify for an execution with no live wake is a safe no-op, not an error.
+	state, err := n.deliverChainEventWake("exec-gone", &avsproto.NotifyTriggersReq{})
+	require.NoError(t, err)
+	assert.Equal(t, "not_found", state.Status)
+}
+
 // TestSignalExecution_AuthGates proves the engine-level transport gates map to the
 // right gRPC codes (so the REST layer returns 400 vs 404, not 500): an invalid
 // decision is InvalidArgument; a signal from a non-owner is NotFound (the ownership

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -428,6 +428,42 @@ func TestAwaitNode_ChainEvent_SuspendThenResume(t *testing.T) {
 	assert.Nil(t, wakes[execID], "wake GC'd after resume")
 }
 
+// TestAwaitNode_RejectsAmbiguousConfig proves the flavors are mutually exclusive: an
+// Await with both an external-signal channel and a chain_event fails rather than
+// silently picking one (and does not suspend).
+func TestAwaitNode_RejectsAmbiguousConfig(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", ChainEvent: chainEventConfig(8453)},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "ambig-wf", Trigger: trigger,
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await},
+		Edges: []*avsproto.TaskEdge{{Id: "e0", Source: "t", Target: "cc1"}, {Id: "e1", Source: "cc1", Target: "wait"}},
+	}}
+	vm, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm.Compile())
+	_ = vm.Run()
+
+	assert.Nil(t, vm.PendingSuspend(), "an ambiguous Await must not suspend")
+	var awaitStep *avsproto.Execution_Step
+	for _, s := range vm.ExecutionLogs {
+		if s.Id == "wait" {
+			awaitStep = s
+		}
+	}
+	require.NotNil(t, awaitStep, "the Await step is recorded")
+	assert.False(t, awaitStep.Success)
+	assert.Contains(t, awaitStep.Error, "mutually exclusive")
+}
+
 // TestAwaitNode_ChainEvent_ExpireOnTimeout proves the timeout sweep's finalize: a
 // WAITING execution whose wake timed out is failed and its durable state GC'd.
 func TestAwaitNode_ChainEvent_ExpireOnTimeout(t *testing.T) {

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -428,6 +428,112 @@ func TestAwaitNode_ChainEvent_SuspendThenResume(t *testing.T) {
 	assert.Nil(t, wakes[execID], "wake GC'd after resume")
 }
 
+// TestAwaitNode_ChainEvent_ExpireOnTimeout proves the timeout sweep's finalize: a
+// WAITING execution whose wake timed out is failed and its durable state GC'd.
+func TestAwaitNode_ChainEvent_ExpireOnTimeout(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453), TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "stuck-wf", Trigger: trigger,
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"},
+			{Id: "e1", Source: "cc1", Target: "wait"},
+			{Id: "e2", Source: "wait", Target: "cc2"},
+		},
+	}}
+
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+
+	const execID = "exec-stuck-1"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+
+	// The wait times out: expire it. cc2 never ran; the execution is FAILED, state GC'd.
+	out, err := executor.ExpireWait(task, execID)
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED, out.Status)
+	assert.Contains(t, out.Error, "timed out")
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "wait"}, ids, "cc2 did not run — the wait expired")
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID], "wake GC'd after expiry")
+
+	// Idempotent: expiring again just returns the terminal record.
+	again, err := executor.ExpireWait(task, execID)
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED, again.Status)
+}
+
+// TestSweepExpiredWaits_TimeGating proves the sweep only touches wakes past their
+// timeout, and GCs a wake whose task is gone (orphan).
+func TestSweepExpiredWaits_TimeGating(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	// A future wake is left alone; an expired orphan (task gone) is GC'd.
+	const farFuture = int64(99999999999999) // unix ms, ~year 5138
+	require.NoError(t, persistWakeSubscription(db, "exec-future", &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "wf-x", ChainEvent: chainEventConfig(8453), TimeoutAt: farFuture,
+	}))
+	require.NoError(t, persistWakeSubscription(db, "exec-expired-orphan", &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "wf-gone", ChainEvent: chainEventConfig(8453), TimeoutAt: 1,
+	}))
+
+	n.sweepExpiredWaits()
+
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.NotNil(t, wakes["exec-future"], "future wake untouched")
+	assert.Nil(t, wakes["exec-expired-orphan"], "expired orphan wake GC'd")
+}
+
+// TestValidateAwaitOperatorCoverage proves the create-time guard: a chain-event Await
+// whose chain no operator covers is rejected (gateway mode); an external-signal Await
+// has no chain and is fine.
+func TestValidateAwaitOperatorCoverage(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	cfg := testutil.GetAggregatorConfig()
+	cfg.IsGateway = true // the guard only runs in gateway mode
+	n := New(db, cfg, nil, testutil.GetLogger())
+
+	awaitNode := func(c *avsproto.AwaitNode_Config) *model.Workflow {
+		return &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{{
+			Id: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+			TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: c}},
+		}}}}
+	}
+
+	// Chain-event Await, no operator connected for the chain → rejected.
+	err := n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453)}))
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	// External-signal Await has no chain → allowed regardless of operators.
+	require.NoError(t, n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{Channel: "telegram"})))
+}
+
 // TestInternalTrigger_SyncAndRoute proves the operator-transport seam: a chain-event
 // wake surfaces as a synthetic event-trigger "task" (pendingChainEventTriggers) that
 // the operator sync streams, and an internal-trigger id round-trips so the notify

--- a/core/taskengine/vm_runner_await.go
+++ b/core/taskengine/vm_runner_await.go
@@ -38,14 +38,27 @@ func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error)
 	if timeoutSec <= 0 {
 		timeoutSec = defaultAwaitTimeoutSeconds
 	}
-	wake := &WakeSubscription{
-		Kind: WakeExternalSignal,
-		External: &ExternalSignalSpec{
-			Channel:   cfg.GetChannel(),
-			Approvers: cfg.GetApprovers(),
-			Prompt:    cfg.GetPrompt(),
-		},
-		TimeoutAt: t0.Add(time.Duration(timeoutSec) * time.Second).UnixMilli(),
+	timeoutAt := t0.Add(time.Duration(timeoutSec) * time.Second).UnixMilli()
+
+	// Two flavors: a chain-event wake (cross-chain — an operator watches the event)
+	// or an external-signal wake (human approval). chain_event selects the former.
+	var wake *WakeSubscription
+	if ev := cfg.GetChainEvent(); ev != nil {
+		wake = &WakeSubscription{
+			Kind:       WakeChainEvent,
+			ChainEvent: ev,
+			TimeoutAt:  timeoutAt,
+		}
+	} else {
+		wake = &WakeSubscription{
+			Kind: WakeExternalSignal,
+			External: &ExternalSignalSpec{
+				Channel:   cfg.GetChannel(),
+				Approvers: cfg.GetApprovers(),
+				Prompt:    cfg.GetPrompt(),
+			},
+			TimeoutAt: timeoutAt,
+		}
 	}
 	if err := wake.Validate(); err != nil {
 		// A misconfigured Await fails the step rather than suspending.
@@ -58,7 +71,11 @@ func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error)
 	v.requestSuspend(node.Id, wake)
 
 	step.Success = true
-	step.Log = fmt.Sprintf("awaiting external signal on channel %q", cfg.GetChannel())
+	if wake.Kind == WakeChainEvent {
+		step.Log = fmt.Sprintf("awaiting chain event on chain %d", wake.ChainEvent.GetChainId())
+	} else {
+		step.Log = fmt.Sprintf("awaiting external signal on channel %q", cfg.GetChannel())
+	}
 	step.EndAt = time.Now().UnixMilli()
 	return step, nil
 }

--- a/core/taskengine/vm_runner_await.go
+++ b/core/taskengine/vm_runner_await.go
@@ -34,6 +34,17 @@ func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error)
 		return step, err
 	}
 
+	// The two flavors are mutually exclusive — reject an ambiguous config rather than
+	// silently preferring one (the proto can't express the XOR).
+	hasExternal := cfg.GetChannel() != "" || len(cfg.GetApprovers()) > 0 || cfg.GetPrompt() != ""
+	if cfg.GetChainEvent() != nil && hasExternal {
+		err := fmt.Errorf("await node %s sets both chain_event and external-signal fields; they are mutually exclusive", node.Id)
+		step.Success = false
+		step.Error = err.Error()
+		step.EndAt = time.Now().UnixMilli()
+		return step, err
+	}
+
 	timeoutSec := int64(cfg.GetTimeoutSeconds())
 	if timeoutSec <= 0 {
 		timeoutSec = defaultAwaitTimeoutSeconds

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -9029,13 +9029,19 @@ func (x *BalanceNode_Output) GetData() *structpb.Value {
 
 type AwaitNode_Config struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// External-signal wake parameters.
+	// External-signal wake parameters (human-approval flavor). Used when chain_event
+	// is unset.
 	Channel        string   `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`                                      // "telegram" | "api"
 	Approvers      []string `protobuf:"bytes,2,rep,name=approvers,proto3" json:"approvers,omitempty"`                                  // authorized parties; empty ⇒ the workflow owner
 	Prompt         string   `protobuf:"bytes,3,opt,name=prompt,proto3" json:"prompt,omitempty"`                                        // shown to the approver
 	TimeoutSeconds uint32   `protobuf:"varint,4,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"` // safety bound; 0 ⇒ server default (never an unbounded wait)
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Chain-event wake (cross-chain flavor). When set, the Await pauses until an
+	// operator covering chain_event.chain_id observes this event — a mid-workflow
+	// EventTrigger (e.g. a bridge arrival on chain B). Reuses the event-trigger
+	// machinery; mutually exclusive with the external-signal fields above.
+	ChainEvent    *EventTrigger_Config `protobuf:"bytes,5,opt,name=chain_event,json=chainEvent,proto3" json:"chain_event,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AwaitNode_Config) Reset() {
@@ -9094,6 +9100,13 @@ func (x *AwaitNode_Config) GetTimeoutSeconds() uint32 {
 		return x.TimeoutSeconds
 	}
 	return 0
+}
+
+func (x *AwaitNode_Config) GetChainEvent() *EventTrigger_Config {
+	if x != nil {
+		return x.ChainEvent
+	}
+	return nil
 }
 
 type AwaitNode_Output struct {
@@ -10161,14 +10174,16 @@ const file_avs_proto_rawDesc = "" +
 	"\x13min_usd_value_cents\x18\x05 \x01(\x03R\x10minUsdValueCents\x12'\n" +
 	"\x0ftoken_addresses\x18\x06 \x03(\tR\x0etokenAddresses\x1a4\n" +
 	"\x06Output\x12*\n" +
-	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xfb\x01\n" +
+	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xbd\x02\n" +
 	"\tAwaitNode\x124\n" +
-	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x1a\x81\x01\n" +
+	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x1a\xc3\x01\n" +
 	"\x06Config\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1c\n" +
 	"\tapprovers\x18\x02 \x03(\tR\tapprovers\x12\x16\n" +
 	"\x06prompt\x18\x03 \x01(\tR\x06prompt\x12'\n" +
-	"\x0ftimeout_seconds\x18\x04 \x01(\rR\x0etimeoutSeconds\x1a4\n" +
+	"\x0ftimeout_seconds\x18\x04 \x01(\rR\x0etimeoutSeconds\x12@\n" +
+	"\vchain_event\x18\x05 \x01(\v2\x1f.aggregator.EventTrigger.ConfigR\n" +
+	"chainEvent\x1a4\n" +
 	"\x06Output\x12*\n" +
 	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\x96\x02\n" +
 	"\n" +
@@ -11117,43 +11132,44 @@ var file_avs_proto_depIdxs = []int32{
 	4,   // 150: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
 	145, // 151: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
 	145, // 152: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
-	145, // 153: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
-	130, // 154: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	145, // 155: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	145, // 156: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	3,   // 157: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	145, // 158: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	5,   // 159: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
-	145, // 160: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	145, // 161: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	145, // 162: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	98,  // 163: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	94,  // 164: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	96,  // 165: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	102, // 166: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	104, // 167: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	108, // 168: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	119, // 169: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	116, // 170: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	111, // 171: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	125, // 172: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	122, // 173: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	132, // 174: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	134, // 175: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	136, // 176: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	127, // 177: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
-	145, // 178: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 179: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 180: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	145, // 181: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 182: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	145, // 183: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 184: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	185, // [185:185] is the sub-list for method output_type
-	185, // [185:185] is the sub-list for method input_type
-	185, // [185:185] is the sub-list for extension type_name
-	185, // [185:185] is the sub-list for extension extendee
-	0,   // [0:185] is the sub-list for field type_name
+	101, // 153: aggregator.AwaitNode.Config.chain_event:type_name -> aggregator.EventTrigger.Config
+	145, // 154: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
+	130, // 155: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	145, // 156: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	145, // 157: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	3,   // 158: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	145, // 159: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	5,   // 160: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
+	145, // 161: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	145, // 162: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	145, // 163: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	98,  // 164: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 165: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 166: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 167: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 168: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	108, // 169: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 170: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 171: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 172: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 173: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 174: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 175: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	134, // 176: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	136, // 177: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	127, // 178: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
+	145, // 179: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 180: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 181: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 182: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 183: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 184: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 185: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	186, // [186:186] is the sub-list for method output_type
+	186, // [186:186] is the sub-list for method input_type
+	186, // [186:186] is the sub-list for extension type_name
+	186, // [186:186] is the sub-list for extension extendee
+	0,   // [0:186] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -595,11 +595,17 @@ message BalanceNode {
 // (cross-chain Await) and timer wakes follow.
 message AwaitNode {
   message Config {
-    // External-signal wake parameters.
+    // External-signal wake parameters (human-approval flavor). Used when chain_event
+    // is unset.
     string channel = 1;             // "telegram" | "api"
     repeated string approvers = 2;  // authorized parties; empty ⇒ the workflow owner
     string prompt = 3;              // shown to the approver
     uint32 timeout_seconds = 4;     // safety bound; 0 ⇒ server default (never an unbounded wait)
+    // Chain-event wake (cross-chain flavor). When set, the Await pauses until an
+    // operator covering chain_event.chain_id observes this event — a mid-workflow
+    // EventTrigger (e.g. a bridge arrival on chain B). Reuses the event-trigger
+    // machinery; mutually exclusive with the external-signal fields above.
+    EventTrigger.Config chain_event = 5;
   }
   message Output {
     // The delivered signal (decision + payload), readable by downstream steps.


### PR DESCRIPTION
**Draft / WIP** — the second wake source for durable execution: a **cross-chain `Await`** that pauses until an operator observes an on-chain event (e.g. a bridge arrival on another chain), then resumes the same execution against the same smart wallet. Builds on the human-approval transport (#646); design in `PLAN_DURABLE_EXECUTION.md` / `PLAN_CROSS_CHAIN_SEQUENCING.md` (P4.3–P4.4). The capstone of the durable-execution work.

```
[contractWrite chainId=A] → [Await chainEvent on B] → [contractWrite chainId=B]
   initiate bridge            operator watches B          act on bridged funds
```

## What's here (3 commits)
**1 — Engine transport.** The operator internal-trigger, reusing the existing event-trigger machinery (zero new transport):
- `AwaitNode.Config.chain_event` (`EventTrigger.Config`); `runAwait` branches to a `WakeChainEvent` subscription. Additive — storage-check clean.
- `WakeSubscription` gains `TaskID` (persisted) — executions are stored task-scoped with no global exec→task index, so a notify / boot re-arm needs it.
- `pendingChainEventTriggers()` surfaces each chain-event wake as a synthetic single-shot `itrig_<execId>` EventTrigger; `StreamCheckToOperator` **broadcasts** it to every operator covering the chain (re-armed on boot/reconnect for free); `AggregateChecksResultWithState` routes an `itrig_` notify → `deliverChainEventWake` → resolve task → `DeliverSignal(WakeChainEvent, matched-log)`. Duplicate/late fire = safe no-op.

**2 — API surface.** `chainEvent` in OpenAPI `AwaitNodeConfig` (`$ref` `EventTriggerConfig`; `channel` no longer required — the two flavors are mutually exclusive). REST mapping needs no code change (`jsonRetargetProto` round-trips the nested config via protojson). `CreateNodeFromType`/`ExtractNodeConfiguration` updated for the run-node path.

**3 — Hardening (P4.4).**
- **Coverage validation** — a chain-event Await whose chain no operator covers is rejected at create (`FailedPrecondition`). A wait nothing could fire never gets registered.
- **Deregistration** — on resume, operators are told to stop (`MessageOp_DeleteTask`); a re-suspend on a new wake re-registers via the next sync.
- **Timeout sweep** — the periodic scan loop fails `WAITING` executions whose wake timed out (`ExpireWait`: terminal `FAILED` + GC, idempotent) and deregisters them; orphan wakes GC'd. Catches waits that expired while no operator was up.

## Proof
Tests at every seam: chain-event suspend→resume end-to-end (wake carries task id + filter; cc2 runs after the event); sync/route seam (synthetic trigger + id round-trip + no-op on missing wake); OpenAPI↔proto round-trip of the nested event config; expire-on-timeout (FAILED + GC, idempotent); sweep time-gating + orphan GC; coverage reject vs. external-signal allow. storage-check clean (additive); taskengine + aggregator suites green (~98s).

## Notes
- Removing `required: [channel]` makes generated `AwaitNodeConfig.Channel` a `*string` — SDK regenerates; mapping uses `jsonRetarget` so no Go call sites changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
