### PR TITLE
fix: surface WAITING execution status over REST (was masked as pending)

### DIFF
--- a/SDK_HANDOFF_DURABLE_EXECUTION.md
+++ b/SDK_HANDOFF_DURABLE_EXECUTION.md
@@ -67,12 +67,14 @@ Chain-event awaits are **not** resumed through this endpoint — an operator fir
 
 ---
 
-## The `WAITING` lifecycle (important for polling/streaming)
+## The `waiting` lifecycle (important for polling/streaming)
 
-`EXECUTION_STATUS_WAITING` is **non-terminal**. Any SDK helper that "waits for an execution to finish" must treat `WAITING` as *keep waiting*, not done:
+Over REST the status is the lowercase wire value **`"waiting"`** (the generated `ExecutionStatus` union member; proto enum `EXECUTION_STATUS_WAITING`). It is **non-terminal**. Any SDK helper that "waits for an execution to finish" must treat `"waiting"` as *keep waiting*, not done:
 
-- `executions.get` / the SSE stream will report `WAITING` while paused, then a terminal status (`SUCCESS` / `FAILED` / `ERROR`) once resumed (or `FAILED` with "await timed out…" if the timeout sweep fires).
-- A `waitForExecution`-style util that currently stops on "any status set" or "not PENDING" will return early on `WAITING` — update its terminal-status predicate to exclude `WAITING`.
+- `executions.get` / the SSE stream report `"waiting"` while paused, then a terminal status (`"success"` / `"failed"` / `"error"`) once resumed (or `"failed"` with "await timed out…" if the timeout sweep fires).
+- A `waitForExecution`-style util that currently stops on "any status set" or "not `pending`" will return early on `"waiting"` — update its terminal-status predicate to exclude `"waiting"`.
+
+> Note: `"waiting"` was added to the OpenAPI `ExecutionStatus` enum and the REST wire mapping together with this hand-off — before that fix a paused execution surfaced as `"pending"` over REST. Make sure your `openapi-download` is current.
 
 ---
 
@@ -116,7 +118,7 @@ signal(
 }
 ```
 
-**3. WAITING-aware wait/stream** — update the terminal-status predicate in any execution-completion helper to exclude `EXECUTION_STATUS_WAITING`.
+**3. WAITING-aware wait/stream** — update the terminal-status predicate in any execution-completion helper to exclude `"waiting"`.
 
 ---
 

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -90,6 +90,7 @@ const (
 	ExecutionStatusFailed  ExecutionStatus = "failed"
 	ExecutionStatusPending ExecutionStatus = "pending"
 	ExecutionStatusSuccess ExecutionStatus = "success"
+	ExecutionStatusWaiting ExecutionStatus = "waiting"
 )
 
 // Defines values for ExecutionTier.
@@ -708,8 +709,12 @@ type Execution struct {
 	Index   *int64 `json:"index,omitempty"`
 	StartAt int64  `json:"startAt"`
 
-	// Status Outcome of an execution. `pending` is in-flight; `success` is full
-	// success; `failed` is logical failure (e.g., a node returned an error);
+	// Status Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+	// mid-workflow at an `await` node, durably parked until a signal arrives
+	// (a human approve/reject or an operator-observed chain event) or the wait
+	// times out — non-terminal, like `pending`, but distinguishable so a client
+	// can show "awaiting approval"; `success` is full success; `failed` is
+	// logical failure (e.g., a node returned an error, or a wait timed out);
 	// `error` is a system / infrastructure failure (e.g., RPC unreachable).
 	Status   ExecutionStatus  `json:"status"`
 	Steps    *[]ExecutionStep `json:"steps,omitempty"`
@@ -740,8 +745,12 @@ type ExecutionStats struct {
 	Total            int64    `json:"total"`
 }
 
-// ExecutionStatus Outcome of an execution. `pending` is in-flight; `success` is full
-// success; `failed` is logical failure (e.g., a node returned an error);
+// ExecutionStatus Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+// mid-workflow at an `await` node, durably parked until a signal arrives
+// (a human approve/reject or an operator-observed chain event) or the wait
+// times out — non-terminal, like `pending`, but distinguishable so a client
+// can show "awaiting approval"; `success` is full success; `failed` is
+// logical failure (e.g., a node returned an error, or a wait timed out);
 // `error` is a system / infrastructure failure (e.g., RPC unreachable).
 type ExecutionStatus string
 
@@ -754,8 +763,12 @@ type ExecutionStatusSummary struct {
 	Id      Ulid   `json:"id"`
 	StartAt *int64 `json:"startAt,omitempty"`
 
-	// Status Outcome of an execution. `pending` is in-flight; `success` is full
-	// success; `failed` is logical failure (e.g., a node returned an error);
+	// Status Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+	// mid-workflow at an `await` node, durably parked until a signal arrives
+	// (a human approve/reject or an operator-observed chain event) or the wait
+	// times out — non-terminal, like `pending`, but distinguishable so a client
+	// can show "awaiting approval"; `success` is full success; `failed` is
+	// logical failure (e.g., a node returned an error, or a wait timed out);
 	// `error` is a system / infrastructure failure (e.g., RPC unreachable).
 	Status ExecutionStatus `json:"status"`
 
@@ -1308,8 +1321,12 @@ type TriggerWorkflowResponse struct {
 	ExecutionId Ulid   `json:"executionId"`
 	StartAt     *int64 `json:"startAt,omitempty"`
 
-	// Status Outcome of an execution. `pending` is in-flight; `success` is full
-	// success; `failed` is logical failure (e.g., a node returned an error);
+	// Status Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+	// mid-workflow at an `await` node, durably parked until a signal arrives
+	// (a human approve/reject or an operator-observed chain event) or the wait
+	// times out — non-terminal, like `pending`, but distinguishable so a client
+	// can show "awaiting approval"; `success` is full success; `failed` is
+	// logical failure (e.g., a node returned an error, or a wait timed out);
 	// `error` is a system / infrastructure failure (e.g., RPC unreachable).
 	Status ExecutionStatus `json:"status"`
 }

--- a/aggregator/rest/handlers_executions.go
+++ b/aggregator/rest/handlers_executions.go
@@ -163,7 +163,7 @@ func (s *Server) GetExecutionStatus(ctx echo.Context, id generated.Ulid, params 
 	// the terminal state via GetExecution.
 	out := generated.ExecutionStatusSummary{
 		Id:     id,
-		Status: generated.ExecutionStatus(executionStatusToWire(statusResp.GetStatus())),
+		Status: generated.ExecutionStatus(mapping.ExecutionStatusProtoToWire(statusResp.GetStatus())),
 	}
 	wid := generated.Ulid(workflowID)
 	out.WorkflowId = &wid
@@ -260,7 +260,7 @@ func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params gen
 			}
 			return false, nil
 		}
-		current := executionStatusToWire(exec.GetStatus())
+		current := mapping.ExecutionStatusProtoToWire(exec.GetStatus())
 		if current != lastStatus {
 			if err := emit(current, exec); err != nil {
 				return true, err
@@ -297,24 +297,6 @@ func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params gen
 				return nil
 			}
 		}
-	}
-}
-
-// executionStatusToWire mirrors the helper in the workflows handler
-// but lives here too because the executions package uses it on every
-// poll and the workflows file is already large.
-func executionStatusToWire(s avsproto.ExecutionStatus) string {
-	switch s {
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:
-		return "pending"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:
-		return "success"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:
-		return "failed"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:
-		return "error"
-	default:
-		return "pending"
 	}
 }
 

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -255,7 +255,7 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 	// translate to a lowercase string.
 	out := generated.TriggerWorkflowResponse{
 		ExecutionId: generated.Ulid(resp.GetExecutionId()),
-		Status:      generated.ExecutionStatus(protoExecStatusToOpenAPI(resp.GetStatus())),
+		Status:      generated.ExecutionStatus(mapping.ExecutionStatusProtoToWire(resp.GetStatus())),
 	}
 	if v := resp.GetStartAt(); v != 0 {
 		out.StartAt = &v
@@ -591,21 +591,4 @@ func openAPIInputVarsToProto(in generated.InputVariables) (map[string]*structpb.
 		out[k] = pv
 	}
 	return out, nil
-}
-
-// protoExecStatusToOpenAPI maps the proto ExecutionStatus enum that
-// TriggerTaskResp returns to the lowercase string used on the wire.
-func protoExecStatusToOpenAPI(s avsproto.ExecutionStatus) string {
-	switch s {
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:
-		return "pending"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:
-		return "success"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:
-		return "failed"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:
-		return "error"
-	default:
-		return "pending"
-	}
 }

--- a/aggregator/rest/mapping/execution.go
+++ b/aggregator/rest/mapping/execution.go
@@ -241,6 +241,8 @@ func executionStatusProtoToWire(s avsproto.ExecutionStatus) string {
 	switch s {
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:
 		return "pending"
+	case avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING:
+		return "waiting"
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:
 		return "success"
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:

--- a/aggregator/rest/mapping/execution.go
+++ b/aggregator/rest/mapping/execution.go
@@ -239,6 +239,9 @@ func normalizeStepType(t string) string {
 // lowercase wire vocabulary used by the OpenAPI spec.
 func executionStatusProtoToWire(s avsproto.ExecutionStatus) string {
 	switch s {
+	case avsproto.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED:
+		// Zero value — status not yet set; treat as in-flight.
+		return "pending"
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:
 		return "pending"
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING:
@@ -250,6 +253,10 @@ func executionStatusProtoToWire(s avsproto.ExecutionStatus) string {
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:
 		return "error"
 	default:
-		return "pending"
+		// Every defined enum value has an explicit case above (guarded by the
+		// mapping test). A value reaching here is an unknown/future enum — surface
+		// it as "error" rather than masquerading it as in-flight "pending" (that
+		// silent default is exactly what once hid WAITING).
+		return "error"
 	}
 }

--- a/aggregator/rest/mapping/execution.go
+++ b/aggregator/rest/mapping/execution.go
@@ -25,7 +25,7 @@ func ProtoToOpenAPIExecution(in *avsproto.Execution, workflowID string) (generat
 		Id:         generated.Ulid(in.GetId()),
 		WorkflowId: generated.Ulid(workflowID),
 		StartAt:    in.GetStartAt(),
-		Status:     generated.ExecutionStatus(executionStatusProtoToWire(in.GetStatus())),
+		Status:     generated.ExecutionStatus(ExecutionStatusProtoToWire(in.GetStatus())),
 	}
 	if v := in.GetEndAt(); v != 0 {
 		out.EndAt = &v
@@ -85,13 +85,16 @@ func ProtoToOpenAPIExecution(in *avsproto.Execution, workflowID string) (generat
 	return out, nil
 }
 
-// ProtoExecutionToOpenAPISummary lifts an Execution into the lightweight
-// status summary returned by the GetExecutionStatus and StreamExecution
-// endpoints. Skips the steps/cogs/fee payload to keep responses small.
+// ProtoExecutionToOpenAPISummary lifts a full Execution into the lightweight
+// status summary shape (skips the steps/cogs/fee payload to keep responses
+// small). Status goes through the shared ExecutionStatusProtoToWire so every
+// status surface stays consistent. NOTE: the GetExecutionStatus handler builds
+// this shape inline (it has only the status enum, not a full Execution), so it
+// does not call this helper — keep the two in sync if you change the shape.
 func ProtoExecutionToOpenAPISummary(in *avsproto.Execution, workflowID string) generated.ExecutionStatusSummary {
 	out := generated.ExecutionStatusSummary{
 		Id:     generated.Ulid(in.GetId()),
-		Status: generated.ExecutionStatus(executionStatusProtoToWire(in.GetStatus())),
+		Status: generated.ExecutionStatus(ExecutionStatusProtoToWire(in.GetStatus())),
 	}
 	if v := in.GetStartAt(); v != 0 {
 		out.StartAt = &v
@@ -235,9 +238,9 @@ func normalizeStepType(t string) string {
 	return t
 }
 
-// executionStatusProtoToWire normalizes ExecutionStatus enum names to the
+// ExecutionStatusProtoToWire normalizes ExecutionStatus enum names to the
 // lowercase wire vocabulary used by the OpenAPI spec.
-func executionStatusProtoToWire(s avsproto.ExecutionStatus) string {
+func ExecutionStatusProtoToWire(s avsproto.ExecutionStatus) string {
 	switch s {
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED:
 		// Zero value — status not yet set; treat as in-flight.

--- a/aggregator/rest/mapping/execution_status_test.go
+++ b/aggregator/rest/mapping/execution_status_test.go
@@ -30,8 +30,8 @@ func TestExecutionStatusProtoToWire(t *testing.T) {
 		s := avsproto.ExecutionStatus(v)
 		want, ok := expected[s]
 		require.Truef(t, ok, "ExecutionStatus %s has no proto→wire mapping/test entry", s)
-		assert.Equal(t, want, executionStatusProtoToWire(s), s.String())
+		assert.Equal(t, want, ExecutionStatusProtoToWire(s), s.String())
 	}
 	// The waiting wire value is a member of the generated OpenAPI enum (no drift).
-	assert.Equal(t, string(generated.ExecutionStatusWaiting), executionStatusProtoToWire(avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING))
+	assert.Equal(t, string(generated.ExecutionStatusWaiting), ExecutionStatusProtoToWire(avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING))
 }

--- a/aggregator/rest/mapping/execution_status_test.go
+++ b/aggregator/rest/mapping/execution_status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
@@ -11,18 +12,26 @@ import (
 
 // TestExecutionStatusProtoToWire pins the proto→wire status vocabulary, including the
 // durable-execution WAITING state — without an explicit case it would fall through to
-// "pending" and a client could not tell "awaiting approval" from "in-flight".
+// the default and a client could not tell "awaiting approval" from "in-flight". The
+// coverage loop fails if a new ExecutionStatus enum value is added without a mapping
+// (exactly the miss that once let WAITING surface as "pending").
 func TestExecutionStatusProtoToWire(t *testing.T) {
-	cases := map[avsproto.ExecutionStatus]string{
-		avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING: "pending",
-		avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING: "waiting",
-		avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS: "success",
-		avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:  "failed",
-		avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:   "error",
+	expected := map[avsproto.ExecutionStatus]string{
+		avsproto.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED: "pending",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:     "pending",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING:     "waiting",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:     "success",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:      "failed",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:       "error",
 	}
-	for in, want := range cases {
-		assert.Equal(t, want, executionStatusProtoToWire(in), in.String())
+	// Every defined proto enum value must have an explicit, asserted mapping — a new
+	// value with no entry here fails the test instead of silently hitting the default.
+	for v := range avsproto.ExecutionStatus_name {
+		s := avsproto.ExecutionStatus(v)
+		want, ok := expected[s]
+		require.Truef(t, ok, "ExecutionStatus %s has no proto→wire mapping/test entry", s)
+		assert.Equal(t, want, executionStatusProtoToWire(s), s.String())
 	}
-	// The wire value is a member of the generated OpenAPI enum (no drift).
+	// The waiting wire value is a member of the generated OpenAPI enum (no drift).
 	assert.Equal(t, string(generated.ExecutionStatusWaiting), executionStatusProtoToWire(avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING))
 }

--- a/aggregator/rest/mapping/execution_status_test.go
+++ b/aggregator/rest/mapping/execution_status_test.go
@@ -1,0 +1,28 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestExecutionStatusProtoToWire pins the proto→wire status vocabulary, including the
+// durable-execution WAITING state — without an explicit case it would fall through to
+// "pending" and a client could not tell "awaiting approval" from "in-flight".
+func TestExecutionStatusProtoToWire(t *testing.T) {
+	cases := map[avsproto.ExecutionStatus]string{
+		avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING: "pending",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING: "waiting",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS: "success",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:  "failed",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:   "error",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, executionStatusProtoToWire(in), in.String())
+	}
+	// The wire value is a member of the generated OpenAPI enum (no drift).
+	assert.Equal(t, string(generated.ExecutionStatusWaiting), executionStatusProtoToWire(avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING))
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1115,12 +1115,17 @@ components:
       type: string
       enum:
         - pending
+        - waiting
         - success
         - failed
         - error
       description: |
-        Outcome of an execution. `pending` is in-flight; `success` is full
-        success; `failed` is logical failure (e.g., a node returned an error);
+        Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+        mid-workflow at an `await` node, durably parked until a signal arrives
+        (a human approve/reject or an operator-observed chain event) or the wait
+        times out — non-terminal, like `pending`, but distinguishable so a client
+        can show "awaiting approval"; `success` is full success; `failed` is
+        logical failure (e.g., a node returned an error, or a wait timed out);
         `error` is a system / infrastructure failure (e.g., RPC unreachable).
 
     Fee:


### PR DESCRIPTION
**Draft** — closes a gap found in review of the durable-execution SDK hand-off.

## The gap
A paused (durable-execution) execution is `EXECUTION_STATUS_WAITING` in the engine, but the REST layer never mapped it:
- `executionStatusProtoToWire` had no `WAITING` case → fell through to `"pending"`.
- The OpenAPI `ExecutionStatus` enum omitted it (`pending | success | failed | error`).

**Net effect:** a client couldn't distinguish "awaiting approval / chain event" from an ordinary in-flight `"pending"` execution. The feature still worked (polling helpers keep waiting either way), but the `WAITING` state was invisible to consumers.

## Fix
- OpenAPI `ExecutionStatus` enum gains `"waiting"` (+ description); `make rest-gen` → `generated.ExecutionStatusWaiting`.
- `executionStatusProtoToWire` maps `EXECUTION_STATUS_WAITING` → `"waiting"`.
- Test pins the full proto→wire vocabulary incl. `WAITING`, with an enum-drift guard against the generated constant.
- SDK hand-off doc updated: the lifecycle section now states the wire value is `"waiting"` and notes this fix.

storage-check clean (enum addition is additive); aggregator suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
