### PR TITLE
feat: durable execution engine — Await node, signal API, cross-chain wake

### DIFF
--- a/PLAN_CHAIN_DECOUPLING.md
+++ b/PLAN_CHAIN_DECOUPLING.md
@@ -34,8 +34,9 @@ Backend gaps (this repo):
 - [x] **OpenAPI renovation** — removed `Workflow.chainId` / `CreateWorkflowRequest.chainId` + the `ChainIdQuery` param on list/count/executions; per-part config `chainId` now `required` — **merged #634**
 - [x] **Executor cross-chain wallet/salt/fee** — execution-time wallet ownership/salt/credit checks scan all configured chains (mirror create-time), not the gateway default — **merged #637**
 - [x] **proto→OpenAPI int64 render fix** — `protoRetargetJSON` unquotes protojson's string-encoded `int64` (chainId) so create/get/list render chain-aware nodes; descriptor-driven so string fields (Amount) are untouched — **merged #640 (closes #639)**
+- [x] **OpenAPI description cleanup** — dropped stale workflow-level / loop-inherited `chainId` prose from `createWorkflow` + `LoopNodeConfig` — **#642 (on `staging`, closes on next promotion)**
 
-**Backend chain decoupling is complete.** Wallet/exec defaults (decided): wallet-ownership
+**Backend chain decoupling is complete and released on `main`.** Wallet/exec defaults (decided): wallet-ownership
 checks across all configured chains (`userOwnsWalletOnAnyChain`); VM-default config = aggregator default;
 salt is chain-invariant. ✅ done.
 
@@ -43,12 +44,12 @@ Client (separate repos — backend spec on `main` now unblocks them):
 
 - [x] **`ava-sdk-js`** — **done.** Types regenerated off the renovated spec, builders require `chainId`, list/count/executions
       `chainId` dropped; `PER_NODE_CHAIN_READY` multichain e2e **passes** against a local gateway.
-- [ ] **studio** — Phase 3: per-part chains in the canvas; drop workflow-level `chainId`; chain-agnostic workflow list (separate repo; not gated on the backend)
+- [ ] **studio** — Phase 3 adoption: per-part chains in the canvas; drop workflow-level `chainId`; chain-agnostic workflow list. **Step-by-step in [`## Studio adoption guide`](#studio-adoption-guide-how-to-adopt-per-part-chains) below.** (separate repo; not gated on the backend)
 
 Release / ops (this repo):
 
 - [x] **staging → main** promotion (chain decoupling, incl. executor cross-chain fix #637): **merged #636**; `wipe-chain-bucketed-task-keys` migration runs at boot after a DB backup.
-- [ ] **staging → main** follow-up promotion: ship the #639 render fix (#640) + dev tooling to `main`. `make storage-check` clean (no new migration). *(SDK lockstep satisfied — e2e green; main currently carries the chain decoupling WITH the #639 render bug until this lands.)*
+- [x] **staging → main** follow-up promotion: #639 render fix (#640) + dev tooling — **merged #641** (storage-check clean, no new migration); `staging` realigned to `main` via sync-main. SDK lockstep satisfied (e2e green). **Backend chain decoupling is fully released on `main`.**
 
 Future (not started):
 
@@ -476,6 +477,65 @@ Ethereum `1`, Base `8453`, Sepolia `11155111`, Base Sepolia `84532`. (Soneium/Mi
 **SDK (`ava-sdk-js`) mapping** — builders already expose the params; the change is to always populate:
 `Triggers.event/block({chainId})`, `Nodes.contractWrite/contractRead/ethTransfer({chainId})`, the Loop
 runner's `chainId`, `runNodeWithInputs` request `chainId`; remove any workflow-level `chainId`.
+
+---
+
+## Studio adoption guide: how to adopt per-part chains
+
+For the **studio** client (Phase 3). The backend is live on `main`; nothing below is blocked. The
+mental model shift: **a workflow no longer has a chain.** Chain is a property of each chain-aware part
+(event/block trigger; contractRead/Write/ethTransfer node). Everything below follows from that.
+
+### 1. Canvas / UX
+- **Remove the workflow-level chain selector** (the single "this workflow runs on chain X" control). There is
+  no `Task.chain_id` / `CreateWorkflowRequest.chainId` anymore — sending one is ignored, and relying on it to
+  scope nodes is gone.
+- **Add a chain selector to each chain-aware part** — on event & block trigger config, and on
+  contractRead / contractWrite / ethTransfer node config. Options = the configured set (below). Required;
+  no "inherit/default" option.
+- A Loop node's **runner** gets its own chain selector when the runner is chain-aware — it does **not**
+  inherit from the loop or workflow.
+- Non-chain parts (cron/manual/fixedtime triggers; customCode/restApi/graphql/branch/filter) show **no**
+  chain selector. The **Balance** node keeps its existing `chain` **string** field (name or id) — leave it.
+
+### 2. Create / save
+- On save, set `chainId` on every chain-aware part via the SDK builders (see `## Client contract` for the
+  exact fields). **Stop sending a workflow-level `chainId`.**
+- The backend **rejects** create if any chain-aware part is missing `chainId`/`0` or names an unconfigured
+  chain (`InvalidArgument`). Validate in-canvas before save and surface the error **on the offending node**
+  (see §4), so the user fixes it inline rather than getting a generic save failure.
+
+### 3. Workflow list / detail (chain-agnostic)
+- `listWorkflows` / `getWorkflow` no longer take a `chainId` query param and storage is not per-chain. **Don't
+  pass a chain to scope these.**
+- A **"chain" column / filter** in the workflow list is now **derived client-side**: read each workflow's
+  parts and show the distinct chains they use (a workflow can legitimately span chains — watch X, act on Y).
+  If you previously grouped/filtered workflows by a single workflow chain, replace that with a
+  derive-from-parts computation.
+
+### 4. Validation & error surfacing
+- Map the backend's `InvalidArgument` chain errors to inline node errors:
+  - *"chain-aware node requires an explicit chain_id"* → highlight the node, prompt to pick a chain.
+  - *"chain_id N is not configured on this aggregator"* → the selected chain isn't in the configured set.
+- Mirror the rule client-side so the canvas blocks save before the round-trip when possible.
+
+### 5. Existing / deployed workflows
+- The `wipe-chain-bucketed-task-keys` migration **deleted old chain-bucketed tasks** at the prod cutover
+  (no backfill — decided trade-off). Studio should **not** assume pre-cutover workflows still exist; users
+  re-create them with explicit per-part chains. Surface a clear empty-state rather than erroring on missing
+  tasks.
+
+### Configured chains (allowed `chainId` values)
+Ethereum `1`, Base `8453`, Sepolia `11155111`, Base Sepolia `84532`. (Soneium/Minato out of scope.) The
+aggregator is the source of truth; selecting anything else is rejected.
+
+### Definition of done (studio Phase 3)
+- [ ] Workflow-level chain selector removed; per-part chain selectors added (triggers + chain-aware nodes + loop runner)
+- [ ] Save sends per-part `chainId`, never a workflow-level one
+- [ ] Workflow list/detail no longer pass a chain; "chain" view derived from parts
+- [ ] `InvalidArgument` chain errors surfaced inline on the offending node, with client-side pre-validation
+- [ ] Empty-state for users whose pre-cutover workflows were wiped
+- [ ] SDK bumped to the version with required per-part `chainId` builders (e2e-verified)
 
 ---
 

--- a/PLAN_CROSS_CHAIN_SEQUENCING.md
+++ b/PLAN_CROSS_CHAIN_SEQUENCING.md
@@ -571,3 +571,93 @@ dead one, and expires the timed-out ones — no in-memory state required to surv
 - **Pre-existing gotchas surfaced** (not fixed here): `BatchWrite` swallows commit errors and splits on
   `ErrTxnTooBig`. Worth a follow-up to make `BatchWrite` return commit errors, but the design above is
   correct without it.
+
+---
+
+## Appendix D — Internal-trigger sync path (wake routing)
+
+The last conceptually-unproven piece. Grounded in the sync protocol (`protobuf/node.proto`),
+`StreamCheckToOperator` (`engine.go:1818`), `AggregateChecksResultWithState` (`engine.go:2627`), and the
+operator watch (`operator/worker_loop.go:1081`).
+
+### D.1 The gap
+The existing pipeline is **`task_id`-keyed**: `SyncMessagesResp.TaskMetadata{ task_id, trigger, chain_id }`
+goes *down* to operators; `NotifyTriggersReq{ task_id, trigger_output, trigger_request_id }` comes *up* when
+it fires; the aggregator starts a **fresh** run. An internal trigger is **execution-scoped** (a specific
+WAITING execution wants a specific event on chain B, and the fire must *resume that execution*, not start a
+new run). So we thread an `execution_id` through both messages and branch on it.
+
+### D.2 Proto additions (additive)
+```proto
+// node.proto — SyncMessagesResp.TaskMetadata
++ string execution_id = 7;   // set for internal/await triggers; "" for a task's own trigger
+// node.proto — NotifyTriggersReq
++ string execution_id = 11;  // operator echoes it back when an internal trigger fires
+```
+That's the entire wire change. An internal trigger is just a `TaskMetadata` with `chain_id = B`,
+`trigger =` the internal EventTrigger (built from `Await.Config`), and `execution_id` set. The operator
+needs no new *watch* logic — only to carry the id through.
+
+### D.3 Registration (suspend → operators covering B)
+- The set the sync loop pushes to operator **O** becomes: *active task triggers* (today) **+** *WAITING
+  executions' internal triggers whose `chain_id ∈ O.supported_chain_ids`*. The internal-trigger set is an
+  in-memory mirror, **rebuilt on boot from the `itrigger:` scan** (Appendix C.5) and updated on
+  suspend/resume.
+- On suspend, don't wait for the next sync tick: **immediately** push `MonitorTaskTrigger(TaskMetadata{…,
+  execution_id})` to operators covering B (reuse the immediate/batched notify path at `engine.go:2341`,
+  same mechanism as `ImmediateTrigger`).
+
+### D.4 Operator side (reuse the per-chain watch; `worker_loop.go`)
+- `EventTrigger.AddCheck` keys the check by **`(task_id, execution_id)`** so a task's own trigger
+  (`execution_id=""`) and its internal triggers (`execution_id` set) coexist without collision.
+- On fire: echo `execution_id` in `NotifyTriggersReq`; the `trigger_request_id` becomes
+  `task_id:exec_id:txHash:logIndex` (per-execution-per-event).
+- A `DeleteTask`/`DisableTask` message scoped by `execution_id` removes one internal check.
+- **No new watch logic** — it's the existing per-chain `EventTrigger` machinery with an extra id passed through.
+
+### D.5 Wake → resume routing (`AggregateChecksResultWithState`)
+Branch right after the dedup (`engine.go:2706`), before the fresh-run path:
+```go
+if payload.ExecutionId != "" {                 // an internal/await trigger fired
+    return n.resumeWaitingExecution(payload)
+}
+// ... existing runnable check + QueueExecutionData + enqueue (fresh run) ...
+```
+`resumeWaitingExecution`:
+1. Load the execution. **If status != WAITING → no-op** (already resumed / cancelled / timed-out). This is
+   the durable exactly-once guard, beyond the 5-min dedup window (**E8**).
+2. (If the bound filter is a data field, post-match it here — see D.7.)
+3. Build `QueueExecutionData{ ExecutionID: payload.ExecutionId, IsResume: true,
+   TriggerOutput: ExtractTriggerOutput(payload.TriggerOutput) }` and enqueue `JobTypeExecuteTask`.
+4. `executor.Perform` sees `IsResume` → the resume entrypoint (Appendix A.4): load checkpoint, set
+   `vars[awaitNode].data = <wake event>`, run the B-leg.
+
+`QueueExecutionData` (Go struct) gains one field: `IsResume bool` (it already carries `ExecutionID`).
+
+### D.6 Dedup & idempotency (two layers)
+- **Short window:** `trigger_request_id` (now per-execution-per-event) → the existing 5-min dedup
+  (`engine.go:2706`) drops immediate duplicates.
+- **Durable:** the **execution-status guard** in D.5 step 1 makes resume exactly-once across a restart
+  (when a wake arrives hours later or twice around a reboot) — the dedup map doesn't need to survive.
+
+### D.7 Filter precision (E6)
+- **Preferred:** the bridge arrival event indexes the discriminator (e.g. `messageId`) as a **topic** — the
+  operator's event check fires *only* on the matching log; no post-match needed.
+- **Fallback:** if the discriminator is in event *data* (not indexed), the operator fires on every arrival
+  event for that address/topic; `resumeWaitingExecution` **post-matches** the bound value against the event
+  data and no-ops on mismatch. The `Await.Config.filter` records which mode applies.
+
+### D.8 Deregistration
+On resolve (resume success/fail, timeout, or cancel), the engine sends a `Delete` scoped by
+`(task_id, execution_id)` to operators covering B, and deletes `itrigger:`/`ckpt:` (Appendix C.4). Boot GC
+(C.5) is the backstop if a deregister is missed.
+
+### D.9 What this satisfies
+- **E3 (restart):** boot `itrigger:` scan → rebuild the internal-trigger mirror → the sync loop re-pushes it
+  to operators covering B on (re)connect. No in-memory state needs to survive.
+- **E6 (correct filter):** topic-indexed precision at the operator, or aggregator post-match (D.7).
+- **E7 (concurrent isolated):** distinct `(task_id, execution_id)` checks + distinct filters; each fire
+  carries its own `execution_id` → resumes exactly its own execution.
+- **Open risk — coverage drift:** chain B is validated as covered at create time (O7/E11), but the only
+  covering operator could drop *while* a wait is pending. Behavior then (re-route on reconnect? alert?) is
+  unresolved and called out in the main Open-questions list.

--- a/PLAN_CROSS_CHAIN_SEQUENCING.md
+++ b/PLAN_CROSS_CHAIN_SEQUENCING.md
@@ -661,3 +661,107 @@ On resolve (resume success/fail, timeout, or cancel), the engine sends a `Delete
 - **Open risk — coverage drift:** chain B is validated as covered at create time (O7/E11), but the only
   covering operator could drop *while* a wait is pending. Behavior then (re-route on reconnect? alert?) is
   unresolved and called out in the main Open-questions list.
+
+---
+
+## Appendix E — P4.3 `Await` node spec (the 7 touch-points)
+
+Mechanical now that the semantics are pinned. The key move: **`AwaitNode.Config` embeds
+`EventTrigger.Config` verbatim**, so the engine builds the internal trigger (Appendix D) directly from it
+and the operator watches it with **zero new logic**. Next free IDs: `NodeType` value `11`, `TaskNode`
+oneof field `20`.
+
+### E.1 Proto (`protobuf/avs.proto`)
+```proto
+enum NodeType { …; NODE_TYPE_AWAIT = 11; }     // append
+
+message AwaitNode {
+  message Config {
+    EventTrigger.Config event           = 1;   // REUSE — chain B = event.chain_id; topics/conditions = the bound filter
+    uint32              timeout_seconds = 2;   // safety bound; 0 ⇒ server default (e.g. 24h), create-time may cap
+    OnTimeout           on_timeout      = 3;   // FAIL (v1) | BRANCH (deferred)
+  }
+  message Output { google.protobuf.Value data = 1; }   // the matched arrival event (mirrors EventTrigger.Output)
+  Config config = 1;
+  Output output = 2;
+}
+enum OnTimeout { AWAIT_ON_TIMEOUT_FAIL = 0; AWAIT_ON_TIMEOUT_BRANCH = 1; }   // FAIL default ⇒ v1 works
+
+message TaskNode { oneof task_type { …; AwaitNode await = 20; } }   // append
+```
+`make protoc-gen` after. Chain B is `Await.Config.event.chain_id` — no separate field.
+
+### E.2 The runner (new `core/taskengine/vm_runner_await.go`)
+The runner only ever runs **once**, on the suspend pass (it is in `completed_node_ids` on resume, so it is
+never re-executed — Appendix A.5):
+```go
+func (v *VM) runAwait(stepID string, node *avsproto.AwaitNode) (*avsproto.Execution_Step, error) {
+    cfg := node.GetConfig()
+    wake := resolveTemplates(cfg.GetEvent(), v.vars)   // bind {{bridge.data.messageId}} into topics/conditions
+    v.mu.Lock()
+    v.suspend = &SuspendRequest{
+        awaitNodeID: stepID,
+        wake:        wake,                              // an EventTrigger.Config — handed straight to Appendix D
+        timeoutAt:   now + timeoutOrDefault(cfg.GetTimeoutSeconds()),
+    }
+    v.mu.Unlock()
+    return suspendedStep(stepID), nil                  // status=WAITING marker; scheduler drains (Appendix A.2)
+}
+```
+The scheduler sees `v.suspend`, drains, returns `suspended`; the executor writes the checkpoint + registers
+the internal trigger (Appendices C.3, D.3).
+
+### E.3 VM dispatch (`vm.go` `executeNode`, ~`:1263`)
+```go
+} else if node.GetAwait() != nil {
+    step, err := v.runAwait(node.Id, node.GetAwait())
+    executionLogForNode = step
+}
+```
+
+### E.4 Config map ↔ proto (`vm.go`)
+- `CreateNodeFromType` (~`:2542`): add an `"await"` case parsing the config map (`event`, `timeoutSeconds`,
+  `onTimeout`) into `AwaitNode_Config`, reusing the existing EventTrigger config parser for `event`.
+- `ExtractNodeConfiguration` (~`:3502`): add the inverse case (proto → camelCase map), so isolated runs /
+  simulation surface the await config. *(Note: `RunNodeImmediately` on a standalone `Await` is degenerate —
+  there's no execution to suspend; it should return a clear "Await runs only inside a workflow" error.)*
+
+### E.5 REST + OpenAPI
+- `aggregator/rest/mapping/node.go`: add the `await` variant to `OpenAPIToProtoNode` (inbound
+  `jsonRetargetProto`) and `ProtoToOpenAPINode` (outbound `protoRetargetJSON` — the #639 int64 unquote
+  already covers the embedded `chain_id`).
+- `api/openapi.yaml`: add `AwaitNode` + `AwaitNodeConfig` schemas. `AwaitNodeConfig.event` references the
+  existing event-config schema; `chainId` (via `event`) is **required** (chain-aware part). `make rest-gen`.
+
+### E.6 Chain-aware validation (O7 / E11)
+`Await.Config.event.chain_id` is a chain-aware part — wire it into the existing checks:
+- `checkNodeChain` (`engine.go`): add a case returning `node.GetAwait().GetConfig().GetEvent().GetChainId()`
+  → enforces required/`>0`/configured like other chain-aware parts.
+- **New coverage check:** additionally require `operatorsCoveringChain(chainB)` non-empty at create
+  (the wait can never fire otherwise). This is the one rule beyond the generic chain-aware validation.
+- `stampNodeChainIfUnset`: **not** applied — `Await` has no aggregator-default fallback; an unset chain is a
+  hard reject.
+
+### E.7 Loop support — explicitly none
+`Await` is a control/suspend node, not a data runner. It is **not** a valid `LoopNode.runner` (suspending
+inside a per-item loop is out of scope). Reject an `Await` loop-runner at create time. So the usual
+"loop-runner support" touch-point is a deliberate *no-op + guard*, not an addition.
+
+### E.8 Resume interaction (closing the loop with A.4 / D.5)
+On resume the runner does **not** run again. The executor (D.5 → A.4):
+1. sets `vars[awaitNodeName].data = <wake event>` (so the B-leg reads `{{await.data.*}}`), and
+2. rewrites the await's execution step from "suspended" to **success** with the arrival event as its output,
+   so the final single record shows the await completing with the event that woke it.
+
+### E.9 Touch-point checklist
+1. `protobuf/avs.proto` — enum + `AwaitNode` + `OnTimeout` + oneof; `make protoc-gen`
+2. `core/taskengine/vm_runner_await.go` — the suspend-pass runner (new file)
+3. `core/taskengine/vm.go` — `executeNode` dispatch
+4. `core/taskengine/vm.go` — `CreateNodeFromType`
+5. `core/taskengine/vm.go` — `ExtractNodeConfiguration`
+6. `aggregator/rest/mapping/node.go` + `api/openapi.yaml` — REST variant + schema; `make rest-gen`
+7. `core/taskengine/engine.go` — `checkNodeChain` case + the operator-coverage create check; loop-runner guard
+
+This is the implementation kickoff for E1 (the `Await` becomes a real node). It depends on P4.0 (the proto
+`WAITING`/checkpoint additions) but is otherwise self-contained; the suspend/resume behavior it triggers is
+specified in Appendices A, C, and D.

--- a/PLAN_CROSS_CHAIN_SEQUENCING.md
+++ b/PLAN_CROSS_CHAIN_SEQUENCING.md
@@ -252,3 +252,228 @@ Adding a node type (P4.3 touch-points):
   `aggregator/rest/mapping/node.go:24` `OpenAPIToProtoNode`; `core/taskengine/vm.go:2542`
   `CreateNodeFromType`; `:3502` `ExtractNodeConfiguration`; a new `vm_runner_await.go`; VM dispatch; loop
   runner support.
+
+---
+
+## Appendix A — P4.2 re-entrant executor (deep-dive)
+
+The load-bearing change. Grounded in `runKahnScheduler` (`core/taskengine/vm.go:947`) and the `VM` struct.
+
+### A.1 What to checkpoint
+Only three `VM` fields carry irrecoverable state; everything else is rebuilt by `Compile()` or re-injected
+by the executor.
+
+| VM field | Checkpoint? | Why |
+|---|---|---|
+| `vars map[string]any` | ✅ | shared context + every node output; JSON-serializable |
+| `ExecutionLogs []*Execution_Step` | ✅ | A-leg steps for the final record |
+| `plans`, `entrypoint`, `mu`, `Status`, `instructionCount` | ❌ | rebuilt by `Compile()` |
+| `smartWalletConfig`, `chainConfigResolver`, `db`, `logger`, `executionFeeWei` | ❌ | re-injected on resume |
+
+`completed_node_ids` is **derived**: `[step.NodeID for step in ExecutionLogs]`. Lean checkpoint:
+
+```
+ckpt:<taskId>:<execId>
+  vars            JSON(v.vars)
+  execution_logs  []Execution_Step            // also yields completed_node_ids
+  resume_node_id  (the Await node)
+  await           { chain_id, address, topics, filter, timeout_at }
+  branch_selections  map[branchNodeId]selectedConditionNodeId   // empty in v1, forward-compat
+```
+
+### A.2 Suspend signal
+`executeNode` returns `(*Step, error)`, but errors become warnings (`vm.go:1069`) and a returned `Step`
+only *adds* branch scheduling — neither halts the run. Add a VM-level flag the `Await` runner sets:
+
+```go
+// VM, guarded by v.mu:
+suspend *SuspendRequest   // nil normally
+// SuspendRequest { awaitNodeID, wake{chain,address,topics,filter}, timeoutAt }
+```
+
+In the worker loop right after `executeNode` (`vm.go:1077`):
+
+```go
+mu.Lock()
+if v.suspendRequested() {
+    suspended = true
+    closeOnce.Do(func() { close(ready) })   // no new work; in-flight drain & exit
+    processed++
+    mu.Unlock()
+    continue                                // skip scheduling Await's successors
+}
+// ... existing decrement-successors / branch-selection ...
+```
+
+`runKahnScheduler` returns a `suspended` bool → executor writes checkpoint, sets **WAITING**, registers the
+internal trigger.
+
+**v1 constraint:** `Await` must be on a **linear path** (nothing else in-flight when it runs — the
+bridge→Await→act pattern guarantees this). Draining N parallel in-flight nodes / partial checkpoint is
+deferred. Reject at create-time (if cheap) a graph where `Await` can run concurrently with siblings.
+
+### A.3 Resume seam (replaces only the initial-ready seed, `vm.go:1037-1046`)
+`runKahnScheduler` gains a `completed map[string]bool` param (empty ⇒ today's behavior, byte-identical):
+
+```go
+queue := []string{}
+for id, c := range predCount {
+    if c == 0 && !branchTargets[id] { queue = append(queue, id) }
+}
+visited := map[string]bool{}
+for len(queue) > 0 {
+    id := queue[0]; queue = queue[1:]
+    if visited[id] { continue }
+    visited[id] = true
+    if completed[id] {
+        scheduled[id] = true                 // counts as done; NOT added to scheduledCount
+        for _, succ := range adj[id] {        // fast-forward = the decrement a finished worker does
+            if _, ok := predCount[succ]; ok {
+                predCount[succ]--
+                if predCount[succ] == 0 && !branchTargets[succ] { queue = append(queue, succ) }
+            }
+        }
+        // branch nodes in the prefix replay via branch_selections — deferred (v1 linear)
+    } else {
+        ready <- id; scheduled[id] = true; scheduledCount++   // the resume frontier
+    }
+}
+```
+
+Fresh run: `completed` empty → every node hits `else` → identical to today. Resume: the completed prefix
+decrements down; frontier = `Await`'s successors (the B-leg). `scheduledCount`/`processed` count only
+executed nodes, so the existing termination (`processed == scheduledCount → close(ready)`) holds.
+
+### A.4 Resume sequence (executor)
+1. Resume job arrives (`executionId` + wake-event payload).
+2. Load checkpoint → new VM; inject restored `vars`, `ExecutionLogs`, per-chain config/resolver/db.
+3. `vars[awaitNodeName].data = <wake event log>` so the B-leg reads `{{await.data.*}}`.
+4. `Compile()`; `runKahnScheduler(completed = set(completed_node_ids))` → run B-leg; append steps.
+5. Terminal status; deregister internal trigger.
+
+### A.5 Why goja never needs serializing
+Completed nodes are **never re-executed** on resume — their outputs are already in restored `vars`. A
+custom-code node from the A-leg is just `vars["myCode"].data`; resume skips it.
+
+### A.6 P4.2 risks
+- **`scheduledCount` accounting** — fast-forwarded nodes set `scheduled[id]=true` but must NOT bump
+  `scheduledCount`, or termination never fires. (Needs a "resumed run terminates" test.)
+- **Branch in the completed prefix** — deferred; needs `branch_selections` replay. v1 Await is post-bridge
+  linear.
+- **Checkpoint atomicity** — checkpoint write + status→WAITING + internal-trigger register = one
+  `BatchWrite` (reuse the atomic end-of-run write at `executor.go:748`).
+- **Idempotent resume** — a resume job delivered twice (around a restart) must no-op; guard on current
+  status before resuming.
+
+---
+
+## Appendix B — Outcomes & e2e test scenarios (build toward these)
+
+The acceptance criteria, expressed as observable outcomes and the scenarios that prove them. We build the
+feature *toward* this list. **Test layers:** most scenarios are **Go integration** tests (engine + executor
++ VM, with the operator's `NotifyTriggers` and chain events **simulated/injected** — deterministic, fast).
+A small subset (the real bridge) are **testnet SDK e2e** (`ava-sdk-js`, Sepolia ↔ Base Sepolia, gated/slow).
+Per repo convention, integration tests **hard-fail** on missing prereqs (`require`, not `t.Skip`).
+
+### Outcomes (definition of done)
+- **O1 — Single execution across the bridge.** One workflow bridges on A, waits, and acts on B as **one
+  execution with one execution record** spanning both legs.
+- **O2 — Shared context.** The B-leg sees the A-leg's full `vars`, including the bridge output and any
+  earlier node's output.
+- **O3 — Restart durability.** A WAITING execution survives an aggregator restart and still completes when
+  the B event fires.
+- **O4 — Exactly-once node execution.** Completed (A-leg) nodes are **not** re-run on resume — no duplicate
+  side effects.
+- **O5 — Correct wake.** Only the matching B event resumes the right execution; concurrent waits don't
+  cross-talk; a duplicate signal resumes once.
+- **O6 — Clean timeout.** A stuck bridge times out → execution FAILED, internal trigger released.
+- **O7 — Create-time validation.** Creation is rejected if chain B is unconfigured/`0` or not
+  operator-covered.
+- **O8 — No resume fee gate.** Resume incurs no extra credit check; `resume_fee_wei = 0`.
+- **O9 — Chain-invariant wallet on B.** The B-leg acts via the same smart-wallet address; auto-deploys on B
+  if needed (salt via #637).
+- **O10 — Cancellable wait.** A WAITING execution can be cancelled/paused, deregistering its wait.
+
+### E2E scenarios
+
+**E1 — Happy path: bridge → wait → act (O1, O2, O9).** *Integration.*
+Build a task: `contractWrite(chainId=A, bridge)` → `Await(chainId=B, event=Arrival, filter=messageId=={{bridge.data.messageId}})` → `contractWrite(chainId=B, act)`. Run it.
+- *Then:* A-leg executes; status becomes **WAITING**; an internal trigger is registered on B with the
+  bound filter. Inject the matching B `Arrival` event. Status becomes **SUCCESS**.
+- *Assert:* one execution record; `ExecutionLogs` = A-leg steps + Await + B-leg steps, in order; the B-leg
+  `contractWrite` resolved `{{bridge.data.transactionHash}}` and `{{await.data.amount}}`; the B UserOp used
+  the same smart-wallet address as the A leg.
+
+**E2 — Shared context proof (O2).** *Integration.*
+Put a `customCode` node in the A-leg that emits a value, and have a B-leg node consume it.
+- *Assert:* the B-leg received the exact A-leg value across the suspend boundary (impossible with two
+  separate workflows — this is the feature's reason for existing).
+
+**E3 — Restart durability (O3).** *Integration — the make-or-break test.*
+Drive E1 to **WAITING**, then **tear down and re-create the engine from the same BadgerDB** (simulated
+aggregator restart). Reconnect a fake operator covering B.
+- *Assert:* the internal trigger is re-registered on boot/reconnect; injecting the B event after restart
+  still resumes the execution to **SUCCESS**.
+
+**E4 — Exactly-once across suspend (O4).** *Integration.*
+A-leg node has an observable side effect (counter / mock tx). Drive to WAITING and resume.
+- *Assert:* the A-leg side effect fired **exactly once** total; resume executed **only** the B-leg.
+
+**E5 — Resumed run terminates (P4.2 A.6).** *Integration.*
+Resume a multi-node B-leg (incl. a fan-out/fan-in).
+- *Assert:* the resumed scheduler reaches a terminal status and does not hang (guards the
+  `scheduledCount`/termination edge case).
+
+**E6 — Correct-filter wake (O5).** *Integration.*
+WAITING execution with `filter=messageId==M1`. Inject a **non-matching** B event (`messageId==M2`).
+- *Assert:* no resume. Then inject the matching `M1` event → resumes once.
+
+**E7 — Concurrent independent waits (O5).** *Integration.*
+Two WAITING executions on the same chain B with distinct filters (M1, M2). Fire M2 then M1.
+- *Assert:* each resumes exactly its own execution; no cross-talk; order-independent.
+
+**E8 — Duplicate resume signal (O5).** *Integration.*
+Deliver the same matching B event **twice** (e.g., around a restart).
+- *Assert:* the execution resumes **once**; the second delivery is a no-op (status guard).
+
+**E9 — Timeout on stuck bridge (O6).** *Integration.*
+WAITING execution, no B event before `timeout_seconds`.
+- *Assert:* the timeout sweep transitions the execution to **FAILED** with a timeout reason; the internal
+  trigger is GC'd; a late B event no longer resumes.
+
+**E10 — B-leg failure after resume (O1 terminal).** *Integration.*
+Resume into a B-leg `contractWrite` that reverts.
+- *Assert:* execution ends **FAILED** with the B-leg error; single record; no dangling WAITING/trigger.
+
+**E11 — Create-time validation (O7).** *Integration.*
+(a) `Await.chainId` not in the configured set / `0` → `CreateWorkflow` rejected (`InvalidArgument`).
+(b) `Await.chainId` configured but **no operator covers it** → rejected.
+(c) Valid + covered → accepted.
+
+**E12 — No resume fee gate (O8).** *Integration.*
+Owner with an outstanding fee balance that would block a fresh task. Drive E1 to resume.
+- *Assert:* the resume leg is **not** blocked; `resume_fee_wei == 0`; total fee = A-leg fee + 0.
+
+**E13 — Cancel a WAITING execution (O10).** *Integration.*
+Drive to WAITING, then cancel/pause the workflow.
+- *Assert:* the internal trigger is deregistered; a subsequent matching B event does **not** resume.
+
+**E14 — Auto-deploy wallet on B (O9).** *Integration.*
+Resume where the smart wallet is **not yet deployed** on B.
+- *Assert:* the B UserOp deploys it (initCode + salt via #637 cross-chain salt lookup) at the same address;
+  the act succeeds.
+
+**E15 — Real bridge on testnet (O1, O9 end-to-end).** *Testnet SDK e2e — gated/slow.*
+Via `ava-sdk-js` against a local gateway + Sepolia/Base-Sepolia workers + operator: bridge a small amount
+Sepolia→Base Sepolia through a real bridge, Await the destination event, act on Base Sepolia.
+- *Assert:* one workflow completes across both real chains; the destination action lands at the same smart
+  wallet. (The single full-stack proof; everything else is deterministic integration.)
+
+### Build order vs. scenarios
+- P4.1 (checkpoint persistence) → unblocks **E4** state restoration assertions.
+- P4.2 (re-entrant executor) → **E1, E2, E4, E5** (resume runs, no re-exec, terminates) via a synthetic
+  resume job (no triggers yet).
+- P4.3 (Await + internal trigger) → **E1 (full), E6, E7, E11**.
+- P4.4 (durability hardening) → **E3, E8, E9, E13**.
+- P4.5 (bridge UX) → **E15**.
+- Cross-cutting: **E10, E12, E14** land alongside their nearest phase.

--- a/PLAN_CROSS_CHAIN_SEQUENCING.md
+++ b/PLAN_CROSS_CHAIN_SEQUENCING.md
@@ -477,3 +477,97 @@ Sepolia→Base Sepolia through a real bridge, Await the destination event, act o
 - P4.4 (durability hardening) → **E3, E8, E9, E13**.
 - P4.5 (bridge UX) → **E15**.
 - Cross-cutting: **E10, E12, E14** land alongside their nearest phase.
+
+---
+
+## Appendix C — Storage contract (the atomic suspend/resume write)
+
+Grounded in the existing schema (`core/taskengine/schema.go`), the executor's atomic end-of-run write
+(`executor.go:748`), and the `storage.Storage` interface (`storage/db.go`).
+
+### C.1 New keys (chain-agnostic, matching `history:`/`u:`)
+Post-decoupling, task/execution keys are chain-agnostic (`history:<taskId>:<execId>`,
+`u:<owner>:<wallet>:<key>`). The new keys follow suit — the watched chain is **data in the value**, not in
+the key (the checkpoint/wait belong to a task+execution, which are chain-agnostic; only the watch *target*
+is per-chain, and that lives inside).
+
+```
+CheckpointKey(taskId, execId)       →  ckpt:<taskId>:<execId>
+InternalTriggerKey(taskId, execId)  →  itrigger:<taskId>:<execId>     // chain_id(B) is in the value
+Scan prefixes for boot recovery:       ckpt:        itrigger:
+```
+
+Both key templates are **new ⇒ additive**: `make storage-check` stays clean, **no migration**.
+
+### C.2 Serialization (proto, protojson — like executions)
+```proto
+message ExecutionCheckpoint {
+  string                  task_id = 1;
+  string                  execution_id = 2;
+  string                  vars_json = 3;            // JSON of v.vars (lossless for the map[string]any)
+  repeated Execution_Step execution_logs = 4;       // A-leg steps (also yields completed_node_ids)
+  string                  resume_node_id = 5;        // the Await node
+  AwaitConfig             await = 6;                 // { chain_id, address, topics, filter, timeout_at }
+  map<string,string>      branch_selections = 7;     // empty in v1, forward-compat
+}
+message InternalTrigger {
+  string              task_id = 1;
+  string              execution_id = 2;
+  int64               chain_id = 3;                  // chain B (the watch target)
+  EventTrigger.Config event_config = 4;              // reuse the existing event-watch config
+  int64               expires_at = 5;                // unix; timeout sweep
+}
+// Execution (additive): + EXECUTION_STATUS_WAITING=4, + resume_node_id, + wait_reason, + resume_fee_wei(0)
+```
+All additive proto changes; `vars` as a JSON string keeps big-int/typed values lossless (a `Struct` would
+coerce them).
+
+### C.3 Atomic suspend write (crash-safe by ordering)
+`BatchWrite` is a single Badger txn **only while it fits**; it splits on `ErrTxnTooBig` (`db.go:125`) and
+**ignores commit errors** (always returns nil). So we don't put the (potentially large) checkpoint in the
+same batch as the small "armed" markers, and we don't trust the return value — the boot scan (C.5) is the
+source of truth.
+
+```
+1. db.Set(CheckpointKey, checkpointBlob)                       // resume DATA first (single txn)
+2. db.BatchWrite({ TaskExecutionKey: execution{WAITING,…},     // ARMED markers — 2 small keys,
+                   InternalTriggerKey: internalTrigger })      //   always one atomic txn
+```
+**Invariant:** armed markers exist ⟹ the checkpoint exists (write order). A crash between 1 and 2 leaves an
+orphan checkpoint that never fires (no trigger, no WAITING execution) → swept by an orphan-checkpoint GC.
+The task's own status row (`WorkflowStorageKey`/`TaskUserKey`) is **untouched** — the task stays Enabled;
+only this *execution* is WAITING, so there's no status-move/`Delete` to coordinate.
+
+### C.4 Resume-completion write (durable terminal first, then cleanup)
+```
+1. db.BatchWrite({ TaskExecutionKey: execution{SUCCESS|FAILED, full steps},
+                   WorkflowStorageKey/TaskUserKey: task status })   // terminal result, durable
+2. db.Delete(CheckpointKey); db.Delete(InternalTriggerKey)          // cleanup (post-commit)
+```
+A crash between 1 and 2 leaves a **terminal** execution plus a stale checkpoint/trigger → reconciled on boot
+(C.5) and by the idempotency guard (a late wake sees a terminal execution → no-op, satisfying **E8**).
+
+### C.5 Boot re-arm + GC (durability O3 / E3, timeout O6 / E9)
+On aggregator start (and the source of truth for the armed set):
+```
+IterateKeysOnly("itrigger:") → for each (taskId, execId):
+   exec = GetKey(TaskExecutionKey)
+   if exec missing OR exec.status != WAITING:        // stale (completed/cancelled or crash-after-terminal)
+       Delete(InternalTriggerKey); Delete(CheckpointKey)        // GC
+   else if now > expires_at:
+       run timeout path → mark exec FAILED; Delete(InternalTriggerKey); Delete(CheckpointKey)   // E9
+   else:
+       re-register the internal trigger into the set synced to operators covering chain_id(B)    // E3
+```
+This makes the persisted `itrigger:` set the durable registry: a restart re-arms every live wait, GCs every
+dead one, and expires the timed-out ones — no in-memory state required to survive the restart.
+`IterateKeysOnly` is constant-memory (safe even with many waits).
+
+### C.6 What this buys / costs
+- **Atomicity:** the armed-markers batch is always a single txn (2 small keys); the large checkpoint is a
+  separate single `Set`; ordering + boot reconciliation cover the seams. No reliance on `BatchWrite`'s
+  (swallowed) error.
+- **storage-check:** two additive key templates + additive proto fields ⇒ **no migration**.
+- **Pre-existing gotchas surfaced** (not fixed here): `BatchWrite` swallows commit errors and splits on
+  `ErrTxnTooBig`. Worth a follow-up to make `BatchWrite` return commit errors, but the design above is
+  correct without it.

--- a/PLAN_CROSS_CHAIN_SEQUENCING.md
+++ b/PLAN_CROSS_CHAIN_SEQUENCING.md
@@ -1,7 +1,10 @@
 # PLAN — Cross-Chain Sequencing (Phase 4)
 
-Status: **design, not started.** Successor to `PLAN_CHAIN_DECOUPLING.md` Phase 4. This doc is the
-design of record; nothing here is implemented yet.
+Status: **design — SUPERSEDED as the engine approach by [`PLAN_DURABLE_EXECUTION.md`](PLAN_DURABLE_EXECUTION.md).**
+The decision (Level 3) is to build a durable execution engine and make cross-chain `Await` one `Suspendable`
+feature on it, rather than the Level-1 bolt-on described here. This doc is retained for **Appendix B
+(test scenarios E1–E15)** and the **reference map**, both still valid; Appendices A/C/D describe the bolt-on
+mechanics that the engine makes native. Read `PLAN_DURABLE_EXECUTION.md` first.
 
 ## What this is
 

--- a/PLAN_CROSS_CHAIN_SEQUENCING.md
+++ b/PLAN_CROSS_CHAIN_SEQUENCING.md
@@ -1,0 +1,254 @@
+# PLAN — Cross-Chain Sequencing (Phase 4)
+
+Status: **design, not started.** Successor to `PLAN_CHAIN_DECOUPLING.md` Phase 4. This doc is the
+design of record; nothing here is implemented yet.
+
+## What this is
+
+Today a workflow can **watch chain X and act on chain Y independently** (per-part chains, shipped in the
+chain-decoupling work). What it *cannot* do is **sequence across a bridge**: run some nodes, initiate a
+bridge transaction on chain A, **wait** until the bridged funds/message arrive on chain B (minutes to
+hours later), then **continue the same workflow** acting on chain B with the earlier nodes' context still
+available.
+
+That requires the executor to **suspend mid-workflow, persist its state, and be woken later** — a
+re-entrant / durable executor. Today the executor is synchronous and single-pass.
+
+## Why not "two workflows"? (decision 5)
+
+A user can already approximate this with two separate workflows — workflow 1 bridges on A; a separate
+EventTrigger workflow on B does the follow-up. **The fatal flaw: the two executions do not share
+context.** Workflow 2 has none of workflow 1's variables, outputs, or execution identity — no
+`{{bridge.data.*}}`, no single execution record, no continuity. Cross-chain sequencing is therefore a
+**single workflow** whose `vars` map (the shared context) is carried across the suspend boundary. That
+carried context is the entire point of the feature.
+
+---
+
+## Current architecture — what we're working with
+
+Grounded in the code (file:line refs in [§ Reference map](#reference-map)).
+
+- **Execution is synchronous, single-pass.** `RunTask → vm.Compile → vm.Run` (a Kahn scheduler runs all
+  ready nodes to completion) → one terminal status. No pause/resume, no checkpoint.
+- **`ExecutionStatus` has only terminal states** beyond start: `PENDING(1) → SUCCESS(2) / FAILED(3) /
+  ERROR(5)`. Slot **`4` is unused** — the natural home for `WAITING`.
+- **Node outputs live only in `vm.vars` in memory** during a run and are discarded at the end; nothing
+  persists them mid-execution.
+- **The existing "wait"** (`waitForUserOpConfirmation`) is a synchronous ≤5-min poll that **blocks a
+  worker** and dies on restart — unusable for bridge-scale waits.
+- **The trigger → wake → execute pipeline already exists and is reusable.** Operators watch each chain
+  via per-chain `EventTrigger`/`BlockTrigger` `AddCheck`; a detected condition flows
+  `NotifyTriggers → AggregateChecksResultWithState → apqueue → executor`. `apqueue` has **no retry limit**
+  (can hold a job indefinitely) and `QueueExecutionData` is an extensible payload that already carries an
+  `ExecutionID`.
+- **The smart-wallet runner address is chain-invariant** (CREATE2 of factory + owner + salt). Acting on
+  chain B uses the **same address**; `resolveSmartWalletForNode` routes per-chain config, and #637 made
+  the cross-chain salt lookup work. **No new wallet work is needed to act on B.**
+- **No native bridge integration exists.** A bridge call is just a `contractWrite` to a bridge contract;
+  bridging is external and user-configured.
+
+---
+
+## Locked design decisions
+
+1. **Wake = event-on-B only** (v1). The wake condition is an event watch on chain B. Block-count and
+   timer wake modes are deferred.
+2. **Restart durability is a first-class requirement.** A WAITING execution must survive an aggregator
+   restart and re-arm its wake sensor.
+3. **Create-time validation:** an `Await` node's chain B must be operator-covered, or creation is rejected.
+4. **Fee model is trivial:** a structure that exists but defaults to `0`. No billing complexity in v1.
+5. **Single workflow, shared context** (see above).
+
+---
+
+## Components to leverage vs. build
+
+The wake-up half already exists (operator trigger-watching); the new engine is durable execution in
+`core/taskengine`. This respects the aggregator-vs-operator split: operators watch chains, the aggregator
+orchestrates.
+
+| Role in Phase 4 | Leverage (exists) | Build (new) |
+|---|---|---|
+| **"Wait for arrival on B" sensor** | Operator `EventTrigger.AddCheck` per chain | Accept engine-created **internal** triggers (same shape as user triggers) |
+| **Wake → resume delivery** | `NotifyTriggers → AggregateChecksResultWithState → apqueue` (dedup + indefinite hold already present) | A **resume job** carrying `executionId` + resume context |
+| **Suspend / checkpoint / resume brain** | `core/taskengine` lifecycle + BadgerDB storage | The **re-entrant executor**, checkpoint store, internal-trigger registry |
+| **Act on chain B** | erc4337 smart wallet (chain-invariant address); `resolveSmartWalletForNode`; #637 cross-chain salt | **Nothing** — a `contractWrite(chainId=B)` just works |
+| **Initiate the bridge** | A normal `contractWrite` to the bridge contract on A | Templating to forward the bridge tx hash / messageId |
+
+---
+
+## The `Await` node (a mid-workflow EventTrigger on chain B)
+
+Because wake is event-only, the `Await` node's config **is** an embedded event-watch on chain B — it
+behaves like an `EventTrigger` dropped into the middle of a workflow. "Bridge wait" is a *usage pattern*;
+`Await` is a reusable "pause until event X on chain Y" primitive.
+
+```
+Await.Config {
+  chain_id            // chain B — required, must be a configured + operator-covered chain
+  address             // bridge / destination contract on B
+  topics / event_sig  // the arrival event (e.g. CCIP MessageReceived, Across FilledRelay, Stargate Received)
+  filter              // templated, bound to THIS execution's arrival
+                      //   e.g. messageId == {{bridge.data.messageId}}
+  timeout_seconds     // safety bound for a stuck bridge — NOT a wake mode
+  on_timeout          // FAIL (v1) | take a fallback edge (deferred)
+}
+Await.Output = the matched log (received amount, sender, …) → readable by downstream B-leg nodes
+```
+
+`Await.chain_id` is a chain-aware part: subject to the required-`chainId` rule and the create-time
+operator-coverage check.
+
+---
+
+## Persisted structures (decision 2 + 4)
+
+All proto additions are **additive** → `make storage-check` stays clean. New storage keys are additive.
+
+```
+ExecutionCheckpoint        key: ckpt:<taskId>:<execId>        (survives restart)
+  task_id, execution_id
+  vars: map(JSON)                  // the SHARED CONTEXT carried across suspend (decision 5)
+  completed_node_ids: []string     // completed nodes are skipped on resume (goja/custom-code NOT re-run)
+  execution_logs: []Execution_Step // steps so far, for the final execution record
+  resume_node_id                   // the Await node; resume runs its successors
+  await { chain_id, address, topics, filter, timeout_at }
+  created_at / updated_at
+
+InternalTrigger            key: itrigger:<taskId>:<execId>    (persisted registry, re-synced on boot)
+  task_id, execution_id, chain_id(B)
+  event_config { address, topics, filter }
+  expires_at, status
+
+Proto additions
+  ExecutionStatus: + EXECUTION_STATUS_WAITING = 4      // slot 4 currently unused
+  Execution:       + resume_node_id, + wait_reason
+  Execution:       + resume_fee_wei (default 0)        // the fee structure (decision 4)
+```
+
+**Fee model (decision 4).** One logical execution = leg-A value fee (the existing #637 credit check at
+start) **+ `resume_fee_wei`, default `0`**. No separate credit gate on resume. The field exists only so
+per-leg billing can be added later without a schema change.
+
+---
+
+## End-to-end flow
+
+```
+[contractWrite chainId=A]  →  [Await chainId=B]  →  [contractWrite chainId=B]
+   initiate bridge,             wake on B-event       act on bridged funds
+   emits txHash/messageId       (this execution)      (same smart wallet)
+```
+
+1. Executor runs the A-leg up to `Await`. The bridge `contractWrite` output feeds `Await`'s chain-B filter.
+2. `Await` **checkpoints** (`vars` + `completed_node_ids` + `resume_node_id`), sets execution status
+   **WAITING**, and the engine **persists + registers an internal EventTrigger** on chain B (filter bound
+   to this execution).
+3. An operator covering B watches it via the existing `AddCheck` path → fires `NotifyTriggers`.
+4. `AggregateChecksResultWithState` (dedup via `TriggerRequestId`, already exactly-once) enqueues a
+   **resume job** carrying the `executionId`.
+5. The **re-entrant executor** loads the checkpoint, rebuilds the VM, **restores `vars`**, marks completed
+   nodes done, seeds the scheduler with `Await`'s successors → runs the B-leg against the **same
+   chain-invariant smart wallet**.
+6. Terminal status → deregister the internal trigger.
+
+---
+
+## Restart durability (decision 2 — the make-or-break path)
+
+- A WAITING execution persists **both** the checkpoint and the `InternalTrigger` registry entry.
+- On aggregator boot — and on every operator (re)connect — WAITING executions' internal triggers are
+  **included in the set synced to operators covering chain B**, exactly as active task triggers and pending
+  executions are resynced today (`StreamCheckToOperator`). A mid-wait restart re-arms the sensor; nothing
+  is lost.
+- Timeouts are persisted (`expires_at`). A periodic sweep (reuse the existing cleanup ticker) fails/expires
+  waits whose `timeout_at` passed while no operator was up.
+
+---
+
+## Create-time validation (decision 3)
+
+At `CreateWorkflow`, every `Await` node's `chain_id` is validated like any chain-aware part (required,
+`>0`, configured) **and** additionally that `operatorsCoveringChain(chainB)` is non-empty — so a wait can
+never be registered that no operator could ever fire.
+
+---
+
+## Implementation sub-phases (incremental, each shippable)
+
+- **P4.0 — contract & schema.** Add `EXECUTION_STATUS_WAITING`, `resume_node_id`, `wait_reason`,
+  `resume_fee_wei` (default 0); define the checkpoint + internal-trigger schemas. No behavior change.
+- **P4.1 — checkpoint persistence.** Persist node outputs after each node (`ckpt:<taskId>:<execId>`). Also
+  a general crash-resilience win.
+- **P4.2 — re-entrant executor (riskiest).** Resume-from-checkpoint entrypoint; teach the Kahn scheduler a
+  "treat completed nodes as done, start from `resume_node_id`'s successors" mode. Restore `vars`; skip
+  completed (goja/custom-code outputs restored, not re-run). Tested via a synthetic resume job — no
+  triggers yet.
+- **P4.3 — `Await` node + internal-trigger registry.** New node type (7 touch-points: proto enum + Config
+  + Output + `TaskNode` oneof; REST mapping; `CreateNodeFromType`; `ExtractNodeConfiguration`; VM runner;
+  dispatch; loop-runner support). Engine registers/deregisters mid-execution triggers and syncs them to
+  operators. Wire wake → resume.
+- **P4.4 — durability hardening.** Boot/reconnect re-registration; timeout sweep; exactly-once resume;
+  cancel/pause of WAITING executions; internal-trigger GC.
+- **P4.5 — bridge UX.** Forward bridge tx hash / messageId templating; chain-B filter helpers; docs +
+  one worked example (e.g. CCIP `MessageReceived`).
+
+---
+
+## Explicitly deferred (out of v1)
+
+- Block-count / timer wake modes (event-on-B only for now)
+- `on_timeout` fallback edges (v1 = FAIL on timeout)
+- Per-leg fee billing (`resume_fee_wei` stays 0)
+- Multi-hop bridges (A→B→C)
+- Non-event arrival detection (balance polling on B)
+
+---
+
+## Open questions / risks
+
+- **Scheduler resume semantics (P4.2)** is the load-bearing change — needs a precise spec of how the Kahn
+  ready-queue is seeded from a partial-completion checkpoint, and how Loop/Branch state mid-graph is
+  represented. Drill-down pending.
+- **Exactly-once across restart** — the existing `TriggerRequestId` dedup is a 5-min window; a resume
+  signal that arrives around a restart must still resume exactly once. Needs an idempotency key tied to
+  `executionId` rather than (or in addition to) the time-windowed dedup.
+- **Operator coverage drift** — chain B is validated as covered at create time, but coverage can change
+  before the wait fires. Behavior if the only covering operator drops while a wait is pending?
+- **Fee credit at resume** — v1 charges `0`; confirm that's acceptable for the B-leg gas/value even though
+  the A-leg credit check already ran.
+
+---
+
+## Reference map
+
+Execution / VM:
+- `core/taskengine/executor.go:212` `RunTask`/`RunTaskWithContext` (single blocking call); `:164` `Perform`
+  (job processor); `:108` `QueueExecutionData` (extensible payload, has `ExecutionID`); `:748` atomic
+  end-of-execution persistence.
+- `core/taskengine/vm.go:896` `Run`; `:945` `runKahnScheduler` (the resume seam for P4.2); `:653` `Compile`;
+  `:99` `SetOutputVarForStep`/`vars` (the shared context); `:339` `resolveSmartWalletForNode`.
+- `ExecutionStatus` enum (proto): `UNSPECIFIED(0) PENDING(1) SUCCESS(2) FAILED(3) ERROR(5)` — `4` free.
+- Existing synchronous wait: `core/taskengine/vm_contract_write_waiting.go:109` `waitForUserOpConfirmation`.
+
+Trigger → wake → execute pipeline:
+- `aggregator/rpc_server.go:559` `NotifyTriggers`; `core/taskengine/engine.go:2627`
+  `AggregateChecksResultWithState` (dedup `:2706`, enqueue `:2874`); `core/apqueue/queue.go:109` `Enqueue`.
+- `core/taskengine/engine.go:1818` `StreamCheckToOperator` (task sync — extend to sync internal triggers);
+  `:702` `triggerMonitoringChainID`; `:718` `operatorsCoveringChain`; `:5073` `supportsTaskChain`.
+- `operator/worker_loop.go:1081` `EventTrigger.AddCheck`; `:263` per-chain trigger sets; `:701` event-fire
+  `NotifyTriggers`.
+
+Smart wallet / per-chain execution:
+- `core/chainio/aa/aa.go:99` `computeSmartWalletAddress` (CREATE2 — chain-invariant).
+- `core/taskengine/vm_runner_contract_write.go:807` send UserOp via per-chain bundler; output receipt with
+  `transactionHash` (→ `{{node.data.transactionHash}}`).
+- `core/config/config.go` `SmartWalletConfig` (per-chain RPC/bundler/factory); `ChainConfigRaw` (gateway
+  multi-chain registry).
+
+Adding a node type (P4.3 touch-points):
+- `protobuf/avs.proto` (`NodeType` enum + `Config`/`Output` messages + `TaskNode` oneof);
+  `aggregator/rest/mapping/node.go:24` `OpenAPIToProtoNode`; `core/taskengine/vm.go:2542`
+  `CreateNodeFromType`; `:3502` `ExtractNodeConfiguration`; a new `vm_runner_await.go`; VM dispatch; loop
+  runner support.

--- a/PLAN_DURABLE_EXECUTION.md
+++ b/PLAN_DURABLE_EXECUTION.md
@@ -90,12 +90,43 @@ The first two implementations:
 
 - **`Await` (cross-chain).** `Config` embeds an event-watch on chain B (chain B = `event.chain_id`); on
   resume the matched log is its output (`{{await.data.amount}}`). Wake source: chain event.
-- **`HumanApproval`.** `Config { prompt, approvers, channel (telegram|api), timeout_seconds, on_timeout }`.
-  Suspends with an external-signal subscription scoped to the execution and the authorized approver(s); the
-  gateway's approve/reject endpoint (hit by the Telegram bot callback or an API client) delivers the signal;
-  the decision becomes the step's output, and a downstream `Branch` routes on approve/reject. Timeout →
-  auto-reject (or escalate). **Security:** the signal must be authenticated and authorized against
-  `Config.approvers` — a money-moving gate is only as safe as who can sign the green-light.
+- **`HumanApproval`.** `Config { prompt, channel (telegram|api), timeout_seconds, on_timeout, approvers? }`.
+  Suspends with an external-signal subscription scoped to the execution; the gateway's approve/reject endpoint
+  (hit by the Telegram bot callback or an API client) delivers the signal; the decision becomes the step's
+  output, and a downstream `Branch` routes on approve/reject. Timeout → auto-reject (or escalate). Security
+  model below.
+
+### Approval security model (resolved)
+
+The trust anchor already exists — no per-approval signature is needed:
+
+1. **Deploy = EOA signature gate.** Creating a workflow is EOA-authenticated (SIWE → JWT); the user signs
+   with the EOA that *owns* the CREATE2-derived smart wallet. That signature proves ownership **and bounds
+   what the workflow may ever do** (its contracts, and — see below — capped recipients/amounts).
+2. **Telegram binding under that auth.** Studio, while the user is EOA-authenticated, links the user's
+   Telegram (bot-verified `telegram_user_id` ↔ owner), stored server-side.
+3. **In-flight approval = a Telegram tap**, relayed by the bot → gateway, checked against the binding. No
+   fresh EOA signature mid-flight.
+
+**Why that's safe:** the EOA signs the *envelope* (what the workflow may do); the Telegram tap is a
+*go/no-go within it*. A compromised Telegram can only green-light **pre-authorized** actions — it cannot
+redirect funds or change amounts. The blast radius is bounded by the signed envelope, not by Telegram
+account security.
+
+**Engine must enforce:**
+- binding established under EOA auth and stored server-side; approval checks
+  `telegram_user_id == bound approver for the workflow's owner` (default approver = owner; `Config.approvers`
+  only for delegated/multi-party).
+- **trusted bot→gateway channel** (bot is backend; shared secret/mTLS) so Telegram's verified user id is the
+  only authenticated input — no forged "approve" injectable.
+- **scoped + idempotent** — the signal advances *this* WAITING execution exactly once (status guard);
+  replayed callbacks no-op.
+- **timeout → auto-reject** (never leave a money-gating await hanging) + **audit** (approver id + time).
+
+**Recommended envelope tightening (so the go/no-go is genuinely bounded):** support an optional, deploy-signed
+**per-workflow value cap / recipient allow-list** for money-moving steps — otherwise a dynamic
+recipient/amount (from a prior node) widens what the tap authorizes. Optionally a **high-value tier** that
+*does* require a fresh EOA signature (via the extension) above a threshold — opt-in, not the default.
 
 Future steps reuse the same interface for free: `Delay`, `WaitForWebhook`, retry/backoff wrappers, SLAs.
 
@@ -156,9 +187,11 @@ the real bridge; a gateway-endpoint integration test for the Telegram approve/re
 
 ## Open questions / risks
 
-- **Approval security model** — authentication of the approve/reject signal, the `approvers` allow-list, and
-  binding a Telegram identity to an authorized party. This is the highest-stakes new surface (it gates money
-  movement) and needs its own mini-design before P-step 2.
+- **Approval security model** — **resolved** (see *Approval security model* above): anchored on the existing
+  deploy-time EOA signature (the bounded envelope) + a studio-established Telegram binding; in-flight approval
+  is a bound Telegram tap, no fresh signature. Remaining *implementation* details: the binding store + check,
+  the trusted bot→gateway channel, and the optional deploy-signed value cap / recipient allow-list (and the
+  opt-in high-value re-sign tier).
 - **Migration** — relaxed same-results ⇒ wipe in-flight/old executions at cutover. Confirm no live executions
   must survive the switch (or provide a drain window).
 - **Crash-recovery re-arm correctness** — the boot `wake:` re-arm + GC must be exactly-once against

--- a/PLAN_DURABLE_EXECUTION.md
+++ b/PLAN_DURABLE_EXECUTION.md
@@ -1,0 +1,175 @@
+# PLAN — Durable Execution Engine
+
+Status: **design, not started.** Supersedes the bolt-on approach in `PLAN_CROSS_CHAIN_SEQUENCING.md`
+(retained for its test scenarios and the file:line reference map). This is the engine-level plan; cross-chain
+and human-approval are the first **features** that ride it.
+
+## Intent
+
+Reshape the task executor into a **durable execution engine**: an execution is a *persisted state machine*,
+and the executor is a re-entrant function that advances it. This makes any step able to **suspend** (wait for
+something) and the whole execution able to **resume** later or **recover** after a crash — uniformly, for
+every workflow, not as a special case.
+
+Driven by two concrete near-term features that the current synchronous, single-pass executor cannot
+support:
+
+- **Cross-chain sequencing** — initiate a bridge on chain A, wait for arrival on chain B (minutes–hours),
+  continue on B. Wake source: a **chain event** (operator-watched).
+- **Human-approval gates** — a money-moving `contractWrite` must wait for a human green-light (e.g. a
+  Telegram approve/reject) before sending. Wake source: an **external signal** (gateway-received).
+
+Both are the same shape: *run some steps → suspend on a condition → resume on a signal → continue.* Build the
+engine once; both features become thin `Suspendable` steps on top.
+
+## Why a homegrown engine (not Temporal/Cadence)
+
+We use neither today and adopt neither. They're the reference architectures for this pattern; the wrong fit
+here because:
+
+1. **Replay is wrong for irreversible on-chain steps.** Temporal/Cadence re-run workflow code from event
+   history and require *deterministic* code. You cannot replay a sent UserOp — re-running a completed
+   `contractWrite` double-spends. Our engine must be **checkpoint-based**: persist each step's *result*,
+   advance from the snapshot, and **never re-run a completed side-effecting step.** (This also *frees* node
+   code from any determinism constraint.)
+2. **Heavy separate infra** vs. our existing BadgerDB + apqueue.
+3. **Deep integration** — execution is already fused with the gateway, operators, chain-watching, ERC-4337
+   wallets, and fees. A focused engine on the existing stack beats bending an external one.
+
+## The model
+
+```
+Execution = persisted state machine:
+  { step_outputs: map<nodeId, result>,    // durable; the resumable state
+    completed: set<nodeId>,
+    status: RUNNING | WAITING | SUCCESS | FAILED,
+    pending_signal: WakeSubscription?,     // set while WAITING
+    … identity, fees, logs … }
+
+Executor = advance(executionId, signal?):
+  1. load state
+  2. if signal: apply it (the wake event/approval becomes the suspended step's output)
+  3. run every ready, not-yet-completed step (predecessors all completed)
+       - persist each step's result as it finishes   ← checkpoint-forward
+       - a step may return Continue | Suspend(wake) | Fail
+  4. on Suspend → persist WAITING + register the wake subscription; return
+     on all-done → SUCCESS;  on fatal → FAILED
+  Re-entrant by construction: a fresh run is advance() from empty; a resume is advance() with a signal;
+  a crash-recovery is advance() over whatever was persisted.
+```
+
+The 10 existing node runners (ContractWrite, ContractRead, ETHTransfer, REST, GraphQL, CustomCode, Branch,
+Filter, Loop, Balance) are **reused as step bodies** — we replace the orchestration shell, not the steps.
+
+## The signal model (the generalization)
+
+A `Suspendable` step suspends with a **WakeSubscription**; a matching **Signal** delivered later advances the
+execution. Three sources, one intake:
+
+| Source | Detected by | Subscription | Signal example |
+|---|---|---|---|
+| **Chain event** | operator (chain watch) | event filter on chain B | bridge arrival log |
+| **External signal** | gateway (inbound API/webhook) | `await signal S for exec E from authorized party` | Telegram approve/reject |
+| **Timer** | scheduler (due-time sweep) | `wake at T` | delay elapse, approval timeout |
+
+All converge on `advance(executionId, signal)`. The chain-event path reuses the operator trigger machinery;
+the external-signal path is a new authenticated gateway endpoint; the timer path is a due-time sweep over
+persisted subscriptions. **Idempotency** is uniform: a signal only advances an execution that is still
+`WAITING` on a *matching* subscription — durable exactly-once across restarts, independent of any in-memory
+dedup window.
+
+## Suspendable steps — the interface
+
+```go
+type StepResult interface{}  // Continue(output) | Suspend(WakeSubscription) | Fail(err)
+// A Suspendable step computes its wake condition from vars and yields Suspend(...).
+// On resume, the delivered signal becomes the step's output; the step is NOT re-run.
+```
+
+The first two implementations:
+
+- **`Await` (cross-chain).** `Config` embeds an event-watch on chain B (chain B = `event.chain_id`); on
+  resume the matched log is its output (`{{await.data.amount}}`). Wake source: chain event.
+- **`HumanApproval`.** `Config { prompt, approvers, channel (telegram|api), timeout_seconds, on_timeout }`.
+  Suspends with an external-signal subscription scoped to the execution and the authorized approver(s); the
+  gateway's approve/reject endpoint (hit by the Telegram bot callback or an API client) delivers the signal;
+  the decision becomes the step's output, and a downstream `Branch` routes on approve/reject. Timeout →
+  auto-reject (or escalate). **Security:** the signal must be authenticated and authorized against
+  `Config.approvers` — a money-moving gate is only as safe as who can sign the green-light.
+
+Future steps reuse the same interface for free: `Delay`, `WaitForWebhook`, retry/backoff wrappers, SLAs.
+
+## Storage / execution-record schema (clean redesign)
+
+Relaxing "existing executions reproduce identically" lets us redesign the execution record around the state
+machine instead of bolting fields on, and **wipe old executions on cutover** (the chain-decoupling playbook:
+a boot migration clears the old shape; tasks re-run fresh). Core persisted shape (chain-agnostic keys,
+additive to task storage):
+
+```
+exec:<execId>            execution state machine (status, completed set, pending subscription, fees, logs)
+exec_out:<execId>:<nodeId>   per-step result (checkpoint-forward; the resumable state)
+wake:<execId>            the active WakeSubscription while WAITING (scanned on boot to re-arm)
+```
+
+`wake:` is the durable signal registry: boot re-arms chain-event subscriptions to operators, reloads timer
+due-times, and GCs subscriptions whose execution is no longer WAITING.
+
+## Triggers unified
+
+The entry trigger becomes **the first condition in the graph** — there is no separate "task trigger vs.
+mid-graph wait" concept. An entry chain-event/cron *creates and advances* an execution; an `Await`/`Approval`
+*resumes and advances* one. All watches are execution-scoped from the start, which removes the
+`task_id`-vs-`execution_id` duality the bolt-on had to thread through the sync protocol.
+
+## Landing — 3 shippable steps
+
+1. **Durable executor core.** Per-step persisted state, `advance()` resume-from-state, the `Suspendable`
+   interface, node runners reused as step bodies. *Outcome: the engine is crash-recoverable for every
+   workflow* (independent of any feature). Built and tested with a synthetic signal (no triggers/UI yet).
+2. **Signal intake + unified triggers.** The three wake sources (operator chain-event, gateway
+   external-signal endpoint, timer sweep) → one `advance(executionId, signal)`; entry triggers folded into
+   the condition model. *Outcome: `Await` (chain) and `HumanApproval` (Telegram) both work end-to-end.*
+3. **Stateless `advance()` shell + retries.** Consolidate orchestration into the re-entrant function; the
+   queue carries `advance` jobs (triggers, signals, timers, crash-sweep, retry/backoff). *Outcome: the final
+   durable shape — long-running, failing, resuming work handled uniformly.*
+
+## Outcomes & test scenarios
+
+Carry forward the cross-chain outcomes/scenarios (`PLAN_CROSS_CHAIN_SEQUENCING.md` Appendix B: O1–O10,
+E1–E15) — they hold for the chain-event feature on this engine — and **add** the approval + crash-recovery
+set:
+
+- **O-A1 — Approval gate.** A `contractWrite` preceded by `HumanApproval` does **not** send until an
+  authorized approve signal arrives; reject → the write never runs; the workflow takes the reject path.
+- **O-A2 — Authorization.** A signal from a non-authorized party is rejected; only `Config.approvers` can
+  decide. Replayed/duplicate approvals advance once.
+- **O-A3 — Approval timeout.** No decision before `timeout_seconds` → auto-reject (or escalate); the gate is
+  released; a late approval no-ops.
+- **O-C1 — Universal crash recovery.** *Any* workflow (not just suspendable ones) killed mid-execution
+  resumes from the last persisted step on restart, re-running only incomplete steps — completed
+  side-effecting steps never re-fire.
+- **O-C2 — Timer wake.** A `Delay`/approval-timeout fires from the due-time sweep after a restart.
+
+E2E layering unchanged: deterministic Go integration (signals injected) for the bulk; one testnet SDK e2e for
+the real bridge; a gateway-endpoint integration test for the Telegram approve/reject round-trip.
+
+## Open questions / risks
+
+- **Approval security model** — authentication of the approve/reject signal, the `approvers` allow-list, and
+  binding a Telegram identity to an authorized party. This is the highest-stakes new surface (it gates money
+  movement) and needs its own mini-design before P-step 2.
+- **Migration** — relaxed same-results ⇒ wipe in-flight/old executions at cutover. Confirm no live executions
+  must survive the switch (or provide a drain window).
+- **Crash-recovery re-arm correctness** — the boot `wake:` re-arm + GC must be exactly-once against
+  operators (chain) and not double-fire timers.
+- **Per-step persistence cost** — a small write per step for all workflows; negligible for typical node
+  counts (loops iterate in-memory), but worth a benchmark on the largest real graphs.
+- **Scope discipline** — adopt the Level-3 *model* but land incrementally (the 3 steps); do not big-bang a
+  from-scratch rewrite. Node runners are reused, not rewritten.
+
+## Relationship to prior docs
+
+- `PLAN_CHAIN_DECOUPLING.md` — done/shipped; the per-part chain model this builds on.
+- `PLAN_CROSS_CHAIN_SEQUENCING.md` — superseded as the *engine* approach (its Level-1 bolt-on becomes native
+  here); retained for Appendix B (test scenarios) and the reference map, both still valid.

--- a/SDK_HANDOFF_DURABLE_EXECUTION.md
+++ b/SDK_HANDOFF_DURABLE_EXECUTION.md
@@ -1,0 +1,138 @@
+# SDK Hand-off — Durable Execution (Await + Signal)
+
+**Audience:** `ava-sdk-js` maintainers. **Status:** as-built, merged to `staging` (PRs #643–#647).
+**Source of truth for shapes:** [`api/openapi.yaml`](api/openapi.yaml) on `staging` — regenerate from it, don't hand-transcribe.
+**Why (design rationale):** [`PLAN_DURABLE_EXECUTION.md`](PLAN_DURABLE_EXECUTION.md). That doc is design intent and predates the final API; **this doc is what actually shipped** — where they disagree, this wins.
+
+---
+
+## What shipped (one paragraph)
+
+A workflow can now **pause mid-execution** and resume later, exactly-once, surviving aggregator restarts. The pause point is a new node type, **`await`**, with two mutually-exclusive flavors:
+
+- **External-signal (human approval):** pauses until someone POSTs an approve/reject (e.g. a Telegram bot or an API client). The decision becomes the node's output.
+- **Chain-event (cross-chain):** pauses until an operator observes an on-chain event (e.g. a bridge arrival on another chain). The matched log becomes the node's output.
+
+While paused, the execution has status **`EXECUTION_STATUS_WAITING`** (non-terminal). It resumes via `POST /executions/{id}:signal` (external-signal) or automatically when the operator sees the chain event.
+
+---
+
+## Step 0 — regenerate types (required, mechanical)
+
+The SDK already pulls types from this repo's `staging` OpenAPI:
+
+```bash
+yarn openapi-download   # curl staging api/openapi.yaml -> packages/types/openapi/openapi.yaml
+yarn types-gen          # openapi-typescript -> packages/types/src/openapi.gen.ts
+```
+
+After regen, `openapi.gen.ts` contains: `AwaitNode` / `AwaitNodeConfig` (incl. `chainEvent`), `"await"` in the Node discriminator + `NodeType` enum, `SignalExecutionRequest`, the `signalExecution` operation, and `EXECUTION_STATUS_WAITING`. Everything below is then type-checked, not stringly-typed.
+
+---
+
+## The `await` node contract
+
+`AwaitNodeConfig` (camelCase, as the SDK sees it):
+
+| field | type | flavor | notes |
+|---|---|---|---|
+| `channel` | string | external-signal | `"telegram"` \| `"api"` |
+| `approvers` | string[] | external-signal | authorized parties; empty ⇒ the workflow owner |
+| `prompt` | string | external-signal | shown to the approver |
+| `chainEvent` | `EventTriggerConfig` | chain-event | the on-chain event to wait for (same shape as an Event trigger's config: `chainId` + `queries[]`) |
+| `timeoutSeconds` | int64 | both | safety bound; `0` ⇒ server default (24h). **Never unbounded.** |
+
+**Mutual exclusivity (enforced server-side):** set **either** `channel` (+ optional `approvers`/`prompt`) **or** `chainEvent` — never both. A config with both is **rejected** (the node fails; it does not suspend). A config with neither is rejected at create. The OpenAPI schema can't express the XOR, so the SDK should guard it in the builder (below) for a good error before the round-trip.
+
+Node discriminator value is `"await"` (like `"contractWrite"`, `"ethTransfer"`).
+
+---
+
+## The signal endpoint (resumes an external-signal await)
+
+```
+POST /executions/{id}:signal?workflowId={workflowId}
+Authorization: Bearer <JWT>          # standard auth; caller must OWN the workflow
+Content-Type: application/json
+
+{ "decision": "approve" | "reject", "payload": { ... }?  }
+```
+
+- `id` (path) = the execution id; `workflowId` (query, **required**) = its workflow (executions are workflow-scoped, same as `getExecution`).
+- `decision` is **required**, enum `approve | reject`. `payload` is optional structured data delivered as the await node's output (readable downstream as `{{<awaitNodeName>.data...}}`).
+- **Returns** the `Execution` — resumed to a terminal status, or still `WAITING` if the workflow hit a *second* await.
+- **Errors:** `400` (bad decision / no matching pending wait / already timed out — mapped from `InvalidArgument`/`FailedPrecondition`), `401` (auth), `404` (workflow not owned / not found).
+
+Chain-event awaits are **not** resumed through this endpoint — an operator fires them automatically; the SDK only needs to poll/stream the execution to observe the resume.
+
+---
+
+## The `WAITING` lifecycle (important for polling/streaming)
+
+`EXECUTION_STATUS_WAITING` is **non-terminal**. Any SDK helper that "waits for an execution to finish" must treat `WAITING` as *keep waiting*, not done:
+
+- `executions.get` / the SSE stream will report `WAITING` while paused, then a terminal status (`SUCCESS` / `FAILED` / `ERROR`) once resumed (or `FAILED` with "await timed out…" if the timeout sweep fires).
+- A `waitForExecution`-style util that currently stops on "any status set" or "not PENDING" will return early on `WAITING` — update its terminal-status predicate to exclude `WAITING`.
+
+---
+
+## Ergonomic wrappers to add (recommended, matches existing DX)
+
+**1. `Nodes.await(...)` builder** — `packages/sdk-js/src/v4/builders/nodes.ts`, alongside `ethTransfer`/`contractWrite`:
+
+```ts
+await(opts: {
+  id: string;
+  name: string;
+  timeoutSeconds?: number;
+} & (
+  | { channel: "telegram" | "api"; approvers?: string[]; prompt?: string }   // external-signal
+  | { chainEvent: v4.EventTriggerConfig }                                      // chain-event
+)): v4.Node {
+  // guard the XOR for a friendly error before the round-trip
+  return {
+    id: opts.id,
+    name: opts.name,
+    type: "await",
+    config: { ...opts, id: undefined, name: undefined },  // pass through the flavor fields + timeoutSeconds
+  } as v4.Node;
+},
+```
+
+**2. `executions.signal(...)` method** — `packages/sdk-js/src/v4/resources/executions.ts` (mirror `workflows.resume` / the `getExecution` query pattern):
+
+```ts
+/** POST /executions/{id}:signal — resume a WAITING execution (human approval). */
+signal(
+  id: string,
+  params: { workflowId: string; decision: "approve" | "reject"; payload?: Record<string, unknown> },
+): Promise<v4.Execution> {
+  return this.transport.request<v4.Execution>({
+    path: `/executions/${encodeURIComponent(id)}:signal`,
+    method: "POST",
+    query: { workflowId: params.workflowId },
+    body: { decision: params.decision, payload: params.payload },
+  });
+}
+```
+
+**3. WAITING-aware wait/stream** — update the terminal-status predicate in any execution-completion helper to exclude `EXECUTION_STATUS_WAITING`.
+
+---
+
+## NOT built yet (don't assume these exist)
+
+These appear in `PLAN_DURABLE_EXECUTION.md` as design/intent but are **not in v1** — building against them will break:
+
+- **Telegram binding & bot→gateway trusted channel.** v1 authorizes the signal endpoint by **workflow owner** (the JWT). There is no `telegram_user_id ↔ owner` binding check and no bot→gateway shared-secret transport yet — that's studio/bot-side work. The `approvers` field is carried but not yet enforced as a delegated-approver check.
+- **`on_timeout` fallback edge.** Timeout ⇒ the execution is failed (`FAILED`, "await timed out…"). There is no "take a fallback edge on timeout" routing.
+- **Per-workflow value cap / recipient allow-list** (the "envelope tightening") and the **high-value fresh-EOA-signature tier** — design recommendations, not implemented.
+- A separate `HumanApproval` node — there isn't one; it's the external-signal flavor of `await`.
+
+---
+
+## Quick reference
+
+- Node contract & signal op: `api/openapi.yaml` (`AwaitNodeConfig`, `SignalExecutionRequest`, `/executions/{id}:signal`).
+- Behavior proven by: `core/taskengine/vm_resume_test.go`, `core/taskengine/durable_test.go`, `aggregator/rest/mapping/node_test.go`.
+- Design/why: `PLAN_DURABLE_EXECUTION.md`. Cross-chain specifics: `PLAN_CROSS_CHAIN_SEQUENCING.md`.

--- a/SDK_HANDOFF_DURABLE_EXECUTION.md
+++ b/SDK_HANDOFF_DURABLE_EXECUTION.md
@@ -67,12 +67,14 @@ Chain-event awaits are **not** resumed through this endpoint — an operator fir
 
 ---
 
-## The `WAITING` lifecycle (important for polling/streaming)
+## The `waiting` lifecycle (important for polling/streaming)
 
-`EXECUTION_STATUS_WAITING` is **non-terminal**. Any SDK helper that "waits for an execution to finish" must treat `WAITING` as *keep waiting*, not done:
+Over REST the status is the lowercase wire value **`"waiting"`** (the generated `ExecutionStatus` union member; proto enum `EXECUTION_STATUS_WAITING`). It is **non-terminal**. Any SDK helper that "waits for an execution to finish" must treat `"waiting"` as *keep waiting*, not done:
 
-- `executions.get` / the SSE stream will report `WAITING` while paused, then a terminal status (`SUCCESS` / `FAILED` / `ERROR`) once resumed (or `FAILED` with "await timed out…" if the timeout sweep fires).
-- A `waitForExecution`-style util that currently stops on "any status set" or "not PENDING" will return early on `WAITING` — update its terminal-status predicate to exclude `WAITING`.
+- `executions.get` / the SSE stream report `"waiting"` while paused, then a terminal status (`"success"` / `"failed"` / `"error"`) once resumed (or `"failed"` with "await timed out…" if the timeout sweep fires).
+- A `waitForExecution`-style util that currently stops on "any status set" or "not `pending`" will return early on `"waiting"` — update its terminal-status predicate to exclude `"waiting"`.
+
+> Note: `"waiting"` was added to the OpenAPI `ExecutionStatus` enum and the REST wire mapping together with this hand-off — before that fix a paused execution surfaced as `"pending"` over REST. Make sure your `openapi-download` is current.
 
 ---
 
@@ -116,7 +118,7 @@ signal(
 }
 ```
 
-**3. WAITING-aware wait/stream** — update the terminal-status predicate in any execution-completion helper to exclude `EXECUTION_STATUS_WAITING`.
+**3. WAITING-aware wait/stream** — update the terminal-status predicate in any execution-completion helper to exclude `"waiting"`.
 
 ---
 

--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -29,6 +29,9 @@ type ServerInterface interface {
 	// Get execution status (lightweight, no steps)
 	// (GET /executions/{id}:getStatus)
 	GetExecutionStatus(ctx echo.Context, id Ulid, params GetExecutionStatusParams) error
+	// Deliver an approval/external signal to a waiting execution
+	// (POST /executions/{id}:signal)
+	SignalExecution(ctx echo.Context, id Ulid, params SignalExecutionParams) error
 	// Stream execution status changes (Server-Sent Events)
 	// (GET /executions/{id}:stream)
 	StreamExecution(ctx echo.Context, id Ulid, params StreamExecutionParams) error
@@ -218,6 +221,33 @@ func (w *ServerInterfaceWrapper) GetExecutionStatus(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.GetExecutionStatus(ctx, id, params)
+	return err
+}
+
+// SignalExecution converts echo context to params.
+func (w *ServerInterfaceWrapper) SignalExecution(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id Ulid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params SignalExecutionParams
+	// ------------- Required query parameter "workflowId" -------------
+
+	err = runtime.BindQueryParameter("form", true, true, "workflowId", ctx.QueryParams(), &params.WorkflowId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workflowId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.SignalExecution(ctx, id, params)
 	return err
 }
 
@@ -820,6 +850,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/executions", wrapper.ListExecutions)
 	router.GET(baseURL+"/executions/:id", wrapper.GetExecution)
 	router.GET(baseURL+"/executions/:id:getStatus", wrapper.GetExecutionStatus)
+	router.POST(baseURL+"/executions/:id:signal", wrapper.SignalExecution)
 	router.GET(baseURL+"/executions/:id:stream", wrapper.StreamExecution)
 	router.GET(baseURL+"/executions:count", wrapper.CountExecutions)
 	router.GET(baseURL+"/executions:stats", wrapper.ExecutionStats)
@@ -1028,6 +1059,58 @@ type GetExecutionStatus404ApplicationProblemPlusJSONResponse struct {
 }
 
 func (response GetExecutionStatus404ApplicationProblemPlusJSONResponse) VisitGetExecutionStatusResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecutionRequestObject struct {
+	Id     Ulid `json:"id"`
+	Params SignalExecutionParams
+	Body   *SignalExecutionJSONRequestBody
+}
+
+type SignalExecutionResponseObject interface {
+	VisitSignalExecutionResponse(w http.ResponseWriter) error
+}
+
+type SignalExecution200JSONResponse Execution
+
+func (response SignalExecution200JSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecution400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response SignalExecution400ApplicationProblemPlusJSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecution401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response SignalExecution401ApplicationProblemPlusJSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SignalExecution404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response SignalExecution404ApplicationProblemPlusJSONResponse) VisitSignalExecutionResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(404)
 
@@ -2138,6 +2221,9 @@ type StrictServerInterface interface {
 	// Get execution status (lightweight, no steps)
 	// (GET /executions/{id}:getStatus)
 	GetExecutionStatus(ctx context.Context, request GetExecutionStatusRequestObject) (GetExecutionStatusResponseObject, error)
+	// Deliver an approval/external signal to a waiting execution
+	// (POST /executions/{id}:signal)
+	SignalExecution(ctx context.Context, request SignalExecutionRequestObject) (SignalExecutionResponseObject, error)
 	// Stream execution status changes (Server-Sent Events)
 	// (GET /executions/{id}:stream)
 	StreamExecution(ctx context.Context, request StreamExecutionRequestObject) (StreamExecutionResponseObject, error)
@@ -2333,6 +2419,38 @@ func (sh *strictHandler) GetExecutionStatus(ctx echo.Context, id Ulid, params Ge
 		return err
 	} else if validResponse, ok := response.(GetExecutionStatusResponseObject); ok {
 		return validResponse.VisitGetExecutionStatusResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// SignalExecution operation middleware
+func (sh *strictHandler) SignalExecution(ctx echo.Context, id Ulid, params SignalExecutionParams) error {
+	var request SignalExecutionRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	var body SignalExecutionJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.SignalExecution(ctx.Request().Context(), request.(SignalExecutionRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "SignalExecution")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(SignalExecutionResponseObject); ok {
+		return validResponse.VisitSignalExecutionResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -861,8 +861,9 @@ type Lang string
 // LoopNode defines model for LoopNode.
 type LoopNode struct {
 	// Config Iterates over an input array, running an inner Node per item. The
-	// runner node is one of the chain-aware or chain-agnostic node types
-	// and inherits chainId from this LoopNode if it does not specify its own.
+	// runner node is one of the chain-aware or chain-agnostic node types;
+	// a chain-aware runner must specify its own required `chainId` (there is
+	// no inheritance from the loop or workflow).
 	Config *LoopNodeConfig `json:"config,omitempty"`
 	Type   *LoopNodeType   `json:"type,omitempty"`
 }
@@ -871,8 +872,9 @@ type LoopNode struct {
 type LoopNodeType string
 
 // LoopNodeConfig Iterates over an input array, running an inner Node per item. The
-// runner node is one of the chain-aware or chain-agnostic node types
-// and inherits chainId from this LoopNode if it does not specify its own.
+// runner node is one of the chain-aware or chain-agnostic node types;
+// a chain-aware runner must specify its own required `chainId` (there is
+// no inheritance from the loop or workflow).
 type LoopNodeConfig struct {
 	// InputVariable Template path for the iterable (e.g., `{{settings.addressList}}`).
 	InputVariable string `json:"inputVariable"`

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -16,9 +16,14 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for AwaitNodeType.
+const (
+	AwaitNodeTypeAwait AwaitNodeType = "await"
+)
+
 // Defines values for BalanceNodeType.
 const (
-	BalanceNodeTypeBalance BalanceNodeType = "balance"
+	Balance BalanceNodeType = "balance"
 )
 
 // Defines values for BlockTriggerType.
@@ -159,6 +164,7 @@ const (
 
 // Defines values for NodeType.
 const (
+	NodeTypeAwait         NodeType = "await"
 	NodeTypeBalance       NodeType = "balance"
 	NodeTypeBranch        NodeType = "branch"
 	NodeTypeContractRead  NodeType = "contractRead"
@@ -256,6 +262,33 @@ type AuthExchangeResponse struct {
 
 	// Token JWT bearer token.
 	Token string `json:"token"`
+}
+
+// AwaitNode defines model for AwaitNode.
+type AwaitNode struct {
+	// Config Pauses the workflow until a signal arrives (durable execution). v1 is the
+	// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+	Config *AwaitNodeConfig `json:"config,omitempty"`
+	Type   *AwaitNodeType   `json:"type,omitempty"`
+}
+
+// AwaitNodeType defines model for AwaitNode.Type.
+type AwaitNodeType string
+
+// AwaitNodeConfig Pauses the workflow until a signal arrives (durable execution). v1 is the
+// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+type AwaitNodeConfig struct {
+	// Approvers Authorized approver identities. Empty = the workflow owner.
+	Approvers *[]string `json:"approvers,omitempty"`
+
+	// Channel Signal channel: `telegram` or `api`.
+	Channel string `json:"channel"`
+
+	// Prompt Message shown to the approver.
+	Prompt *string `json:"prompt,omitempty"`
+
+	// TimeoutSeconds Safety bound; 0 = server default (the wait is never unbounded).
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
 
 // BalanceNode defines model for BalanceNode.
@@ -1972,6 +2005,36 @@ func (t *Node) MergeBalanceNode(v BalanceNode) error {
 	return err
 }
 
+// AsAwaitNode returns the union data inside the Node as a AwaitNode
+func (t Node) AsAwaitNode() (AwaitNode, error) {
+	var body AwaitNode
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAwaitNode overwrites any union data inside the Node as the provided AwaitNode
+func (t *Node) FromAwaitNode(v AwaitNode) error {
+	t.Type = "await"
+
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAwaitNode performs a merge with any union data inside the Node, using the provided AwaitNode
+func (t *Node) MergeAwaitNode(v AwaitNode) error {
+	t.Type = "await"
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t Node) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -1986,6 +2049,8 @@ func (t Node) ValueByDiscriminator() (interface{}, error) {
 		return nil, err
 	}
 	switch discriminator {
+	case "await":
+		return t.AsAwaitNode()
 	case "balance":
 		return t.AsBalanceNode()
 	case "branch":

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -1523,15 +1523,15 @@ type DeleteSecretParams struct {
 
 // GetTokenParams defines parameters for GetToken.
 type GetTokenParams struct {
-	// ChainId Chain ID filter. Omit to use the aggregator default chain. Repeat
-	// the parameter to filter by multiple chains.
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
 	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 
 // GetWalletNonceParams defines parameters for GetWalletNonce.
 type GetWalletNonceParams struct {
-	// ChainId Chain ID filter. Omit to use the aggregator default chain. Repeat
-	// the parameter to filter by multiple chains.
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
 	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -200,6 +200,12 @@ const (
 	SecretScopeWorkflow SecretScope = "workflow"
 )
 
+// Defines values for SignalExecutionRequestDecision.
+const (
+	Approve SignalExecutionRequestDecision = "approve"
+	Reject  SignalExecutionRequestDecision = "reject"
+)
+
 // Defines values for TokenMetadataResponseSource.
 const (
 	Cache     TokenMetadataResponseSource = "cache"
@@ -1193,6 +1199,18 @@ type SecretList struct {
 	PageInfo PageInfo `json:"pageInfo"`
 }
 
+// SignalExecutionRequest defines model for SignalExecutionRequest.
+type SignalExecutionRequest struct {
+	// Decision The approver's decision.
+	Decision SignalExecutionRequestDecision `json:"decision"`
+
+	// Payload Optional structured data delivered as the await step's output.
+	Payload *map[string]interface{} `json:"payload,omitempty"`
+}
+
+// SignalExecutionRequestDecision The approver's decision.
+type SignalExecutionRequestDecision string
+
 // SimulateWorkflowRequest defines model for SimulateWorkflowRequest.
 type SimulateWorkflowRequest struct {
 	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
@@ -1515,6 +1533,12 @@ type GetExecutionStatusParams struct {
 	WorkflowId Ulid `form:"workflowId" json:"workflowId"`
 }
 
+// SignalExecutionParams defines parameters for SignalExecution.
+type SignalExecutionParams struct {
+	// WorkflowId Workflow id the execution belongs to. See `getExecution`.
+	WorkflowId Ulid `form:"workflowId" json:"workflowId"`
+}
+
 // StreamExecutionParams defines parameters for StreamExecution.
 type StreamExecutionParams struct {
 	Interval *string `form:"interval,omitempty" json:"interval,omitempty"`
@@ -1606,6 +1630,9 @@ type CountWorkflowsParams struct {
 
 // AuthExchangeJSONRequestBody defines body for AuthExchange for application/json ContentType.
 type AuthExchangeJSONRequestBody = AuthExchangeRequest
+
+// SignalExecutionJSONRequestBody defines body for SignalExecution for application/json ContentType.
+type SignalExecutionJSONRequestBody = SignalExecutionRequest
 
 // RunNodeJSONRequestBody defines body for RunNode for application/json ContentType.
 type RunNodeJSONRequestBody = RunNodeRequest

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -272,8 +272,11 @@ type AuthExchangeResponse struct {
 
 // AwaitNode defines model for AwaitNode.
 type AwaitNode struct {
-	// Config Pauses the workflow until a signal arrives (durable execution). v1 is the
-	// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+	// Config Pauses the workflow until a wake arrives (durable execution). Two mutually
+	// exclusive flavors: the external-signal flavor (human approval — set `channel`,
+	// e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+	// `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+	// bridge arrival on another chain). Exactly one flavor must be configured.
 	Config *AwaitNodeConfig `json:"config,omitempty"`
 	Type   *AwaitNodeType   `json:"type,omitempty"`
 }
@@ -281,16 +284,24 @@ type AwaitNode struct {
 // AwaitNodeType defines model for AwaitNode.Type.
 type AwaitNodeType string
 
-// AwaitNodeConfig Pauses the workflow until a signal arrives (durable execution). v1 is the
-// external-signal flavor (human approval — e.g. a Telegram approve/reject).
+// AwaitNodeConfig Pauses the workflow until a wake arrives (durable execution). Two mutually
+// exclusive flavors: the external-signal flavor (human approval — set `channel`,
+// e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+// `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+// bridge arrival on another chain). Exactly one flavor must be configured.
 type AwaitNodeConfig struct {
-	// Approvers Authorized approver identities. Empty = the workflow owner.
+	// Approvers External-signal flavor — authorized approver identities. Empty = the workflow owner.
 	Approvers *[]string `json:"approvers,omitempty"`
 
-	// Channel Signal channel: `telegram` or `api`.
-	Channel string `json:"channel"`
+	// ChainEvent Chain-event flavor — the on-chain event to wait for (a mid-workflow
+	// EventTrigger). An operator covering `chainEvent.chainId` watches it and
+	// resumes the execution when it fires. Mutually exclusive with `channel`.
+	ChainEvent *EventTriggerConfig `json:"chainEvent,omitempty"`
 
-	// Prompt Message shown to the approver.
+	// Channel External-signal flavor — signal channel: `telegram` or `api`.
+	Channel *string `json:"channel,omitempty"`
+
+	// Prompt External-signal flavor — message shown to the approver.
 	Prompt *string `json:"prompt,omitempty"`
 
 	// TimeoutSeconds Safety bound; 0 = server default (the wait is never unbounded).

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -90,6 +90,7 @@ const (
 	ExecutionStatusFailed  ExecutionStatus = "failed"
 	ExecutionStatusPending ExecutionStatus = "pending"
 	ExecutionStatusSuccess ExecutionStatus = "success"
+	ExecutionStatusWaiting ExecutionStatus = "waiting"
 )
 
 // Defines values for ExecutionTier.
@@ -708,8 +709,12 @@ type Execution struct {
 	Index   *int64 `json:"index,omitempty"`
 	StartAt int64  `json:"startAt"`
 
-	// Status Outcome of an execution. `pending` is in-flight; `success` is full
-	// success; `failed` is logical failure (e.g., a node returned an error);
+	// Status Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+	// mid-workflow at an `await` node, durably parked until a signal arrives
+	// (a human approve/reject or an operator-observed chain event) or the wait
+	// times out — non-terminal, like `pending`, but distinguishable so a client
+	// can show "awaiting approval"; `success` is full success; `failed` is
+	// logical failure (e.g., a node returned an error, or a wait timed out);
 	// `error` is a system / infrastructure failure (e.g., RPC unreachable).
 	Status   ExecutionStatus  `json:"status"`
 	Steps    *[]ExecutionStep `json:"steps,omitempty"`
@@ -740,8 +745,12 @@ type ExecutionStats struct {
 	Total            int64    `json:"total"`
 }
 
-// ExecutionStatus Outcome of an execution. `pending` is in-flight; `success` is full
-// success; `failed` is logical failure (e.g., a node returned an error);
+// ExecutionStatus Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+// mid-workflow at an `await` node, durably parked until a signal arrives
+// (a human approve/reject or an operator-observed chain event) or the wait
+// times out — non-terminal, like `pending`, but distinguishable so a client
+// can show "awaiting approval"; `success` is full success; `failed` is
+// logical failure (e.g., a node returned an error, or a wait timed out);
 // `error` is a system / infrastructure failure (e.g., RPC unreachable).
 type ExecutionStatus string
 
@@ -754,8 +763,12 @@ type ExecutionStatusSummary struct {
 	Id      Ulid   `json:"id"`
 	StartAt *int64 `json:"startAt,omitempty"`
 
-	// Status Outcome of an execution. `pending` is in-flight; `success` is full
-	// success; `failed` is logical failure (e.g., a node returned an error);
+	// Status Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+	// mid-workflow at an `await` node, durably parked until a signal arrives
+	// (a human approve/reject or an operator-observed chain event) or the wait
+	// times out — non-terminal, like `pending`, but distinguishable so a client
+	// can show "awaiting approval"; `success` is full success; `failed` is
+	// logical failure (e.g., a node returned an error, or a wait timed out);
 	// `error` is a system / infrastructure failure (e.g., RPC unreachable).
 	Status ExecutionStatus `json:"status"`
 
@@ -1308,8 +1321,12 @@ type TriggerWorkflowResponse struct {
 	ExecutionId Ulid   `json:"executionId"`
 	StartAt     *int64 `json:"startAt,omitempty"`
 
-	// Status Outcome of an execution. `pending` is in-flight; `success` is full
-	// success; `failed` is logical failure (e.g., a node returned an error);
+	// Status Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+	// mid-workflow at an `await` node, durably parked until a signal arrives
+	// (a human approve/reject or an operator-observed chain event) or the wait
+	// times out — non-terminal, like `pending`, but distinguishable so a client
+	// can show "awaiting approval"; `success` is full success; `failed` is
+	// logical failure (e.g., a node returned an error, or a wait timed out);
 	// `error` is a system / infrastructure failure (e.g., RPC unreachable).
 	Status ExecutionStatus `json:"status"`
 }

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -291,7 +291,7 @@ type AwaitNodeType string
 // `chainEvent` to pause until an operator observes that on-chain event, e.g. a
 // bridge arrival on another chain). Exactly one flavor must be configured.
 type AwaitNodeConfig struct {
-	// Approvers External-signal flavor — authorized approver identities. Empty = the workflow owner.
+	// Approvers External-signal flavor — authorized approver identities. Empty = the workflow owner. NOTE (v1): not yet enforced — the signal endpoint authorizes by workflow ownership only, so the owner can always approve regardless of this list. Delegated-approver enforcement (Telegram binding) is a follow-up; do not rely on this field for security yet.
 	Approvers *[]string `json:"approvers,omitempty"`
 
 	// ChainEvent Chain-event flavor — the on-chain event to wait for (a mid-workflow

--- a/aggregator/rest/handlers_executions.go
+++ b/aggregator/rest/handlers_executions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/mapping"
@@ -93,6 +94,43 @@ func (s *Server) GetExecution(ctx echo.Context, id generated.Ulid, params genera
 	})
 	if err != nil {
 		return notFoundOrError(err)
+	}
+	resp, err := mapping.ProtoToOpenAPIExecution(exec, workflowID)
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// SignalExecution — POST /api/v1/executions/{id}:signal
+//
+// Delivers an approval/external signal to a WAITING execution (durable execution).
+// The caller must own the workflow; the engine's gate (DeliverSignal) rejects a
+// signal with no pending wait, a mismatched kind, or one that has timed out.
+func (s *Server) SignalExecution(ctx echo.Context, id generated.Ulid, params generated.SignalExecutionParams) error {
+	user, err := s.requireUser(ctx)
+	if err != nil {
+		return err
+	}
+	var body generated.SignalExecutionRequest
+	if err := ctx.Bind(&body); err != nil {
+		return badRequest("SIGNAL_BAD_REQUEST", "Invalid request body", err.Error())
+	}
+	var payload *structpb.Value
+	if body.Payload != nil {
+		p, perr := structpb.NewValue(map[string]interface{}(*body.Payload))
+		if perr != nil {
+			return badRequest("SIGNAL_BAD_PAYLOAD", "Invalid payload", perr.Error())
+		}
+		payload = p
+	}
+	workflowID := string(params.WorkflowId)
+	exec, err := s.engine.SignalExecution(user, workflowID, string(id), string(body.Decision), payload)
+	if err != nil {
+		// SignalExecution returns gRPC status errors (NotFound / InvalidArgument /
+		// FailedPrecondition); the central ProblemErrorHandler maps them to the right
+		// HTTP status (404 vs 400), so don't force a 404 here.
+		return err
 	}
 	resp, err := mapping.ProtoToOpenAPIExecution(exec, workflowID)
 	if err != nil {

--- a/aggregator/rest/handlers_executions.go
+++ b/aggregator/rest/handlers_executions.go
@@ -163,7 +163,7 @@ func (s *Server) GetExecutionStatus(ctx echo.Context, id generated.Ulid, params 
 	// the terminal state via GetExecution.
 	out := generated.ExecutionStatusSummary{
 		Id:     id,
-		Status: generated.ExecutionStatus(executionStatusToWire(statusResp.GetStatus())),
+		Status: generated.ExecutionStatus(mapping.ExecutionStatusProtoToWire(statusResp.GetStatus())),
 	}
 	wid := generated.Ulid(workflowID)
 	out.WorkflowId = &wid
@@ -260,7 +260,7 @@ func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params gen
 			}
 			return false, nil
 		}
-		current := executionStatusToWire(exec.GetStatus())
+		current := mapping.ExecutionStatusProtoToWire(exec.GetStatus())
 		if current != lastStatus {
 			if err := emit(current, exec); err != nil {
 				return true, err
@@ -297,24 +297,6 @@ func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params gen
 				return nil
 			}
 		}
-	}
-}
-
-// executionStatusToWire mirrors the helper in the workflows handler
-// but lives here too because the executions package uses it on every
-// poll and the workflows file is already large.
-func executionStatusToWire(s avsproto.ExecutionStatus) string {
-	switch s {
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:
-		return "pending"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:
-		return "success"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:
-		return "failed"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:
-		return "error"
-	default:
-		return "pending"
 	}
 }
 

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -255,7 +255,7 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 	// translate to a lowercase string.
 	out := generated.TriggerWorkflowResponse{
 		ExecutionId: generated.Ulid(resp.GetExecutionId()),
-		Status:      generated.ExecutionStatus(protoExecStatusToOpenAPI(resp.GetStatus())),
+		Status:      generated.ExecutionStatus(mapping.ExecutionStatusProtoToWire(resp.GetStatus())),
 	}
 	if v := resp.GetStartAt(); v != 0 {
 		out.StartAt = &v
@@ -591,21 +591,4 @@ func openAPIInputVarsToProto(in generated.InputVariables) (map[string]*structpb.
 		out[k] = pv
 	}
 	return out, nil
-}
-
-// protoExecStatusToOpenAPI maps the proto ExecutionStatus enum that
-// TriggerTaskResp returns to the lowercase string used on the wire.
-func protoExecStatusToOpenAPI(s avsproto.ExecutionStatus) string {
-	switch s {
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:
-		return "pending"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:
-		return "success"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:
-		return "failed"
-	case avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:
-		return "error"
-	default:
-		return "pending"
-	}
 }

--- a/aggregator/rest/mapping/execution.go
+++ b/aggregator/rest/mapping/execution.go
@@ -25,7 +25,7 @@ func ProtoToOpenAPIExecution(in *avsproto.Execution, workflowID string) (generat
 		Id:         generated.Ulid(in.GetId()),
 		WorkflowId: generated.Ulid(workflowID),
 		StartAt:    in.GetStartAt(),
-		Status:     generated.ExecutionStatus(executionStatusProtoToWire(in.GetStatus())),
+		Status:     generated.ExecutionStatus(ExecutionStatusProtoToWire(in.GetStatus())),
 	}
 	if v := in.GetEndAt(); v != 0 {
 		out.EndAt = &v
@@ -85,13 +85,16 @@ func ProtoToOpenAPIExecution(in *avsproto.Execution, workflowID string) (generat
 	return out, nil
 }
 
-// ProtoExecutionToOpenAPISummary lifts an Execution into the lightweight
-// status summary returned by the GetExecutionStatus and StreamExecution
-// endpoints. Skips the steps/cogs/fee payload to keep responses small.
+// ProtoExecutionToOpenAPISummary lifts a full Execution into the lightweight
+// status summary shape (skips the steps/cogs/fee payload to keep responses
+// small). Status goes through the shared ExecutionStatusProtoToWire so every
+// status surface stays consistent. NOTE: the GetExecutionStatus handler builds
+// this shape inline (it has only the status enum, not a full Execution), so it
+// does not call this helper — keep the two in sync if you change the shape.
 func ProtoExecutionToOpenAPISummary(in *avsproto.Execution, workflowID string) generated.ExecutionStatusSummary {
 	out := generated.ExecutionStatusSummary{
 		Id:     generated.Ulid(in.GetId()),
-		Status: generated.ExecutionStatus(executionStatusProtoToWire(in.GetStatus())),
+		Status: generated.ExecutionStatus(ExecutionStatusProtoToWire(in.GetStatus())),
 	}
 	if v := in.GetStartAt(); v != 0 {
 		out.StartAt = &v
@@ -235,12 +238,17 @@ func normalizeStepType(t string) string {
 	return t
 }
 
-// executionStatusProtoToWire normalizes ExecutionStatus enum names to the
+// ExecutionStatusProtoToWire normalizes ExecutionStatus enum names to the
 // lowercase wire vocabulary used by the OpenAPI spec.
-func executionStatusProtoToWire(s avsproto.ExecutionStatus) string {
+func ExecutionStatusProtoToWire(s avsproto.ExecutionStatus) string {
 	switch s {
+	case avsproto.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED:
+		// Zero value — status not yet set; treat as in-flight.
+		return "pending"
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:
 		return "pending"
+	case avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING:
+		return "waiting"
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:
 		return "success"
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:
@@ -248,6 +256,10 @@ func executionStatusProtoToWire(s avsproto.ExecutionStatus) string {
 	case avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:
 		return "error"
 	default:
-		return "pending"
+		// Every defined enum value has an explicit case above (guarded by the
+		// mapping test). A value reaching here is an unknown/future enum — surface
+		// it as "error" rather than masquerading it as in-flight "pending" (that
+		// silent default is exactly what once hid WAITING).
+		return "error"
 	}
 }

--- a/aggregator/rest/mapping/execution_status_test.go
+++ b/aggregator/rest/mapping/execution_status_test.go
@@ -1,0 +1,37 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestExecutionStatusProtoToWire pins the proto→wire status vocabulary, including the
+// durable-execution WAITING state — without an explicit case it would fall through to
+// the default and a client could not tell "awaiting approval" from "in-flight". The
+// coverage loop fails if a new ExecutionStatus enum value is added without a mapping
+// (exactly the miss that once let WAITING surface as "pending").
+func TestExecutionStatusProtoToWire(t *testing.T) {
+	expected := map[avsproto.ExecutionStatus]string{
+		avsproto.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED: "pending",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_PENDING:     "pending",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING:     "waiting",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS:     "success",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED:      "failed",
+		avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR:       "error",
+	}
+	// Every defined proto enum value must have an explicit, asserted mapping — a new
+	// value with no entry here fails the test instead of silently hitting the default.
+	for v := range avsproto.ExecutionStatus_name {
+		s := avsproto.ExecutionStatus(v)
+		want, ok := expected[s]
+		require.Truef(t, ok, "ExecutionStatus %s has no proto→wire mapping/test entry", s)
+		assert.Equal(t, want, ExecutionStatusProtoToWire(s), s.String())
+	}
+	// The waiting wire value is a member of the generated OpenAPI enum (no drift).
+	assert.Equal(t, string(generated.ExecutionStatusWaiting), ExecutionStatusProtoToWire(avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING))
+}

--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -176,6 +176,18 @@ func OpenAPIToProtoNode(in generated.Node) (*avsproto.TaskNode, error) {
 		out.Type = avsproto.NodeType_NODE_TYPE_BALANCE
 		out.TaskType = &avsproto.TaskNode_Balance{Balance: &avsproto.BalanceNode{Config: cfg}}
 
+	case string(generated.NodeTypeAwait):
+		v, err := in.AsAwaitNode()
+		if err != nil {
+			return nil, fmt.Errorf("node %s: decode AwaitNode: %w", in.Id, err)
+		}
+		cfg := &avsproto.AwaitNode_Config{}
+		if err := jsonRetargetProto(v.Config, cfg); err != nil {
+			return nil, fmt.Errorf("node %s: %w", in.Id, err)
+		}
+		out.Type = avsproto.NodeType_NODE_TYPE_AWAIT
+		out.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: cfg}}
+
 	default:
 		return nil, fmt.Errorf("node %s: unknown type %q", in.Id, discriminator)
 	}
@@ -323,7 +335,7 @@ func ProtoToOpenAPINode(in *avsproto.TaskNode) (generated.Node, error) {
 		return out, out.FromCustomCodeNode(v)
 
 	case avsproto.NodeType_NODE_TYPE_BALANCE:
-		t := generated.BalanceNodeTypeBalance
+		t := generated.Balance
 		v := generated.BalanceNode{Type: &t}
 		v.Config = &generated.BalanceNodeConfig{}
 		if err := protoRetargetJSON(in.GetBalance().GetConfig(), v.Config); err != nil {
@@ -331,6 +343,16 @@ func ProtoToOpenAPINode(in *avsproto.TaskNode) (generated.Node, error) {
 		}
 		out.Type = generated.NodeTypeBalance
 		return out, out.FromBalanceNode(v)
+
+	case avsproto.NodeType_NODE_TYPE_AWAIT:
+		t := generated.AwaitNodeTypeAwait
+		v := generated.AwaitNode{Type: &t}
+		v.Config = &generated.AwaitNodeConfig{}
+		if err := protoRetargetJSON(in.GetAwait().GetConfig(), v.Config); err != nil {
+			return out, err
+		}
+		out.Type = generated.NodeTypeAwait
+		return out, out.FromAwaitNode(v)
 	}
 
 	return out, fmt.Errorf("node %s: unsupported proto type %v", in.GetId(), in.GetType())

--- a/aggregator/rest/mapping/node_test.go
+++ b/aggregator/rest/mapping/node_test.go
@@ -160,6 +160,42 @@ func TestNodeRoundTrip_PerNodeChainId(t *testing.T) {
 	})
 }
 
+// TestNodeRoundTrip_Await proves the Await node survives the create→render REST
+// round-trip (OpenAPI → proto → OpenAPI), so the SDK/studio can put it in a workflow.
+func TestNodeRoundTrip_Await(t *testing.T) {
+	typ := generated.AwaitNodeTypeAwait
+	approvers := []string{"0xowner"}
+	prompt := "approve the transfer?"
+	timeout := int64(3600)
+	inner := generated.AwaitNode{Type: &typ, Config: &generated.AwaitNodeConfig{
+		Channel:        "telegram",
+		Approvers:      &approvers,
+		Prompt:         &prompt,
+		TimeoutSeconds: &timeout,
+	}}
+	n := generated.Node{Id: "appr", Type: generated.NodeTypeAwait}
+	require.NoError(t, n.FromAwaitNode(inner))
+
+	// Inbound (CreateWorkflow path).
+	pn, err := OpenAPIToProtoNode(n)
+	require.NoError(t, err)
+	cfg := pn.GetAwait().GetConfig()
+	require.NotNil(t, cfg)
+	assert.Equal(t, "telegram", cfg.GetChannel())
+	assert.Equal(t, []string{"0xowner"}, cfg.GetApprovers())
+	assert.Equal(t, "approve the transfer?", cfg.GetPrompt())
+	assert.Equal(t, uint32(3600), cfg.GetTimeoutSeconds())
+
+	// Outbound (GET/list render).
+	rt, err := ProtoToOpenAPINode(pn)
+	require.NoError(t, err)
+	v, err := rt.AsAwaitNode()
+	require.NoError(t, err)
+	assert.Equal(t, "telegram", v.Config.Channel)
+	require.NotNil(t, v.Config.TimeoutSeconds)
+	assert.Equal(t, int64(3600), *v.Config.TimeoutSeconds)
+}
+
 func TestNodeRoundTrip_LoopWithCustomCodeRunner(t *testing.T) {
 	innerTyp := generated.CustomCode
 	runnerNode := generated.Node{Id: "inner", Type: generated.NodeTypeCustomCode}

--- a/aggregator/rest/mapping/node_test.go
+++ b/aggregator/rest/mapping/node_test.go
@@ -164,11 +164,12 @@ func TestNodeRoundTrip_PerNodeChainId(t *testing.T) {
 // round-trip (OpenAPI → proto → OpenAPI), so the SDK/studio can put it in a workflow.
 func TestNodeRoundTrip_Await(t *testing.T) {
 	typ := generated.AwaitNodeTypeAwait
+	channel := "telegram"
 	approvers := []string{"0xowner"}
 	prompt := "approve the transfer?"
 	timeout := int64(3600)
 	inner := generated.AwaitNode{Type: &typ, Config: &generated.AwaitNodeConfig{
-		Channel:        "telegram",
+		Channel:        &channel,
 		Approvers:      &approvers,
 		Prompt:         &prompt,
 		TimeoutSeconds: &timeout,
@@ -191,9 +192,47 @@ func TestNodeRoundTrip_Await(t *testing.T) {
 	require.NoError(t, err)
 	v, err := rt.AsAwaitNode()
 	require.NoError(t, err)
-	assert.Equal(t, "telegram", v.Config.Channel)
+	require.NotNil(t, v.Config.Channel)
+	assert.Equal(t, "telegram", *v.Config.Channel)
 	require.NotNil(t, v.Config.TimeoutSeconds)
 	assert.Equal(t, int64(3600), *v.Config.TimeoutSeconds)
+}
+
+// TestNodeRoundTrip_AwaitChainEvent proves the cross-chain (chain-event) flavor of
+// Await survives OpenAPI → proto → OpenAPI, including the nested EventTrigger config.
+func TestNodeRoundTrip_AwaitChainEvent(t *testing.T) {
+	typ := generated.AwaitNodeTypeAwait
+	timeout := int64(7200)
+	addrs := []generated.EthereumAddress{"0xbridge0000000000000000000000000000000000"}
+	topics := []string{"0xMessageReceived00000000000000000000000000000000000000000000000000"}
+	inner := generated.AwaitNode{Type: &typ, Config: &generated.AwaitNodeConfig{
+		TimeoutSeconds: &timeout,
+		ChainEvent: &generated.EventTriggerConfig{
+			ChainId: generated.ChainId(8453),
+			Queries: []generated.EventTriggerQuery{{Addresses: &addrs, Topics: &topics}},
+		},
+	}}
+	n := generated.Node{Id: "wait", Type: generated.NodeTypeAwait}
+	require.NoError(t, n.FromAwaitNode(inner))
+
+	// Inbound (CreateWorkflow path) — the chain-event config retargets into the proto.
+	pn, err := OpenAPIToProtoNode(n)
+	require.NoError(t, err)
+	cfg := pn.GetAwait().GetConfig()
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg.GetChannel(), "chain-event flavor has no channel")
+	require.NotNil(t, cfg.GetChainEvent())
+	assert.Equal(t, int64(8453), cfg.GetChainEvent().GetChainId())
+	require.Len(t, cfg.GetChainEvent().GetQueries(), 1)
+	assert.Equal(t, []string{"0xbridge0000000000000000000000000000000000"}, cfg.GetChainEvent().GetQueries()[0].GetAddresses())
+
+	// Outbound (GET/list render).
+	rt, err := ProtoToOpenAPINode(pn)
+	require.NoError(t, err)
+	v, err := rt.AsAwaitNode()
+	require.NoError(t, err)
+	require.NotNil(t, v.Config.ChainEvent)
+	assert.Equal(t, generated.ChainId(8453), v.Config.ChainEvent.ChainId)
 }
 
 func TestNodeRoundTrip_LoopWithCustomCodeRunner(t *testing.T) {

--- a/aggregator/rest/server.go
+++ b/aggregator/rest/server.go
@@ -359,6 +359,12 @@ func registerColonActionShimRoutes(api *echo.Group, s *Server) {
 		}
 		return s.StreamExecution(c, generated.Ulid(c.Param("id")), params)
 	})
+	api.POST("/executions/:id"+colonActionShim+"signal", func(c echo.Context) error {
+		params := generated.SignalExecutionParams{
+			WorkflowId: generated.Ulid(c.QueryParam("workflowId")),
+		}
+		return s.SignalExecution(c, generated.Ulid(c.Param("id")), params)
+	})
 
 	// Collection-level actions. Routed via the generated wrapper so the
 	// oapi-codegen runtime handles query-param binding the same way the

--- a/aggregator/rest/server_routing_test.go
+++ b/aggregator/rest/server_routing_test.go
@@ -41,6 +41,7 @@ func TestColonActionRouting(t *testing.T) {
 		{"POST", "/wallets/:address:withdraw", "WALLET_WITHDRAW"},
 		{"GET", "/wallets/:address:getNonce", "WALLET_GET_NONCE"},
 		{"GET", "/executions/:id:getStatus", "EXECUTION_GET_STATUS"},
+		{"POST", "/executions/:id:signal", "EXECUTION_SIGNAL"},
 		{"GET", "/executions/:id:stream", "EXECUTION_STREAM"},
 		// Collection-level — these are the ones the original bug missed
 		{"POST", "/auth:exchange", "AUTH_EXCHANGE"},

--- a/aggregator/rest/signal_route_test.go
+++ b/aggregator/rest/signal_route_test.go
@@ -1,0 +1,42 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSignalColonRouteReachesHandler is the HTTP-level regression for the
+// POST /executions/{id}:signal 404 the SDK hit: the generated colon-route is
+// dropped by filteringRouter and must be re-registered in
+// registerColonActionShimRoutes — which originally omitted :signal, so the
+// rewritten path matched nothing. Unlike TestColonActionRouting (which replays
+// its own shim list), this exercises the REAL registerColonActionShimRoutes, so
+// a future colon-action added to the spec but not the shim fails here.
+func TestSignalColonRouteReachesHandler(t *testing.T) {
+	e := echo.New()
+	e.Pre(rewriteColonActions)
+	api := e.Group("/api/v1")
+	registerColonActionShimRoutes(api, &Server{}) // closures aren't invoked at registration
+
+	// The signal route must match (404 = the bug; any other code = route reached
+	// its handler, which then fails auth/validation — not our concern here).
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/executions/abc:signal?workflowId=wf",
+		strings.NewReader(`{"decision":"approve"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.NotEqualf(t, http.StatusNotFound, rec.Code,
+		"POST /executions/{id}:signal must route to a handler; 404 means the shim is missing")
+
+	// Control: an unregistered colon-verb correctly 404s — proves the check above
+	// distinguishes "routed" from "not found".
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/executions/abc:bogusverb", nil)
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusNotFound, rec2.Code, "an unregistered colon-verb should 404")
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -763,20 +763,28 @@ components:
     AwaitNodeConfig:
       type: object
       description: |
-        Pauses the workflow until a signal arrives (durable execution). v1 is the
-        external-signal flavor (human approval — e.g. a Telegram approve/reject).
-      required: [channel]
+        Pauses the workflow until a wake arrives (durable execution). Two mutually
+        exclusive flavors: the external-signal flavor (human approval — set `channel`,
+        e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+        `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+        bridge arrival on another chain). Exactly one flavor must be configured.
       properties:
         channel:
           type: string
-          description: 'Signal channel: `telegram` or `api`.'
+          description: 'External-signal flavor — signal channel: `telegram` or `api`.'
         approvers:
           type: array
           items: { type: string }
-          description: Authorized approver identities. Empty = the workflow owner.
+          description: External-signal flavor — authorized approver identities. Empty = the workflow owner.
         prompt:
           type: string
-          description: Message shown to the approver.
+          description: External-signal flavor — message shown to the approver.
+        chainEvent:
+          allOf: [{ $ref: '#/components/schemas/EventTriggerConfig' }]
+          description: |
+            Chain-event flavor — the on-chain event to wait for (a mid-workflow
+            EventTrigger). An operator covering `chainEvent.chainId` watches it and
+            resumes the execution when it fires. Mutually exclusive with `channel`.
         timeoutSeconds:
           type: integer
           format: int64

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -103,8 +103,8 @@ components:
       name: chainId
       in: query
       description: |
-        Chain ID filter. Omit to use the aggregator default chain. Repeat
-        the parameter to filter by multiple chains.
+        The chain to operate on (a single value). Omit to use the aggregator
+        default (the request's JWT `aud` chain, then the gateway default).
       schema:
         type: integer
         format: int64

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -725,8 +725,9 @@ components:
       type: object
       description: |
         Iterates over an input array, running an inner Node per item. The
-        runner node is one of the chain-aware or chain-agnostic node types
-        and inherits chainId from this LoopNode if it does not specify its own.
+        runner node is one of the chain-aware or chain-agnostic node types;
+        a chain-aware runner must specify its own required `chainId` (there is
+        no inheritance from the loop or workflow).
       required: [inputVariable, runner]
       properties:
         inputVariable:
@@ -1658,10 +1659,10 @@ paths:
       tags: [Workflows]
       summary: Create a workflow
       description: |
-        Persist a new workflow definition. The server resolves the
-        workflow-level `chainId` (falling back to the aggregator default
-        if omitted) and ensures the smart wallet belongs to the
-        authenticated user. Returns the persisted Workflow with its
+        Persist a new workflow definition. Each chain-aware trigger and node
+        carries its own required `chainId` (there is no workflow-level chain);
+        the server validates those chains and ensures the smart wallet belongs
+        to the authenticated user. Returns the persisted Workflow with its
         server-assigned `id` and `createdAt`.
       operationId: createWorkflow
       requestBody:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -324,6 +324,7 @@ components:
         - filter
         - loop
         - balance
+        - await
       description: |
         Discriminator field for the Node union. Mirrors the proto
         `NodeType` enum but without the `NODE_TYPE_` prefix.
@@ -759,6 +760,28 @@ components:
           items: { $ref: '#/components/schemas/EthereumAddress' }
           description: Restrict to these tokens. Empty = fetch all.
 
+    AwaitNodeConfig:
+      type: object
+      description: |
+        Pauses the workflow until a signal arrives (durable execution). v1 is the
+        external-signal flavor (human approval — e.g. a Telegram approve/reject).
+      required: [channel]
+      properties:
+        channel:
+          type: string
+          description: 'Signal channel: `telegram` or `api`.'
+        approvers:
+          type: array
+          items: { type: string }
+          description: Authorized approver identities. Empty = the workflow owner.
+        prompt:
+          type: string
+          description: Message shown to the approver.
+        timeoutSeconds:
+          type: integer
+          format: int64
+          description: Safety bound; 0 = server default (the wait is never unbounded).
+
     # ---- Node union ----
 
     Node:
@@ -781,6 +804,7 @@ components:
           filter:        '#/components/schemas/FilterNode'
           loop:          '#/components/schemas/LoopNode'
           balance:       '#/components/schemas/BalanceNode'
+          await:         '#/components/schemas/AwaitNode'
       oneOf:
         - $ref: '#/components/schemas/ETHTransferNode'
         - $ref: '#/components/schemas/ContractWriteNode'
@@ -792,6 +816,7 @@ components:
         - $ref: '#/components/schemas/FilterNode'
         - $ref: '#/components/schemas/LoopNode'
         - $ref: '#/components/schemas/BalanceNode'
+        - $ref: '#/components/schemas/AwaitNode'
 
     ETHTransferNode:
       allOf:
@@ -862,6 +887,13 @@ components:
           properties:
             type: { type: string, enum: [balance] }
             config: { $ref: '#/components/schemas/BalanceNodeConfig' }
+
+    AwaitNode:
+      allOf:
+        - type: object
+          properties:
+            type: { type: string, enum: [await] }
+            config: { $ref: '#/components/schemas/AwaitNodeConfig' }
 
     # ---- Workflow envelope ----
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1115,12 +1115,17 @@ components:
       type: string
       enum:
         - pending
+        - waiting
         - success
         - failed
         - error
       description: |
-        Outcome of an execution. `pending` is in-flight; `success` is full
-        success; `failed` is logical failure (e.g., a node returned an error);
+        Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+        mid-workflow at an `await` node, durably parked until a signal arrives
+        (a human approve/reject or an operator-observed chain event) or the wait
+        times out — non-terminal, like `pending`, but distinguishable so a client
+        can show "awaiting approval"; `success` is full success; `failed` is
+        logical failure (e.g., a node returned an error, or a wait timed out);
         `error` is a system / infrastructure failure (e.g., RPC unreachable).
 
     Fee:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -782,6 +782,19 @@ components:
           format: int64
           description: Safety bound; 0 = server default (the wait is never unbounded).
 
+    SignalExecutionRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          type: string
+          enum: [approve, reject]
+          description: The approver's decision.
+        payload:
+          type: object
+          additionalProperties: true
+          description: Optional structured data delivered as the await step's output.
+
     # ---- Node union ----
 
     Node:
@@ -2035,6 +2048,41 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ExecutionStatusSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /executions/{id}:signal:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/Ulid' }
+      - name: workflowId
+        in: query
+        required: true
+        description: Workflow id the execution belongs to. See `getExecution`.
+        schema: { $ref: '#/components/schemas/Ulid' }
+    post:
+      tags: [Executions]
+      summary: Deliver an approval/external signal to a waiting execution
+      description: |
+        Resumes a WAITING execution (durable execution). The caller must own the
+        workflow; the signal only counts against an actual pending wait whose kind
+        it matches and which has not timed out. v1 is the external-signal (human
+        approval) flavor — e.g. a Telegram approve/reject for a money-moving step.
+      operationId: signalExecution
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SignalExecutionRequest' }
+      responses:
+        '200':
+          description: The resumed (terminal or still-waiting) execution.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Execution' }
+        '400': { $ref: '#/components/responses/BadRequest' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '404': { $ref: '#/components/responses/NotFound' }
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -775,7 +775,12 @@ components:
         approvers:
           type: array
           items: { type: string }
-          description: External-signal flavor — authorized approver identities. Empty = the workflow owner.
+          description: >-
+            External-signal flavor — authorized approver identities. Empty = the
+            workflow owner. NOTE (v1): not yet enforced — the signal endpoint
+            authorizes by workflow ownership only, so the owner can always approve
+            regardless of this list. Delegated-approver enforcement (Telegram binding)
+            is a follow-up; do not rely on this field for security yet.
         prompt:
           type: string
           description: External-signal flavor — message shown to the approver.

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -105,6 +105,12 @@ func (k WakeKind) String() string {
 type WakeSubscription struct {
 	Kind WakeKind `json:"kind"`
 
+	// TaskID is the workflow that owns the suspended execution. Carried here because
+	// executions are stored task-scoped (TaskExecutionKey) and there is no global
+	// exec→task index, so resuming from a wake (a chain-event notify or boot re-arm)
+	// needs the task to load the execution.
+	TaskID string `json:"taskId"`
+
 	// ChainEvent is the event filter the operator watches (chain = ChainEvent's
 	// chain_id). Set iff Kind == WakeChainEvent. Reuses the existing event-trigger
 	// config so the operator watches it with no new logic.
@@ -315,13 +321,14 @@ func wakeSubscriptionKey(execID string) []byte {
 // faithfully — plain encoding/json cannot serialize those.
 type persistedWake struct {
 	Kind       WakeKind            `json:"kind"`
+	TaskID     string              `json:"taskId"`
 	ChainEvent json.RawMessage     `json:"chainEvent,omitempty"`
 	External   *ExternalSignalSpec `json:"external,omitempty"`
 	TimeoutAt  int64               `json:"timeoutAt"`
 }
 
 func marshalWake(sub *WakeSubscription) ([]byte, error) {
-	rec := persistedWake{Kind: sub.Kind, External: sub.External, TimeoutAt: sub.TimeoutAt}
+	rec := persistedWake{Kind: sub.Kind, TaskID: sub.TaskID, External: sub.External, TimeoutAt: sub.TimeoutAt}
 	if sub.ChainEvent != nil {
 		b, err := protojson.Marshal(sub.ChainEvent)
 		if err != nil {
@@ -337,7 +344,7 @@ func unmarshalWake(b []byte) (*WakeSubscription, error) {
 	if err := json.Unmarshal(b, &rec); err != nil {
 		return nil, err
 	}
-	sub := &WakeSubscription{Kind: rec.Kind, External: rec.External, TimeoutAt: rec.TimeoutAt}
+	sub := &WakeSubscription{Kind: rec.Kind, TaskID: rec.TaskID, External: rec.External, TimeoutAt: rec.TimeoutAt}
 	if len(rec.ChainEvent) > 0 {
 		cfg := &avsproto.EventTrigger_Config{}
 		if err := protojson.Unmarshal(rec.ChainEvent, cfg); err != nil {

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -386,6 +386,14 @@ func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription,
 	return out, nil
 }
 
+func loadWakeSubscription(db storage.Storage, execID string) (*WakeSubscription, error) {
+	b, err := db.GetKey(wakeSubscriptionKey(execID))
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalWake(b)
+}
+
 func deleteWakeSubscription(db storage.Storage, execID string) error {
 	return db.Delete(wakeSubscriptionKey(execID))
 }

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -371,7 +372,7 @@ func persistWakeSubscription(db storage.Storage, execID string, sub *WakeSubscri
 // loadAllWakeSubscriptions scans the registry — the boot re-arm entrypoint. The
 // engine uses the result to re-register chain waits to operators, reload timers,
 // and GC entries whose execution is no longer WAITING.
-func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription, error) {
+func loadAllWakeSubscriptions(db storage.Storage, logger ...sdklogging.Logger) (map[string]*WakeSubscription, error) {
 	items, err := db.GetByPrefix([]byte(wakeSubscriptionPrefix))
 	if err != nil {
 		return nil, err
@@ -379,14 +380,19 @@ func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription,
 	out := make(map[string]*WakeSubscription, len(items))
 	for _, it := range items {
 		execID := strings.TrimPrefix(string(it.Key), wakeSubscriptionPrefix)
-		sub, err := unmarshalWake(it.Value)
-		if err != nil {
-			return nil, fmt.Errorf("load wake %s: %w", execID, err)
+		sub, uErr := unmarshalWake(it.Value)
+		if uErr == nil {
+			// Re-validate on load to catch a partially-written / version-mismatched record.
+			uErr = sub.Validate()
 		}
-		// Re-validate on load: a corrupted or partially-written record gets a clear
-		// error path here rather than surfacing as hard-to-debug behavior later.
-		if err := sub.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid wake %s: %w", execID, err)
+		if uErr != nil {
+			// Skip a corrupt/invalid record — do NOT abort the whole scan. One bad
+			// record must never block every timeout sweep and chain-event re-arm on
+			// each periodic tick (it would silently freeze durable execution).
+			if len(logger) > 0 && logger[0] != nil {
+				logger[0].Error("skipping corrupt wake record", "exec_id", execID, "error", uErr)
+			}
+			continue
 		}
 		out[execID] = sub
 	}

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -43,6 +43,40 @@ func (d RunDisposition) String() string {
 	}
 }
 
+// SuspendRequest is recorded by a Suspendable step's runner (Await, HumanApproval)
+// to pause the execution. The scheduler stops scheduling new work; the executor
+// then checkpoints the run (snapshot vars + status WAITING) and registers Wake in
+// the durable registry. AwaitNodeID is the step that suspended.
+type SuspendRequest struct {
+	AwaitNodeID string
+	Wake        *WakeSubscription
+}
+
+// requestSuspend records a suspension (called by a step runner during executeNode).
+// First-writer-wins: once a step has asked to suspend, later requests are ignored.
+func (v *VM) requestSuspend(nodeID string, wake *WakeSubscription) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.suspend == nil {
+		v.suspend = &SuspendRequest{AwaitNodeID: nodeID, Wake: wake}
+	}
+}
+
+// isSuspendRequested reports whether a step asked the execution to suspend.
+func (v *VM) isSuspendRequested() bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.suspend != nil
+}
+
+// PendingSuspend returns the recorded suspension after a Run (nil if the run
+// completed normally). The executor consumes this to decide checkpoint vs. finish.
+func (v *VM) PendingSuspend() *SuspendRequest {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.suspend
+}
+
 // WakeKind identifies which signal source can advance a suspended execution.
 type WakeKind int
 
@@ -176,7 +210,7 @@ var reservedSystemVarNames = map[string]bool{
 func (v *VM) snapshotNodeVars() ([]byte, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	out := make(map[string]any, len(v.TaskNodes))
+	out := make(map[string]any, len(v.TaskNodes)+1)
 	for nodeID := range v.TaskNodes {
 		name := v.getNodeNameAsVarLocked(nodeID)
 		if name == "" || reservedSystemVarNames[name] {
@@ -184,6 +218,16 @@ func (v *VM) snapshotNodeVars() ([]byte, error) {
 		}
 		if val, ok := v.vars[name]; ok {
 			out[name] = val
+		}
+	}
+	// Include the trigger's output var too (keyed by sanitized trigger name) so a
+	// resumed leg can still reference {{trigger.data.x}}.
+	if v.task != nil && v.task.Trigger != nil {
+		tname := sanitizeTriggerNameForJS(v.task.Trigger.GetName())
+		if tname != "" && !reservedSystemVarNames[tname] {
+			if val, ok := v.vars[tname]; ok {
+				out[tname] = val
+			}
 		}
 	}
 	return json.Marshal(out)
@@ -227,6 +271,30 @@ func completedNodeIDsFromSteps(steps []*avsproto.Execution_Step) map[string]bool
 		}
 	}
 	return out
+}
+
+// ---- Durable checkpoint (key: ckpt:<execId>) ---------------------------------
+//
+// The resumable vars snapshot for a suspended execution (snapshotNodeVars output).
+// Paired with the WAITING execution record (which carries the completed steps) and
+// the wake subscription. New key template — additive, no migration.
+
+const checkpointPrefix = "ckpt:"
+
+func checkpointKey(execID string) []byte {
+	return []byte(checkpointPrefix + execID)
+}
+
+func persistCheckpoint(db storage.Storage, execID string, varsSnapshot []byte) error {
+	return db.Set(checkpointKey(execID), varsSnapshot)
+}
+
+func loadCheckpoint(db storage.Storage, execID string) ([]byte, error) {
+	return db.GetKey(checkpointKey(execID))
+}
+
+func deleteCheckpoint(db storage.Storage, execID string) error {
+	return db.Delete(checkpointKey(execID))
 }
 
 // ---- Durable wake registry (key: wake:<execId>) ------------------------------

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -1,0 +1,323 @@
+package taskengine
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Durable execution vocabulary (Level-3 engine — see PLAN_DURABLE_EXECUTION.md).
+//
+// These are pure type definitions: the foundation the re-entrant executor
+// (advance) and the suspendable steps (Await, HumanApproval) build on. Nothing
+// wires them yet — increment 2 establishes the vocabulary; later increments use it.
+
+// RunDisposition is what the executor should do after a step's run returns. The
+// core of the durable model is that any step may ask to suspend, not just fail or
+// continue.
+type RunDisposition int
+
+const (
+	RunContinue RunDisposition = iota // normal completion; schedule successors
+	RunSuspend                        // pause: persist WAITING + register the wake subscription
+	RunFail                           // fatal: terminate the execution as FAILED
+)
+
+func (d RunDisposition) String() string {
+	switch d {
+	case RunContinue:
+		return "continue"
+	case RunSuspend:
+		return "suspend"
+	case RunFail:
+		return "fail"
+	default:
+		return fmt.Sprintf("RunDisposition(%d)", int(d))
+	}
+}
+
+// WakeKind identifies which signal source can advance a suspended execution.
+type WakeKind int
+
+const (
+	WakeChainEvent     WakeKind = iota // operator-watched event on a chain (cross-chain Await)
+	WakeExternalSignal                 // gateway-received signal (Telegram approval, webhook)
+	WakeTimer                          // scheduler due-time (delay, approval timeout)
+)
+
+func (k WakeKind) String() string {
+	switch k {
+	case WakeChainEvent:
+		return "chain_event"
+	case WakeExternalSignal:
+		return "external_signal"
+	case WakeTimer:
+		return "timer"
+	default:
+		return fmt.Sprintf("WakeKind(%d)", int(k))
+	}
+}
+
+// WakeSubscription is what a suspended execution is waiting for. Exactly one
+// source field is populated, matching Kind. Persisted (key wake:<execId>) while
+// the execution is WAITING, and matched by an inbound Signal to advance it.
+type WakeSubscription struct {
+	Kind WakeKind `json:"kind"`
+
+	// ChainEvent is the event filter the operator watches (chain = ChainEvent's
+	// chain_id). Set iff Kind == WakeChainEvent. Reuses the existing event-trigger
+	// config so the operator watches it with no new logic.
+	ChainEvent *avsproto.EventTrigger_Config `json:"chainEvent,omitempty"`
+
+	// External describes who/what may deliver the wake. Set iff Kind == WakeExternalSignal.
+	External *ExternalSignalSpec `json:"external,omitempty"`
+
+	// TimeoutAt bounds every wait (unix ms). For Kind == WakeTimer it is the fire
+	// time; for the other kinds it is the hard timeout after which the wait expires.
+	TimeoutAt int64 `json:"timeoutAt"`
+}
+
+// ExternalSignalSpec describes an externally-delivered wake (human approval, webhook).
+// Authorization is anchored on the deploy-time EOA signature (the bounded envelope);
+// the signal just provides the go/no-go within it. See the approval security model
+// in PLAN_DURABLE_EXECUTION.md.
+type ExternalSignalSpec struct {
+	Channel   string   `json:"channel"`             // "telegram" | "api"
+	Approvers []string `json:"approvers,omitempty"` // authorized parties; empty ⇒ the workflow owner
+	Prompt    string   `json:"prompt,omitempty"`
+}
+
+// Validate asserts the subscription is internally consistent: exactly the source
+// field matching Kind is populated, and a timeout is set.
+func (w *WakeSubscription) Validate() error {
+	if w == nil {
+		return fmt.Errorf("nil wake subscription")
+	}
+	switch w.Kind {
+	case WakeChainEvent:
+		if w.ChainEvent == nil {
+			return fmt.Errorf("chain-event wake requires ChainEvent config")
+		}
+		if w.External != nil {
+			return fmt.Errorf("chain-event wake must not set External")
+		}
+	case WakeExternalSignal:
+		if w.External == nil || w.External.Channel == "" {
+			return fmt.Errorf("external-signal wake requires External with a channel")
+		}
+		if w.ChainEvent != nil {
+			return fmt.Errorf("external-signal wake must not set ChainEvent")
+		}
+	case WakeTimer:
+		if w.ChainEvent != nil || w.External != nil {
+			return fmt.Errorf("timer wake must not set ChainEvent/External")
+		}
+	default:
+		return fmt.Errorf("unknown wake kind %d", int(w.Kind))
+	}
+	if w.TimeoutAt <= 0 {
+		return fmt.Errorf("wake subscription requires a positive TimeoutAt (every wait is bounded)")
+	}
+	return nil
+}
+
+// Signal is an inbound wake delivered to one waiting execution via
+// advance(executionId, signal). Its Payload becomes the suspended step's output.
+type Signal struct {
+	ExecutionID string    `json:"executionId"`
+	Kind        WakeKind  `json:"kind"`
+	// Decision is set for external/approval signals: "approve" | "reject".
+	Decision string `json:"decision,omitempty"`
+	// Approver identifies who delivered an external signal (audit + authorization).
+	Approver string `json:"approver,omitempty"`
+	// Payload carries the wake event (e.g. the matched chain log) as structured data
+	// that becomes the suspended step's output, readable by downstream steps.
+	Payload *structpb.Value `json:"-"`
+}
+
+// Validate asserts the signal can be routed to a waiting execution.
+func (s *Signal) Validate() error {
+	if s == nil {
+		return fmt.Errorf("nil signal")
+	}
+	if s.ExecutionID == "" {
+		return fmt.Errorf("signal requires an executionId")
+	}
+	if s.Kind == WakeExternalSignal && s.Decision == "" {
+		return fmt.Errorf("external signal requires a decision")
+	}
+	return nil
+}
+
+// reservedSystemVarNames are VM vars that hold system/secret context, re-injected
+// fresh on resume — never node outputs. A node whose (user-chosen) name collides
+// with one of these must NOT have its var snapshotted or restored: snapshotting
+// would persist secrets (apContext) to disk; restoring would clobber system state.
+var reservedSystemVarNames = map[string]bool{
+	"apContext":     true, // secrets / ap.* JS context
+	"settings":      true, // runner + chain_id
+	"aa_sender":     true, // smart-wallet address
+	"aa_salt":       true, // wallet salt
+	"triggerConfig": true, // trigger config
+}
+
+// snapshotNodeVars serializes only the per-node output vars (keyed by node name)
+// for a durable suspend. System/secret vars are deliberately excluded — they are
+// re-injected fresh on resume, never persisted (apContext carries secrets). This
+// is the restorable slice of state that lets a resumed leg reference prior steps'
+// outputs ({{node.data.x}}).
+func (v *VM) snapshotNodeVars() ([]byte, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make(map[string]any, len(v.TaskNodes))
+	for nodeID := range v.TaskNodes {
+		name := v.getNodeNameAsVarLocked(nodeID)
+		if name == "" || reservedSystemVarNames[name] {
+			continue // never persist a system/secret var, even if a node is named one
+		}
+		if val, ok := v.vars[name]; ok {
+			out[name] = val
+		}
+	}
+	return json.Marshal(out)
+}
+
+// restoreNodeVars overlays a snapshot from snapshotNodeVars back onto the VM's
+// vars, so resumed nodes resolve prior steps' outputs. UseNumber keeps integers
+// from being silently coerced to float64, preserving template-render fidelity.
+func (v *VM) restoreNodeVars(snapshot []byte) error {
+	if len(snapshot) == 0 {
+		return nil
+	}
+	var restored map[string]any
+	dec := json.NewDecoder(bytes.NewReader(snapshot))
+	dec.UseNumber()
+	if err := dec.Decode(&restored); err != nil {
+		return fmt.Errorf("restore node vars: %w", err)
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.vars == nil {
+		v.vars = make(map[string]any)
+	}
+	for k, val := range restored {
+		if reservedSystemVarNames[k] {
+			continue // defense-in-depth: a corrupt/tampered snapshot must not clobber system/secret vars
+		}
+		v.vars[k] = val
+	}
+	return nil
+}
+
+// completedNodeIDsFromSteps derives the resume completion set from a prior leg's
+// persisted execution steps (each executed node appended one step). This is the
+// resumeCompleted the re-entrant scheduler consumes.
+func completedNodeIDsFromSteps(steps []*avsproto.Execution_Step) map[string]bool {
+	out := make(map[string]bool, len(steps))
+	for _, s := range steps {
+		if s != nil && s.Id != "" {
+			out[s.Id] = true
+		}
+	}
+	return out
+}
+
+// ---- Durable wake registry (key: wake:<execId>) ------------------------------
+//
+// The persisted set of pending waits. It is the source of truth for restart
+// durability: on boot, loadAllWakeSubscriptions rebuilds the in-memory registry,
+// which the engine then re-arms to operators (chain), reloads timers, and GCs
+// against execution status. New key template — additive, no migration.
+
+const wakeSubscriptionPrefix = "wake:"
+
+func wakeSubscriptionKey(execID string) []byte {
+	return []byte(wakeSubscriptionPrefix + execID)
+}
+
+// persistedWake is the on-disk shape. ChainEvent is stored as protojson so its
+// proto oneofs / well-known types (structpb.Value in contract_abi) round-trip
+// faithfully — plain encoding/json cannot serialize those.
+type persistedWake struct {
+	Kind       WakeKind            `json:"kind"`
+	ChainEvent json.RawMessage     `json:"chainEvent,omitempty"`
+	External   *ExternalSignalSpec `json:"external,omitempty"`
+	TimeoutAt  int64               `json:"timeoutAt"`
+}
+
+func marshalWake(sub *WakeSubscription) ([]byte, error) {
+	rec := persistedWake{Kind: sub.Kind, External: sub.External, TimeoutAt: sub.TimeoutAt}
+	if sub.ChainEvent != nil {
+		b, err := protojson.Marshal(sub.ChainEvent)
+		if err != nil {
+			return nil, fmt.Errorf("marshal wake chain event: %w", err)
+		}
+		rec.ChainEvent = b
+	}
+	return json.Marshal(rec)
+}
+
+func unmarshalWake(b []byte) (*WakeSubscription, error) {
+	var rec persistedWake
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return nil, err
+	}
+	sub := &WakeSubscription{Kind: rec.Kind, External: rec.External, TimeoutAt: rec.TimeoutAt}
+	if len(rec.ChainEvent) > 0 {
+		cfg := &avsproto.EventTrigger_Config{}
+		if err := protojson.Unmarshal(rec.ChainEvent, cfg); err != nil {
+			return nil, fmt.Errorf("unmarshal wake chain event: %w", err)
+		}
+		sub.ChainEvent = cfg
+	}
+	return sub, nil
+}
+
+// persistWakeSubscription writes the wait for execID. Validated first so we never
+// persist an inconsistent subscription.
+func persistWakeSubscription(db storage.Storage, execID string, sub *WakeSubscription) error {
+	if err := sub.Validate(); err != nil {
+		return err
+	}
+	b, err := marshalWake(sub)
+	if err != nil {
+		return err
+	}
+	return db.Set(wakeSubscriptionKey(execID), b)
+}
+
+// loadAllWakeSubscriptions scans the registry — the boot re-arm entrypoint. The
+// engine uses the result to re-register chain waits to operators, reload timers,
+// and GC entries whose execution is no longer WAITING.
+func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription, error) {
+	items, err := db.GetByPrefix([]byte(wakeSubscriptionPrefix))
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]*WakeSubscription, len(items))
+	for _, it := range items {
+		execID := strings.TrimPrefix(string(it.Key), wakeSubscriptionPrefix)
+		sub, err := unmarshalWake(it.Value)
+		if err != nil {
+			return nil, fmt.Errorf("load wake %s: %w", execID, err)
+		}
+		// Re-validate on load: a corrupted or partially-written record gets a clear
+		// error path here rather than surfacing as hard-to-debug behavior later.
+		if err := sub.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid wake %s: %w", execID, err)
+		}
+		out[execID] = sub
+	}
+	return out, nil
+}
+
+func deleteWakeSubscription(db storage.Storage, execID string) error {
+	return db.Delete(wakeSubscriptionKey(execID))
+}

--- a/core/taskengine/durable_test.go
+++ b/core/taskengine/durable_test.go
@@ -1,0 +1,134 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+func TestWakeSubscription_Validate(t *testing.T) {
+	cases := []struct {
+		name string
+		sub  WakeSubscription
+		ok   bool
+	}{
+		{
+			name: "chain event valid",
+			sub:  WakeSubscription{Kind: WakeChainEvent, ChainEvent: &avsproto.EventTrigger_Config{ChainId: 84532}, TimeoutAt: 1},
+			ok:   true,
+		},
+		{
+			name: "chain event missing config",
+			sub:  WakeSubscription{Kind: WakeChainEvent, TimeoutAt: 1},
+			ok:   false,
+		},
+		{
+			name: "external valid",
+			sub:  WakeSubscription{Kind: WakeExternalSignal, External: &ExternalSignalSpec{Channel: "telegram"}, TimeoutAt: 1},
+			ok:   true,
+		},
+		{
+			name: "external missing channel",
+			sub:  WakeSubscription{Kind: WakeExternalSignal, External: &ExternalSignalSpec{}, TimeoutAt: 1},
+			ok:   false,
+		},
+		{
+			name: "external must not set chain event",
+			sub:  WakeSubscription{Kind: WakeExternalSignal, External: &ExternalSignalSpec{Channel: "api"}, ChainEvent: &avsproto.EventTrigger_Config{}, TimeoutAt: 1},
+			ok:   false,
+		},
+		{
+			name: "timer valid",
+			sub:  WakeSubscription{Kind: WakeTimer, TimeoutAt: 1},
+			ok:   true,
+		},
+		{
+			name: "every wait must be bounded",
+			sub:  WakeSubscription{Kind: WakeTimer, TimeoutAt: 0},
+			ok:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.sub.Validate()
+			if tc.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestSignal_Validate(t *testing.T) {
+	require.Error(t, (&Signal{}).Validate(), "missing executionId")
+	require.Error(t, (&Signal{ExecutionID: "e1", Kind: WakeExternalSignal}).Validate(), "approval needs a decision")
+	require.NoError(t, (&Signal{ExecutionID: "e1", Kind: WakeChainEvent}).Validate())
+	require.NoError(t, (&Signal{ExecutionID: "e1", Kind: WakeExternalSignal, Decision: "approve", Approver: "0xowner"}).Validate())
+}
+
+func TestEnumStrings(t *testing.T) {
+	assert.Equal(t, "suspend", RunSuspend.String())
+	assert.Equal(t, "chain_event", WakeChainEvent.String())
+	assert.Equal(t, "external_signal", WakeExternalSignal.String())
+	assert.Equal(t, "timer", WakeTimer.String())
+}
+
+// TestWakeRegistry_RoundTrip proves the durable wake registry: persist (chain +
+// external), scan/load (the boot re-arm entrypoint) with faithful round-trip
+// including the proto chain-event, and GC. Restart durability rides on this.
+func TestWakeRegistry_RoundTrip(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	chainSub := &WakeSubscription{
+		Kind: WakeChainEvent,
+		ChainEvent: &avsproto.EventTrigger_Config{
+			ChainId: 84532,
+			Queries: []*avsproto.EventTrigger_Query{{
+				Addresses: []string{"0xbridge"},
+				Topics:    []string{"0xdeadbeef"},
+			}},
+		},
+		TimeoutAt: 1234,
+	}
+	extSub := &WakeSubscription{
+		Kind:      WakeExternalSignal,
+		External:  &ExternalSignalSpec{Channel: "telegram", Approvers: []string{"0xowner"}, Prompt: "approve?"},
+		TimeoutAt: 5678,
+	}
+
+	require.NoError(t, persistWakeSubscription(db, "exec-A", chainSub))
+	require.NoError(t, persistWakeSubscription(db, "exec-B", extSub))
+
+	all, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	// Chain-event survived the protojson round-trip (chain_id + topics + addresses).
+	a := all["exec-A"]
+	require.NotNil(t, a)
+	assert.Equal(t, WakeChainEvent, a.Kind)
+	assert.Equal(t, int64(84532), a.ChainEvent.GetChainId())
+	require.Len(t, a.ChainEvent.GetQueries(), 1)
+	assert.Equal(t, []string{"0xdeadbeef"}, a.ChainEvent.GetQueries()[0].GetTopics())
+	assert.Equal(t, []string{"0xbridge"}, a.ChainEvent.GetQueries()[0].GetAddresses())
+
+	b := all["exec-B"]
+	require.NotNil(t, b)
+	assert.Equal(t, "telegram", b.External.Channel)
+	assert.Equal(t, []string{"0xowner"}, b.External.Approvers)
+	assert.Equal(t, int64(5678), b.TimeoutAt)
+
+	// GC one; the scan reflects it.
+	require.NoError(t, deleteWakeSubscription(db, "exec-A"))
+	all, err = loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Nil(t, all["exec-A"])
+	assert.NotNil(t, all["exec-B"])
+}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -4292,6 +4292,34 @@ func (n *Engine) getExecutionStatusFromQueue(task *model.Workflow, executionID s
 	return &statusValue, nil
 }
 
+// SignalExecution delivers an external/approval signal to a WAITING execution
+// (durable execution — the human-approval transport). The authenticated user must
+// own the workflow (GetWorkflow → NotFound otherwise); the decision is validated
+// (InvalidArgument); and a DeliverSignal gate failure (no pending wait / mismatched
+// kind / timed out) is mapped to FailedPrecondition, so the REST layer returns a
+// 4xx rather than a 500. Decision is "approve" | "reject".
+func (n *Engine) SignalExecution(user *model.User, workflowID, executionID, decision string, payload *structpb.Value) (*avsproto.Execution, error) {
+	if decision != "approve" && decision != "reject" {
+		return nil, status.Errorf(codes.InvalidArgument, "decision must be 'approve' or 'reject', got %q", decision)
+	}
+	task, err := n.GetWorkflow(user, workflowID)
+	if err != nil {
+		return nil, err // GetWorkflow returns codes.NotFound for a missing/non-owned workflow
+	}
+	executor := NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
+	exec, err := executor.DeliverSignal(task, &Signal{
+		ExecutionID: executionID,
+		Kind:        WakeExternalSignal,
+		Decision:    decision,
+		Approver:    strings.ToLower(user.Address.Hex()),
+		Payload:     payload,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "deliver signal: %v", err)
+	}
+	return exec, nil
+}
+
 // GetExecution for a given task id and execution id
 func (n *Engine) GetExecution(user *model.User, payload *avsproto.ExecutionReq) (*avsproto.Execution, error) {
 	task, err := n.GetWorkflow(user, payload.TaskId)

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -575,6 +575,12 @@ func checkNodeChain(node *avsproto.TaskNode, check func(string, int64) error) er
 	if et := node.GetEthTransfer(); et != nil && et.Config != nil {
 		return check("eth transfer node", et.Config.GetChainId())
 	}
+	if await := node.GetAwait(); await != nil && await.Config != nil {
+		// Only the chain-event flavor is chain-aware; external-signal Awaits have no chain.
+		if ce := await.Config.GetChainEvent(); ce != nil {
+			return check("await node chain event", ce.GetChainId())
+		}
+	}
 	if loop := node.GetLoop(); loop != nil {
 		if cw := loop.GetContractWrite(); cw != nil && cw.Config != nil {
 			return check("loop contract write runner", cw.Config.GetChainId())
@@ -987,6 +993,7 @@ func (n *Engine) runOrphanScanLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			n.scanOrphanedTasks()
+			n.sweepExpiredWaits()
 		}
 	}
 }
@@ -1780,6 +1787,12 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		return nil, err
 	}
 
+	// Reject a chain-event Await whose chain no operator currently covers — a wait
+	// that nothing could ever fire would never resume.
+	if err := n.validateAwaitOperatorCoverage(task); err != nil {
+		return nil, err
+	}
+
 	updates := map[string][]byte{}
 
 	taskJSON, err := task.ToJSON()
@@ -2231,6 +2244,23 @@ func (n *Engine) StreamCheckToOperator(payload *avsproto.SyncMessagesReq, srv av
 			tasksByTriggerType[triggerTypeName]++
 		}
 
+		// Internal triggers: synthetic single-shot event-watches standing in for
+		// WAITING executions' chain-event waits (cross-chain Await). Unlike user tasks
+		// (single-operator assignment), these BROADCAST to every operator covering the
+		// chain — any one firing resumes the execution and the aggregator dedups the
+		// rest. They flow through the same tracked-task + send path, so a boot or
+		// operator reconnect re-arms every live wait automatically.
+		for _, itrigger := range n.pendingChainEventTriggers() {
+			if _, ok := tracked[itrigger.Id]; ok {
+				continue
+			}
+			if !n.supportsTaskTrigger(address, itrigger) || !n.supportsTaskChain(address, itrigger) {
+				continue
+			}
+			tasksToStream = append(tasksToStream, itrigger)
+			tasksByTriggerType[itrigger.Trigger.String()]++
+		}
+
 		// Log task processing results
 		n.logger.Debug("🔍 Task processing completed for operator",
 			"operator", address,
@@ -2636,6 +2666,14 @@ func (n *Engine) AggregateChecksResultWithState(address string, payload *avsprot
 	// Update operator task tracking
 	if state, exists := n.trackSyncedTasks[address]; exists {
 		state.TaskID[payload.TaskId] = true
+	}
+
+	// Internal trigger (itrig_<execId>): an operator-watched chain event standing in
+	// for a suspended execution's chain-event wake. Route it to resume that execution
+	// rather than the normal task-execution path (it has no user workflow to enqueue).
+	if executionID, ok := parseInternalTriggerTaskID(payload.TaskId); ok {
+		n.lock.Unlock()
+		return n.deliverChainEventWake(executionID, payload)
 	}
 
 	// Get task information to determine execution state

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1787,6 +1787,12 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		return nil, err
 	}
 
+	// Reject an Await with an invalid config (the two flavors are mutually exclusive;
+	// exactly one is required) before it can persist and fail only at execution time.
+	if err := n.validateAwaitConfigs(task); err != nil {
+		return nil, err
+	}
+
 	// Reject a chain-event Await whose chain no operator currently covers — a wait
 	// that nothing could ever fire would never resume.
 	if err := n.validateAwaitOperatorCoverage(task); err != nil {

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -300,6 +300,29 @@ type Engine struct {
 	pendingNotifications map[string][]PendingNotification // operatorAddr -> list of notifications
 	notificationMutex    *sync.RWMutex
 	notificationTicker   *time.Ticker
+
+	// Per-execution serialization for durable resume (exactly-once). Sharded so a
+	// fixed set of mutexes bounds memory — the same executionID always maps to the
+	// same shard, so concurrent resumes of one execution serialize. See executionMutex.
+	executionMutexes [executionLockShards]sync.Mutex
+}
+
+// executionLockShards bounds the per-execution resume locks to a fixed set of mutexes.
+const executionLockShards = 256
+
+// executionMutex returns the lock guarding resume of executionID. Holding it across
+// the load-status → run → write-terminal sequence makes durable resume exactly-once:
+// a second concurrent signal (two approvers, a duplicate operator notify) blocks, then
+// finds the execution already terminal and no-ops — so an on-chain ContractWrite /
+// ETHTransfer in the resumed leg can never run twice.
+func (n *Engine) executionMutex(executionID string) *sync.Mutex {
+	// FNV-1a — allocation-free, deterministic (same id → same shard).
+	var h uint32 = 2166136261
+	for i := 0; i < len(executionID); i++ {
+		h ^= uint32(executionID[i])
+		h *= 16777619
+	}
+	return &n.executionMutexes[h%executionLockShards]
 }
 
 // create a new task engine using given storage, config and queue
@@ -4350,6 +4373,10 @@ func (n *Engine) SignalExecution(user *model.User, workflowID, executionID, deci
 	if err != nil {
 		return nil, err // GetWorkflow returns codes.NotFound for a missing/non-owned workflow
 	}
+	// Serialize concurrent resumes of this execution (exactly-once — see executionMutex).
+	mu := n.executionMutex(executionID)
+	mu.Lock()
+	defer mu.Unlock()
 	executor := NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
 	exec, err := executor.DeliverSignal(task, &Signal{
 		ExecutionID: executionID,
@@ -4564,6 +4591,10 @@ func (n *Engine) DeleteWorkflowByUser(user *model.User, taskID string) (*avsprot
 			Id:      taskID,
 		}, nil
 	}
+
+	// GC durable state of any suspended (WAITING) execution this task owned, so its
+	// checkpoint/wake — and any operator internal trigger — don't outlive the workflow.
+	n.gcDurableStateForTask(taskID)
 
 	n.logger.Info("📢 Starting operator notifications", "task_id", taskID)
 	n.notifyOperatorsTaskOperation(taskID, avsproto.MessageOp_DeleteTask)

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -676,6 +676,13 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 		runTaskErr = vm.Run()
 	}
 
+	// Durable execution: a Suspendable step (Await / HumanApproval) may have paused
+	// the run. Checkpoint and return WAITING instead of finalizing. Inert today — no
+	// current node calls requestSuspend, so PendingSuspend is always nil.
+	if susp := vm.PendingSuspend(); susp != nil {
+		return x.checkpointSuspendedExecution(task, execution, vm, susp)
+	}
+
 	t1 := time.Now()
 
 	// when MaxExecution is 0, it means unlimited run until cancel
@@ -802,6 +809,168 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 		x.logger.Warn("task execution completed with step failures", "task_id", task.Id, "failed_steps", failedStepCount, "triggermark", queueData)
 	}
 
+	return execution, nil
+}
+
+// checkpointSuspendedExecution persists a paused execution so it can resume later
+// (PLAN_DURABLE_EXECUTION.md). It writes, in crash-safe order (Appendix C.3): the
+// resume DATA (vars snapshot) first, then the armed markers (wake subscription +
+// the WAITING execution record whose `steps` carry the completed-node outputs).
+// The task's own status row is untouched — the task stays Enabled; only this
+// execution is WAITING.
+func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, execution *avsproto.Execution, vm *VM, susp *SuspendRequest) (*avsproto.Execution, error) {
+	execution.Steps = vm.ExecutionLogs
+	execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING
+	execution.ResumeNodeId = susp.AwaitNodeID
+	if susp.Wake != nil {
+		execution.WaitReason = "waiting on " + susp.Wake.Kind.String()
+	}
+	// EndAt intentionally left unset — the execution has not finished.
+	sanitizeExecutionForPersistence(execution)
+
+	// 1. Resume data first.
+	snapshot, err := vm.snapshotNodeVars()
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint snapshot vars: %w", err)
+	}
+	if err := persistCheckpoint(x.db, execution.Id, snapshot); err != nil {
+		return nil, fmt.Errorf("persist checkpoint: %w", err)
+	}
+	// 2. Armed markers: the wake subscription...
+	if susp.Wake != nil {
+		if err := persistWakeSubscription(x.db, execution.Id, susp.Wake); err != nil {
+			return nil, fmt.Errorf("persist wake: %w", err)
+		}
+	}
+	// ...and the WAITING execution record.
+	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	execBytes, err := mo.Marshal(execution)
+	if err != nil {
+		return nil, fmt.Errorf("marshal suspended execution: %w", err)
+	}
+	if err := x.db.BatchWrite(map[string][]byte{
+		string(TaskExecutionKey(task, execution.Id)): execBytes,
+	}); err != nil {
+		return nil, fmt.Errorf("persist suspended execution: %w", err)
+	}
+
+	if x.logger != nil {
+		x.logger.Info("execution suspended (durable)",
+			"task_id", task.Id, "execution_id", execution.Id, "resume_node", susp.AwaitNodeID)
+	}
+	return execution, nil
+}
+
+// Advance resumes a WAITING execution from storage. An optional signal's payload
+// becomes the suspended step's output (readable by downstream steps). Idempotent
+// (durable exactly-once, E8): a non-WAITING execution is a no-op, so a duplicate or
+// post-restart signal resumes at most once. On a terminal finish it persists the
+// final record and GCs the checkpoint + wake; if the run suspends again it
+// re-checkpoints.
+//
+// Reconstructs node + trigger output vars from the checkpoint; faithful
+// reconstruction of arbitrary input variables is a follow-up.
+func (x *WorkflowExecutor) Advance(task *model.Workflow, executionID string, signal *Signal) (*avsproto.Execution, error) {
+	raw, err := x.db.GetKey(TaskExecutionKey(task, executionID))
+	if err != nil {
+		return nil, fmt.Errorf("load execution %s: %w", executionID, err)
+	}
+	execution := &avsproto.Execution{}
+	if err := protojson.Unmarshal(raw, execution); err != nil {
+		return nil, fmt.Errorf("unmarshal execution %s: %w", executionID, err)
+	}
+	// Only a WAITING execution resumes (exactly-once across a duplicate / post-restart
+	// signal). On the no-op path, still best-effort GC any orphaned durable state in
+	// case a prior finalize crashed between persisting the terminal record and cleanup.
+	if execution.Status != avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING {
+		_ = deleteCheckpoint(x.db, executionID)
+		_ = deleteWakeSubscription(x.db, executionID)
+		return execution, nil
+	}
+
+	// Rebuild the VM, mirroring RunTask's swConfig resolution so the resumed leg uses
+	// the same wallet/chain settings as the initial leg.
+	secrets, secErr := LoadSecretForTask(x.db, task)
+	if secErr != nil {
+		secrets = map[string]string{}
+	}
+	swConfig := x.smartWalletConfig
+	if x.engine != nil {
+		swConfig = x.engine.ResolveSmartWalletConfig(x.engine.defaultChainID())
+	}
+	vm, err := NewVMWithData(task, nil, swConfig, secrets)
+	if err != nil {
+		return nil, fmt.Errorf("rebuild vm on resume: %w", err)
+	}
+	vm.WithDb(x.db).WithLogger(x.logger)
+	if x.engine != nil {
+		vm.WithChainConfigResolver(x.engine.ResolveSmartWalletConfig)
+	}
+	if err := vm.Compile(); err != nil {
+		return nil, fmt.Errorf("compile on resume: %w", err)
+	}
+
+	// Restore prior-leg vars. A WAITING execution always has a checkpoint (written
+	// at suspend); a missing/unreadable one is corruption — fail rather than resume
+	// with partial state.
+	ckpt, lErr := loadCheckpoint(x.db, executionID)
+	if lErr != nil {
+		return nil, fmt.Errorf("load checkpoint for WAITING execution %s: %w", executionID, lErr)
+	}
+	if err := vm.restoreNodeVars(ckpt); err != nil {
+		return nil, fmt.Errorf("restore vars on resume: %w", err)
+	}
+
+	// The wake delivers the suspended step's output.
+	if signal != nil && signal.Payload != nil && execution.ResumeNodeId != "" {
+		(&CommonProcessor{vm: vm}).SetOutputVarForStep(execution.ResumeNodeId,
+			map[string]any{"data": signal.Payload.AsInterface()})
+	}
+
+	// Resume state: skip the completed prefix, keep its steps in the final record.
+	vm.resumeCompleted = completedNodeIDsFromSteps(execution.Steps)
+	vm.ExecutionLogs = append([]*avsproto.Execution_Step{}, execution.Steps...)
+
+	runErr := vm.Run()
+
+	// Suspended again — re-checkpoint and stay WAITING.
+	if susp := vm.PendingSuspend(); susp != nil {
+		return x.checkpointSuspendedExecution(task, execution, vm, susp)
+	}
+
+	// Terminal — finalize and GC the durable state.
+	executionError, _, resultStatus := vm.AnalyzeExecutionResult()
+	execution.Steps = vm.ExecutionLogs
+	execution.Status = convertToExecutionStatus(resultStatus)
+	execution.Error = executionError
+	execution.EndAt = time.Now().UnixMilli()
+	if runErr != nil {
+		execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR
+		if execution.Error == "" {
+			execution.Error = fmt.Sprintf("VM execution error: %s", runErr.Error())
+		}
+	}
+	execution.ResumeNodeId = ""
+	execution.WaitReason = ""
+	sanitizeExecutionForPersistence(execution)
+
+	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	execBytes, err := mo.Marshal(execution)
+	if err != nil {
+		return nil, fmt.Errorf("marshal resumed execution: %w", err)
+	}
+	if err := x.db.BatchWrite(map[string][]byte{
+		string(TaskExecutionKey(task, executionID)): execBytes,
+	}); err != nil {
+		return nil, fmt.Errorf("persist resumed execution: %w", err)
+	}
+	_ = deleteCheckpoint(x.db, executionID)
+	_ = deleteWakeSubscription(x.db, executionID)
+
+	if x.logger != nil {
+		x.logger.Info("execution resumed to terminal",
+			"task_id", task.Id, "execution_id", executionID, "status", execution.Status.String())
+	}
 	return execution, nil
 }
 

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -676,9 +676,9 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 		runTaskErr = vm.Run()
 	}
 
-	// Durable execution: a Suspendable step (Await / HumanApproval) may have paused
-	// the run. Checkpoint and return WAITING instead of finalizing. Inert today — no
-	// current node calls requestSuspend, so PendingSuspend is always nil.
+	// Durable execution: an Await node may have paused the run via requestSuspend.
+	// Checkpoint and return WAITING instead of finalizing; the execution resumes later
+	// via DeliverSignal/Advance (human approval) or an operator chain-event wake.
 	if susp := vm.PendingSuspend(); susp != nil {
 		return x.checkpointSuspendedExecution(task, execution, vm, susp)
 	}
@@ -836,25 +836,34 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	if err := persistCheckpoint(x.db, execution.Id, snapshot); err != nil {
 		return nil, fmt.Errorf("persist checkpoint: %w", err)
 	}
-	// 2. Armed markers: the wake subscription...
+	// 2. Armed markers — the wake subscription AND the WAITING execution record are
+	//    written ATOMICALLY in one batch. As separate writes, a crash between them
+	//    could leave a wake pointing at an execution that was never persisted: the
+	//    internal-trigger sync would then watch and fire a wake that can never resume.
+	//    (The checkpoint above stays a separate prior write — it's resume data with no
+	//    wake referencing it, so a partial write is an inert orphan.)
+	batch := map[string][]byte{}
 	if susp.Wake != nil {
 		// Bind the wake to its task so a chain-event notify / boot re-arm can resolve
 		// the task (executions are stored task-scoped; no global exec→task index).
 		susp.Wake.TaskID = task.Id
-		if err := persistWakeSubscription(x.db, execution.Id, susp.Wake); err != nil {
-			return nil, fmt.Errorf("persist wake: %w", err)
+		if err := susp.Wake.Validate(); err != nil {
+			return nil, fmt.Errorf("validate wake: %w", err)
 		}
+		wakeBytes, err := marshalWake(susp.Wake)
+		if err != nil {
+			return nil, fmt.Errorf("marshal wake: %w", err)
+		}
+		batch[string(wakeSubscriptionKey(execution.Id))] = wakeBytes
 	}
-	// ...and the WAITING execution record.
 	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
 	execBytes, err := mo.Marshal(execution)
 	if err != nil {
 		return nil, fmt.Errorf("marshal suspended execution: %w", err)
 	}
-	if err := x.db.BatchWrite(map[string][]byte{
-		string(TaskExecutionKey(task, execution.Id)): execBytes,
-	}); err != nil {
-		return nil, fmt.Errorf("persist suspended execution: %w", err)
+	batch[string(TaskExecutionKey(task, execution.Id))] = execBytes
+	if err := x.db.BatchWrite(batch); err != nil {
+		return nil, fmt.Errorf("persist suspended execution + wake: %w", err)
 	}
 
 	if x.logger != nil {

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -862,8 +862,35 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 		return nil, fmt.Errorf("marshal suspended execution: %w", err)
 	}
 	batch[string(TaskExecutionKey(task, execution.Id))] = execBytes
+
+	// Count this run toward MaxExecution at suspend time — a suspended execution is a
+	// run in progress, so the limit must not be bypassed (nor a new execution fire)
+	// while it waits. ExecutionCount was already incremented in RunTask; persist the
+	// task now, in the same atomic batch. The resume in Advance does NOT re-count.
+	initialTaskStatus := task.Status
+	if task.MaxExecution > 0 && task.ExecutionCount >= task.MaxExecution {
+		task.SetCompleted()
+	}
+	if task.ExpiredAt > 0 && time.Now().UnixMilli() >= task.ExpiredAt {
+		task.SetCompleted()
+	}
+	taskJSON, err := task.ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal suspended task: %w", err)
+	}
+	batch[string(WorkflowStorageKey(task.Id, task.Status))] = taskJSON
+	batch[string(TaskUserKey(task))] = []byte(fmt.Sprintf("%d", task.Status))
+
 	if err := x.db.BatchWrite(batch); err != nil {
-		return nil, fmt.Errorf("persist suspended execution + wake: %w", err)
+		// The batch always holds the execution + task, and the wake when present.
+		return nil, fmt.Errorf("persist suspended execution state: %w", err)
+	}
+	// If MaxExecution/expiry flipped the task to a terminal status, drop the stale
+	// status-keyed record (mirrors RunTask's normal finalize).
+	if task.Status != initialTaskStatus {
+		if err := x.db.Delete(WorkflowStorageKey(task.Id, initialTaskStatus)); err != nil && x.logger != nil {
+			x.logger.Warn("failed to delete stale task status key after suspend", "task_id", task.Id, "error", err)
+		}
 	}
 
 	if x.logger != nil {
@@ -875,8 +902,17 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 
 // DeliverSignal is the signal-intake entrypoint: a gateway approve/reject endpoint
 // or operator internal-trigger calls this to wake a suspended execution. It
-// validates the signal and advances the execution. (Authorization of the signal
-// against the wait's approvers is a follow-up — see the approval security model.)
+// validates the signal and advances the execution.
+//
+// SECURITY (v1, must close before delegated approval ships): the wake's `Approvers`
+// list is NOT yet enforced — the engine relies on the caller having authorized the
+// signal (SignalExecution gates on workflow ownership, so today only the owner can
+// signal). Consequently the signal `Payload` is owner-trusted; because a downstream
+// node may template `{{await.data.*}}` into JS source, an UNtrusted payload could
+// inject code. That is safe while only the owner (who already controls the workflow
+// source) can signal. When delegated approvers are enforced, the payload must be
+// treated as untrusted data (escaped / passed as a runtime value, not into source).
+// See the approval security model in PLAN_DURABLE_EXECUTION.md.
 func (x *WorkflowExecutor) DeliverSignal(task *model.Workflow, signal *Signal) (*avsproto.Execution, error) {
 	if err := signal.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid signal: %w", err)

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -838,6 +838,9 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	}
 	// 2. Armed markers: the wake subscription...
 	if susp.Wake != nil {
+		// Bind the wake to its task so a chain-event notify / boot re-arm can resolve
+		// the task (executions are stored task-scoped; no global exec→task index).
+		susp.Wake.TaskID = task.Id
 		if err := persistWakeSubscription(x.db, execution.Id, susp.Wake); err != nil {
 			return nil, fmt.Errorf("persist wake: %w", err)
 		}
@@ -995,6 +998,53 @@ func (x *WorkflowExecutor) Advance(task *model.Workflow, executionID string, sig
 		x.logger.Info("execution resumed to terminal",
 			"task_id", task.Id, "execution_id", executionID, "status", execution.Status.String())
 	}
+	return execution, nil
+}
+
+// ExpireWait fails a WAITING execution whose wake timed out, writing a terminal
+// (FAILED) record and GC'ing the durable state. Idempotent: a non-WAITING execution
+// just GCs any orphaned state. Mirrors Advance's finalize without running the VM —
+// nothing resumes, the wait simply expires.
+func (x *WorkflowExecutor) ExpireWait(task *model.Workflow, executionID string) (*avsproto.Execution, error) {
+	raw, err := x.db.GetKey(TaskExecutionKey(task, executionID))
+	if err != nil {
+		_ = deleteCheckpoint(x.db, executionID)
+		_ = deleteWakeSubscription(x.db, executionID)
+		return nil, fmt.Errorf("load execution %s: %w", executionID, err)
+	}
+	execution := &avsproto.Execution{}
+	if err := protojson.Unmarshal(raw, execution); err != nil {
+		return nil, fmt.Errorf("unmarshal execution %s: %w", executionID, err)
+	}
+	// Only a still-WAITING execution expires; otherwise just GC (a resume may have
+	// raced the sweep) and return the record as-is.
+	if execution.Status != avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING {
+		_ = deleteCheckpoint(x.db, executionID)
+		_ = deleteWakeSubscription(x.db, executionID)
+		return execution, nil
+	}
+
+	execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED
+	if execution.Error == "" {
+		execution.Error = "await timed out before a wake arrived"
+	}
+	execution.EndAt = time.Now().UnixMilli()
+	execution.ResumeNodeId = ""
+	execution.WaitReason = ""
+	sanitizeExecutionForPersistence(execution)
+
+	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	execBytes, err := mo.Marshal(execution)
+	if err != nil {
+		return nil, fmt.Errorf("marshal expired execution: %w", err)
+	}
+	if err := x.db.BatchWrite(map[string][]byte{
+		string(TaskExecutionKey(task, executionID)): execBytes,
+	}); err != nil {
+		return nil, fmt.Errorf("persist expired execution: %w", err)
+	}
+	_ = deleteCheckpoint(x.db, executionID)
+	_ = deleteWakeSubscription(x.db, executionID)
 	return execution, nil
 }
 

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -861,6 +861,30 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	return execution, nil
 }
 
+// DeliverSignal is the signal-intake entrypoint: a gateway approve/reject endpoint
+// or operator internal-trigger calls this to wake a suspended execution. It
+// validates the signal and advances the execution. (Authorization of the signal
+// against the wait's approvers is a follow-up — see the approval security model.)
+func (x *WorkflowExecutor) DeliverSignal(task *model.Workflow, signal *Signal) (*avsproto.Execution, error) {
+	if err := signal.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid signal: %w", err)
+	}
+	// Enforce the gate: a signal only counts against an actual pending wait whose
+	// kind it matches and which hasn't timed out. Otherwise resumption could be
+	// triggered with no wait outstanding (or with the wrong wake source).
+	wake, err := loadWakeSubscription(x.db, signal.ExecutionID)
+	if err != nil {
+		return nil, fmt.Errorf("no pending wait for execution %s: %w", signal.ExecutionID, err)
+	}
+	if signal.Kind != wake.Kind {
+		return nil, fmt.Errorf("signal kind %s does not match the pending wait (%s)", signal.Kind, wake.Kind)
+	}
+	if wake.TimeoutAt > 0 && time.Now().UnixMilli() > wake.TimeoutAt {
+		return nil, fmt.Errorf("the wait for execution %s has timed out", signal.ExecutionID)
+	}
+	return x.Advance(task, signal.ExecutionID, signal)
+}
+
 // Advance resumes a WAITING execution from storage. An optional signal's payload
 // becomes the suspended step's output (readable by downstream steps). Idempotent
 // (durable exactly-once, E8): a non-WAITING execution is a no-op, so a duplicate or

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -55,6 +55,12 @@ func (n *Engine) validateAwaitConfigs(task *model.Workflow) error {
 		if await == nil {
 			continue
 		}
+		// An Await whose name is a reserved system var would, on resume, overwrite that
+		// var (the delivered signal is set under the node's name) — reject it at create.
+		if reservedSystemVarNames[node.GetName()] {
+			return status.Errorf(codes.InvalidArgument,
+				"await node name %q collides with a reserved system variable; rename it", node.GetName())
+		}
 		cfg := await.GetConfig()
 		if cfg == nil {
 			return status.Errorf(codes.InvalidArgument, "await node %s has no config", node.GetId())
@@ -84,11 +90,34 @@ func (n *Engine) deregisterInternalTrigger(executionID string) {
 	n.notifyOperatorsTaskOperation(internalTriggerTaskID(executionID), avsproto.MessageOp_DeleteTask)
 }
 
+// gcDurableStateForTask removes the durable state (checkpoint + wake, plus the operator
+// internal trigger for chain-event waits) of every suspended execution belonging to
+// taskID. Called when a workflow is deleted so a WAITING execution's wake doesn't
+// linger until the timeout sweep — and so external-signal waits (which the sync-time GC
+// never sees) are cleaned up promptly too.
+func (n *Engine) gcDurableStateForTask(taskID string) {
+	wakes, err := loadAllWakeSubscriptions(n.db, n.logger)
+	if err != nil {
+		n.logger.Error("gc durable state for deleted task: load wakes", "task_id", taskID, "error", err)
+		return
+	}
+	for executionID, wake := range wakes {
+		if wake.TaskID != taskID {
+			continue
+		}
+		_ = deleteCheckpoint(n.db, executionID)
+		_ = deleteWakeSubscription(n.db, executionID)
+		if wake.Kind == WakeChainEvent {
+			n.deregisterInternalTrigger(executionID)
+		}
+	}
+}
+
 // sweepExpiredWaits fails WAITING executions whose wake timed out (a stuck bridge, an
 // approver who never responded) and GCs their durable state. Runs on the periodic
 // scan loop, so a wait whose timeout passed while no operator was up still resolves.
 func (n *Engine) sweepExpiredWaits() {
-	wakes, err := loadAllWakeSubscriptions(n.db)
+	wakes, err := loadAllWakeSubscriptions(n.db, n.logger)
 	if err != nil {
 		n.logger.Error("sweep expired waits: load wakes", "error", err)
 		return
@@ -114,8 +143,14 @@ func (n *Engine) sweepExpiredWaits() {
 		if executor == nil {
 			executor = NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
 		}
-		if _, err := executor.ExpireWait(task, executionID); err != nil {
-			n.logger.Error("sweep expired waits: expire", "execution_id", executionID, "error", err)
+		// Serialize against a concurrent resume of the same execution (exactly-once):
+		// a signal landing as the sweep expires must not double-finalize.
+		mu := n.executionMutex(executionID)
+		mu.Lock()
+		_, expireErr := executor.ExpireWait(task, executionID)
+		mu.Unlock()
+		if expireErr != nil {
+			n.logger.Error("sweep expired waits: expire", "execution_id", executionID, "error", expireErr)
 			continue
 		}
 		// Deregistration only applies to chain-event waits (operator-watched triggers).
@@ -155,7 +190,7 @@ func parseInternalTriggerTaskID(taskID string) (executionID string, ok bool) {
 // them with zero new transport. Re-derived from storage on every sync, so a boot or
 // operator reconnect re-arms every live wait for free.
 func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
-	wakes, err := loadAllWakeSubscriptions(n.db)
+	wakes, err := loadAllWakeSubscriptions(n.db, n.logger)
 	if err != nil {
 		n.logger.Error("internal-trigger sync: load wake subscriptions", "error", err)
 		return nil
@@ -173,6 +208,10 @@ func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
 			if status.Code(err) == codes.NotFound {
 				_ = deleteCheckpoint(n.db, executionID)
 				_ = deleteWakeSubscription(n.db, executionID)
+				n.logger.Warn("gc orphaned wake: workflow gone", "execution_id", executionID, "task_id", wake.TaskID)
+			} else {
+				// Transient/corrupt error — preserve the state, but surface it (mirrors sweepExpiredWaits).
+				n.logger.Error("internal-trigger sync: resolve task for wake", "execution_id", executionID, "task_id", wake.TaskID, "error", err)
 			}
 			continue
 		}
@@ -200,6 +239,13 @@ func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
 // A duplicate or late fire is a safe no-op — the wake is gone once resumed, and
 // Advance only acts on a still-WAITING execution.
 func (n *Engine) deliverChainEventWake(executionID string, payload *avsproto.NotifyTriggersReq) (*ExecutionState, error) {
+	// Serialize against any other resume of this execution (a duplicate operator notify
+	// or a concurrent external signal) so the load-wake → run sequence is exactly-once.
+	// The gate read below must be inside the lock: the loser then finds no wake and no-ops.
+	mu := n.executionMutex(executionID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	wake, err := loadWakeSubscription(n.db, executionID)
 	if err != nil {
 		// No pending wait — already resumed, timed out, or GC'd. Nothing to do.

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -1,0 +1,180 @@
+package taskengine
+
+import (
+	"strings"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// validateAwaitOperatorCoverage rejects, at create time, a chain-event Await whose
+// chain no operator currently covers — the wait could never be observed, so it would
+// never resume. Gateway-only (where operators advertise chain coverage); a transient
+// FailedPrecondition, not a malformed request, since coverage is connection state.
+func (n *Engine) validateAwaitOperatorCoverage(task *model.Workflow) error {
+	if n.config == nil || !n.config.IsGateway || task == nil {
+		return nil
+	}
+	for _, node := range task.Nodes {
+		await := node.GetAwait()
+		if await == nil || await.Config == nil {
+			continue
+		}
+		ce := await.Config.GetChainEvent()
+		if ce == nil {
+			continue // external-signal flavor needs no operator
+		}
+		// operatorsCoveringChain reads trackSyncedTasks and requires n.lock.
+		n.lock.Lock()
+		covered := len(n.operatorsCoveringChain(ce.GetChainId()))
+		n.lock.Unlock()
+		if covered == 0 {
+			return status.Errorf(codes.FailedPrecondition,
+				"await node waits on chain_id=%d but no operator currently covers it; the wait could never fire", ce.GetChainId())
+		}
+	}
+	return nil
+}
+
+// deregisterInternalTrigger tells operators to stop watching a consumed internal
+// trigger (the wake it stood for is gone). If the execution re-suspended on a new
+// chain-event wake, the next sync re-registers it (DeleteTask also untracks it).
+func (n *Engine) deregisterInternalTrigger(executionID string) {
+	n.notifyOperatorsTaskOperation(internalTriggerTaskID(executionID), avsproto.MessageOp_DeleteTask)
+}
+
+// sweepExpiredWaits fails WAITING executions whose wake timed out (a stuck bridge, an
+// approver who never responded) and GCs their durable state. Runs on the periodic
+// scan loop, so a wait whose timeout passed while no operator was up still resolves.
+func (n *Engine) sweepExpiredWaits() {
+	wakes, err := loadAllWakeSubscriptions(n.db)
+	if err != nil {
+		n.logger.Error("sweep expired waits: load wakes", "error", err)
+		return
+	}
+	now := time.Now().UnixMilli()
+	var executor *WorkflowExecutor
+	for executionID, wake := range wakes {
+		if wake.TimeoutAt <= 0 || wake.TimeoutAt > now {
+			continue
+		}
+		task, err := n.GetWorkflowByID(wake.TaskID)
+		if err != nil {
+			// Only GC when the task is genuinely gone. On a corrupted/transient error,
+			// preserve the durable state so the problem stays diagnosable + recoverable.
+			if status.Code(err) == codes.NotFound {
+				_ = deleteCheckpoint(n.db, executionID)
+				_ = deleteWakeSubscription(n.db, executionID)
+			} else {
+				n.logger.Error("sweep expired waits: load task", "task_id", wake.TaskID, "execution_id", executionID, "error", err)
+			}
+			continue
+		}
+		if executor == nil {
+			executor = NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
+		}
+		if _, err := executor.ExpireWait(task, executionID); err != nil {
+			n.logger.Error("sweep expired waits: expire", "execution_id", executionID, "error", err)
+			continue
+		}
+		// Deregistration only applies to chain-event waits (operator-watched triggers).
+		if wake.Kind == WakeChainEvent {
+			n.deregisterInternalTrigger(executionID)
+		}
+		n.logger.Info("expired timed-out wait", "execution_id", executionID, "task_id", wake.TaskID)
+	}
+}
+
+// internalTriggerPrefix namespaces the synthetic task IDs that stand in for a
+// suspended execution's chain-event wake. Real task IDs are ULIDs (base32, no
+// underscore), so this prefix can never collide with a user workflow ID — and it
+// lets the notify path tell an internal-trigger notification apart from a normal
+// task one by the ID alone.
+const internalTriggerPrefix = "itrig_"
+
+// internalTriggerTaskID is the synthetic task ID an operator watches for a
+// chain-event wake. The execution ID is embedded so the operator's NotifyTriggers
+// round-trips straight back to the waiting execution.
+func internalTriggerTaskID(executionID string) string {
+	return internalTriggerPrefix + executionID
+}
+
+// parseInternalTriggerTaskID reports whether taskID is an internal-trigger ID and,
+// if so, returns the execution ID it carries.
+func parseInternalTriggerTaskID(taskID string) (executionID string, ok bool) {
+	if strings.HasPrefix(taskID, internalTriggerPrefix) {
+		return strings.TrimPrefix(taskID, internalTriggerPrefix), true
+	}
+	return "", false
+}
+
+// pendingChainEventTriggers builds one synthetic, single-shot EventTrigger "task"
+// per WAITING execution that is waiting on a chain event. They are streamed to
+// operators through the very same sync path as user tasks, so the operator watches
+// them with zero new transport. Re-derived from storage on every sync, so a boot or
+// operator reconnect re-arms every live wait for free.
+func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
+	wakes, err := loadAllWakeSubscriptions(n.db)
+	if err != nil {
+		n.logger.Error("internal-trigger sync: load wake subscriptions", "error", err)
+		return nil
+	}
+	out := make([]*model.Workflow, 0, len(wakes))
+	for executionID, wake := range wakes {
+		if wake.Kind != WakeChainEvent || wake.ChainEvent == nil {
+			continue
+		}
+		id := internalTriggerTaskID(executionID)
+		out = append(out, &model.Workflow{Task: &avsproto.Task{
+			Id:           id,
+			Status:       avsproto.TaskStatus_Enabled,
+			MaxExecution: 1,
+			ExpiredAt:    wake.TimeoutAt, // operator stops watching past the wait's timeout
+			Trigger: &avsproto.TaskTrigger{
+				Id:   id,
+				Name: "await",
+				TriggerType: &avsproto.TaskTrigger_Event{
+					Event: &avsproto.EventTrigger{Config: wake.ChainEvent},
+				},
+			},
+		}})
+	}
+	return out
+}
+
+// deliverChainEventWake routes an operator's notification for an internal trigger
+// (itrig_<execId>) to its suspended execution: resolve the task from the wake, build
+// a chain-event Signal from the matched event output, and advance the execution.
+// A duplicate or late fire is a safe no-op — the wake is gone once resumed, and
+// Advance only acts on a still-WAITING execution.
+func (n *Engine) deliverChainEventWake(executionID string, payload *avsproto.NotifyTriggersReq) (*ExecutionState, error) {
+	wake, err := loadWakeSubscription(n.db, executionID)
+	if err != nil {
+		// No pending wait — already resumed, timed out, or GC'd. Nothing to do.
+		return &ExecutionState{Status: "not_found", Message: "no pending wait for " + executionID}, nil
+	}
+	task, err := n.GetWorkflowByID(wake.TaskID)
+	if err != nil {
+		return &ExecutionState{Status: "not_found", Message: "task " + wake.TaskID + " for wake " + executionID + " not found"}, nil
+	}
+
+	var eventOutput *structpb.Value
+	if out, ok := ExtractTriggerOutput(payload.TriggerOutput).(*avsproto.EventTrigger_Output); ok && out != nil {
+		eventOutput = out.GetData()
+	}
+
+	executor := NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
+	signal := &Signal{ExecutionID: executionID, Kind: WakeChainEvent, Payload: eventOutput}
+	if _, err := executor.DeliverSignal(task, signal); err != nil {
+		n.logger.Error("internal-trigger wake: deliver signal", "execution_id", executionID, "error", err)
+		return &ExecutionState{Status: "error", Message: err.Error()}, err
+	}
+	// The wake it watched is consumed — tell operators to stop. A re-suspend on a new
+	// chain-event wake re-registers via the next sync.
+	n.deregisterInternalTrigger(executionID)
+	return &ExecutionState{Status: "wake_delivered", TaskStillEnabled: true, Message: "resumed execution " + executionID}, nil
+}

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -40,6 +40,43 @@ func (n *Engine) validateAwaitOperatorCoverage(task *model.Workflow) error {
 	return nil
 }
 
+// validateAwaitConfigs rejects, at create time, an Await node with an invalid config:
+// the external-signal flavor (a channel) and the chain-event flavor are mutually
+// exclusive, and exactly one must be set (an external-signal Await requires a channel).
+// Without this an invalid Await would persist and only fail later at execution in
+// runAwait / WakeSubscription.Validate. Runs in every mode (it's a config error, not a
+// coverage condition).
+func (n *Engine) validateAwaitConfigs(task *model.Workflow) error {
+	if task == nil {
+		return nil
+	}
+	for _, node := range task.Nodes {
+		await := node.GetAwait()
+		if await == nil {
+			continue
+		}
+		cfg := await.GetConfig()
+		if cfg == nil {
+			return status.Errorf(codes.InvalidArgument, "await node %s has no config", node.GetId())
+		}
+		hasChainEvent := cfg.GetChainEvent() != nil
+		hasExternalFields := cfg.GetChannel() != "" || len(cfg.GetApprovers()) > 0 || cfg.GetPrompt() != ""
+		if hasChainEvent && hasExternalFields {
+			return status.Errorf(codes.InvalidArgument,
+				"await node %s sets both an external-signal field and chain_event; they are mutually exclusive", node.GetId())
+		}
+		if hasChainEvent {
+			continue // chain-event flavor is valid
+		}
+		// External-signal flavor — channel is required (approvers/prompt alone is invalid).
+		if cfg.GetChannel() == "" {
+			return status.Errorf(codes.InvalidArgument,
+				"await node %s requires either an external-signal 'channel' or 'chain_event'", node.GetId())
+		}
+	}
+	return nil
+}
+
 // deregisterInternalTrigger tells operators to stop watching a consumed internal
 // trigger (the wake it stood for is gone). If the execution re-suspended on a new
 // chain-event wake, the next sync re-registers it (DeleteTask also untracks it).
@@ -126,6 +163,17 @@ func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
 	out := make([]*model.Workflow, 0, len(wakes))
 	for executionID, wake := range wakes {
 		if wake.Kind != WakeChainEvent || wake.ChainEvent == nil {
+			continue
+		}
+		// GC a wake whose workflow has been deleted (e.g. DELETE /workflows/{id})
+		// instead of streaming an internal trigger that can never resume — otherwise
+		// operators keep watching it until the timeout sweep eventually clears it.
+		// NotFound only; a transient/corrupt error preserves the state for recovery.
+		if _, err := n.GetWorkflowByID(wake.TaskID); err != nil {
+			if status.Code(err) == codes.NotFound {
+				_ = deleteCheckpoint(n.db, executionID)
+				_ = deleteWakeSubscription(n.db, executionID)
+			}
 			continue
 		}
 		id := internalTriggerTaskID(executionID)

--- a/core/taskengine/node_types.go
+++ b/core/taskengine/node_types.go
@@ -27,6 +27,7 @@ const (
 	NodeTypeFilter        = "filter"
 	NodeTypeLoop          = "loop"
 	NodeTypeBalance       = "balance"
+	NodeTypeAwait         = "await"
 )
 
 // AllNodeTypes returns a slice of all supported node types

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1438,6 +1438,11 @@ func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
 		if executionLogForNode != nil {
 			v.addExecutionLog(executionLogForNode)
 		}
+	} else if node.GetAwait() != nil {
+		executionLogForNode, err = v.runAwait(node)
+		if executionLogForNode != nil {
+			v.addExecutionLog(executionLogForNode)
+		}
 	} else {
 		err = fmt.Errorf("unknown node type for node ID %s", node.Id)
 	}
@@ -3316,6 +3321,31 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 				Config: balanceConfig,
 			},
 		}
+	case NodeTypeAwait:
+		node.Type = avsproto.NodeType_NODE_TYPE_AWAIT
+		awaitConfig := &avsproto.AwaitNode_Config{}
+		if channel, ok := config["channel"].(string); ok {
+			awaitConfig.Channel = channel
+		} else {
+			return nil, fmt.Errorf("await node requires 'channel' field")
+		}
+		if approvers, ok := config["approvers"].([]interface{}); ok {
+			for _, a := range approvers {
+				if s, ok := a.(string); ok {
+					awaitConfig.Approvers = append(awaitConfig.Approvers, s)
+				}
+			}
+		}
+		if prompt, ok := config["prompt"].(string); ok {
+			awaitConfig.Prompt = prompt
+		}
+		if timeout, ok := config["timeoutSeconds"].(float64); ok {
+			if timeout < 0 || timeout > float64(^uint32(0)) {
+				return nil, fmt.Errorf("await node 'timeoutSeconds' out of range: %v", timeout)
+			}
+			awaitConfig.TimeoutSeconds = uint32(timeout)
+		}
+		node.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: awaitConfig}}
 	default:
 		return nil, fmt.Errorf("unsupported node type for CreateNodeFromType: %s", nodeType)
 	}
@@ -3813,6 +3843,21 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 
 			// Clean up complex protobuf types before returning
 			return removeComplexProtobufTypes(config)
+		}
+
+	case *avsproto.TaskNode_Await:
+		await := taskNode.GetAwait()
+		if await != nil && await.Config != nil {
+			approvers := make([]interface{}, len(await.Config.Approvers))
+			for i, a := range await.Config.Approvers {
+				approvers[i] = a
+			}
+			return map[string]interface{}{
+				"channel":        await.Config.Channel,
+				"approvers":      approvers, // []interface{} so structpb.NewValue accepts it
+				"prompt":         await.Config.Prompt,
+				"timeoutSeconds": float64(await.Config.TimeoutSeconds),
+			}
 		}
 
 	case *avsproto.TaskNode_Branch:

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1062,6 +1062,18 @@ func (v *VM) runKahnScheduler() error {
 			seedQueue = append(seedQueue, nodeID)
 		}
 	}
+	// On resume, a branch-target node that already ran in a prior leg must also be
+	// fast-forwarded so its completion propagates to its successors — the Branch
+	// runtime (which is what normally schedules a target) does not re-run on resume,
+	// and the phantom predCount keeps the target from ever reaching the queue via the
+	// predCount path. Without this, a completed Branch-before-Await prefix would leave
+	// the await's successors permanently unschedulable. Fresh runs have empty
+	// `completed`, so this adds nothing there.
+	for nodeID := range completed {
+		if branchTargets[nodeID] {
+			seedQueue = append(seedQueue, nodeID)
+		}
+	}
 	seedVisited := make(map[string]bool)
 	for len(seedQueue) > 0 {
 		nodeID := seedQueue[0]

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -274,6 +274,12 @@ type VM struct {
 	// without re-executing them, so it resumes from where execution left off.
 	// Set once before Run(); read-only during the run.
 	resumeCompleted map[string]bool
+
+	// suspend is set by a Suspendable step's runner (via requestSuspend) to pause
+	// the execution mid-run. The scheduler stops scheduling new work; after Run()
+	// the executor reads PendingSuspend() to checkpoint + register the wake instead
+	// of finishing. nil for a normal run.
+	suspend *SuspendRequest
 }
 
 func NewVM() *VM {
@@ -1100,6 +1106,7 @@ func (v *VM) runKahnScheduler() error {
 	wg.Add(workers)
 
 	var closeOnce sync.Once
+	var suspended bool // guarded by mu; set when a Suspendable step pauses the run
 	worker := func() {
 		defer wg.Done()
 		for id := range ready {
@@ -1119,8 +1126,28 @@ func (v *VM) runKahnScheduler() error {
 				}
 			}
 
-			// On completion, decrement successors
+			// On completion (or suspension), update scheduling state.
 			mu.Lock()
+			if suspended {
+				// Another worker already suspended the run; stop scheduling. (An
+				// in-flight node still finishes its executeNode above, but schedules
+				// nothing further.)
+				processed++
+				mu.Unlock()
+				continue
+			}
+			if v.isSuspendRequested() {
+				// A Suspendable step (Await/HumanApproval) asked to pause. Stop
+				// scheduling new work and wind the run down; the executor will then
+				// checkpoint + register the wake. Successors are NOT scheduled.
+				suspended = true
+				closeOnce.Do(func() { close(ready) })
+				processed++
+				mu.Unlock()
+				continue
+			}
+
+			// Schedule successors.
 			for _, succ := range adj[id] {
 				if _, exists := predCount[succ]; exists {
 					predCount[succ]--

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -266,6 +266,14 @@ type VM struct {
 	// per-node chain_id overrides. When nil or called with 0, callers fall back to
 	// v.smartWalletConfig. Set via WithChainConfigResolver after construction.
 	chainConfigResolver func(chainID int64) *config.SmartWalletConfig
+
+	// resumeCompleted marks nodes that completed in a prior leg of a durable
+	// execution (PLAN_DURABLE_EXECUTION.md). nil/empty for a fresh run — in which
+	// case the scheduler behaves exactly as before. When set, the scheduler
+	// fast-forwards these nodes (applies their completion to downstream predCounts)
+	// without re-executing them, so it resumes from where execution left off.
+	// Set once before Run(); read-only during the run.
+	resumeCompleted map[string]bool
 }
 
 func NewVM() *VM {
@@ -957,6 +965,7 @@ func (v *VM) runKahnScheduler() error {
 	}
 	trigger := v.task.Trigger
 	edges := v.task.Edges
+	completed := v.resumeCompleted // nil for a fresh run; read-only during the run
 	v.mu.Unlock()
 
 	for _, e := range edges {
@@ -1034,15 +1043,51 @@ func (v *VM) runKahnScheduler() error {
 		}
 	}
 
+	// Seed the initial ready frontier. For a fresh run (completed nil/empty) this is
+	// every predCount==0 non-branch node — identical to the original seed. For a
+	// resume, the already-completed prefix is "fast-forwarded" (its successors are
+	// decremented as if it had run, without executing it), so the frontier becomes the
+	// not-yet-completed nodes that have become ready — i.e. where execution left off.
+	// See PLAN_DURABLE_EXECUTION.md (Appendix A.3).
+	seedQueue := make([]string, 0, len(predCount))
 	for nodeID, c := range predCount {
-		if c == 0 {
-			if branchTargets[nodeID] {
-				continue // still gated by branch until a condition is selected
-			}
-			ready <- nodeID
-			scheduled[nodeID] = true
-			scheduledCount++
+		if c == 0 && !branchTargets[nodeID] {
+			seedQueue = append(seedQueue, nodeID)
 		}
+	}
+	seedVisited := make(map[string]bool)
+	for len(seedQueue) > 0 {
+		nodeID := seedQueue[0]
+		seedQueue = seedQueue[1:]
+		if seedVisited[nodeID] {
+			continue
+		}
+		seedVisited[nodeID] = true
+		if completed[nodeID] {
+			// Already ran in a prior leg: apply its completion to downstream predCounts
+			// without executing it. Counts as done; NOT added to scheduledCount.
+			scheduled[nodeID] = true
+			for _, succ := range adj[nodeID] {
+				if _, exists := predCount[succ]; exists {
+					predCount[succ]--
+					if predCount[succ] == 0 && !branchTargets[succ] {
+						seedQueue = append(seedQueue, succ)
+					}
+				}
+			}
+			continue
+		}
+		ready <- nodeID
+		scheduled[nodeID] = true
+		scheduledCount++
+	}
+
+	// Empty frontier — e.g. a resume where every node already completed, or a graph
+	// with no runnable roots. Nothing will be processed, so the termination check
+	// inside the worker loop is never reached; return now instead of spawning
+	// workers that would block forever on an unclosed, empty channel.
+	if scheduledCount == 0 {
+		return nil
 	}
 
 	var processed int64

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dop251/goja"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
@@ -3326,8 +3327,6 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 		awaitConfig := &avsproto.AwaitNode_Config{}
 		if channel, ok := config["channel"].(string); ok {
 			awaitConfig.Channel = channel
-		} else {
-			return nil, fmt.Errorf("await node requires 'channel' field")
 		}
 		if approvers, ok := config["approvers"].([]interface{}); ok {
 			for _, a := range approvers {
@@ -3344,6 +3343,26 @@ func CreateNodeFromType(nodeType string, config map[string]interface{}, nodeID s
 				return nil, fmt.Errorf("await node 'timeoutSeconds' out of range: %v", timeout)
 			}
 			awaitConfig.TimeoutSeconds = uint32(timeout)
+		}
+		// Chain-event flavor — a nested EventTrigger config. protojson handles its
+		// well-known types (e.g. structpb in contract_abi) that plain decoding can't.
+		if chainEvent, ok := config["chainEvent"].(map[string]interface{}); ok {
+			raw, err := json.Marshal(chainEvent)
+			if err != nil {
+				return nil, fmt.Errorf("await node: marshal chainEvent: %w", err)
+			}
+			eventConfig := &avsproto.EventTrigger_Config{}
+			if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(raw, eventConfig); err != nil {
+				return nil, fmt.Errorf("await node: invalid chainEvent: %w", err)
+			}
+			awaitConfig.ChainEvent = eventConfig
+		}
+		hasExternal := awaitConfig.Channel != "" || len(awaitConfig.Approvers) > 0 || awaitConfig.Prompt != ""
+		if awaitConfig.ChainEvent != nil && hasExternal {
+			return nil, fmt.Errorf("await node sets both 'chainEvent' and external-signal fields; they are mutually exclusive")
+		}
+		if !hasExternal && awaitConfig.ChainEvent == nil {
+			return nil, fmt.Errorf("await node requires either 'channel' (external signal) or 'chainEvent' (chain event)")
 		}
 		node.TaskType = &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: awaitConfig}}
 	default:
@@ -3848,16 +3867,30 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 	case *avsproto.TaskNode_Await:
 		await := taskNode.GetAwait()
 		if await != nil && await.Config != nil {
-			approvers := make([]interface{}, len(await.Config.Approvers))
-			for i, a := range await.Config.Approvers {
-				approvers[i] = a
-			}
-			return map[string]interface{}{
-				"channel":        await.Config.Channel,
-				"approvers":      approvers, // []interface{} so structpb.NewValue accepts it
-				"prompt":         await.Config.Prompt,
+			result := map[string]interface{}{
 				"timeoutSeconds": float64(await.Config.TimeoutSeconds),
 			}
+			// Emit only the active flavor's fields (they are mutually exclusive), so
+			// the serialized config isn't a confusing mix of channel:"" + chainEvent.
+			if await.Config.ChainEvent != nil {
+				// Re-encode via protojson so the nested config (and its well-known
+				// types) round-trips as clean JSON map types.
+				if raw, err := protojson.Marshal(await.Config.ChainEvent); err == nil {
+					var chainEvent map[string]interface{}
+					if json.Unmarshal(raw, &chainEvent) == nil {
+						result["chainEvent"] = chainEvent
+					}
+				}
+			} else {
+				approvers := make([]interface{}, len(await.Config.Approvers))
+				for i, a := range await.Config.Approvers {
+					approvers[i] = a // []interface{} so structpb.NewValue accepts it
+				}
+				result["channel"] = await.Config.Channel
+				result["approvers"] = approvers
+				result["prompt"] = await.Config.Prompt
+			}
+			return result
 		}
 
 	case *avsproto.TaskNode_Branch:

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -346,6 +348,29 @@ func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
 	wakes, err := loadAllWakeSubscriptions(db)
 	require.NoError(t, err)
 	assert.Nil(t, wakes[execID])
+}
+
+// TestSignalExecution_AuthGates proves the engine-level transport gates map to the
+// right gRPC codes (so the REST layer returns 400 vs 404, not 500): an invalid
+// decision is InvalidArgument; a signal from a non-owner is NotFound (the ownership
+// gate — User2 cannot signal User1's workflow). The full suspend→signal→resume path
+// is covered by TestAwaitNode_SuspendThenSignal_EndToEnd + the Advance tests.
+func TestSignalExecution_AuthGates(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	// Invalid decision is rejected up front, before any workflow lookup.
+	_, err := n.SignalExecution(testutil.TestUser1(), "any-workflow", "exec-1", "maybe", nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err), "invalid decision → InvalidArgument")
+
+	// User1 owns a workflow; User2 must not be able to signal it.
+	created, err := n.CreateWorkflow(testutil.TestUser1(), testutil.RestTask())
+	require.NoError(t, err)
+	_, err = n.SignalExecution(testutil.TestUser2(), created.Id, "exec-1", "approve", nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err), "non-owner signal → NotFound (ownership gate)")
 }
 
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -7,12 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 )
+
+func customCodeNode(id string) *avsproto.TaskNode {
+	return &avsproto.TaskNode{
+		Id: id, Name: id,
+		TaskType: &avsproto.TaskNode_CustomCode{CustomCode: &avsproto.CustomCodeNode{
+			Config: &avsproto.CustomCodeNode_Config{Lang: avsproto.Lang_LANG_JAVASCRIPT, Source: "return { ok: true };"},
+		}},
+	}
+}
 
 // buildLinearCustomCodeVM builds trigger -> cc1 -> cc2 -> cc3 (all self-contained
 // CustomCode nodes, no cross-references), compiled and ready to Run.
@@ -272,6 +282,70 @@ func TestExecutor_Advance_ResumesAndFinalizes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, out.Status, again.Status)
 	assert.Len(t, again.Steps, 3, "no re-execution on a duplicate advance")
+}
+
+// TestAwaitNode_SuspendThenSignal_EndToEnd is the whole user-facing feature: a
+// workflow [cc1 -> await -> cc2] runs, the Await node suspends it, a delivered
+// approval signal (DeliverSignal) resumes it, and cc2 runs. The first real
+// Suspendable node, end-to-end through storage.
+func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "appr", Name: "appr", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", Approvers: []string{"0xowner"}, Prompt: "approve?", TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id:      "approval-wf",
+		Trigger: trigger,
+		Nodes:   []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"},
+			{Id: "e1", Source: "cc1", Target: "appr"},
+			{Id: "e2", Source: "appr", Target: "cc2"},
+		},
+	}}
+
+	// Leg 1 — run; the Await node suspends after cc1.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	assert.Equal(t, []string{"cc1", "appr"}, executedNodeIDs(vm1), "ran up to the Await, then suspended")
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+	assert.Equal(t, WakeExternalSignal, susp.Wake.Kind)
+	assert.Equal(t, "appr", susp.AwaitNodeID)
+	assert.Equal(t, "telegram", susp.Wake.External.Channel)
+
+	const execID = "exec-appr-1"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+
+	// Leg 2 — deliver the approval signal; the execution resumes and runs cc2.
+	payload, err := structpb.NewValue(map[string]any{"decision": "approve", "by": "0xowner"})
+	require.NoError(t, err)
+	out, err := executor.DeliverSignal(task, &Signal{
+		ExecutionID: execID, Kind: WakeExternalSignal, Decision: "approve", Approver: "0xowner", Payload: payload,
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status, "resumed to terminal")
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "appr", "cc2"}, ids, "signal resumed the workflow; cc2 ran")
+
+	// Durable state GC'd.
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID])
 }
 
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -568,6 +569,123 @@ func TestValidateAwaitOperatorCoverage(t *testing.T) {
 
 	// External-signal Await has no chain → allowed regardless of operators.
 	require.NoError(t, n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{Channel: "telegram"})))
+}
+
+// TestDeliverChainEventWake_ConcurrentExactlyOnce proves the per-execution lock makes
+// resume exactly-once: two concurrent chain-event wakes for the same execution resume
+// it exactly once (the other no-ops), so an on-chain step in the resumed leg can't run
+// twice.
+func TestDeliverChainEventWake_ConcurrentExactlyOnce(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453), TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "concurrent-wf", Trigger: trigger, Status: avsproto.TaskStatus_Enabled,
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"}, {Id: "e1", Source: "cc1", Target: "wait"}, {Id: "e2", Source: "wait", Target: "cc2"},
+		},
+	}}
+	// Store the task so GetWorkflowByID resolves it from the wake's TaskID.
+	taskJSON, err := task.ToJSON()
+	require.NoError(t, err)
+	require.NoError(t, db.Set(WorkflowStorageKey(task.Id, avsproto.TaskStatus_Enabled), taskJSON))
+
+	// Build the WAITING execution.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	require.NotNil(t, vm1.PendingSuspend())
+	const execID = "exec-concurrent"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+
+	// Fire two concurrent wakes for the same execution.
+	var wg sync.WaitGroup
+	results := make([]string, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			state, _ := n.deliverChainEventWake(execID, &avsproto.NotifyTriggersReq{})
+			if state != nil {
+				results[idx] = state.Status
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	delivered := 0
+	for _, s := range results {
+		if s == "wake_delivered" {
+			delivered++
+		}
+	}
+	assert.Equal(t, 1, delivered, "exactly one concurrent wake resumes the execution; the other no-ops")
+}
+
+// TestLoadAllWakeSubscriptions_SkipsCorrupt proves one corrupt wake record does not
+// abort the whole scan — otherwise a single bad record would freeze every timeout
+// sweep and chain-event re-arm permanently.
+func TestLoadAllWakeSubscriptions_SkipsCorrupt(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	require.NoError(t, persistWakeSubscription(db, "good", &WakeSubscription{
+		Kind: WakeExternalSignal, TaskID: "wf", External: &ExternalSignalSpec{Channel: "telegram"}, TimeoutAt: 1 << 40,
+	}))
+	require.NoError(t, db.Set(wakeSubscriptionKey("bad"), []byte("{not valid json")))
+
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err, "a corrupt record must not fail the scan")
+	assert.NotNil(t, wakes["good"], "the healthy wake still loads")
+	assert.Nil(t, wakes["bad"], "the corrupt wake is skipped")
+}
+
+// TestCheckpoint_CountsTowardMaxExecution proves a suspended run counts toward
+// MaxExecution at suspend time (the task is completed), so a MaxExecution=1 workflow
+// that suspends does not fire again while it waits.
+func TestCheckpoint_CountsTowardMaxExecution(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "maxexec-wf", Trigger: trigger,
+		MaxExecution: 1, ExecutionCount: 1, Status: avsproto.TaskStatus_Enabled, // RunTask already incremented the count
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await},
+		Edges: []*avsproto.TaskEdge{{Id: "e0", Source: "t", Target: "cc1"}, {Id: "e1", Source: "cc1", Target: "wait"}},
+	}}
+
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	require.NotNil(t, vm1.PendingSuspend())
+
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: "e1", StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.TaskStatus_Completed, task.Status,
+		"MaxExecution=1 task is Completed at suspend so it won't fire again while waiting")
 }
 
 // TestAwaitNode_ResumeThroughBranchTarget guards the resume scheduler: when the

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -350,6 +350,266 @@ func TestAwaitNode_SuspendThenSignal_EndToEnd(t *testing.T) {
 	assert.Nil(t, wakes[execID])
 }
 
+// chainEventConfig is a small EventTrigger.Config fixture for chain-event Await tests.
+func chainEventConfig(chainID int64) *avsproto.EventTrigger_Config {
+	return &avsproto.EventTrigger_Config{
+		ChainId: chainID,
+		Queries: []*avsproto.EventTrigger_Query{{
+			Addresses: []string{"0xbridge0000000000000000000000000000000000"},
+			Topics:    []string{"0xMessageReceived00000000000000000000000000000000000000000000000000"},
+		}},
+	}
+}
+
+// TestAwaitNode_ChainEvent_SuspendThenResume proves the cross-chain flavor: an Await
+// with a chain_event config suspends with a WakeChainEvent subscription (carrying the
+// task id + event filter), and a chain-event Signal (the matched log) resumes it.
+func TestAwaitNode_ChainEvent_SuspendThenResume(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453), TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id:      "bridge-wf",
+		Trigger: trigger,
+		Nodes:   []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"},
+			{Id: "e1", Source: "cc1", Target: "wait"},
+			{Id: "e2", Source: "wait", Target: "cc2"},
+		},
+	}}
+
+	// Leg 1 — runs to the Await, then suspends on the chain event.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+	assert.Equal(t, WakeChainEvent, susp.Wake.Kind)
+	require.NotNil(t, susp.Wake.ChainEvent)
+	assert.Equal(t, int64(8453), susp.Wake.ChainEvent.GetChainId())
+
+	const execID = "exec-bridge-1"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+
+	// The persisted wake carries its task id (so a notify can resolve the task) + the event filter.
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.NotNil(t, wakes[execID])
+	assert.Equal(t, "bridge-wf", wakes[execID].TaskID)
+	assert.Equal(t, WakeChainEvent, wakes[execID].Kind)
+	require.NotNil(t, wakes[execID].ChainEvent)
+
+	// Leg 2 — the matched chain log arrives as a chain-event signal; the execution resumes.
+	eventData, err := structpb.NewValue(map[string]any{"amount": "1000", "messageId": "0xabc"})
+	require.NoError(t, err)
+	out, err := executor.DeliverSignal(task, &Signal{ExecutionID: execID, Kind: WakeChainEvent, Payload: eventData})
+	require.NoError(t, err)
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status, "resumed to terminal")
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "wait", "cc2"}, ids, "chain event resumed the workflow; cc2 ran")
+
+	wakes, err = loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID], "wake GC'd after resume")
+}
+
+// TestAwaitNode_RejectsAmbiguousConfig proves the flavors are mutually exclusive: an
+// Await with both an external-signal channel and a chain_event fails rather than
+// silently picking one (and does not suspend).
+func TestAwaitNode_RejectsAmbiguousConfig(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", ChainEvent: chainEventConfig(8453)},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "ambig-wf", Trigger: trigger,
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await},
+		Edges: []*avsproto.TaskEdge{{Id: "e0", Source: "t", Target: "cc1"}, {Id: "e1", Source: "cc1", Target: "wait"}},
+	}}
+	vm, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm.Compile())
+	_ = vm.Run()
+
+	assert.Nil(t, vm.PendingSuspend(), "an ambiguous Await must not suspend")
+	var awaitStep *avsproto.Execution_Step
+	for _, s := range vm.ExecutionLogs {
+		if s.Id == "wait" {
+			awaitStep = s
+		}
+	}
+	require.NotNil(t, awaitStep, "the Await step is recorded")
+	assert.False(t, awaitStep.Success)
+	assert.Contains(t, awaitStep.Error, "mutually exclusive")
+}
+
+// TestAwaitNode_ChainEvent_ExpireOnTimeout proves the timeout sweep's finalize: a
+// WAITING execution whose wake timed out is failed and its durable state GC'd.
+func TestAwaitNode_ChainEvent_ExpireOnTimeout(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453), TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "stuck-wf", Trigger: trigger,
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"},
+			{Id: "e1", Source: "cc1", Target: "wait"},
+			{Id: "e2", Source: "wait", Target: "cc2"},
+		},
+	}}
+
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+
+	const execID = "exec-stuck-1"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+
+	// The wait times out: expire it. cc2 never ran; the execution is FAILED, state GC'd.
+	out, err := executor.ExpireWait(task, execID)
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED, out.Status)
+	assert.Contains(t, out.Error, "timed out")
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "wait"}, ids, "cc2 did not run — the wait expired")
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID], "wake GC'd after expiry")
+
+	// Idempotent: expiring again just returns the terminal record.
+	again, err := executor.ExpireWait(task, execID)
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED, again.Status)
+}
+
+// TestSweepExpiredWaits_TimeGating proves the sweep only touches wakes past their
+// timeout, and GCs a wake whose task is gone (orphan).
+func TestSweepExpiredWaits_TimeGating(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	// A future wake is left alone; an expired orphan (task gone) is GC'd.
+	const farFuture = int64(99999999999999) // unix ms, ~year 5138
+	require.NoError(t, persistWakeSubscription(db, "exec-future", &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "wf-x", ChainEvent: chainEventConfig(8453), TimeoutAt: farFuture,
+	}))
+	require.NoError(t, persistWakeSubscription(db, "exec-expired-orphan", &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "wf-gone", ChainEvent: chainEventConfig(8453), TimeoutAt: 1,
+	}))
+
+	n.sweepExpiredWaits()
+
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.NotNil(t, wakes["exec-future"], "future wake untouched")
+	assert.Nil(t, wakes["exec-expired-orphan"], "expired orphan wake GC'd")
+}
+
+// TestValidateAwaitOperatorCoverage proves the create-time guard: a chain-event Await
+// whose chain no operator covers is rejected (gateway mode); an external-signal Await
+// has no chain and is fine.
+func TestValidateAwaitOperatorCoverage(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	cfg := testutil.GetAggregatorConfig()
+	cfg.IsGateway = true // the guard only runs in gateway mode
+	n := New(db, cfg, nil, testutil.GetLogger())
+
+	awaitNode := func(c *avsproto.AwaitNode_Config) *model.Workflow {
+		return &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{{
+			Id: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+			TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: c}},
+		}}}}
+	}
+
+	// Chain-event Await, no operator connected for the chain → rejected.
+	err := n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453)}))
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	// External-signal Await has no chain → allowed regardless of operators.
+	require.NoError(t, n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{Channel: "telegram"})))
+}
+
+// TestInternalTrigger_SyncAndRoute proves the operator-transport seam: a chain-event
+// wake surfaces as a synthetic event-trigger "task" (pendingChainEventTriggers) that
+// the operator sync streams, and an internal-trigger id round-trips so the notify
+// path can route it back. A notify with no live wake is a safe no-op.
+func TestInternalTrigger_SyncAndRoute(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	// id round-trip; a real ULID-style id is not mistaken for an internal trigger.
+	const execID = "exec-itrig-1"
+	id := internalTriggerTaskID(execID)
+	got, ok := parseInternalTriggerTaskID(id)
+	require.True(t, ok)
+	assert.Equal(t, execID, got)
+	_, ok = parseInternalTriggerTaskID("01HZY8M0000000000000000000")
+	assert.False(t, ok, "a normal task id is not an internal trigger")
+
+	// A persisted chain-event wake surfaces as a synthetic single-shot event trigger.
+	require.NoError(t, persistWakeSubscription(db, execID, &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "wf-1", ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
+	}))
+	// An external-signal wake must NOT surface (it's not operator-watched).
+	require.NoError(t, persistWakeSubscription(db, "exec-ext-1", &WakeSubscription{
+		Kind: WakeExternalSignal, TaskID: "wf-2", External: &ExternalSignalSpec{Channel: "telegram"}, TimeoutAt: 1 << 40,
+	}))
+
+	triggers := n.pendingChainEventTriggers()
+	require.Len(t, triggers, 1, "only the chain-event wake yields an internal trigger")
+	syn := triggers[0]
+	assert.Equal(t, id, syn.Id)
+	assert.Equal(t, int64(8453), syn.Trigger.GetEvent().GetConfig().GetChainId())
+	assert.Equal(t, int64(1<<40), syn.ExpiredAt)
+
+	// A notify for an execution with no live wake is a safe no-op, not an error.
+	state, err := n.deliverChainEventWake("exec-gone", &avsproto.NotifyTriggersReq{})
+	require.NoError(t, err)
+	assert.Equal(t, "not_found", state.Status)
+}
+
 // TestSignalExecution_AuthGates proves the engine-level transport gates map to the
 // right gRPC codes (so the REST layer returns 400 vs 404, not 500): an invalid
 // decision is InvalidArgument; a signal from a non-owner is NotFound (the ownership

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -1,0 +1,193 @@
+package taskengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// buildLinearCustomCodeVM builds trigger -> cc1 -> cc2 -> cc3 (all self-contained
+// CustomCode nodes, no cross-references), compiled and ready to Run.
+func buildLinearCustomCodeVM(t *testing.T) (*VM, []string) {
+	t.Helper()
+	ids := []string{"cc1", "cc2", "cc3"}
+	nodes := make([]*avsproto.TaskNode, len(ids))
+	for i, id := range ids {
+		nodes[i] = &avsproto.TaskNode{
+			Id:   id,
+			Name: id,
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{
+						Lang:   avsproto.Lang_LANG_JAVASCRIPT,
+						Source: "return { ok: true };",
+					},
+				},
+			},
+		}
+	}
+	trigger := &avsproto.TaskTrigger{Id: "trig", Name: "trig", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	edges := []*avsproto.TaskEdge{
+		{Id: "e0", Source: trigger.Id, Target: "cc1"},
+		{Id: "e1", Source: "cc1", Target: "cc2"},
+		{Id: "e2", Source: "cc2", Target: "cc3"},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{Id: "resume-test", Nodes: nodes, Edges: edges, Trigger: trigger}}
+
+	vm, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm.WithLogger(testutil.GetLogger())
+	require.NoError(t, vm.Compile())
+	return vm, ids
+}
+
+func executedNodeIDs(vm *VM) []string {
+	out := []string{}
+	for _, step := range vm.ExecutionLogs {
+		out = append(out, step.Id)
+	}
+	return out
+}
+
+// TestScheduler_FreshRun_RunsAllNodes is the parity baseline: with no resume state,
+// every node executes (the dry-replay seed degenerates to the original behavior).
+func TestScheduler_FreshRun_RunsAllNodes(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm.Run())
+	assert.ElementsMatch(t, ids, executedNodeIDs(vm), "fresh run executes every node")
+}
+
+// TestScheduler_Resume_SkipsCompletedNodes proves the re-entrant scheduler:
+// marking cc1+cc2 completed makes the resumed run execute ONLY cc3 (the frontier).
+// Covers E4 (completed nodes don't re-run) and E5 (resumed run terminates).
+func TestScheduler_Resume_SkipsCompletedNodes(t *testing.T) {
+	vm, _ := buildLinearCustomCodeVM(t)
+	vm.resumeCompleted = map[string]bool{"cc1": true, "cc2": true}
+
+	require.NoError(t, vm.Run(), "resumed run must terminate, not hang (E5)")
+
+	executed := executedNodeIDs(vm)
+	assert.Equal(t, []string{"cc3"}, executed, "resume executes only the frontier; cc1/cc2 are not re-run (E4)")
+}
+
+// TestScheduler_Resume_EmptyCompletedEqualsFresh asserts the gate: an empty
+// resumeCompleted map behaves exactly like a fresh run.
+func TestScheduler_Resume_EmptyCompletedEqualsFresh(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	vm.resumeCompleted = map[string]bool{} // empty, not nil
+	require.NoError(t, vm.Run())
+	assert.ElementsMatch(t, ids, executedNodeIDs(vm), "empty completed == fresh run")
+}
+
+// TestVM_SnapshotRestoreNodeVars_Fidelity is the fidelity-critical proof for
+// increment 4: a node's output survives a snapshot → restore (into a fresh VM)
+// such that template resolution is byte-identical — so a resumed leg can read
+// {{prior.data.x}}. Also asserts secrets/system vars are NOT snapshotted.
+func TestVM_SnapshotRestoreNodeVars_Fidelity(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	cc1 := ids[0]
+
+	proc := &CommonProcessor{vm: vm}
+	proc.SetOutputVarForStep(cc1, map[string]any{"data": map[string]any{
+		"value":  42,
+		"msg":    "hi",
+		"amount": "1000000000000000000",
+	}})
+
+	name := vm.GetNodeNameAsVar(cc1)
+	tmpl := "{{" + name + ".data.value}}|{{" + name + ".data.msg}}|{{" + name + ".data.amount}}"
+	before := vm.preprocessText(tmpl)
+	require.Equal(t, "42|hi|1000000000000000000", before, "sanity: original resolution")
+
+	snap, err := vm.snapshotNodeVars()
+	require.NoError(t, err)
+	require.Contains(t, string(snap), name, "snapshot includes the node output")
+	require.NotContains(t, string(snap), "apContext", "snapshot excludes system/secret vars")
+
+	// Restore into a fresh VM (same task) and assert identical resolution.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(snap))
+	after := vm2.preprocessText(tmpl)
+	assert.Equal(t, before, after, "template resolution must be identical after snapshot/restore")
+}
+
+func TestCompletedNodeIDsFromSteps(t *testing.T) {
+	steps := []*avsproto.Execution_Step{{Id: "a"}, {Id: "b"}, nil, {Id: ""}}
+	assert.Equal(t, map[string]bool{"a": true, "b": true}, completedNodeIDsFromSteps(steps))
+}
+
+// TestScheduler_Resume_AllCompleted_Terminates guards the empty-frontier case
+// (every node already completed). Without the early return it would hang on an
+// unclosed channel; the timeout fails fast rather than wedging the suite.
+func TestScheduler_Resume_AllCompleted_Terminates(t *testing.T) {
+	vm, ids := buildLinearCustomCodeVM(t)
+	vm.resumeCompleted = map[string]bool{ids[0]: true, ids[1]: true, ids[2]: true}
+
+	done := make(chan error, 1)
+	go func() { done <- vm.Run() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler hung on an all-completed (empty frontier) resume")
+	}
+	assert.Empty(t, executedNodeIDs(vm), "no nodes execute when all are completed")
+}
+
+// TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:
+// a node literally named a system var (apContext) must not be snapshotted, or a
+// resume could persist secrets to disk.
+func TestSnapshotNodeVars_ExcludesReservedNames(t *testing.T) {
+	node := &avsproto.TaskNode{
+		Id: "apContext", Name: "apContext",
+		TaskType: &avsproto.TaskNode_CustomCode{CustomCode: &avsproto.CustomCodeNode{
+			Config: &avsproto.CustomCodeNode_Config{Lang: avsproto.Lang_LANG_JAVASCRIPT, Source: "return {};"},
+		}},
+	}
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "x", Nodes: []*avsproto.TaskNode{node}, Trigger: trigger,
+		Edges: []*avsproto.TaskEdge{{Id: "e", Source: "t", Target: "apContext"}},
+	}}
+	vm, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+
+	proc := &CommonProcessor{vm: vm}
+	proc.SetOutputVarForStep("apContext", map[string]any{"data": map[string]any{"secret": "leak"}})
+
+	snap, err := vm.snapshotNodeVars()
+	require.NoError(t, err)
+	assert.NotContains(t, string(snap), "leak", "a node named apContext must not be snapshotted")
+	assert.Equal(t, "{}", string(snap), "snapshot is empty — the only node collides with a reserved name")
+}
+
+// TestResume_RestoredVarsUsableByFrontier ties it together: restore a prior leg's
+// node vars into a fresh VM, mark them completed, and run — the frontier node
+// executes (only it) with the restored vars available. This is the in-memory
+// shape of advance(); the storage-backed wiring is the remaining step.
+func TestResume_RestoredVarsUsableByFrontier(t *testing.T) {
+	// Leg 1: run fully, snapshot the node vars.
+	vm1, ids := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm1.Run())
+	require.Len(t, executedNodeIDs(vm1), 3)
+	snap, err := vm1.snapshotNodeVars()
+	require.NoError(t, err)
+
+	// Leg 2 (resume): fresh VM, restore vars, mark cc1+cc2 done, run.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(snap))
+	vm2.resumeCompleted = completedNodeIDsFromSteps([]*avsproto.Execution_Step{{Id: ids[0]}, {Id: ids[1]}})
+	require.NoError(t, vm2.Run())
+
+	assert.Equal(t, []string{ids[2]}, executedNodeIDs(vm2), "only the frontier runs on resume")
+	// The restored prior output is present and resolvable.
+	assert.Contains(t, vm2.preprocessText("{{"+vm2.GetNodeNameAsVar(ids[0])+".data.ok}}"), "true",
+		"restored prior-node output is readable by the resumed leg")
+}

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -570,6 +570,112 @@ func TestValidateAwaitOperatorCoverage(t *testing.T) {
 	require.NoError(t, n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{Channel: "telegram"})))
 }
 
+// TestAwaitNode_ResumeThroughBranchTarget guards the resume scheduler: when the
+// completed prefix runs through a Branch-selected node before the Await, that branch
+// target must be fast-forwarded on resume so the Await's successors become schedulable.
+// Without the fix the workflow resumes to a dead frontier and ccAfter never runs.
+func TestAwaitNode_ResumeThroughBranchTarget(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	branch := &avsproto.TaskNode{
+		Id: "br", Name: "br",
+		TaskType: &avsproto.TaskNode_Branch{Branch: &avsproto.BranchNode{
+			Config: &avsproto.BranchNode_Config{
+				Conditions: []*avsproto.BranchNode_Condition{{Id: "a1", Type: "if", Expression: "true"}},
+			},
+		}},
+	}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "branch-await-wf", Trigger: trigger,
+		Nodes: []*avsproto.TaskNode{branch, customCodeNode("ccTarget"), await, customCodeNode("ccAfter")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "br"},
+			{Id: "e1", Source: "br.a1", Target: "ccTarget"}, // branch-condition edge → branch target
+			{Id: "e2", Source: "ccTarget", Target: "wait"},
+			{Id: "e3", Source: "wait", Target: "ccAfter"},
+		},
+	}}
+
+	// Leg 1 — branch selects ccTarget, it runs, the Await suspends.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	require.NotNil(t, vm1.PendingSuspend(), "suspended at the Await")
+	assert.Contains(t, executedNodeIDs(vm1), "ccTarget", "the branch target ran in leg 1")
+
+	const execID = "exec-branch-await"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+
+	// Leg 2 — resume; ccAfter (downstream of the Await, past the completed branch target) must run.
+	payload, err := structpb.NewValue(map[string]any{"decision": "approve"})
+	require.NoError(t, err)
+	out, err := executor.DeliverSignal(task, &Signal{ExecutionID: execID, Kind: WakeExternalSignal, Decision: "approve", Payload: payload})
+	require.NoError(t, err)
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Contains(t, ids, "ccAfter", "resume must schedule the Await's successor past the completed branch target")
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status, "resumed to terminal")
+}
+
+// TestValidateAwaitConfigs proves invalid Await configs are rejected at create time
+// (the XOR + required-flavor rule), not deferred to execution.
+func TestValidateAwaitConfigs(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	awaitTask := func(c *avsproto.AwaitNode_Config) *model.Workflow {
+		return &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{{
+			Id: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+			TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: c}},
+		}}}}
+	}
+
+	require.NoError(t, n.validateAwaitConfigs(awaitTask(&avsproto.AwaitNode_Config{Channel: "telegram"})), "external-signal valid")
+	require.NoError(t, n.validateAwaitConfigs(awaitTask(&avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453)})), "chain-event valid")
+
+	for _, bad := range []*avsproto.AwaitNode_Config{
+		{Channel: "telegram", ChainEvent: chainEventConfig(8453)}, // both flavors
+		{},                  // neither flavor
+		{Prompt: "approve?"}, // external fields but no channel
+	} {
+		err := n.validateAwaitConfigs(awaitTask(bad))
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	}
+}
+
+// TestPendingChainEventTriggers_GCsOrphanedWake proves a chain-event wake whose
+// workflow was deleted is GC'd (not streamed) at sync time, so operators stop watching
+// promptly instead of waiting for the timeout sweep.
+func TestPendingChainEventTriggers_GCsOrphanedWake(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	require.NoError(t, persistWakeSubscription(db, "exec-orphan", &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "deleted-wf", ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
+	}))
+	assert.Empty(t, n.pendingChainEventTriggers(), "an orphaned wake (deleted workflow) is not streamed")
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes["exec-orphan"], "the orphaned wake is GC'd")
+}
+
 // TestInternalTrigger_SyncAndRoute proves the operator-transport seam: a chain-event
 // wake surfaces as a synthetic event-trigger "task" (pendingChainEventTriggers) that
 // the operator sync streams, and an internal-trigger id round-trips so the notify
@@ -588,9 +694,13 @@ func TestInternalTrigger_SyncAndRoute(t *testing.T) {
 	_, ok = parseInternalTriggerTaskID("01HZY8M0000000000000000000")
 	assert.False(t, ok, "a normal task id is not an internal trigger")
 
+	// A real workflow backs the wake — pendingChainEventTriggers GCs wakes whose task is gone.
+	created, err := n.CreateWorkflow(testutil.TestUser1(), testutil.RestTask())
+	require.NoError(t, err)
+
 	// A persisted chain-event wake surfaces as a synthetic single-shot event trigger.
 	require.NoError(t, persistWakeSubscription(db, execID, &WakeSubscription{
-		Kind: WakeChainEvent, TaskID: "wf-1", ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
+		Kind: WakeChainEvent, TaskID: created.Id, ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
 	}))
 	// An external-signal wake must NOT surface (it's not operator-watched).
 	require.NoError(t, persistWakeSubscription(db, "exec-ext-1", &WakeSubscription{

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
@@ -141,6 +142,138 @@ func TestScheduler_Resume_AllCompleted_Terminates(t *testing.T) {
 	assert.Empty(t, executedNodeIDs(vm), "no nodes execute when all are completed")
 }
 
+// TestScheduler_Suspend_StopsAfterCurrentNode proves the suspend path: a step that
+// requests suspension (simulated via requestSuspend on cc1) runs, then the scheduler
+// stops — cc2/cc3 are never scheduled — and the suspension is available to the
+// executor via PendingSuspend.
+func TestScheduler_Suspend_StopsAfterCurrentNode(t *testing.T) {
+	vm, _ := buildLinearCustomCodeVM(t)
+	vm.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 1})
+
+	require.NoError(t, vm.Run())
+
+	assert.Equal(t, []string{"cc1"}, executedNodeIDs(vm), "run stops after the suspending step")
+	susp := vm.PendingSuspend()
+	require.NotNil(t, susp, "executor can see the pending suspension")
+	assert.Equal(t, "cc1", susp.AwaitNodeID)
+}
+
+// TestSuspendThenResume_EndToEnd is the in-memory shape of the whole feature
+// (minus storage + real signals): leg 1 runs and suspends after cc1; leg 2 restores
+// its vars, marks cc1 completed, and resumes — running exactly cc2+cc3.
+func TestSuspendThenResume_EndToEnd(t *testing.T) {
+	// Leg 1 — run, suspend after cc1, snapshot.
+	vm1, _ := buildLinearCustomCodeVM(t)
+	vm1.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 1})
+	require.NoError(t, vm1.Run())
+	require.Equal(t, []string{"cc1"}, executedNodeIDs(vm1))
+	require.NotNil(t, vm1.PendingSuspend())
+	snap, err := vm1.snapshotNodeVars()
+	require.NoError(t, err)
+
+	// Leg 2 — resume: restore vars, mark cc1 done, run the rest.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(snap))
+	vm2.resumeCompleted = map[string]bool{"cc1": true}
+	require.NoError(t, vm2.Run())
+	assert.Equal(t, []string{"cc2", "cc3"}, executedNodeIDs(vm2), "resume runs exactly the remaining steps")
+}
+
+// TestExecutor_CheckpointAndResume_DBBacked is the storage-backed proof: the real
+// executor method checkpoints a suspended run to BadgerDB (WAITING execution +
+// vars checkpoint + wake), then a fresh VM reloads it and resumes to completion.
+func TestExecutor_CheckpointAndResume_DBBacked(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	// Minimal executor — checkpointSuspendedExecution only needs db + logger (no
+	// engine/RPC), so avoid NewExecutorForTesting which dials an RPC.
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger()}
+
+	// Leg 1 — run, suspend after cc1.
+	vm1, _ := buildLinearCustomCodeVM(t)
+	vm1.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 999})
+	require.NoError(t, vm1.Run())
+	require.Equal(t, []string{"cc1"}, executedNodeIDs(vm1))
+	susp := vm1.PendingSuspend()
+	require.NotNil(t, susp)
+
+	const execID = "exec-durable-1"
+	out, err := executor.checkpointSuspendedExecution(vm1.task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, susp)
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status)
+
+	// Persisted: the WAITING execution record (with its one completed step)...
+	raw, err := db.GetKey(TaskExecutionKey(vm1.task, execID))
+	require.NoError(t, err)
+	loaded := &avsproto.Execution{}
+	require.NoError(t, protojson.Unmarshal(raw, loaded))
+	assert.Equal(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, loaded.Status)
+	assert.Equal(t, "cc1", loaded.ResumeNodeId)
+	require.Len(t, loaded.Steps, 1)
+	// ...the vars checkpoint...
+	ckpt, err := loadCheckpoint(db, execID)
+	require.NoError(t, err)
+	require.NotEmpty(t, ckpt)
+	// ...and the wake subscription.
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	require.NotNil(t, wakes[execID])
+
+	// Leg 2 — resume from storage: fresh VM, restore the checkpoint, completed from
+	// the persisted steps, run the rest.
+	vm2, _ := buildLinearCustomCodeVM(t)
+	require.NoError(t, vm2.restoreNodeVars(ckpt))
+	vm2.resumeCompleted = completedNodeIDsFromSteps(loaded.Steps)
+	require.NoError(t, vm2.Run())
+	assert.Equal(t, []string{"cc2", "cc3"}, executedNodeIDs(vm2), "resumed from storage, runs the remaining steps")
+
+	// Terminal cleanup (what advance() does on completion).
+	require.NoError(t, deleteCheckpoint(db, execID))
+	require.NoError(t, deleteWakeSubscription(db, execID))
+	gone, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, gone[execID])
+}
+
+// TestExecutor_Advance_ResumesAndFinalizes exercises the production resume
+// entrypoint: a stored WAITING execution → Advance() rebuilds the VM, restores,
+// runs the rest to a terminal status, and GCs the durable state. Plus idempotency.
+func TestExecutor_Advance_ResumesAndFinalizes(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	// Arrange a WAITING execution: run+suspend after cc1, then checkpoint it.
+	vm1, _ := buildLinearCustomCodeVM(t)
+	vm1.WithDb(db)
+	vm1.requestSuspend("cc1", &WakeSubscription{Kind: WakeTimer, TimeoutAt: 999})
+	require.NoError(t, vm1.Run())
+	const execID = "exec-advance-1"
+	_, err := executor.checkpointSuspendedExecution(vm1.task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+
+	// Act: advance (resume).
+	out, err := executor.Advance(vm1.task, execID, nil)
+	require.NoError(t, err)
+
+	// Resumed to a terminal status, ran the remaining steps, durable state GC'd.
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status)
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Equal(t, []string{"cc1", "cc2", "cc3"}, ids, "resume appended the remaining steps to the record")
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes[execID], "wake GC'd on terminal finish")
+
+	// Idempotent: advancing a now-terminal execution is a no-op (E8).
+	again, err := executor.Advance(vm1.task, execID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, out.Status, again.Status)
+	assert.Len(t, again.Steps, 3, "no re-execution on a duplicate advance")
+}
+
 // TestSnapshotNodeVars_ExcludesReservedNames guards the reserved-name collision:
 // a node literally named a system var (apContext) must not be snapshotted, or a
 // resume could persist secrets to disk.
@@ -164,8 +297,8 @@ func TestSnapshotNodeVars_ExcludesReservedNames(t *testing.T) {
 
 	snap, err := vm.snapshotNodeVars()
 	require.NoError(t, err)
-	assert.NotContains(t, string(snap), "leak", "a node named apContext must not be snapshotted")
-	assert.Equal(t, "{}", string(snap), "snapshot is empty — the only node collides with a reserved name")
+	assert.NotContains(t, string(snap), "leak", "the apContext node's secret value must not be snapshotted")
+	assert.NotContains(t, string(snap), "apContext", "a node named apContext must be excluded from the snapshot")
 }
 
 // TestResume_RestoredVarsUsableByFrontier ties it together: restore a prior leg's

--- a/core/taskengine/vm_runner_await.go
+++ b/core/taskengine/vm_runner_await.go
@@ -34,18 +34,42 @@ func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error)
 		return step, err
 	}
 
+	// The two flavors are mutually exclusive — reject an ambiguous config rather than
+	// silently preferring one (the proto can't express the XOR).
+	hasExternal := cfg.GetChannel() != "" || len(cfg.GetApprovers()) > 0 || cfg.GetPrompt() != ""
+	if cfg.GetChainEvent() != nil && hasExternal {
+		err := fmt.Errorf("await node %s sets both chain_event and external-signal fields; they are mutually exclusive", node.Id)
+		step.Success = false
+		step.Error = err.Error()
+		step.EndAt = time.Now().UnixMilli()
+		return step, err
+	}
+
 	timeoutSec := int64(cfg.GetTimeoutSeconds())
 	if timeoutSec <= 0 {
 		timeoutSec = defaultAwaitTimeoutSeconds
 	}
-	wake := &WakeSubscription{
-		Kind: WakeExternalSignal,
-		External: &ExternalSignalSpec{
-			Channel:   cfg.GetChannel(),
-			Approvers: cfg.GetApprovers(),
-			Prompt:    cfg.GetPrompt(),
-		},
-		TimeoutAt: t0.Add(time.Duration(timeoutSec) * time.Second).UnixMilli(),
+	timeoutAt := t0.Add(time.Duration(timeoutSec) * time.Second).UnixMilli()
+
+	// Two flavors: a chain-event wake (cross-chain — an operator watches the event)
+	// or an external-signal wake (human approval). chain_event selects the former.
+	var wake *WakeSubscription
+	if ev := cfg.GetChainEvent(); ev != nil {
+		wake = &WakeSubscription{
+			Kind:       WakeChainEvent,
+			ChainEvent: ev,
+			TimeoutAt:  timeoutAt,
+		}
+	} else {
+		wake = &WakeSubscription{
+			Kind: WakeExternalSignal,
+			External: &ExternalSignalSpec{
+				Channel:   cfg.GetChannel(),
+				Approvers: cfg.GetApprovers(),
+				Prompt:    cfg.GetPrompt(),
+			},
+			TimeoutAt: timeoutAt,
+		}
 	}
 	if err := wake.Validate(); err != nil {
 		// A misconfigured Await fails the step rather than suspending.
@@ -58,7 +82,11 @@ func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error)
 	v.requestSuspend(node.Id, wake)
 
 	step.Success = true
-	step.Log = fmt.Sprintf("awaiting external signal on channel %q", cfg.GetChannel())
+	if wake.Kind == WakeChainEvent {
+		step.Log = fmt.Sprintf("awaiting chain event on chain %d", wake.ChainEvent.GetChainId())
+	} else {
+		step.Log = fmt.Sprintf("awaiting external signal on channel %q", cfg.GetChannel())
+	}
 	step.EndAt = time.Now().UnixMilli()
 	return step, nil
 }

--- a/core/taskengine/vm_runner_await.go
+++ b/core/taskengine/vm_runner_await.go
@@ -1,0 +1,64 @@
+package taskengine
+
+import (
+	"fmt"
+	"time"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// defaultAwaitTimeoutSeconds bounds an Await with no explicit timeout. Every wait
+// is bounded — an unbounded human-approval gate would park funds forever.
+const defaultAwaitTimeoutSeconds = 86400 // 24h
+
+// runAwait executes an Await node: it builds the wake subscription from config and
+// requests suspension (the scheduler then stops; the executor checkpoints +
+// registers the wake). The runner runs exactly once, on the suspend pass — on
+// resume the node is in resumeCompleted and Advance injects the delivered signal
+// as this node's output.
+func (v *VM) runAwait(node *avsproto.TaskNode) (*avsproto.Execution_Step, error) {
+	t0 := time.Now()
+	step := &avsproto.Execution_Step{
+		Id:      node.Id,
+		Type:    avsproto.NodeType_NODE_TYPE_AWAIT.String(),
+		Name:    node.Name,
+		StartAt: t0.UnixMilli(),
+	}
+
+	cfg := node.GetAwait().GetConfig()
+	if cfg == nil {
+		err := fmt.Errorf("await node %s has no config", node.Id)
+		step.Success = false
+		step.Error = err.Error()
+		step.EndAt = time.Now().UnixMilli()
+		return step, err
+	}
+
+	timeoutSec := int64(cfg.GetTimeoutSeconds())
+	if timeoutSec <= 0 {
+		timeoutSec = defaultAwaitTimeoutSeconds
+	}
+	wake := &WakeSubscription{
+		Kind: WakeExternalSignal,
+		External: &ExternalSignalSpec{
+			Channel:   cfg.GetChannel(),
+			Approvers: cfg.GetApprovers(),
+			Prompt:    cfg.GetPrompt(),
+		},
+		TimeoutAt: t0.Add(time.Duration(timeoutSec) * time.Second).UnixMilli(),
+	}
+	if err := wake.Validate(); err != nil {
+		// A misconfigured Await fails the step rather than suspending.
+		step.Success = false
+		step.Error = err.Error()
+		step.EndAt = time.Now().UnixMilli()
+		return step, err
+	}
+
+	v.requestSuspend(node.Id, wake)
+
+	step.Success = true
+	step.Log = fmt.Sprintf("awaiting external signal on channel %q", cfg.GetChannel())
+	step.EndAt = time.Now().UnixMilli()
+	return step, nil
+}

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -562,6 +562,9 @@ const (
 	ExecutionStatus_EXECUTION_STATUS_SUCCESS     ExecutionStatus = 2
 	ExecutionStatus_EXECUTION_STATUS_FAILED      ExecutionStatus = 3
 	ExecutionStatus_EXECUTION_STATUS_ERROR       ExecutionStatus = 5
+	// Durable execution: the execution is suspended mid-workflow, waiting for a
+	// signal (chain event, external approval, or timer) to advance. Non-terminal.
+	ExecutionStatus_EXECUTION_STATUS_WAITING ExecutionStatus = 6
 )
 
 // Enum value maps for ExecutionStatus.
@@ -572,6 +575,7 @@ var (
 		2: "EXECUTION_STATUS_SUCCESS",
 		3: "EXECUTION_STATUS_FAILED",
 		5: "EXECUTION_STATUS_ERROR",
+		6: "EXECUTION_STATUS_WAITING",
 	}
 	ExecutionStatus_value = map[string]int32{
 		"EXECUTION_STATUS_UNSPECIFIED": 0,
@@ -579,6 +583,7 @@ var (
 		"EXECUTION_STATUS_SUCCESS":     2,
 		"EXECUTION_STATUS_FAILED":      3,
 		"EXECUTION_STATUS_ERROR":       5,
+		"EXECUTION_STATUS_WAITING":     6,
 	}
 )
 
@@ -2112,9 +2117,15 @@ type Execution struct {
 	// This helps clients understand execution order without calculating based on timestamps
 	Index int64 `protobuf:"varint,6,opt,name=index,proto3" json:"index,omitempty"`
 	// Fees actually charged for this execution (matches EstimateFeesResp format)
-	ExecutionFee  *Fee              `protobuf:"bytes,7,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"` // Flat platform fee charged {amount, unit: "USD"}
-	Cogs          []*NodeCOGS       `protobuf:"bytes,9,rep,name=cogs,proto3" json:"cogs,omitempty"`                                     // Per-node actual gas/API costs {fee: {amount, unit: "WEI"}}
-	ValueFee      *ValueFee         `protobuf:"bytes,10,opt,name=value_fee,json=valueFee,proto3" json:"value_fee,omitempty"`            // Value-capture fee charged (post-paid) {fee: {amount, unit: "PERCENTAGE"}}
+	ExecutionFee *Fee        `protobuf:"bytes,7,opt,name=execution_fee,json=executionFee,proto3" json:"execution_fee,omitempty"` // Flat platform fee charged {amount, unit: "USD"}
+	Cogs         []*NodeCOGS `protobuf:"bytes,9,rep,name=cogs,proto3" json:"cogs,omitempty"`                                     // Per-node actual gas/API costs {fee: {amount, unit: "WEI"}}
+	ValueFee     *ValueFee   `protobuf:"bytes,10,opt,name=value_fee,json=valueFee,proto3" json:"value_fee,omitempty"`            // Value-capture fee charged (post-paid) {fee: {amount, unit: "PERCENTAGE"}}
+	// Durable execution (suspend/resume). Set only while status == WAITING; cleared
+	// on resume to a terminal status. The accumulated `steps` above carry each
+	// completed step's output, so they are the resumable state — these fields just
+	// mark where/why the execution is parked.
+	ResumeNodeId  string            `protobuf:"bytes,11,opt,name=resume_node_id,json=resumeNodeId,proto3" json:"resume_node_id,omitempty"` // the suspended step; execution resumes at its successors
+	WaitReason    string            `protobuf:"bytes,12,opt,name=wait_reason,json=waitReason,proto3" json:"wait_reason,omitempty"`         // debug/human label for why it is waiting
 	Steps         []*Execution_Step `protobuf:"bytes,8,rep,name=steps,proto3" json:"steps,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2211,6 +2222,20 @@ func (x *Execution) GetValueFee() *ValueFee {
 		return x.ValueFee
 	}
 	return nil
+}
+
+func (x *Execution) GetResumeNodeId() string {
+	if x != nil {
+		return x.ResumeNodeId
+	}
+	return ""
+}
+
+func (x *Execution) GetWaitReason() string {
+	if x != nil {
+		return x.WaitReason
+	}
+	return ""
 }
 
 func (x *Execution) GetSteps() []*Execution_Step {
@@ -10019,7 +10044,7 @@ const file_avs_proto_rawDesc = "" +
 	"\vcustom_code\x18\x12 \x01(\v2\x1a.aggregator.CustomCodeNodeH\x00R\n" +
 	"customCode\x123\n" +
 	"\abalance\x18\x13 \x01(\v2\x17.aggregator.BalanceNodeH\x00R\abalanceB\v\n" +
-	"\ttask_type\"\x8a\x0f\n" +
+	"\ttask_type\"\xd1\x0f\n" +
 	"\tExecution\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
 	"\bstart_at\x18\x02 \x01(\x03R\astartAt\x12\x15\n" +
@@ -10030,7 +10055,10 @@ const file_avs_proto_rawDesc = "" +
 	"\rexecution_fee\x18\a \x01(\v2\x0f.aggregator.FeeR\fexecutionFee\x12(\n" +
 	"\x04cogs\x18\t \x03(\v2\x14.aggregator.NodeCOGSR\x04cogs\x121\n" +
 	"\tvalue_fee\x18\n" +
-	" \x01(\v2\x14.aggregator.ValueFeeR\bvalueFee\x120\n" +
+	" \x01(\v2\x14.aggregator.ValueFeeR\bvalueFee\x12$\n" +
+	"\x0eresume_node_id\x18\v \x01(\tR\fresumeNodeId\x12\x1f\n" +
+	"\vwait_reason\x18\f \x01(\tR\n" +
+	"waitReason\x120\n" +
 	"\x05steps\x18\b \x03(\v2\x1a.aggregator.Execution.StepR\x05steps\x1a\x94\f\n" +
 	"\x04Step\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -10570,13 +10598,14 @@ const file_avs_proto_rawDesc = "" +
 	"\n" +
 	"\x06Failed\x10\x02\x12\v\n" +
 	"\aRunning\x10\x04\x12\f\n" +
-	"\bDisabled\x10\x05*\xd0\x01\n" +
+	"\bDisabled\x10\x05*\xee\x01\n" +
 	"\x0fExecutionStatus\x12 \n" +
 	"\x1cEXECUTION_STATUS_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18EXECUTION_STATUS_PENDING\x10\x01\x12\x1c\n" +
 	"\x18EXECUTION_STATUS_SUCCESS\x10\x02\x12\x1b\n" +
 	"\x17EXECUTION_STATUS_FAILED\x10\x03\x12\x1a\n" +
-	"\x16EXECUTION_STATUS_ERROR\x10\x05\"\x04\b\x04\x10\x04* EXECUTION_STATUS_PARTIAL_SUCCESSB\fZ\n" +
+	"\x16EXECUTION_STATUS_ERROR\x10\x05\x12\x1c\n" +
+	"\x18EXECUTION_STATUS_WAITING\x10\x06\"\x04\b\x04\x10\x04* EXECUTION_STATUS_PARTIAL_SUCCESSB\fZ\n" +
 	"./avsprotob\x06proto3"
 
 var (

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -98,6 +98,7 @@ const (
 	NodeType_NODE_TYPE_FILTER         NodeType = 8  // Filter node
 	NodeType_NODE_TYPE_LOOP           NodeType = 9  // Loop node
 	NodeType_NODE_TYPE_BALANCE        NodeType = 10 // Balance node for retrieving wallet token balances
+	NodeType_NODE_TYPE_AWAIT          NodeType = 11 // Suspendable node: pause until a signal arrives (durable execution)
 )
 
 // Enum value maps for NodeType.
@@ -114,6 +115,7 @@ var (
 		8:  "NODE_TYPE_FILTER",
 		9:  "NODE_TYPE_LOOP",
 		10: "NODE_TYPE_BALANCE",
+		11: "NODE_TYPE_AWAIT",
 	}
 	NodeType_value = map[string]int32{
 		"NODE_TYPE_UNSPECIFIED":    0,
@@ -127,6 +129,7 @@ var (
 		"NODE_TYPE_FILTER":         8,
 		"NODE_TYPE_LOOP":           9,
 		"NODE_TYPE_BALANCE":        10,
+		"NODE_TYPE_AWAIT":          11,
 	}
 )
 
@@ -1546,6 +1549,54 @@ func (x *BalanceNode) GetConfig() *BalanceNode_Config {
 	return nil
 }
 
+// AwaitNode pauses the workflow until a signal arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
+// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
+// (cross-chain Await) and timer wakes follow.
+type AwaitNode struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Config        *AwaitNode_Config      `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AwaitNode) Reset() {
+	*x = AwaitNode{}
+	mi := &file_avs_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AwaitNode) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AwaitNode) ProtoMessage() {}
+
+func (x *AwaitNode) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AwaitNode.ProtoReflect.Descriptor instead.
+func (*AwaitNode) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *AwaitNode) GetConfig() *AwaitNode_Config {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
 type BranchNode struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Include Config as field
@@ -1556,7 +1607,7 @@ type BranchNode struct {
 
 func (x *BranchNode) Reset() {
 	*x = BranchNode{}
-	mi := &file_avs_proto_msgTypes[17]
+	mi := &file_avs_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1568,7 +1619,7 @@ func (x *BranchNode) String() string {
 func (*BranchNode) ProtoMessage() {}
 
 func (x *BranchNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[17]
+	mi := &file_avs_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1581,7 +1632,7 @@ func (x *BranchNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode.ProtoReflect.Descriptor instead.
 func (*BranchNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17}
+	return file_avs_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *BranchNode) GetConfig() *BranchNode_Config {
@@ -1601,7 +1652,7 @@ type FilterNode struct {
 
 func (x *FilterNode) Reset() {
 	*x = FilterNode{}
-	mi := &file_avs_proto_msgTypes[18]
+	mi := &file_avs_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1613,7 +1664,7 @@ func (x *FilterNode) String() string {
 func (*FilterNode) ProtoMessage() {}
 
 func (x *FilterNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[18]
+	mi := &file_avs_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1626,7 +1677,7 @@ func (x *FilterNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterNode.ProtoReflect.Descriptor instead.
 func (*FilterNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{18}
+	return file_avs_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *FilterNode) GetConfig() *FilterNode_Config {
@@ -1658,7 +1709,7 @@ type LoopNode struct {
 
 func (x *LoopNode) Reset() {
 	*x = LoopNode{}
-	mi := &file_avs_proto_msgTypes[19]
+	mi := &file_avs_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1670,7 +1721,7 @@ func (x *LoopNode) String() string {
 func (*LoopNode) ProtoMessage() {}
 
 func (x *LoopNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[19]
+	mi := &file_avs_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1683,7 +1734,7 @@ func (x *LoopNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoopNode.ProtoReflect.Descriptor instead.
 func (*LoopNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{19}
+	return file_avs_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *LoopNode) GetRunner() isLoopNode_Runner {
@@ -1812,7 +1863,7 @@ type TaskEdge struct {
 
 func (x *TaskEdge) Reset() {
 	*x = TaskEdge{}
-	mi := &file_avs_proto_msgTypes[20]
+	mi := &file_avs_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1824,7 +1875,7 @@ func (x *TaskEdge) String() string {
 func (*TaskEdge) ProtoMessage() {}
 
 func (x *TaskEdge) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[20]
+	mi := &file_avs_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1837,7 +1888,7 @@ func (x *TaskEdge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskEdge.ProtoReflect.Descriptor instead.
 func (*TaskEdge) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{20}
+	return file_avs_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TaskEdge) GetId() string {
@@ -1881,6 +1932,7 @@ type TaskNode struct {
 	//	*TaskNode_Loop
 	//	*TaskNode_CustomCode
 	//	*TaskNode_Balance
+	//	*TaskNode_Await
 	TaskType      isTaskNode_TaskType `protobuf_oneof:"task_type"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1888,7 +1940,7 @@ type TaskNode struct {
 
 func (x *TaskNode) Reset() {
 	*x = TaskNode{}
-	mi := &file_avs_proto_msgTypes[21]
+	mi := &file_avs_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1900,7 +1952,7 @@ func (x *TaskNode) String() string {
 func (*TaskNode) ProtoMessage() {}
 
 func (x *TaskNode) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[21]
+	mi := &file_avs_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1913,7 +1965,7 @@ func (x *TaskNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskNode.ProtoReflect.Descriptor instead.
 func (*TaskNode) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{21}
+	return file_avs_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TaskNode) GetId() string {
@@ -2034,6 +2086,15 @@ func (x *TaskNode) GetBalance() *BalanceNode {
 	return nil
 }
 
+func (x *TaskNode) GetAwait() *AwaitNode {
+	if x != nil {
+		if x, ok := x.TaskType.(*TaskNode_Await); ok {
+			return x.Await
+		}
+	}
+	return nil
+}
+
 type isTaskNode_TaskType interface {
 	isTaskNode_TaskType()
 }
@@ -2086,6 +2147,11 @@ type TaskNode_Balance struct {
 	Balance *BalanceNode `protobuf:"bytes,19,opt,name=balance,proto3,oneof"`
 }
 
+type TaskNode_Await struct {
+	// Pause until a signal arrives (durable execution)
+	Await *AwaitNode `protobuf:"bytes,20,opt,name=await,proto3,oneof"`
+}
+
 func (*TaskNode_EthTransfer) isTaskNode_TaskType() {}
 
 func (*TaskNode_ContractWrite) isTaskNode_TaskType() {}
@@ -2105,6 +2171,8 @@ func (*TaskNode_Loop) isTaskNode_TaskType() {}
 func (*TaskNode_CustomCode) isTaskNode_TaskType() {}
 
 func (*TaskNode_Balance) isTaskNode_TaskType() {}
+
+func (*TaskNode_Await) isTaskNode_TaskType() {}
 
 type Execution struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
@@ -2133,7 +2201,7 @@ type Execution struct {
 
 func (x *Execution) Reset() {
 	*x = Execution{}
-	mi := &file_avs_proto_msgTypes[22]
+	mi := &file_avs_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2145,7 +2213,7 @@ func (x *Execution) String() string {
 func (*Execution) ProtoMessage() {}
 
 func (x *Execution) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[22]
+	mi := &file_avs_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2158,7 +2226,7 @@ func (x *Execution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution.ProtoReflect.Descriptor instead.
 func (*Execution) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{22}
+	return file_avs_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Execution) GetId() string {
@@ -2290,7 +2358,7 @@ type Task struct {
 
 func (x *Task) Reset() {
 	*x = Task{}
-	mi := &file_avs_proto_msgTypes[23]
+	mi := &file_avs_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2302,7 +2370,7 @@ func (x *Task) String() string {
 func (*Task) ProtoMessage() {}
 
 func (x *Task) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[23]
+	mi := &file_avs_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2315,7 +2383,7 @@ func (x *Task) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Task.ProtoReflect.Descriptor instead.
 func (*Task) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{23}
+	return file_avs_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Task) GetId() string {
@@ -2459,7 +2527,7 @@ type CreateTaskReq struct {
 
 func (x *CreateTaskReq) Reset() {
 	*x = CreateTaskReq{}
-	mi := &file_avs_proto_msgTypes[24]
+	mi := &file_avs_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2471,7 +2539,7 @@ func (x *CreateTaskReq) String() string {
 func (*CreateTaskReq) ProtoMessage() {}
 
 func (x *CreateTaskReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[24]
+	mi := &file_avs_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2484,7 +2552,7 @@ func (x *CreateTaskReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskReq.ProtoReflect.Descriptor instead.
 func (*CreateTaskReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{24}
+	return file_avs_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CreateTaskReq) GetTrigger() *TaskTrigger {
@@ -2559,7 +2627,7 @@ type CreateTaskResp struct {
 
 func (x *CreateTaskResp) Reset() {
 	*x = CreateTaskResp{}
-	mi := &file_avs_proto_msgTypes[25]
+	mi := &file_avs_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2571,7 +2639,7 @@ func (x *CreateTaskResp) String() string {
 func (*CreateTaskResp) ProtoMessage() {}
 
 func (x *CreateTaskResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[25]
+	mi := &file_avs_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2584,7 +2652,7 @@ func (x *CreateTaskResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskResp.ProtoReflect.Descriptor instead.
 func (*CreateTaskResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{25}
+	return file_avs_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *CreateTaskResp) GetId() string {
@@ -2603,7 +2671,7 @@ type NonceRequest struct {
 
 func (x *NonceRequest) Reset() {
 	*x = NonceRequest{}
-	mi := &file_avs_proto_msgTypes[26]
+	mi := &file_avs_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2615,7 +2683,7 @@ func (x *NonceRequest) String() string {
 func (*NonceRequest) ProtoMessage() {}
 
 func (x *NonceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[26]
+	mi := &file_avs_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2628,7 +2696,7 @@ func (x *NonceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NonceRequest.ProtoReflect.Descriptor instead.
 func (*NonceRequest) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{26}
+	return file_avs_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *NonceRequest) GetOwner() string {
@@ -2647,7 +2715,7 @@ type NonceResp struct {
 
 func (x *NonceResp) Reset() {
 	*x = NonceResp{}
-	mi := &file_avs_proto_msgTypes[27]
+	mi := &file_avs_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2659,7 +2727,7 @@ func (x *NonceResp) String() string {
 func (*NonceResp) ProtoMessage() {}
 
 func (x *NonceResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[27]
+	mi := &file_avs_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2672,7 +2740,7 @@ func (x *NonceResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NonceResp.ProtoReflect.Descriptor instead.
 func (*NonceResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{27}
+	return file_avs_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *NonceResp) GetNonce() string {
@@ -2694,7 +2762,7 @@ type ListWalletReq struct {
 
 func (x *ListWalletReq) Reset() {
 	*x = ListWalletReq{}
-	mi := &file_avs_proto_msgTypes[28]
+	mi := &file_avs_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2706,7 +2774,7 @@ func (x *ListWalletReq) String() string {
 func (*ListWalletReq) ProtoMessage() {}
 
 func (x *ListWalletReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[28]
+	mi := &file_avs_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2719,7 +2787,7 @@ func (x *ListWalletReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletReq.ProtoReflect.Descriptor instead.
 func (*ListWalletReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{28}
+	return file_avs_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListWalletReq) GetFactoryAddress() string {
@@ -2748,7 +2816,7 @@ type SmartWallet struct {
 
 func (x *SmartWallet) Reset() {
 	*x = SmartWallet{}
-	mi := &file_avs_proto_msgTypes[29]
+	mi := &file_avs_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2760,7 +2828,7 @@ func (x *SmartWallet) String() string {
 func (*SmartWallet) ProtoMessage() {}
 
 func (x *SmartWallet) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[29]
+	mi := &file_avs_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2773,7 +2841,7 @@ func (x *SmartWallet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SmartWallet.ProtoReflect.Descriptor instead.
 func (*SmartWallet) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{29}
+	return file_avs_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SmartWallet) GetAddress() string {
@@ -2813,7 +2881,7 @@ type ListWalletResp struct {
 
 func (x *ListWalletResp) Reset() {
 	*x = ListWalletResp{}
-	mi := &file_avs_proto_msgTypes[30]
+	mi := &file_avs_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2825,7 +2893,7 @@ func (x *ListWalletResp) String() string {
 func (*ListWalletResp) ProtoMessage() {}
 
 func (x *ListWalletResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[30]
+	mi := &file_avs_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2838,7 +2906,7 @@ func (x *ListWalletResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWalletResp.ProtoReflect.Descriptor instead.
 func (*ListWalletResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{30}
+	return file_avs_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListWalletResp) GetItems() []*SmartWallet {
@@ -2866,7 +2934,7 @@ type ListTasksReq struct {
 
 func (x *ListTasksReq) Reset() {
 	*x = ListTasksReq{}
-	mi := &file_avs_proto_msgTypes[31]
+	mi := &file_avs_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2878,7 +2946,7 @@ func (x *ListTasksReq) String() string {
 func (*ListTasksReq) ProtoMessage() {}
 
 func (x *ListTasksReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[31]
+	mi := &file_avs_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2891,7 +2959,7 @@ func (x *ListTasksReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksReq.ProtoReflect.Descriptor instead.
 func (*ListTasksReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{31}
+	return file_avs_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListTasksReq) GetSmartWalletAddress() []string {
@@ -2946,7 +3014,7 @@ type ListTasksResp struct {
 
 func (x *ListTasksResp) Reset() {
 	*x = ListTasksResp{}
-	mi := &file_avs_proto_msgTypes[32]
+	mi := &file_avs_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2958,7 +3026,7 @@ func (x *ListTasksResp) String() string {
 func (*ListTasksResp) ProtoMessage() {}
 
 func (x *ListTasksResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[32]
+	mi := &file_avs_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2971,7 +3039,7 @@ func (x *ListTasksResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTasksResp.ProtoReflect.Descriptor instead.
 func (*ListTasksResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{32}
+	return file_avs_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListTasksResp) GetItems() []*Task {
@@ -3002,7 +3070,7 @@ type ListExecutionsReq struct {
 
 func (x *ListExecutionsReq) Reset() {
 	*x = ListExecutionsReq{}
-	mi := &file_avs_proto_msgTypes[33]
+	mi := &file_avs_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3014,7 +3082,7 @@ func (x *ListExecutionsReq) String() string {
 func (*ListExecutionsReq) ProtoMessage() {}
 
 func (x *ListExecutionsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[33]
+	mi := &file_avs_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3027,7 +3095,7 @@ func (x *ListExecutionsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsReq.ProtoReflect.Descriptor instead.
 func (*ListExecutionsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{33}
+	return file_avs_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListExecutionsReq) GetTaskIds() []string {
@@ -3068,7 +3136,7 @@ type ListExecutionsResp struct {
 
 func (x *ListExecutionsResp) Reset() {
 	*x = ListExecutionsResp{}
-	mi := &file_avs_proto_msgTypes[34]
+	mi := &file_avs_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3080,7 +3148,7 @@ func (x *ListExecutionsResp) String() string {
 func (*ListExecutionsResp) ProtoMessage() {}
 
 func (x *ListExecutionsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[34]
+	mi := &file_avs_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3093,7 +3161,7 @@ func (x *ListExecutionsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExecutionsResp.ProtoReflect.Descriptor instead.
 func (*ListExecutionsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{34}
+	return file_avs_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListExecutionsResp) GetItems() []*Execution {
@@ -3120,7 +3188,7 @@ type ExecutionReq struct {
 
 func (x *ExecutionReq) Reset() {
 	*x = ExecutionReq{}
-	mi := &file_avs_proto_msgTypes[35]
+	mi := &file_avs_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3132,7 +3200,7 @@ func (x *ExecutionReq) String() string {
 func (*ExecutionReq) ProtoMessage() {}
 
 func (x *ExecutionReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[35]
+	mi := &file_avs_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3145,7 +3213,7 @@ func (x *ExecutionReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionReq.ProtoReflect.Descriptor instead.
 func (*ExecutionReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{35}
+	return file_avs_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ExecutionReq) GetTaskId() string {
@@ -3171,7 +3239,7 @@ type ExecutionStatusResp struct {
 
 func (x *ExecutionStatusResp) Reset() {
 	*x = ExecutionStatusResp{}
-	mi := &file_avs_proto_msgTypes[36]
+	mi := &file_avs_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3183,7 +3251,7 @@ func (x *ExecutionStatusResp) String() string {
 func (*ExecutionStatusResp) ProtoMessage() {}
 
 func (x *ExecutionStatusResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[36]
+	mi := &file_avs_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3196,7 +3264,7 @@ func (x *ExecutionStatusResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStatusResp.ProtoReflect.Descriptor instead.
 func (*ExecutionStatusResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{36}
+	return file_avs_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ExecutionStatusResp) GetStatus() ExecutionStatus {
@@ -3218,7 +3286,7 @@ type GetKeyReq struct {
 
 func (x *GetKeyReq) Reset() {
 	*x = GetKeyReq{}
-	mi := &file_avs_proto_msgTypes[37]
+	mi := &file_avs_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3230,7 +3298,7 @@ func (x *GetKeyReq) String() string {
 func (*GetKeyReq) ProtoMessage() {}
 
 func (x *GetKeyReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[37]
+	mi := &file_avs_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3243,7 +3311,7 @@ func (x *GetKeyReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetKeyReq.ProtoReflect.Descriptor instead.
 func (*GetKeyReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{37}
+	return file_avs_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetKeyReq) GetMessage() string {
@@ -3276,7 +3344,7 @@ type KeyResp struct {
 
 func (x *KeyResp) Reset() {
 	*x = KeyResp{}
-	mi := &file_avs_proto_msgTypes[38]
+	mi := &file_avs_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3288,7 +3356,7 @@ func (x *KeyResp) String() string {
 func (*KeyResp) ProtoMessage() {}
 
 func (x *KeyResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[38]
+	mi := &file_avs_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3301,7 +3369,7 @@ func (x *KeyResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyResp.ProtoReflect.Descriptor instead.
 func (*KeyResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{38}
+	return file_avs_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *KeyResp) GetAddress() string {
@@ -3343,7 +3411,7 @@ type GetWalletReq struct {
 
 func (x *GetWalletReq) Reset() {
 	*x = GetWalletReq{}
-	mi := &file_avs_proto_msgTypes[39]
+	mi := &file_avs_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3355,7 +3423,7 @@ func (x *GetWalletReq) String() string {
 func (*GetWalletReq) ProtoMessage() {}
 
 func (x *GetWalletReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[39]
+	mi := &file_avs_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3368,7 +3436,7 @@ func (x *GetWalletReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletReq.ProtoReflect.Descriptor instead.
 func (*GetWalletReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{39}
+	return file_avs_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetWalletReq) GetSalt() string {
@@ -3402,7 +3470,7 @@ type GetWalletResp struct {
 
 func (x *GetWalletResp) Reset() {
 	*x = GetWalletResp{}
-	mi := &file_avs_proto_msgTypes[40]
+	mi := &file_avs_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3414,7 +3482,7 @@ func (x *GetWalletResp) String() string {
 func (*GetWalletResp) ProtoMessage() {}
 
 func (x *GetWalletResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[40]
+	mi := &file_avs_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3427,7 +3495,7 @@ func (x *GetWalletResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWalletResp.ProtoReflect.Descriptor instead.
 func (*GetWalletResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{40}
+	return file_avs_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetWalletResp) GetAddress() string {
@@ -3506,7 +3574,7 @@ type SetWalletReq struct {
 
 func (x *SetWalletReq) Reset() {
 	*x = SetWalletReq{}
-	mi := &file_avs_proto_msgTypes[41]
+	mi := &file_avs_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3518,7 +3586,7 @@ func (x *SetWalletReq) String() string {
 func (*SetWalletReq) ProtoMessage() {}
 
 func (x *SetWalletReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[41]
+	mi := &file_avs_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3531,7 +3599,7 @@ func (x *SetWalletReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetWalletReq.ProtoReflect.Descriptor instead.
 func (*SetWalletReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{41}
+	return file_avs_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SetWalletReq) GetSalt() string {
@@ -3575,7 +3643,7 @@ type WithdrawFundsReq struct {
 
 func (x *WithdrawFundsReq) Reset() {
 	*x = WithdrawFundsReq{}
-	mi := &file_avs_proto_msgTypes[42]
+	mi := &file_avs_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3587,7 +3655,7 @@ func (x *WithdrawFundsReq) String() string {
 func (*WithdrawFundsReq) ProtoMessage() {}
 
 func (x *WithdrawFundsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[42]
+	mi := &file_avs_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3600,7 +3668,7 @@ func (x *WithdrawFundsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawFundsReq.ProtoReflect.Descriptor instead.
 func (*WithdrawFundsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{42}
+	return file_avs_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *WithdrawFundsReq) GetRecipientAddress() string {
@@ -3657,7 +3725,7 @@ type WithdrawFundsResp struct {
 
 func (x *WithdrawFundsResp) Reset() {
 	*x = WithdrawFundsResp{}
-	mi := &file_avs_proto_msgTypes[43]
+	mi := &file_avs_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3669,7 +3737,7 @@ func (x *WithdrawFundsResp) String() string {
 func (*WithdrawFundsResp) ProtoMessage() {}
 
 func (x *WithdrawFundsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[43]
+	mi := &file_avs_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3682,7 +3750,7 @@ func (x *WithdrawFundsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawFundsResp.ProtoReflect.Descriptor instead.
 func (*WithdrawFundsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{43}
+	return file_avs_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *WithdrawFundsResp) GetSuccess() bool {
@@ -3785,7 +3853,7 @@ type TriggerTaskReq struct {
 
 func (x *TriggerTaskReq) Reset() {
 	*x = TriggerTaskReq{}
-	mi := &file_avs_proto_msgTypes[44]
+	mi := &file_avs_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3797,7 +3865,7 @@ func (x *TriggerTaskReq) String() string {
 func (*TriggerTaskReq) ProtoMessage() {}
 
 func (x *TriggerTaskReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[44]
+	mi := &file_avs_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3810,7 +3878,7 @@ func (x *TriggerTaskReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTaskReq.ProtoReflect.Descriptor instead.
 func (*TriggerTaskReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{44}
+	return file_avs_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *TriggerTaskReq) GetTaskId() string {
@@ -3956,7 +4024,7 @@ type TriggerTaskResp struct {
 
 func (x *TriggerTaskResp) Reset() {
 	*x = TriggerTaskResp{}
-	mi := &file_avs_proto_msgTypes[45]
+	mi := &file_avs_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3968,7 +4036,7 @@ func (x *TriggerTaskResp) String() string {
 func (*TriggerTaskResp) ProtoMessage() {}
 
 func (x *TriggerTaskResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[45]
+	mi := &file_avs_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3981,7 +4049,7 @@ func (x *TriggerTaskResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTaskResp.ProtoReflect.Descriptor instead.
 func (*TriggerTaskResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{45}
+	return file_avs_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *TriggerTaskResp) GetExecutionId() string {
@@ -4052,7 +4120,7 @@ type CreateOrUpdateSecretReq struct {
 
 func (x *CreateOrUpdateSecretReq) Reset() {
 	*x = CreateOrUpdateSecretReq{}
-	mi := &file_avs_proto_msgTypes[46]
+	mi := &file_avs_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4064,7 +4132,7 @@ func (x *CreateOrUpdateSecretReq) String() string {
 func (*CreateOrUpdateSecretReq) ProtoMessage() {}
 
 func (x *CreateOrUpdateSecretReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[46]
+	mi := &file_avs_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4077,7 +4145,7 @@ func (x *CreateOrUpdateSecretReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateOrUpdateSecretReq.ProtoReflect.Descriptor instead.
 func (*CreateOrUpdateSecretReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{46}
+	return file_avs_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CreateOrUpdateSecretReq) GetName() string {
@@ -4126,7 +4194,7 @@ type ListSecretsReq struct {
 
 func (x *ListSecretsReq) Reset() {
 	*x = ListSecretsReq{}
-	mi := &file_avs_proto_msgTypes[47]
+	mi := &file_avs_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4138,7 +4206,7 @@ func (x *ListSecretsReq) String() string {
 func (*ListSecretsReq) ProtoMessage() {}
 
 func (x *ListSecretsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[47]
+	mi := &file_avs_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4151,7 +4219,7 @@ func (x *ListSecretsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretsReq.ProtoReflect.Descriptor instead.
 func (*ListSecretsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{47}
+	return file_avs_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ListSecretsReq) GetWorkflowId() string {
@@ -4216,7 +4284,7 @@ type PageInfo struct {
 
 func (x *PageInfo) Reset() {
 	*x = PageInfo{}
-	mi := &file_avs_proto_msgTypes[48]
+	mi := &file_avs_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4228,7 +4296,7 @@ func (x *PageInfo) String() string {
 func (*PageInfo) ProtoMessage() {}
 
 func (x *PageInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[48]
+	mi := &file_avs_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4241,7 +4309,7 @@ func (x *PageInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PageInfo.ProtoReflect.Descriptor instead.
 func (*PageInfo) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{48}
+	return file_avs_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *PageInfo) GetStartCursor() string {
@@ -4291,7 +4359,7 @@ type Secret struct {
 
 func (x *Secret) Reset() {
 	*x = Secret{}
-	mi := &file_avs_proto_msgTypes[49]
+	mi := &file_avs_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4303,7 +4371,7 @@ func (x *Secret) String() string {
 func (*Secret) ProtoMessage() {}
 
 func (x *Secret) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[49]
+	mi := &file_avs_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4316,7 +4384,7 @@ func (x *Secret) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Secret.ProtoReflect.Descriptor instead.
 func (*Secret) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{49}
+	return file_avs_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *Secret) GetName() string {
@@ -4385,7 +4453,7 @@ type ListSecretsResp struct {
 
 func (x *ListSecretsResp) Reset() {
 	*x = ListSecretsResp{}
-	mi := &file_avs_proto_msgTypes[50]
+	mi := &file_avs_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4397,7 +4465,7 @@ func (x *ListSecretsResp) String() string {
 func (*ListSecretsResp) ProtoMessage() {}
 
 func (x *ListSecretsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[50]
+	mi := &file_avs_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4410,7 +4478,7 @@ func (x *ListSecretsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretsResp.ProtoReflect.Descriptor instead.
 func (*ListSecretsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{50}
+	return file_avs_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ListSecretsResp) GetItems() []*Secret {
@@ -4440,7 +4508,7 @@ type DeleteSecretReq struct {
 
 func (x *DeleteSecretReq) Reset() {
 	*x = DeleteSecretReq{}
-	mi := &file_avs_proto_msgTypes[51]
+	mi := &file_avs_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4452,7 +4520,7 @@ func (x *DeleteSecretReq) String() string {
 func (*DeleteSecretReq) ProtoMessage() {}
 
 func (x *DeleteSecretReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[51]
+	mi := &file_avs_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4465,7 +4533,7 @@ func (x *DeleteSecretReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSecretReq.ProtoReflect.Descriptor instead.
 func (*DeleteSecretReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{51}
+	return file_avs_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DeleteSecretReq) GetName() string {
@@ -4504,7 +4572,7 @@ type DeleteSecretResp struct {
 
 func (x *DeleteSecretResp) Reset() {
 	*x = DeleteSecretResp{}
-	mi := &file_avs_proto_msgTypes[52]
+	mi := &file_avs_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4516,7 +4584,7 @@ func (x *DeleteSecretResp) String() string {
 func (*DeleteSecretResp) ProtoMessage() {}
 
 func (x *DeleteSecretResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[52]
+	mi := &file_avs_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4529,7 +4597,7 @@ func (x *DeleteSecretResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSecretResp.ProtoReflect.Descriptor instead.
 func (*DeleteSecretResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{52}
+	return file_avs_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *DeleteSecretResp) GetSuccess() bool {
@@ -4584,7 +4652,7 @@ type GetSignatureFormatReq struct {
 
 func (x *GetSignatureFormatReq) Reset() {
 	*x = GetSignatureFormatReq{}
-	mi := &file_avs_proto_msgTypes[53]
+	mi := &file_avs_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4596,7 +4664,7 @@ func (x *GetSignatureFormatReq) String() string {
 func (*GetSignatureFormatReq) ProtoMessage() {}
 
 func (x *GetSignatureFormatReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[53]
+	mi := &file_avs_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4609,7 +4677,7 @@ func (x *GetSignatureFormatReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSignatureFormatReq.ProtoReflect.Descriptor instead.
 func (*GetSignatureFormatReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{53}
+	return file_avs_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetSignatureFormatReq) GetWallet() string {
@@ -4629,7 +4697,7 @@ type GetSignatureFormatResp struct {
 
 func (x *GetSignatureFormatResp) Reset() {
 	*x = GetSignatureFormatResp{}
-	mi := &file_avs_proto_msgTypes[54]
+	mi := &file_avs_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4641,7 +4709,7 @@ func (x *GetSignatureFormatResp) String() string {
 func (*GetSignatureFormatResp) ProtoMessage() {}
 
 func (x *GetSignatureFormatResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[54]
+	mi := &file_avs_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4654,7 +4722,7 @@ func (x *GetSignatureFormatResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSignatureFormatResp.ProtoReflect.Descriptor instead.
 func (*GetSignatureFormatResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{54}
+	return file_avs_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetSignatureFormatResp) GetMessage() string {
@@ -4679,7 +4747,7 @@ type CreateSecretResp struct {
 
 func (x *CreateSecretResp) Reset() {
 	*x = CreateSecretResp{}
-	mi := &file_avs_proto_msgTypes[55]
+	mi := &file_avs_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4691,7 +4759,7 @@ func (x *CreateSecretResp) String() string {
 func (*CreateSecretResp) ProtoMessage() {}
 
 func (x *CreateSecretResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[55]
+	mi := &file_avs_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4704,7 +4772,7 @@ func (x *CreateSecretResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSecretResp.ProtoReflect.Descriptor instead.
 func (*CreateSecretResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{55}
+	return file_avs_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *CreateSecretResp) GetSuccess() bool {
@@ -4764,7 +4832,7 @@ type UpdateSecretResp struct {
 
 func (x *UpdateSecretResp) Reset() {
 	*x = UpdateSecretResp{}
-	mi := &file_avs_proto_msgTypes[56]
+	mi := &file_avs_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4776,7 +4844,7 @@ func (x *UpdateSecretResp) String() string {
 func (*UpdateSecretResp) ProtoMessage() {}
 
 func (x *UpdateSecretResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[56]
+	mi := &file_avs_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4789,7 +4857,7 @@ func (x *UpdateSecretResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSecretResp.ProtoReflect.Descriptor instead.
 func (*UpdateSecretResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{56}
+	return file_avs_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *UpdateSecretResp) GetSuccess() bool {
@@ -4849,7 +4917,7 @@ type DeleteTaskResp struct {
 
 func (x *DeleteTaskResp) Reset() {
 	*x = DeleteTaskResp{}
-	mi := &file_avs_proto_msgTypes[57]
+	mi := &file_avs_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4861,7 +4929,7 @@ func (x *DeleteTaskResp) String() string {
 func (*DeleteTaskResp) ProtoMessage() {}
 
 func (x *DeleteTaskResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[57]
+	mi := &file_avs_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4874,7 +4942,7 @@ func (x *DeleteTaskResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTaskResp.ProtoReflect.Descriptor instead.
 func (*DeleteTaskResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{57}
+	return file_avs_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *DeleteTaskResp) GetSuccess() bool {
@@ -4930,7 +4998,7 @@ type SetTaskEnabledReq struct {
 
 func (x *SetTaskEnabledReq) Reset() {
 	*x = SetTaskEnabledReq{}
-	mi := &file_avs_proto_msgTypes[58]
+	mi := &file_avs_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4942,7 +5010,7 @@ func (x *SetTaskEnabledReq) String() string {
 func (*SetTaskEnabledReq) ProtoMessage() {}
 
 func (x *SetTaskEnabledReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[58]
+	mi := &file_avs_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4955,7 +5023,7 @@ func (x *SetTaskEnabledReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTaskEnabledReq.ProtoReflect.Descriptor instead.
 func (*SetTaskEnabledReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{58}
+	return file_avs_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *SetTaskEnabledReq) GetId() string {
@@ -4986,7 +5054,7 @@ type SetTaskEnabledResp struct {
 
 func (x *SetTaskEnabledResp) Reset() {
 	*x = SetTaskEnabledResp{}
-	mi := &file_avs_proto_msgTypes[59]
+	mi := &file_avs_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4998,7 +5066,7 @@ func (x *SetTaskEnabledResp) String() string {
 func (*SetTaskEnabledResp) ProtoMessage() {}
 
 func (x *SetTaskEnabledResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[59]
+	mi := &file_avs_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5011,7 +5079,7 @@ func (x *SetTaskEnabledResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetTaskEnabledResp.ProtoReflect.Descriptor instead.
 func (*SetTaskEnabledResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{59}
+	return file_avs_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *SetTaskEnabledResp) GetSuccess() bool {
@@ -5066,7 +5134,7 @@ type GetWorkflowCountReq struct {
 
 func (x *GetWorkflowCountReq) Reset() {
 	*x = GetWorkflowCountReq{}
-	mi := &file_avs_proto_msgTypes[60]
+	mi := &file_avs_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5078,7 +5146,7 @@ func (x *GetWorkflowCountReq) String() string {
 func (*GetWorkflowCountReq) ProtoMessage() {}
 
 func (x *GetWorkflowCountReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[60]
+	mi := &file_avs_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5091,7 +5159,7 @@ func (x *GetWorkflowCountReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkflowCountReq.ProtoReflect.Descriptor instead.
 func (*GetWorkflowCountReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{60}
+	return file_avs_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetWorkflowCountReq) GetAddresses() []string {
@@ -5112,7 +5180,7 @@ type GetWorkflowCountResp struct {
 
 func (x *GetWorkflowCountResp) Reset() {
 	*x = GetWorkflowCountResp{}
-	mi := &file_avs_proto_msgTypes[61]
+	mi := &file_avs_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5124,7 +5192,7 @@ func (x *GetWorkflowCountResp) String() string {
 func (*GetWorkflowCountResp) ProtoMessage() {}
 
 func (x *GetWorkflowCountResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[61]
+	mi := &file_avs_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5137,7 +5205,7 @@ func (x *GetWorkflowCountResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkflowCountResp.ProtoReflect.Descriptor instead.
 func (*GetWorkflowCountResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{61}
+	return file_avs_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetWorkflowCountResp) GetTotal() int64 {
@@ -5156,7 +5224,7 @@ type GetExecutionCountReq struct {
 
 func (x *GetExecutionCountReq) Reset() {
 	*x = GetExecutionCountReq{}
-	mi := &file_avs_proto_msgTypes[62]
+	mi := &file_avs_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5168,7 +5236,7 @@ func (x *GetExecutionCountReq) String() string {
 func (*GetExecutionCountReq) ProtoMessage() {}
 
 func (x *GetExecutionCountReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[62]
+	mi := &file_avs_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5181,7 +5249,7 @@ func (x *GetExecutionCountReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionCountReq.ProtoReflect.Descriptor instead.
 func (*GetExecutionCountReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{62}
+	return file_avs_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetExecutionCountReq) GetWorkflowIds() []string {
@@ -5202,7 +5270,7 @@ type GetExecutionCountResp struct {
 
 func (x *GetExecutionCountResp) Reset() {
 	*x = GetExecutionCountResp{}
-	mi := &file_avs_proto_msgTypes[63]
+	mi := &file_avs_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5214,7 +5282,7 @@ func (x *GetExecutionCountResp) String() string {
 func (*GetExecutionCountResp) ProtoMessage() {}
 
 func (x *GetExecutionCountResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[63]
+	mi := &file_avs_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5227,7 +5295,7 @@ func (x *GetExecutionCountResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionCountResp.ProtoReflect.Descriptor instead.
 func (*GetExecutionCountResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{63}
+	return file_avs_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetExecutionCountResp) GetTotal() int64 {
@@ -5248,7 +5316,7 @@ type GetExecutionStatsReq struct {
 
 func (x *GetExecutionStatsReq) Reset() {
 	*x = GetExecutionStatsReq{}
-	mi := &file_avs_proto_msgTypes[64]
+	mi := &file_avs_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5260,7 +5328,7 @@ func (x *GetExecutionStatsReq) String() string {
 func (*GetExecutionStatsReq) ProtoMessage() {}
 
 func (x *GetExecutionStatsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[64]
+	mi := &file_avs_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5273,7 +5341,7 @@ func (x *GetExecutionStatsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionStatsReq.ProtoReflect.Descriptor instead.
 func (*GetExecutionStatsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{64}
+	return file_avs_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetExecutionStatsReq) GetWorkflowIds() []string {
@@ -5303,7 +5371,7 @@ type GetExecutionStatsResp struct {
 
 func (x *GetExecutionStatsResp) Reset() {
 	*x = GetExecutionStatsResp{}
-	mi := &file_avs_proto_msgTypes[65]
+	mi := &file_avs_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5315,7 +5383,7 @@ func (x *GetExecutionStatsResp) String() string {
 func (*GetExecutionStatsResp) ProtoMessage() {}
 
 func (x *GetExecutionStatsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[65]
+	mi := &file_avs_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5328,7 +5396,7 @@ func (x *GetExecutionStatsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionStatsResp.ProtoReflect.Descriptor instead.
 func (*GetExecutionStatsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{65}
+	return file_avs_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *GetExecutionStatsResp) GetTotal() int64 {
@@ -5382,7 +5450,7 @@ type RunNodeWithInputsReq struct {
 
 func (x *RunNodeWithInputsReq) Reset() {
 	*x = RunNodeWithInputsReq{}
-	mi := &file_avs_proto_msgTypes[66]
+	mi := &file_avs_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5394,7 +5462,7 @@ func (x *RunNodeWithInputsReq) String() string {
 func (*RunNodeWithInputsReq) ProtoMessage() {}
 
 func (x *RunNodeWithInputsReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[66]
+	mi := &file_avs_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5407,7 +5475,7 @@ func (x *RunNodeWithInputsReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunNodeWithInputsReq.ProtoReflect.Descriptor instead.
 func (*RunNodeWithInputsReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{66}
+	return file_avs_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *RunNodeWithInputsReq) GetNode() *TaskNode {
@@ -5458,7 +5526,7 @@ type ERC20StateOverride struct {
 
 func (x *ERC20StateOverride) Reset() {
 	*x = ERC20StateOverride{}
-	mi := &file_avs_proto_msgTypes[67]
+	mi := &file_avs_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5470,7 +5538,7 @@ func (x *ERC20StateOverride) String() string {
 func (*ERC20StateOverride) ProtoMessage() {}
 
 func (x *ERC20StateOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[67]
+	mi := &file_avs_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5483,7 +5551,7 @@ func (x *ERC20StateOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ERC20StateOverride.ProtoReflect.Descriptor instead.
 func (*ERC20StateOverride) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{67}
+	return file_avs_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ERC20StateOverride) GetTokenAddress() string {
@@ -5566,7 +5634,7 @@ type RunNodeWithInputsResp struct {
 
 func (x *RunNodeWithInputsResp) Reset() {
 	*x = RunNodeWithInputsResp{}
-	mi := &file_avs_proto_msgTypes[68]
+	mi := &file_avs_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5578,7 +5646,7 @@ func (x *RunNodeWithInputsResp) String() string {
 func (*RunNodeWithInputsResp) ProtoMessage() {}
 
 func (x *RunNodeWithInputsResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[68]
+	mi := &file_avs_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5591,7 +5659,7 @@ func (x *RunNodeWithInputsResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunNodeWithInputsResp.ProtoReflect.Descriptor instead.
 func (*RunNodeWithInputsResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{68}
+	return file_avs_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *RunNodeWithInputsResp) GetSuccess() bool {
@@ -5803,7 +5871,7 @@ type RunTriggerReq struct {
 
 func (x *RunTriggerReq) Reset() {
 	*x = RunTriggerReq{}
-	mi := &file_avs_proto_msgTypes[69]
+	mi := &file_avs_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5815,7 +5883,7 @@ func (x *RunTriggerReq) String() string {
 func (*RunTriggerReq) ProtoMessage() {}
 
 func (x *RunTriggerReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[69]
+	mi := &file_avs_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5828,7 +5896,7 @@ func (x *RunTriggerReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTriggerReq.ProtoReflect.Descriptor instead.
 func (*RunTriggerReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{69}
+	return file_avs_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *RunTriggerReq) GetTrigger() *TaskTrigger {
@@ -5871,7 +5939,7 @@ type RunTriggerResp struct {
 
 func (x *RunTriggerResp) Reset() {
 	*x = RunTriggerResp{}
-	mi := &file_avs_proto_msgTypes[70]
+	mi := &file_avs_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5883,7 +5951,7 @@ func (x *RunTriggerResp) String() string {
 func (*RunTriggerResp) ProtoMessage() {}
 
 func (x *RunTriggerResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[70]
+	mi := &file_avs_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5896,7 +5964,7 @@ func (x *RunTriggerResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTriggerResp.ProtoReflect.Descriptor instead.
 func (*RunTriggerResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{70}
+	return file_avs_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *RunTriggerResp) GetSuccess() bool {
@@ -6037,7 +6105,7 @@ type SimulateTaskReq struct {
 
 func (x *SimulateTaskReq) Reset() {
 	*x = SimulateTaskReq{}
-	mi := &file_avs_proto_msgTypes[71]
+	mi := &file_avs_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6049,7 +6117,7 @@ func (x *SimulateTaskReq) String() string {
 func (*SimulateTaskReq) ProtoMessage() {}
 
 func (x *SimulateTaskReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[71]
+	mi := &file_avs_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6062,7 +6130,7 @@ func (x *SimulateTaskReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SimulateTaskReq.ProtoReflect.Descriptor instead.
 func (*SimulateTaskReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{71}
+	return file_avs_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *SimulateTaskReq) GetTrigger() *TaskTrigger {
@@ -6124,7 +6192,7 @@ type EstimateFeesReq struct {
 
 func (x *EstimateFeesReq) Reset() {
 	*x = EstimateFeesReq{}
-	mi := &file_avs_proto_msgTypes[72]
+	mi := &file_avs_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6136,7 +6204,7 @@ func (x *EstimateFeesReq) String() string {
 func (*EstimateFeesReq) ProtoMessage() {}
 
 func (x *EstimateFeesReq) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[72]
+	mi := &file_avs_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6149,7 +6217,7 @@ func (x *EstimateFeesReq) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeesReq.ProtoReflect.Descriptor instead.
 func (*EstimateFeesReq) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{72}
+	return file_avs_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *EstimateFeesReq) GetTrigger() *TaskTrigger {
@@ -6228,7 +6296,7 @@ type FeeAmount struct {
 
 func (x *FeeAmount) Reset() {
 	*x = FeeAmount{}
-	mi := &file_avs_proto_msgTypes[73]
+	mi := &file_avs_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6240,7 +6308,7 @@ func (x *FeeAmount) String() string {
 func (*FeeAmount) ProtoMessage() {}
 
 func (x *FeeAmount) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[73]
+	mi := &file_avs_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6253,7 +6321,7 @@ func (x *FeeAmount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeAmount.ProtoReflect.Descriptor instead.
 func (*FeeAmount) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{73}
+	return file_avs_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *FeeAmount) GetNativeTokenAmount() string {
@@ -6301,7 +6369,7 @@ type GasFeeBreakdown struct {
 
 func (x *GasFeeBreakdown) Reset() {
 	*x = GasFeeBreakdown{}
-	mi := &file_avs_proto_msgTypes[74]
+	mi := &file_avs_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6313,7 +6381,7 @@ func (x *GasFeeBreakdown) String() string {
 func (*GasFeeBreakdown) ProtoMessage() {}
 
 func (x *GasFeeBreakdown) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[74]
+	mi := &file_avs_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6326,7 +6394,7 @@ func (x *GasFeeBreakdown) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GasFeeBreakdown.ProtoReflect.Descriptor instead.
 func (*GasFeeBreakdown) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{74}
+	return file_avs_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GasFeeBreakdown) GetTotalGasFees() *FeeAmount {
@@ -6385,7 +6453,7 @@ type GasOperationFee struct {
 
 func (x *GasOperationFee) Reset() {
 	*x = GasOperationFee{}
-	mi := &file_avs_proto_msgTypes[75]
+	mi := &file_avs_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6397,7 +6465,7 @@ func (x *GasOperationFee) String() string {
 func (*GasOperationFee) ProtoMessage() {}
 
 func (x *GasOperationFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[75]
+	mi := &file_avs_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6410,7 +6478,7 @@ func (x *GasOperationFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GasOperationFee.ProtoReflect.Descriptor instead.
 func (*GasOperationFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{75}
+	return file_avs_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GasOperationFee) GetOperationType() string {
@@ -6461,7 +6529,7 @@ type SmartWalletCreationFee struct {
 
 func (x *SmartWalletCreationFee) Reset() {
 	*x = SmartWalletCreationFee{}
-	mi := &file_avs_proto_msgTypes[76]
+	mi := &file_avs_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6473,7 +6541,7 @@ func (x *SmartWalletCreationFee) String() string {
 func (*SmartWalletCreationFee) ProtoMessage() {}
 
 func (x *SmartWalletCreationFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[76]
+	mi := &file_avs_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6486,7 +6554,7 @@ func (x *SmartWalletCreationFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SmartWalletCreationFee.ProtoReflect.Descriptor instead.
 func (*SmartWalletCreationFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{76}
+	return file_avs_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *SmartWalletCreationFee) GetCreationRequired() bool {
@@ -6529,7 +6597,7 @@ type Fee struct {
 
 func (x *Fee) Reset() {
 	*x = Fee{}
-	mi := &file_avs_proto_msgTypes[77]
+	mi := &file_avs_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6541,7 +6609,7 @@ func (x *Fee) String() string {
 func (*Fee) ProtoMessage() {}
 
 func (x *Fee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[77]
+	mi := &file_avs_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6554,7 +6622,7 @@ func (x *Fee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Fee.ProtoReflect.Descriptor instead.
 func (*Fee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{77}
+	return file_avs_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *Fee) GetAmount() string {
@@ -6582,7 +6650,7 @@ type NativeToken struct {
 
 func (x *NativeToken) Reset() {
 	*x = NativeToken{}
-	mi := &file_avs_proto_msgTypes[78]
+	mi := &file_avs_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6594,7 +6662,7 @@ func (x *NativeToken) String() string {
 func (*NativeToken) ProtoMessage() {}
 
 func (x *NativeToken) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[78]
+	mi := &file_avs_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6607,7 +6675,7 @@ func (x *NativeToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NativeToken.ProtoReflect.Descriptor instead.
 func (*NativeToken) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{78}
+	return file_avs_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *NativeToken) GetSymbol() string {
@@ -6637,7 +6705,7 @@ type NodeCOGS struct {
 
 func (x *NodeCOGS) Reset() {
 	*x = NodeCOGS{}
-	mi := &file_avs_proto_msgTypes[79]
+	mi := &file_avs_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6649,7 +6717,7 @@ func (x *NodeCOGS) String() string {
 func (*NodeCOGS) ProtoMessage() {}
 
 func (x *NodeCOGS) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[79]
+	mi := &file_avs_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6662,7 +6730,7 @@ func (x *NodeCOGS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeCOGS.ProtoReflect.Descriptor instead.
 func (*NodeCOGS) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{79}
+	return file_avs_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *NodeCOGS) GetNodeId() string {
@@ -6709,7 +6777,7 @@ type ValueFee struct {
 
 func (x *ValueFee) Reset() {
 	*x = ValueFee{}
-	mi := &file_avs_proto_msgTypes[80]
+	mi := &file_avs_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6721,7 +6789,7 @@ func (x *ValueFee) String() string {
 func (*ValueFee) ProtoMessage() {}
 
 func (x *ValueFee) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[80]
+	mi := &file_avs_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6734,7 +6802,7 @@ func (x *ValueFee) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValueFee.ProtoReflect.Descriptor instead.
 func (*ValueFee) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{80}
+	return file_avs_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ValueFee) GetFee() *Fee {
@@ -6793,7 +6861,7 @@ type FeeDiscount struct {
 
 func (x *FeeDiscount) Reset() {
 	*x = FeeDiscount{}
-	mi := &file_avs_proto_msgTypes[81]
+	mi := &file_avs_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6805,7 +6873,7 @@ func (x *FeeDiscount) String() string {
 func (*FeeDiscount) ProtoMessage() {}
 
 func (x *FeeDiscount) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[81]
+	mi := &file_avs_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6818,7 +6886,7 @@ func (x *FeeDiscount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeDiscount.ProtoReflect.Descriptor instead.
 func (*FeeDiscount) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{81}
+	return file_avs_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *FeeDiscount) GetDiscountType() string {
@@ -6884,7 +6952,7 @@ type EstimateFeesResp struct {
 
 func (x *EstimateFeesResp) Reset() {
 	*x = EstimateFeesResp{}
-	mi := &file_avs_proto_msgTypes[82]
+	mi := &file_avs_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6896,7 +6964,7 @@ func (x *EstimateFeesResp) String() string {
 func (*EstimateFeesResp) ProtoMessage() {}
 
 func (x *EstimateFeesResp) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[82]
+	mi := &file_avs_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6909,7 +6977,7 @@ func (x *EstimateFeesResp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeesResp.ProtoReflect.Descriptor instead.
 func (*EstimateFeesResp) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{82}
+	return file_avs_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *EstimateFeesResp) GetSuccess() bool {
@@ -7006,7 +7074,7 @@ type EventCondition struct {
 
 func (x *EventCondition) Reset() {
 	*x = EventCondition{}
-	mi := &file_avs_proto_msgTypes[83]
+	mi := &file_avs_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7018,7 +7086,7 @@ func (x *EventCondition) String() string {
 func (*EventCondition) ProtoMessage() {}
 
 func (x *EventCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[83]
+	mi := &file_avs_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7031,7 +7099,7 @@ func (x *EventCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventCondition.ProtoReflect.Descriptor instead.
 func (*EventCondition) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{83}
+	return file_avs_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *EventCondition) GetFieldName() string {
@@ -7071,7 +7139,7 @@ type FixedTimeTrigger_Config struct {
 
 func (x *FixedTimeTrigger_Config) Reset() {
 	*x = FixedTimeTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[84]
+	mi := &file_avs_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7083,7 +7151,7 @@ func (x *FixedTimeTrigger_Config) String() string {
 func (*FixedTimeTrigger_Config) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[84]
+	mi := &file_avs_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7115,7 +7183,7 @@ type FixedTimeTrigger_Output struct {
 
 func (x *FixedTimeTrigger_Output) Reset() {
 	*x = FixedTimeTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7127,7 +7195,7 @@ func (x *FixedTimeTrigger_Output) String() string {
 func (*FixedTimeTrigger_Output) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7159,7 +7227,7 @@ type CronTrigger_Config struct {
 
 func (x *CronTrigger_Config) Reset() {
 	*x = CronTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7171,7 +7239,7 @@ func (x *CronTrigger_Config) String() string {
 func (*CronTrigger_Config) ProtoMessage() {}
 
 func (x *CronTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7203,7 +7271,7 @@ type CronTrigger_Output struct {
 
 func (x *CronTrigger_Output) Reset() {
 	*x = CronTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7215,7 +7283,7 @@ func (x *CronTrigger_Output) String() string {
 func (*CronTrigger_Output) ProtoMessage() {}
 
 func (x *CronTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7249,7 +7317,7 @@ type BlockTrigger_Config struct {
 
 func (x *BlockTrigger_Config) Reset() {
 	*x = BlockTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7261,7 +7329,7 @@ func (x *BlockTrigger_Config) String() string {
 func (*BlockTrigger_Config) ProtoMessage() {}
 
 func (x *BlockTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7300,7 +7368,7 @@ type BlockTrigger_Output struct {
 
 func (x *BlockTrigger_Output) Reset() {
 	*x = BlockTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7312,7 +7380,7 @@ func (x *BlockTrigger_Output) String() string {
 func (*BlockTrigger_Output) ProtoMessage() {}
 
 func (x *BlockTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7372,7 +7440,7 @@ type EventTrigger_Query struct {
 
 func (x *EventTrigger_Query) Reset() {
 	*x = EventTrigger_Query{}
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7384,7 +7452,7 @@ func (x *EventTrigger_Query) String() string {
 func (*EventTrigger_Query) ProtoMessage() {}
 
 func (x *EventTrigger_Query) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7455,7 +7523,7 @@ type EventTrigger_MethodCall struct {
 
 func (x *EventTrigger_MethodCall) Reset() {
 	*x = EventTrigger_MethodCall{}
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7467,7 +7535,7 @@ func (x *EventTrigger_MethodCall) String() string {
 func (*EventTrigger_MethodCall) ProtoMessage() {}
 
 func (x *EventTrigger_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7530,7 +7598,7 @@ type EventTrigger_Config struct {
 
 func (x *EventTrigger_Config) Reset() {
 	*x = EventTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7542,7 +7610,7 @@ func (x *EventTrigger_Config) String() string {
 func (*EventTrigger_Config) ProtoMessage() {}
 
 func (x *EventTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7588,7 +7656,7 @@ type EventTrigger_Output struct {
 
 func (x *EventTrigger_Output) Reset() {
 	*x = EventTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7600,7 +7668,7 @@ func (x *EventTrigger_Output) String() string {
 func (*EventTrigger_Output) ProtoMessage() {}
 
 func (x *EventTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7640,7 +7708,7 @@ type ManualTrigger_Config struct {
 
 func (x *ManualTrigger_Config) Reset() {
 	*x = ManualTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7652,7 +7720,7 @@ func (x *ManualTrigger_Config) String() string {
 func (*ManualTrigger_Config) ProtoMessage() {}
 
 func (x *ManualTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7706,7 +7774,7 @@ type ManualTrigger_Output struct {
 
 func (x *ManualTrigger_Output) Reset() {
 	*x = ManualTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[95]
+	mi := &file_avs_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7718,7 +7786,7 @@ func (x *ManualTrigger_Output) String() string {
 func (*ManualTrigger_Output) ProtoMessage() {}
 
 func (x *ManualTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[95]
+	mi := &file_avs_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7753,7 +7821,7 @@ type ETHTransferNode_Config struct {
 
 func (x *ETHTransferNode_Config) Reset() {
 	*x = ETHTransferNode_Config{}
-	mi := &file_avs_proto_msgTypes[98]
+	mi := &file_avs_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7765,7 +7833,7 @@ func (x *ETHTransferNode_Config) String() string {
 func (*ETHTransferNode_Config) ProtoMessage() {}
 
 func (x *ETHTransferNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[98]
+	mi := &file_avs_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7811,7 +7879,7 @@ type ETHTransferNode_Output struct {
 
 func (x *ETHTransferNode_Output) Reset() {
 	*x = ETHTransferNode_Output{}
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7823,7 +7891,7 @@ func (x *ETHTransferNode_Output) String() string {
 func (*ETHTransferNode_Output) ProtoMessage() {}
 
 func (x *ETHTransferNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7868,7 +7936,7 @@ type ContractWriteNode_Config struct {
 
 func (x *ContractWriteNode_Config) Reset() {
 	*x = ContractWriteNode_Config{}
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7880,7 +7948,7 @@ func (x *ContractWriteNode_Config) String() string {
 func (*ContractWriteNode_Config) ProtoMessage() {}
 
 func (x *ContractWriteNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7964,7 +8032,7 @@ type ContractWriteNode_MethodCall struct {
 
 func (x *ContractWriteNode_MethodCall) Reset() {
 	*x = ContractWriteNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7976,7 +8044,7 @@ func (x *ContractWriteNode_MethodCall) String() string {
 func (*ContractWriteNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8031,7 +8099,7 @@ type ContractWriteNode_Output struct {
 
 func (x *ContractWriteNode_Output) Reset() {
 	*x = ContractWriteNode_Output{}
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8043,7 +8111,7 @@ func (x *ContractWriteNode_Output) String() string {
 func (*ContractWriteNode_Output) ProtoMessage() {}
 
 func (x *ContractWriteNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8081,7 +8149,7 @@ type ContractWriteNode_MethodResult struct {
 
 func (x *ContractWriteNode_MethodResult) Reset() {
 	*x = ContractWriteNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8093,7 +8161,7 @@ func (x *ContractWriteNode_MethodResult) String() string {
 func (*ContractWriteNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8170,7 +8238,7 @@ type ContractReadNode_MethodCall struct {
 
 func (x *ContractReadNode_MethodCall) Reset() {
 	*x = ContractReadNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8182,7 +8250,7 @@ func (x *ContractReadNode_MethodCall) String() string {
 func (*ContractReadNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8241,7 +8309,7 @@ type ContractReadNode_Config struct {
 
 func (x *ContractReadNode_Config) Reset() {
 	*x = ContractReadNode_Config{}
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8253,7 +8321,7 @@ func (x *ContractReadNode_Config) String() string {
 func (*ContractReadNode_Config) ProtoMessage() {}
 
 func (x *ContractReadNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8310,7 +8378,7 @@ type ContractReadNode_MethodResult struct {
 
 func (x *ContractReadNode_MethodResult) Reset() {
 	*x = ContractReadNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8322,7 +8390,7 @@ func (x *ContractReadNode_MethodResult) String() string {
 func (*ContractReadNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8377,7 +8445,7 @@ type ContractReadNode_Output struct {
 
 func (x *ContractReadNode_Output) Reset() {
 	*x = ContractReadNode_Output{}
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8389,7 +8457,7 @@ func (x *ContractReadNode_Output) String() string {
 func (*ContractReadNode_Output) ProtoMessage() {}
 
 func (x *ContractReadNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8424,7 +8492,7 @@ type ContractReadNode_MethodResult_StructuredField struct {
 
 func (x *ContractReadNode_MethodResult_StructuredField) Reset() {
 	*x = ContractReadNode_MethodResult_StructuredField{}
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8436,7 +8504,7 @@ func (x *ContractReadNode_MethodResult_StructuredField) String() string {
 func (*ContractReadNode_MethodResult_StructuredField) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult_StructuredField) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8485,7 +8553,7 @@ type GraphQLQueryNode_Config struct {
 
 func (x *GraphQLQueryNode_Config) Reset() {
 	*x = GraphQLQueryNode_Config{}
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8497,7 +8565,7 @@ func (x *GraphQLQueryNode_Config) String() string {
 func (*GraphQLQueryNode_Config) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8545,7 +8613,7 @@ type GraphQLQueryNode_Output struct {
 
 func (x *GraphQLQueryNode_Output) Reset() {
 	*x = GraphQLQueryNode_Output{}
-	mi := &file_avs_proto_msgTypes[110]
+	mi := &file_avs_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8557,7 +8625,7 @@ func (x *GraphQLQueryNode_Output) String() string {
 func (*GraphQLQueryNode_Output) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[110]
+	mi := &file_avs_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8594,7 +8662,7 @@ type RestAPINode_Config struct {
 
 func (x *RestAPINode_Config) Reset() {
 	*x = RestAPINode_Config{}
-	mi := &file_avs_proto_msgTypes[112]
+	mi := &file_avs_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8606,7 +8674,7 @@ func (x *RestAPINode_Config) String() string {
 func (*RestAPINode_Config) ProtoMessage() {}
 
 func (x *RestAPINode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[112]
+	mi := &file_avs_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8667,7 +8735,7 @@ type RestAPINode_Output struct {
 
 func (x *RestAPINode_Output) Reset() {
 	*x = RestAPINode_Output{}
-	mi := &file_avs_proto_msgTypes[113]
+	mi := &file_avs_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8679,7 +8747,7 @@ func (x *RestAPINode_Output) String() string {
 func (*RestAPINode_Output) ProtoMessage() {}
 
 func (x *RestAPINode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[113]
+	mi := &file_avs_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8712,7 +8780,7 @@ type CustomCodeNode_Config struct {
 
 func (x *CustomCodeNode_Config) Reset() {
 	*x = CustomCodeNode_Config{}
-	mi := &file_avs_proto_msgTypes[115]
+	mi := &file_avs_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8724,7 +8792,7 @@ func (x *CustomCodeNode_Config) String() string {
 func (*CustomCodeNode_Config) ProtoMessage() {}
 
 func (x *CustomCodeNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[115]
+	mi := &file_avs_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8764,7 +8832,7 @@ type CustomCodeNode_Output struct {
 
 func (x *CustomCodeNode_Output) Reset() {
 	*x = CustomCodeNode_Output{}
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8776,7 +8844,7 @@ func (x *CustomCodeNode_Output) String() string {
 func (*CustomCodeNode_Output) ProtoMessage() {}
 
 func (x *CustomCodeNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8841,7 +8909,7 @@ type BalanceNode_Config struct {
 
 func (x *BalanceNode_Config) Reset() {
 	*x = BalanceNode_Config{}
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8853,7 +8921,7 @@ func (x *BalanceNode_Config) String() string {
 func (*BalanceNode_Config) ProtoMessage() {}
 
 func (x *BalanceNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8924,7 +8992,7 @@ type BalanceNode_Output struct {
 
 func (x *BalanceNode_Output) Reset() {
 	*x = BalanceNode_Output{}
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8936,7 +9004,7 @@ func (x *BalanceNode_Output) String() string {
 func (*BalanceNode_Output) ProtoMessage() {}
 
 func (x *BalanceNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8959,6 +9027,120 @@ func (x *BalanceNode_Output) GetData() *structpb.Value {
 	return nil
 }
 
+type AwaitNode_Config struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// External-signal wake parameters.
+	Channel        string   `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`                                      // "telegram" | "api"
+	Approvers      []string `protobuf:"bytes,2,rep,name=approvers,proto3" json:"approvers,omitempty"`                                  // authorized parties; empty ⇒ the workflow owner
+	Prompt         string   `protobuf:"bytes,3,opt,name=prompt,proto3" json:"prompt,omitempty"`                                        // shown to the approver
+	TimeoutSeconds uint32   `protobuf:"varint,4,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"` // safety bound; 0 ⇒ server default (never an unbounded wait)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AwaitNode_Config) Reset() {
+	*x = AwaitNode_Config{}
+	mi := &file_avs_proto_msgTypes[120]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AwaitNode_Config) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AwaitNode_Config) ProtoMessage() {}
+
+func (x *AwaitNode_Config) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[120]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AwaitNode_Config.ProtoReflect.Descriptor instead.
+func (*AwaitNode_Config) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{17, 0}
+}
+
+func (x *AwaitNode_Config) GetChannel() string {
+	if x != nil {
+		return x.Channel
+	}
+	return ""
+}
+
+func (x *AwaitNode_Config) GetApprovers() []string {
+	if x != nil {
+		return x.Approvers
+	}
+	return nil
+}
+
+func (x *AwaitNode_Config) GetPrompt() string {
+	if x != nil {
+		return x.Prompt
+	}
+	return ""
+}
+
+func (x *AwaitNode_Config) GetTimeoutSeconds() uint32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
+}
+
+type AwaitNode_Output struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The delivered signal (decision + payload), readable by downstream steps.
+	Data          *structpb.Value `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AwaitNode_Output) Reset() {
+	*x = AwaitNode_Output{}
+	mi := &file_avs_proto_msgTypes[121]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AwaitNode_Output) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AwaitNode_Output) ProtoMessage() {}
+
+func (x *AwaitNode_Output) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[121]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AwaitNode_Output.ProtoReflect.Descriptor instead.
+func (*AwaitNode_Output) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{17, 1}
+}
+
+func (x *AwaitNode_Output) GetData() *structpb.Value {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 type BranchNode_Condition struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -8970,7 +9152,7 @@ type BranchNode_Condition struct {
 
 func (x *BranchNode_Condition) Reset() {
 	*x = BranchNode_Condition{}
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8982,7 +9164,7 @@ func (x *BranchNode_Condition) String() string {
 func (*BranchNode_Condition) ProtoMessage() {}
 
 func (x *BranchNode_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8995,7 +9177,7 @@ func (x *BranchNode_Condition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode_Condition.ProtoReflect.Descriptor instead.
 func (*BranchNode_Condition) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17, 0}
+	return file_avs_proto_rawDescGZIP(), []int{18, 0}
 }
 
 func (x *BranchNode_Condition) GetId() string {
@@ -9028,7 +9210,7 @@ type BranchNode_Config struct {
 
 func (x *BranchNode_Config) Reset() {
 	*x = BranchNode_Config{}
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9040,7 +9222,7 @@ func (x *BranchNode_Config) String() string {
 func (*BranchNode_Config) ProtoMessage() {}
 
 func (x *BranchNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9053,7 +9235,7 @@ func (x *BranchNode_Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode_Config.ProtoReflect.Descriptor instead.
 func (*BranchNode_Config) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17, 1}
+	return file_avs_proto_rawDescGZIP(), []int{18, 1}
 }
 
 func (x *BranchNode_Config) GetConditions() []*BranchNode_Condition {
@@ -9075,7 +9257,7 @@ type BranchNode_Output struct {
 
 func (x *BranchNode_Output) Reset() {
 	*x = BranchNode_Output{}
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9087,7 +9269,7 @@ func (x *BranchNode_Output) String() string {
 func (*BranchNode_Output) ProtoMessage() {}
 
 func (x *BranchNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9100,7 +9282,7 @@ func (x *BranchNode_Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BranchNode_Output.ProtoReflect.Descriptor instead.
 func (*BranchNode_Output) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{17, 2}
+	return file_avs_proto_rawDescGZIP(), []int{18, 2}
 }
 
 func (x *BranchNode_Output) GetData() *structpb.Value {
@@ -9123,7 +9305,7 @@ type FilterNode_Config struct {
 
 func (x *FilterNode_Config) Reset() {
 	*x = FilterNode_Config{}
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9135,7 +9317,7 @@ func (x *FilterNode_Config) String() string {
 func (*FilterNode_Config) ProtoMessage() {}
 
 func (x *FilterNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9148,7 +9330,7 @@ func (x *FilterNode_Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterNode_Config.ProtoReflect.Descriptor instead.
 func (*FilterNode_Config) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{18, 0}
+	return file_avs_proto_rawDescGZIP(), []int{19, 0}
 }
 
 func (x *FilterNode_Config) GetExpression() string {
@@ -9175,7 +9357,7 @@ type FilterNode_Output struct {
 
 func (x *FilterNode_Output) Reset() {
 	*x = FilterNode_Output{}
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9187,7 +9369,7 @@ func (x *FilterNode_Output) String() string {
 func (*FilterNode_Output) ProtoMessage() {}
 
 func (x *FilterNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9200,7 +9382,7 @@ func (x *FilterNode_Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterNode_Output.ProtoReflect.Descriptor instead.
 func (*FilterNode_Output) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{18, 1}
+	return file_avs_proto_rawDescGZIP(), []int{19, 1}
 }
 
 func (x *FilterNode_Output) GetData() *structpb.Value {
@@ -9231,7 +9413,7 @@ type LoopNode_Config struct {
 
 func (x *LoopNode_Config) Reset() {
 	*x = LoopNode_Config{}
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9243,7 +9425,7 @@ func (x *LoopNode_Config) String() string {
 func (*LoopNode_Config) ProtoMessage() {}
 
 func (x *LoopNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9256,7 +9438,7 @@ func (x *LoopNode_Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoopNode_Config.ProtoReflect.Descriptor instead.
 func (*LoopNode_Config) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{19, 0}
+	return file_avs_proto_rawDescGZIP(), []int{20, 0}
 }
 
 func (x *LoopNode_Config) GetInputVariable() string {
@@ -9303,7 +9485,7 @@ type LoopNode_Output struct {
 
 func (x *LoopNode_Output) Reset() {
 	*x = LoopNode_Output{}
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9315,7 +9497,7 @@ func (x *LoopNode_Output) String() string {
 func (*LoopNode_Output) ProtoMessage() {}
 
 func (x *LoopNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9328,7 +9510,7 @@ func (x *LoopNode_Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoopNode_Output.ProtoReflect.Descriptor instead.
 func (*LoopNode_Output) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{19, 1}
+	return file_avs_proto_rawDescGZIP(), []int{20, 1}
 }
 
 func (x *LoopNode_Output) GetData() *structpb.Value {
@@ -9390,7 +9572,7 @@ type Execution_Step struct {
 
 func (x *Execution_Step) Reset() {
 	*x = Execution_Step{}
-	mi := &file_avs_proto_msgTypes[126]
+	mi := &file_avs_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9402,7 +9584,7 @@ func (x *Execution_Step) String() string {
 func (*Execution_Step) ProtoMessage() {}
 
 func (x *Execution_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[126]
+	mi := &file_avs_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9415,7 +9597,7 @@ func (x *Execution_Step) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Execution_Step.ProtoReflect.Descriptor instead.
 func (*Execution_Step) Descriptor() ([]byte, []int) {
-	return file_avs_proto_rawDescGZIP(), []int{22, 0}
+	return file_avs_proto_rawDescGZIP(), []int{23, 0}
 }
 
 func (x *Execution_Step) GetId() string {
@@ -9979,6 +10161,15 @@ const file_avs_proto_rawDesc = "" +
 	"\x13min_usd_value_cents\x18\x05 \x01(\x03R\x10minUsdValueCents\x12'\n" +
 	"\x0ftoken_addresses\x18\x06 \x03(\tR\x0etokenAddresses\x1a4\n" +
 	"\x06Output\x12*\n" +
+	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xfb\x01\n" +
+	"\tAwaitNode\x124\n" +
+	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x1a\x81\x01\n" +
+	"\x06Config\x12\x18\n" +
+	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1c\n" +
+	"\tapprovers\x18\x02 \x03(\tR\tapprovers\x12\x16\n" +
+	"\x06prompt\x18\x03 \x01(\tR\x06prompt\x12'\n" +
+	"\x0ftimeout_seconds\x18\x04 \x01(\rR\x0etimeoutSeconds\x1a4\n" +
+	"\x06Output\x12*\n" +
 	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\x96\x02\n" +
 	"\n" +
 	"BranchNode\x125\n" +
@@ -10027,7 +10218,7 @@ const file_avs_proto_rawDesc = "" +
 	"\bTaskEdge\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06source\x18\x02 \x01(\tR\x06source\x12\x16\n" +
-	"\x06target\x18\x03 \x01(\tR\x06target\"\xb3\x05\n" +
+	"\x06target\x18\x03 \x01(\tR\x06target\"\xe2\x05\n" +
 	"\bTaskNode\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12(\n" +
@@ -10043,7 +10234,8 @@ const file_avs_proto_rawDesc = "" +
 	"\x04loop\x18\x11 \x01(\v2\x14.aggregator.LoopNodeH\x00R\x04loop\x12=\n" +
 	"\vcustom_code\x18\x12 \x01(\v2\x1a.aggregator.CustomCodeNodeH\x00R\n" +
 	"customCode\x123\n" +
-	"\abalance\x18\x13 \x01(\v2\x17.aggregator.BalanceNodeH\x00R\abalanceB\v\n" +
+	"\abalance\x18\x13 \x01(\v2\x17.aggregator.BalanceNodeH\x00R\abalance\x12-\n" +
+	"\x05await\x18\x14 \x01(\v2\x15.aggregator.AwaitNodeH\x00R\x05awaitB\v\n" +
 	"\ttask_type\"\xd1\x0f\n" +
 	"\tExecution\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
@@ -10522,7 +10714,7 @@ const file_avs_proto_rawDesc = "" +
 	"\x17TRIGGER_TYPE_FIXED_TIME\x10\x02\x12\x15\n" +
 	"\x11TRIGGER_TYPE_CRON\x10\x03\x12\x16\n" +
 	"\x12TRIGGER_TYPE_BLOCK\x10\x04\x12\x16\n" +
-	"\x12TRIGGER_TYPE_EVENT\x10\x05*\xa3\x02\n" +
+	"\x12TRIGGER_TYPE_EVENT\x10\x05*\xb8\x02\n" +
 	"\bNodeType\x12\x19\n" +
 	"\x15NODE_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16NODE_TYPE_ETH_TRANSFER\x10\x01\x12\x1c\n" +
@@ -10535,7 +10727,8 @@ const file_avs_proto_rawDesc = "" +
 	"\x10NODE_TYPE_FILTER\x10\b\x12\x12\n" +
 	"\x0eNODE_TYPE_LOOP\x10\t\x12\x15\n" +
 	"\x11NODE_TYPE_BALANCE\x10\n" +
-	"*q\n" +
+	"\x12\x13\n" +
+	"\x0fNODE_TYPE_AWAIT\x10\v*q\n" +
 	"\rExecutionTier\x12\x1e\n" +
 	"\x1aEXECUTION_TIER_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10EXECUTION_TIER_1\x10\x01\x12\x14\n" +
@@ -10621,7 +10814,7 @@ func file_avs_proto_rawDescGZIP() []byte {
 }
 
 var file_avs_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 134)
+var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 137)
 var file_avs_proto_goTypes = []any{
 	(TriggerType)(0),                                      // 0: aggregator.TriggerType
 	(NodeType)(0),                                         // 1: aggregator.NodeType
@@ -10648,313 +10841,319 @@ var file_avs_proto_goTypes = []any{
 	(*RestAPINode)(nil),                                   // 22: aggregator.RestAPINode
 	(*CustomCodeNode)(nil),                                // 23: aggregator.CustomCodeNode
 	(*BalanceNode)(nil),                                   // 24: aggregator.BalanceNode
-	(*BranchNode)(nil),                                    // 25: aggregator.BranchNode
-	(*FilterNode)(nil),                                    // 26: aggregator.FilterNode
-	(*LoopNode)(nil),                                      // 27: aggregator.LoopNode
-	(*TaskEdge)(nil),                                      // 28: aggregator.TaskEdge
-	(*TaskNode)(nil),                                      // 29: aggregator.TaskNode
-	(*Execution)(nil),                                     // 30: aggregator.Execution
-	(*Task)(nil),                                          // 31: aggregator.Task
-	(*CreateTaskReq)(nil),                                 // 32: aggregator.CreateTaskReq
-	(*CreateTaskResp)(nil),                                // 33: aggregator.CreateTaskResp
-	(*NonceRequest)(nil),                                  // 34: aggregator.NonceRequest
-	(*NonceResp)(nil),                                     // 35: aggregator.NonceResp
-	(*ListWalletReq)(nil),                                 // 36: aggregator.ListWalletReq
-	(*SmartWallet)(nil),                                   // 37: aggregator.SmartWallet
-	(*ListWalletResp)(nil),                                // 38: aggregator.ListWalletResp
-	(*ListTasksReq)(nil),                                  // 39: aggregator.ListTasksReq
-	(*ListTasksResp)(nil),                                 // 40: aggregator.ListTasksResp
-	(*ListExecutionsReq)(nil),                             // 41: aggregator.ListExecutionsReq
-	(*ListExecutionsResp)(nil),                            // 42: aggregator.ListExecutionsResp
-	(*ExecutionReq)(nil),                                  // 43: aggregator.ExecutionReq
-	(*ExecutionStatusResp)(nil),                           // 44: aggregator.ExecutionStatusResp
-	(*GetKeyReq)(nil),                                     // 45: aggregator.GetKeyReq
-	(*KeyResp)(nil),                                       // 46: aggregator.KeyResp
-	(*GetWalletReq)(nil),                                  // 47: aggregator.GetWalletReq
-	(*GetWalletResp)(nil),                                 // 48: aggregator.GetWalletResp
-	(*SetWalletReq)(nil),                                  // 49: aggregator.SetWalletReq
-	(*WithdrawFundsReq)(nil),                              // 50: aggregator.WithdrawFundsReq
-	(*WithdrawFundsResp)(nil),                             // 51: aggregator.WithdrawFundsResp
-	(*TriggerTaskReq)(nil),                                // 52: aggregator.TriggerTaskReq
-	(*TriggerTaskResp)(nil),                               // 53: aggregator.TriggerTaskResp
-	(*CreateOrUpdateSecretReq)(nil),                       // 54: aggregator.CreateOrUpdateSecretReq
-	(*ListSecretsReq)(nil),                                // 55: aggregator.ListSecretsReq
-	(*PageInfo)(nil),                                      // 56: aggregator.PageInfo
-	(*Secret)(nil),                                        // 57: aggregator.Secret
-	(*ListSecretsResp)(nil),                               // 58: aggregator.ListSecretsResp
-	(*DeleteSecretReq)(nil),                               // 59: aggregator.DeleteSecretReq
-	(*DeleteSecretResp)(nil),                              // 60: aggregator.DeleteSecretResp
-	(*GetSignatureFormatReq)(nil),                         // 61: aggregator.GetSignatureFormatReq
-	(*GetSignatureFormatResp)(nil),                        // 62: aggregator.GetSignatureFormatResp
-	(*CreateSecretResp)(nil),                              // 63: aggregator.CreateSecretResp
-	(*UpdateSecretResp)(nil),                              // 64: aggregator.UpdateSecretResp
-	(*DeleteTaskResp)(nil),                                // 65: aggregator.DeleteTaskResp
-	(*SetTaskEnabledReq)(nil),                             // 66: aggregator.SetTaskEnabledReq
-	(*SetTaskEnabledResp)(nil),                            // 67: aggregator.SetTaskEnabledResp
-	(*GetWorkflowCountReq)(nil),                           // 68: aggregator.GetWorkflowCountReq
-	(*GetWorkflowCountResp)(nil),                          // 69: aggregator.GetWorkflowCountResp
-	(*GetExecutionCountReq)(nil),                          // 70: aggregator.GetExecutionCountReq
-	(*GetExecutionCountResp)(nil),                         // 71: aggregator.GetExecutionCountResp
-	(*GetExecutionStatsReq)(nil),                          // 72: aggregator.GetExecutionStatsReq
-	(*GetExecutionStatsResp)(nil),                         // 73: aggregator.GetExecutionStatsResp
-	(*RunNodeWithInputsReq)(nil),                          // 74: aggregator.RunNodeWithInputsReq
-	(*ERC20StateOverride)(nil),                            // 75: aggregator.ERC20StateOverride
-	(*RunNodeWithInputsResp)(nil),                         // 76: aggregator.RunNodeWithInputsResp
-	(*RunTriggerReq)(nil),                                 // 77: aggregator.RunTriggerReq
-	(*RunTriggerResp)(nil),                                // 78: aggregator.RunTriggerResp
-	(*SimulateTaskReq)(nil),                               // 79: aggregator.SimulateTaskReq
-	(*EstimateFeesReq)(nil),                               // 80: aggregator.EstimateFeesReq
-	(*FeeAmount)(nil),                                     // 81: aggregator.FeeAmount
-	(*GasFeeBreakdown)(nil),                               // 82: aggregator.GasFeeBreakdown
-	(*GasOperationFee)(nil),                               // 83: aggregator.GasOperationFee
-	(*SmartWalletCreationFee)(nil),                        // 84: aggregator.SmartWalletCreationFee
-	(*Fee)(nil),                                           // 85: aggregator.Fee
-	(*NativeToken)(nil),                                   // 86: aggregator.NativeToken
-	(*NodeCOGS)(nil),                                      // 87: aggregator.NodeCOGS
-	(*ValueFee)(nil),                                      // 88: aggregator.ValueFee
-	(*FeeDiscount)(nil),                                   // 89: aggregator.FeeDiscount
-	(*EstimateFeesResp)(nil),                              // 90: aggregator.EstimateFeesResp
-	(*EventCondition)(nil),                                // 91: aggregator.EventCondition
-	(*FixedTimeTrigger_Config)(nil),                       // 92: aggregator.FixedTimeTrigger.Config
-	(*FixedTimeTrigger_Output)(nil),                       // 93: aggregator.FixedTimeTrigger.Output
-	(*CronTrigger_Config)(nil),                            // 94: aggregator.CronTrigger.Config
-	(*CronTrigger_Output)(nil),                            // 95: aggregator.CronTrigger.Output
-	(*BlockTrigger_Config)(nil),                           // 96: aggregator.BlockTrigger.Config
-	(*BlockTrigger_Output)(nil),                           // 97: aggregator.BlockTrigger.Output
-	(*EventTrigger_Query)(nil),                            // 98: aggregator.EventTrigger.Query
-	(*EventTrigger_MethodCall)(nil),                       // 99: aggregator.EventTrigger.MethodCall
-	(*EventTrigger_Config)(nil),                           // 100: aggregator.EventTrigger.Config
-	(*EventTrigger_Output)(nil),                           // 101: aggregator.EventTrigger.Output
-	(*ManualTrigger_Config)(nil),                          // 102: aggregator.ManualTrigger.Config
-	(*ManualTrigger_Output)(nil),                          // 103: aggregator.ManualTrigger.Output
-	nil,                                                   // 104: aggregator.ManualTrigger.Config.HeadersEntry
-	nil,                                                   // 105: aggregator.ManualTrigger.Config.PathParamsEntry
-	(*ETHTransferNode_Config)(nil),                        // 106: aggregator.ETHTransferNode.Config
-	(*ETHTransferNode_Output)(nil),                        // 107: aggregator.ETHTransferNode.Output
-	(*ContractWriteNode_Config)(nil),                      // 108: aggregator.ContractWriteNode.Config
-	(*ContractWriteNode_MethodCall)(nil),                  // 109: aggregator.ContractWriteNode.MethodCall
-	(*ContractWriteNode_Output)(nil),                      // 110: aggregator.ContractWriteNode.Output
-	(*ContractWriteNode_MethodResult)(nil),                // 111: aggregator.ContractWriteNode.MethodResult
-	(*ContractReadNode_MethodCall)(nil),                   // 112: aggregator.ContractReadNode.MethodCall
-	(*ContractReadNode_Config)(nil),                       // 113: aggregator.ContractReadNode.Config
-	(*ContractReadNode_MethodResult)(nil),                 // 114: aggregator.ContractReadNode.MethodResult
-	(*ContractReadNode_Output)(nil),                       // 115: aggregator.ContractReadNode.Output
-	(*ContractReadNode_MethodResult_StructuredField)(nil), // 116: aggregator.ContractReadNode.MethodResult.StructuredField
-	(*GraphQLQueryNode_Config)(nil),                       // 117: aggregator.GraphQLQueryNode.Config
-	(*GraphQLQueryNode_Output)(nil),                       // 118: aggregator.GraphQLQueryNode.Output
-	nil,                                                   // 119: aggregator.GraphQLQueryNode.Config.VariablesEntry
-	(*RestAPINode_Config)(nil),                            // 120: aggregator.RestAPINode.Config
-	(*RestAPINode_Output)(nil),                            // 121: aggregator.RestAPINode.Output
-	nil,                                                   // 122: aggregator.RestAPINode.Config.HeadersEntry
-	(*CustomCodeNode_Config)(nil),                         // 123: aggregator.CustomCodeNode.Config
-	(*CustomCodeNode_Output)(nil),                         // 124: aggregator.CustomCodeNode.Output
-	(*BalanceNode_Config)(nil),                            // 125: aggregator.BalanceNode.Config
-	(*BalanceNode_Output)(nil),                            // 126: aggregator.BalanceNode.Output
-	(*BranchNode_Condition)(nil),                          // 127: aggregator.BranchNode.Condition
-	(*BranchNode_Config)(nil),                             // 128: aggregator.BranchNode.Config
-	(*BranchNode_Output)(nil),                             // 129: aggregator.BranchNode.Output
-	(*FilterNode_Config)(nil),                             // 130: aggregator.FilterNode.Config
-	(*FilterNode_Output)(nil),                             // 131: aggregator.FilterNode.Output
-	(*LoopNode_Config)(nil),                               // 132: aggregator.LoopNode.Config
-	(*LoopNode_Output)(nil),                               // 133: aggregator.LoopNode.Output
-	(*Execution_Step)(nil),                                // 134: aggregator.Execution.Step
-	nil,                                                   // 135: aggregator.Task.InputVariablesEntry
-	nil,                                                   // 136: aggregator.CreateTaskReq.InputVariablesEntry
-	nil,                                                   // 137: aggregator.TriggerTaskReq.TriggerInputEntry
-	nil,                                                   // 138: aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	nil,                                                   // 139: aggregator.RunTriggerReq.TriggerInputEntry
-	nil,                                                   // 140: aggregator.SimulateTaskReq.InputVariablesEntry
-	nil,                                                   // 141: aggregator.EstimateFeesReq.InputVariablesEntry
-	(*structpb.Value)(nil),                                // 142: google.protobuf.Value
+	(*AwaitNode)(nil),                                     // 25: aggregator.AwaitNode
+	(*BranchNode)(nil),                                    // 26: aggregator.BranchNode
+	(*FilterNode)(nil),                                    // 27: aggregator.FilterNode
+	(*LoopNode)(nil),                                      // 28: aggregator.LoopNode
+	(*TaskEdge)(nil),                                      // 29: aggregator.TaskEdge
+	(*TaskNode)(nil),                                      // 30: aggregator.TaskNode
+	(*Execution)(nil),                                     // 31: aggregator.Execution
+	(*Task)(nil),                                          // 32: aggregator.Task
+	(*CreateTaskReq)(nil),                                 // 33: aggregator.CreateTaskReq
+	(*CreateTaskResp)(nil),                                // 34: aggregator.CreateTaskResp
+	(*NonceRequest)(nil),                                  // 35: aggregator.NonceRequest
+	(*NonceResp)(nil),                                     // 36: aggregator.NonceResp
+	(*ListWalletReq)(nil),                                 // 37: aggregator.ListWalletReq
+	(*SmartWallet)(nil),                                   // 38: aggregator.SmartWallet
+	(*ListWalletResp)(nil),                                // 39: aggregator.ListWalletResp
+	(*ListTasksReq)(nil),                                  // 40: aggregator.ListTasksReq
+	(*ListTasksResp)(nil),                                 // 41: aggregator.ListTasksResp
+	(*ListExecutionsReq)(nil),                             // 42: aggregator.ListExecutionsReq
+	(*ListExecutionsResp)(nil),                            // 43: aggregator.ListExecutionsResp
+	(*ExecutionReq)(nil),                                  // 44: aggregator.ExecutionReq
+	(*ExecutionStatusResp)(nil),                           // 45: aggregator.ExecutionStatusResp
+	(*GetKeyReq)(nil),                                     // 46: aggregator.GetKeyReq
+	(*KeyResp)(nil),                                       // 47: aggregator.KeyResp
+	(*GetWalletReq)(nil),                                  // 48: aggregator.GetWalletReq
+	(*GetWalletResp)(nil),                                 // 49: aggregator.GetWalletResp
+	(*SetWalletReq)(nil),                                  // 50: aggregator.SetWalletReq
+	(*WithdrawFundsReq)(nil),                              // 51: aggregator.WithdrawFundsReq
+	(*WithdrawFundsResp)(nil),                             // 52: aggregator.WithdrawFundsResp
+	(*TriggerTaskReq)(nil),                                // 53: aggregator.TriggerTaskReq
+	(*TriggerTaskResp)(nil),                               // 54: aggregator.TriggerTaskResp
+	(*CreateOrUpdateSecretReq)(nil),                       // 55: aggregator.CreateOrUpdateSecretReq
+	(*ListSecretsReq)(nil),                                // 56: aggregator.ListSecretsReq
+	(*PageInfo)(nil),                                      // 57: aggregator.PageInfo
+	(*Secret)(nil),                                        // 58: aggregator.Secret
+	(*ListSecretsResp)(nil),                               // 59: aggregator.ListSecretsResp
+	(*DeleteSecretReq)(nil),                               // 60: aggregator.DeleteSecretReq
+	(*DeleteSecretResp)(nil),                              // 61: aggregator.DeleteSecretResp
+	(*GetSignatureFormatReq)(nil),                         // 62: aggregator.GetSignatureFormatReq
+	(*GetSignatureFormatResp)(nil),                        // 63: aggregator.GetSignatureFormatResp
+	(*CreateSecretResp)(nil),                              // 64: aggregator.CreateSecretResp
+	(*UpdateSecretResp)(nil),                              // 65: aggregator.UpdateSecretResp
+	(*DeleteTaskResp)(nil),                                // 66: aggregator.DeleteTaskResp
+	(*SetTaskEnabledReq)(nil),                             // 67: aggregator.SetTaskEnabledReq
+	(*SetTaskEnabledResp)(nil),                            // 68: aggregator.SetTaskEnabledResp
+	(*GetWorkflowCountReq)(nil),                           // 69: aggregator.GetWorkflowCountReq
+	(*GetWorkflowCountResp)(nil),                          // 70: aggregator.GetWorkflowCountResp
+	(*GetExecutionCountReq)(nil),                          // 71: aggregator.GetExecutionCountReq
+	(*GetExecutionCountResp)(nil),                         // 72: aggregator.GetExecutionCountResp
+	(*GetExecutionStatsReq)(nil),                          // 73: aggregator.GetExecutionStatsReq
+	(*GetExecutionStatsResp)(nil),                         // 74: aggregator.GetExecutionStatsResp
+	(*RunNodeWithInputsReq)(nil),                          // 75: aggregator.RunNodeWithInputsReq
+	(*ERC20StateOverride)(nil),                            // 76: aggregator.ERC20StateOverride
+	(*RunNodeWithInputsResp)(nil),                         // 77: aggregator.RunNodeWithInputsResp
+	(*RunTriggerReq)(nil),                                 // 78: aggregator.RunTriggerReq
+	(*RunTriggerResp)(nil),                                // 79: aggregator.RunTriggerResp
+	(*SimulateTaskReq)(nil),                               // 80: aggregator.SimulateTaskReq
+	(*EstimateFeesReq)(nil),                               // 81: aggregator.EstimateFeesReq
+	(*FeeAmount)(nil),                                     // 82: aggregator.FeeAmount
+	(*GasFeeBreakdown)(nil),                               // 83: aggregator.GasFeeBreakdown
+	(*GasOperationFee)(nil),                               // 84: aggregator.GasOperationFee
+	(*SmartWalletCreationFee)(nil),                        // 85: aggregator.SmartWalletCreationFee
+	(*Fee)(nil),                                           // 86: aggregator.Fee
+	(*NativeToken)(nil),                                   // 87: aggregator.NativeToken
+	(*NodeCOGS)(nil),                                      // 88: aggregator.NodeCOGS
+	(*ValueFee)(nil),                                      // 89: aggregator.ValueFee
+	(*FeeDiscount)(nil),                                   // 90: aggregator.FeeDiscount
+	(*EstimateFeesResp)(nil),                              // 91: aggregator.EstimateFeesResp
+	(*EventCondition)(nil),                                // 92: aggregator.EventCondition
+	(*FixedTimeTrigger_Config)(nil),                       // 93: aggregator.FixedTimeTrigger.Config
+	(*FixedTimeTrigger_Output)(nil),                       // 94: aggregator.FixedTimeTrigger.Output
+	(*CronTrigger_Config)(nil),                            // 95: aggregator.CronTrigger.Config
+	(*CronTrigger_Output)(nil),                            // 96: aggregator.CronTrigger.Output
+	(*BlockTrigger_Config)(nil),                           // 97: aggregator.BlockTrigger.Config
+	(*BlockTrigger_Output)(nil),                           // 98: aggregator.BlockTrigger.Output
+	(*EventTrigger_Query)(nil),                            // 99: aggregator.EventTrigger.Query
+	(*EventTrigger_MethodCall)(nil),                       // 100: aggregator.EventTrigger.MethodCall
+	(*EventTrigger_Config)(nil),                           // 101: aggregator.EventTrigger.Config
+	(*EventTrigger_Output)(nil),                           // 102: aggregator.EventTrigger.Output
+	(*ManualTrigger_Config)(nil),                          // 103: aggregator.ManualTrigger.Config
+	(*ManualTrigger_Output)(nil),                          // 104: aggregator.ManualTrigger.Output
+	nil,                                                   // 105: aggregator.ManualTrigger.Config.HeadersEntry
+	nil,                                                   // 106: aggregator.ManualTrigger.Config.PathParamsEntry
+	(*ETHTransferNode_Config)(nil),                        // 107: aggregator.ETHTransferNode.Config
+	(*ETHTransferNode_Output)(nil),                        // 108: aggregator.ETHTransferNode.Output
+	(*ContractWriteNode_Config)(nil),                      // 109: aggregator.ContractWriteNode.Config
+	(*ContractWriteNode_MethodCall)(nil),                  // 110: aggregator.ContractWriteNode.MethodCall
+	(*ContractWriteNode_Output)(nil),                      // 111: aggregator.ContractWriteNode.Output
+	(*ContractWriteNode_MethodResult)(nil),                // 112: aggregator.ContractWriteNode.MethodResult
+	(*ContractReadNode_MethodCall)(nil),                   // 113: aggregator.ContractReadNode.MethodCall
+	(*ContractReadNode_Config)(nil),                       // 114: aggregator.ContractReadNode.Config
+	(*ContractReadNode_MethodResult)(nil),                 // 115: aggregator.ContractReadNode.MethodResult
+	(*ContractReadNode_Output)(nil),                       // 116: aggregator.ContractReadNode.Output
+	(*ContractReadNode_MethodResult_StructuredField)(nil), // 117: aggregator.ContractReadNode.MethodResult.StructuredField
+	(*GraphQLQueryNode_Config)(nil),                       // 118: aggregator.GraphQLQueryNode.Config
+	(*GraphQLQueryNode_Output)(nil),                       // 119: aggregator.GraphQLQueryNode.Output
+	nil,                                                   // 120: aggregator.GraphQLQueryNode.Config.VariablesEntry
+	(*RestAPINode_Config)(nil),                            // 121: aggregator.RestAPINode.Config
+	(*RestAPINode_Output)(nil),                            // 122: aggregator.RestAPINode.Output
+	nil,                                                   // 123: aggregator.RestAPINode.Config.HeadersEntry
+	(*CustomCodeNode_Config)(nil),                         // 124: aggregator.CustomCodeNode.Config
+	(*CustomCodeNode_Output)(nil),                         // 125: aggregator.CustomCodeNode.Output
+	(*BalanceNode_Config)(nil),                            // 126: aggregator.BalanceNode.Config
+	(*BalanceNode_Output)(nil),                            // 127: aggregator.BalanceNode.Output
+	(*AwaitNode_Config)(nil),                              // 128: aggregator.AwaitNode.Config
+	(*AwaitNode_Output)(nil),                              // 129: aggregator.AwaitNode.Output
+	(*BranchNode_Condition)(nil),                          // 130: aggregator.BranchNode.Condition
+	(*BranchNode_Config)(nil),                             // 131: aggregator.BranchNode.Config
+	(*BranchNode_Output)(nil),                             // 132: aggregator.BranchNode.Output
+	(*FilterNode_Config)(nil),                             // 133: aggregator.FilterNode.Config
+	(*FilterNode_Output)(nil),                             // 134: aggregator.FilterNode.Output
+	(*LoopNode_Config)(nil),                               // 135: aggregator.LoopNode.Config
+	(*LoopNode_Output)(nil),                               // 136: aggregator.LoopNode.Output
+	(*Execution_Step)(nil),                                // 137: aggregator.Execution.Step
+	nil,                                                   // 138: aggregator.Task.InputVariablesEntry
+	nil,                                                   // 139: aggregator.CreateTaskReq.InputVariablesEntry
+	nil,                                                   // 140: aggregator.TriggerTaskReq.TriggerInputEntry
+	nil,                                                   // 141: aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	nil,                                                   // 142: aggregator.RunTriggerReq.TriggerInputEntry
+	nil,                                                   // 143: aggregator.SimulateTaskReq.InputVariablesEntry
+	nil,                                                   // 144: aggregator.EstimateFeesReq.InputVariablesEntry
+	(*structpb.Value)(nil),                                // 145: google.protobuf.Value
 }
 var file_avs_proto_depIdxs = []int32{
 	8,   // 0: aggregator.GetTokenMetadataResp.token:type_name -> aggregator.TokenMetadata
-	92,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
-	94,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
-	96,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
-	100, // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
-	102, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
+	93,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
+	95,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
+	97,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
+	101, // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
+	103, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
 	0,   // 6: aggregator.TaskTrigger.type:type_name -> aggregator.TriggerType
 	16,  // 7: aggregator.TaskTrigger.manual:type_name -> aggregator.ManualTrigger
 	12,  // 8: aggregator.TaskTrigger.fixed_time:type_name -> aggregator.FixedTimeTrigger
 	13,  // 9: aggregator.TaskTrigger.cron:type_name -> aggregator.CronTrigger
 	14,  // 10: aggregator.TaskTrigger.block:type_name -> aggregator.BlockTrigger
 	15,  // 11: aggregator.TaskTrigger.event:type_name -> aggregator.EventTrigger
-	106, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
-	108, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
-	113, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
-	117, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
-	120, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
-	123, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
-	125, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
-	128, // 19: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
-	130, // 20: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
-	18,  // 21: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
-	19,  // 22: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
-	20,  // 23: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
-	21,  // 24: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
-	22,  // 25: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
-	23,  // 26: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
-	132, // 27: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
-	1,   // 28: aggregator.TaskNode.type:type_name -> aggregator.NodeType
-	18,  // 29: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
-	19,  // 30: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
-	20,  // 31: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
-	21,  // 32: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
-	22,  // 33: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
-	25,  // 34: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
-	26,  // 35: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
-	27,  // 36: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
-	23,  // 37: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
-	24,  // 38: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
-	7,   // 39: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
-	85,  // 40: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
-	87,  // 41: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
-	88,  // 42: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
-	134, // 43: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
-	6,   // 44: aggregator.Task.status:type_name -> aggregator.TaskStatus
-	17,  // 45: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 46: aggregator.Task.nodes:type_name -> aggregator.TaskNode
-	28,  // 47: aggregator.Task.edges:type_name -> aggregator.TaskEdge
-	135, // 48: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
-	17,  // 49: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 50: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 51: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
-	136, // 52: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
-	37,  // 53: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
-	31,  // 54: aggregator.ListTasksResp.items:type_name -> aggregator.Task
-	56,  // 55: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
-	30,  // 56: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
-	56,  // 57: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
-	7,   // 58: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
-	0,   // 59: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
-	97,  // 60: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	93,  // 61: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	95,  // 62: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	101, // 63: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
-	103, // 64: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	137, // 65: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
-	7,   // 66: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
-	134, // 67: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
-	57,  // 68: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
-	56,  // 69: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
-	29,  // 70: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
-	138, // 71: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	75,  // 72: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
-	142, // 73: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
-	142, // 74: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 75: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
-	107, // 76: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	118, // 77: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	115, // 78: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
-	110, // 79: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	124, // 80: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	121, // 81: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
-	129, // 82: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
-	131, // 83: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
-	133, // 84: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
-	126, // 85: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
-	17,  // 86: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
-	139, // 87: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
-	142, // 88: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
-	142, // 89: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 90: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
-	97,  // 91: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	93,  // 92: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	95,  // 93: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	101, // 94: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
-	103, // 95: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	17,  // 96: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 97: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 98: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
-	140, // 99: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
-	17,  // 100: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
-	29,  // 101: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
-	28,  // 102: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
-	141, // 103: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
-	81,  // 104: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
-	83,  // 105: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
-	81,  // 106: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
-	81,  // 107: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
-	81,  // 108: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
-	85,  // 109: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
-	85,  // 110: aggregator.ValueFee.fee:type_name -> aggregator.Fee
-	2,   // 111: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
-	85,  // 112: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
-	5,   // 113: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
-	86,  // 114: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
-	85,  // 115: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
-	87,  // 116: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
-	88,  // 117: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
-	89,  // 118: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
-	142, // 119: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 120: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 121: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 122: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
-	91,  // 123: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
-	99,  // 124: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
-	98,  // 125: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
-	142, // 126: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 127: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
-	104, // 128: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
-	105, // 129: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
-	4,   // 130: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
-	142, // 131: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
-	142, // 132: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
-	142, // 133: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
-	109, // 134: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
-	142, // 135: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
-	142, // 136: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
-	142, // 137: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
-	142, // 138: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
-	142, // 139: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
-	112, // 140: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
-	116, // 141: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
-	142, // 142: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
-	119, // 143: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
-	142, // 144: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
-	122, // 145: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
-	142, // 146: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
-	142, // 147: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
-	4,   // 148: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
-	142, // 149: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
-	142, // 150: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
-	127, // 151: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	142, // 152: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	142, // 153: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	3,   // 154: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	142, // 155: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	5,   // 156: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
-	142, // 157: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	142, // 158: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	142, // 159: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	97,  // 160: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	93,  // 161: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	95,  // 162: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	101, // 163: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	103, // 164: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	107, // 165: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	118, // 166: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	115, // 167: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	110, // 168: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	124, // 169: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	121, // 170: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	129, // 171: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	131, // 172: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	133, // 173: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	126, // 174: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
-	142, // 175: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 176: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 177: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	142, // 178: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 179: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	142, // 180: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	142, // 181: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	182, // [182:182] is the sub-list for method output_type
-	182, // [182:182] is the sub-list for method input_type
-	182, // [182:182] is the sub-list for extension type_name
-	182, // [182:182] is the sub-list for extension extendee
-	0,   // [0:182] is the sub-list for field type_name
+	107, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
+	109, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
+	114, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
+	118, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
+	121, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
+	124, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
+	126, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
+	128, // 19: aggregator.AwaitNode.config:type_name -> aggregator.AwaitNode.Config
+	131, // 20: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
+	133, // 21: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
+	18,  // 22: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
+	19,  // 23: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
+	20,  // 24: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
+	21,  // 25: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
+	22,  // 26: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
+	23,  // 27: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
+	135, // 28: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
+	1,   // 29: aggregator.TaskNode.type:type_name -> aggregator.NodeType
+	18,  // 30: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
+	19,  // 31: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
+	20,  // 32: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
+	21,  // 33: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
+	22,  // 34: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
+	26,  // 35: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
+	27,  // 36: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
+	28,  // 37: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
+	23,  // 38: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
+	24,  // 39: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
+	25,  // 40: aggregator.TaskNode.await:type_name -> aggregator.AwaitNode
+	7,   // 41: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
+	86,  // 42: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
+	88,  // 43: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
+	89,  // 44: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
+	137, // 45: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
+	6,   // 46: aggregator.Task.status:type_name -> aggregator.TaskStatus
+	17,  // 47: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 48: aggregator.Task.nodes:type_name -> aggregator.TaskNode
+	29,  // 49: aggregator.Task.edges:type_name -> aggregator.TaskEdge
+	138, // 50: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
+	17,  // 51: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 52: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 53: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
+	139, // 54: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
+	38,  // 55: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
+	32,  // 56: aggregator.ListTasksResp.items:type_name -> aggregator.Task
+	57,  // 57: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
+	31,  // 58: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
+	57,  // 59: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
+	7,   // 60: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
+	0,   // 61: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
+	98,  // 62: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 63: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 64: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 65: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 66: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	140, // 67: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
+	7,   // 68: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
+	137, // 69: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
+	58,  // 70: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
+	57,  // 71: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
+	30,  // 72: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
+	141, // 73: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	76,  // 74: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
+	145, // 75: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
+	145, // 76: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 77: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
+	108, // 78: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 79: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 80: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 81: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 82: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 83: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 84: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
+	134, // 85: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
+	136, // 86: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
+	127, // 87: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
+	17,  // 88: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
+	142, // 89: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
+	145, // 90: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
+	145, // 91: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 92: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
+	98,  // 93: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 94: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 95: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 96: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 97: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	17,  // 98: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 99: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 100: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
+	143, // 101: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
+	17,  // 102: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
+	30,  // 103: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
+	29,  // 104: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
+	144, // 105: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
+	82,  // 106: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
+	84,  // 107: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
+	82,  // 108: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
+	82,  // 109: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
+	82,  // 110: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
+	86,  // 111: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
+	86,  // 112: aggregator.ValueFee.fee:type_name -> aggregator.Fee
+	2,   // 113: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
+	86,  // 114: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
+	5,   // 115: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
+	87,  // 116: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
+	86,  // 117: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
+	88,  // 118: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
+	89,  // 119: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
+	90,  // 120: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
+	145, // 121: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 122: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 123: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 124: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
+	92,  // 125: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
+	100, // 126: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
+	99,  // 127: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
+	145, // 128: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 129: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
+	105, // 130: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
+	106, // 131: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
+	4,   // 132: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
+	145, // 133: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
+	145, // 134: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
+	145, // 135: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
+	110, // 136: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
+	145, // 137: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
+	145, // 138: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
+	145, // 139: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
+	145, // 140: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
+	145, // 141: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
+	113, // 142: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
+	117, // 143: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
+	145, // 144: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
+	120, // 145: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
+	145, // 146: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
+	123, // 147: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
+	145, // 148: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
+	145, // 149: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
+	4,   // 150: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
+	145, // 151: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
+	145, // 152: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
+	145, // 153: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
+	130, // 154: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	145, // 155: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	145, // 156: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	3,   // 157: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	145, // 158: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	5,   // 159: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
+	145, // 160: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	145, // 161: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	145, // 162: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	98,  // 163: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 164: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 165: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 166: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 167: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	108, // 168: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 169: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 170: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 171: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 172: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 173: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 174: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	134, // 175: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	136, // 176: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	127, // 177: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
+	145, // 178: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 179: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 180: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 181: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 182: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 183: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 184: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	185, // [185:185] is the sub-list for method output_type
+	185, // [185:185] is the sub-list for method input_type
+	185, // [185:185] is the sub-list for extension type_name
+	185, // [185:185] is the sub-list for extension extendee
+	0,   // [0:185] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }
@@ -10969,7 +11168,7 @@ func file_avs_proto_init() {
 		(*TaskTrigger_Block)(nil),
 		(*TaskTrigger_Event)(nil),
 	}
-	file_avs_proto_msgTypes[19].OneofWrappers = []any{
+	file_avs_proto_msgTypes[20].OneofWrappers = []any{
 		(*LoopNode_EthTransfer)(nil),
 		(*LoopNode_ContractWrite)(nil),
 		(*LoopNode_ContractRead)(nil),
@@ -10977,7 +11176,7 @@ func file_avs_proto_init() {
 		(*LoopNode_RestApi)(nil),
 		(*LoopNode_CustomCode)(nil),
 	}
-	file_avs_proto_msgTypes[21].OneofWrappers = []any{
+	file_avs_proto_msgTypes[22].OneofWrappers = []any{
 		(*TaskNode_EthTransfer)(nil),
 		(*TaskNode_ContractWrite)(nil),
 		(*TaskNode_ContractRead)(nil),
@@ -10988,17 +11187,18 @@ func file_avs_proto_init() {
 		(*TaskNode_Loop)(nil),
 		(*TaskNode_CustomCode)(nil),
 		(*TaskNode_Balance)(nil),
+		(*TaskNode_Await)(nil),
 	}
-	file_avs_proto_msgTypes[44].OneofWrappers = []any{
+	file_avs_proto_msgTypes[45].OneofWrappers = []any{
 		(*TriggerTaskReq_BlockTrigger)(nil),
 		(*TriggerTaskReq_FixedTimeTrigger)(nil),
 		(*TriggerTaskReq_CronTrigger)(nil),
 		(*TriggerTaskReq_EventTrigger)(nil),
 		(*TriggerTaskReq_ManualTrigger)(nil),
 	}
-	file_avs_proto_msgTypes[45].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[67].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[68].OneofWrappers = []any{
+	file_avs_proto_msgTypes[46].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[68].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[69].OneofWrappers = []any{
 		(*RunNodeWithInputsResp_EthTransfer)(nil),
 		(*RunNodeWithInputsResp_Graphql)(nil),
 		(*RunNodeWithInputsResp_ContractRead)(nil),
@@ -11010,22 +11210,22 @@ func file_avs_proto_init() {
 		(*RunNodeWithInputsResp_Loop)(nil),
 		(*RunNodeWithInputsResp_Balance)(nil),
 	}
-	file_avs_proto_msgTypes[70].OneofWrappers = []any{
+	file_avs_proto_msgTypes[71].OneofWrappers = []any{
 		(*RunTriggerResp_BlockTrigger)(nil),
 		(*RunTriggerResp_FixedTimeTrigger)(nil),
 		(*RunTriggerResp_CronTrigger)(nil),
 		(*RunTriggerResp_EventTrigger)(nil),
 		(*RunTriggerResp_ManualTrigger)(nil),
 	}
-	file_avs_proto_msgTypes[90].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[91].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[92].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[100].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[93].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[101].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[103].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[102].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[104].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[112].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[126].OneofWrappers = []any{
+	file_avs_proto_msgTypes[105].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[113].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[129].OneofWrappers = []any{
 		(*Execution_Step_BlockTrigger)(nil),
 		(*Execution_Step_FixedTimeTrigger)(nil),
 		(*Execution_Step_CronTrigger)(nil),
@@ -11048,7 +11248,7 @@ func file_avs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_avs_proto_rawDesc), len(file_avs_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   134,
+			NumMessages:   137,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -1549,10 +1549,11 @@ func (x *BalanceNode) GetConfig() *BalanceNode_Config {
 	return nil
 }
 
-// AwaitNode pauses the workflow until a signal arrives (durable execution — see
-// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
-// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
-// (cross-chain Await) and timer wakes follow.
+// AwaitNode pauses the workflow until a wake arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). Two mutually-exclusive flavors: external-signal (human
+// approval — the gateway delivers an approve/reject, e.g. from Telegram) and
+// chain-event (cross-chain Await — an operator observes an on-chain event). Timer
+// wakes follow.
 type AwaitNode struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Config        *AwaitNode_Config      `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -9029,13 +9029,19 @@ func (x *BalanceNode_Output) GetData() *structpb.Value {
 
 type AwaitNode_Config struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// External-signal wake parameters.
+	// External-signal wake parameters (human-approval flavor). Used when chain_event
+	// is unset.
 	Channel        string   `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`                                      // "telegram" | "api"
 	Approvers      []string `protobuf:"bytes,2,rep,name=approvers,proto3" json:"approvers,omitempty"`                                  // authorized parties; empty ⇒ the workflow owner
 	Prompt         string   `protobuf:"bytes,3,opt,name=prompt,proto3" json:"prompt,omitempty"`                                        // shown to the approver
 	TimeoutSeconds uint32   `protobuf:"varint,4,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"` // safety bound; 0 ⇒ server default (never an unbounded wait)
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Chain-event wake (cross-chain flavor). When set, the Await pauses until an
+	// operator covering chain_event.chain_id observes this event — a mid-workflow
+	// EventTrigger (e.g. a bridge arrival on chain B). Reuses the event-trigger
+	// machinery; mutually exclusive with the external-signal fields above.
+	ChainEvent    *EventTrigger_Config `protobuf:"bytes,5,opt,name=chain_event,json=chainEvent,proto3" json:"chain_event,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AwaitNode_Config) Reset() {
@@ -9094,6 +9100,13 @@ func (x *AwaitNode_Config) GetTimeoutSeconds() uint32 {
 		return x.TimeoutSeconds
 	}
 	return 0
+}
+
+func (x *AwaitNode_Config) GetChainEvent() *EventTrigger_Config {
+	if x != nil {
+		return x.ChainEvent
+	}
+	return nil
 }
 
 type AwaitNode_Output struct {
@@ -10161,14 +10174,16 @@ const file_avs_proto_rawDesc = "" +
 	"\x13min_usd_value_cents\x18\x05 \x01(\x03R\x10minUsdValueCents\x12'\n" +
 	"\x0ftoken_addresses\x18\x06 \x03(\tR\x0etokenAddresses\x1a4\n" +
 	"\x06Output\x12*\n" +
-	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xfb\x01\n" +
+	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\xbd\x02\n" +
 	"\tAwaitNode\x124\n" +
-	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x1a\x81\x01\n" +
+	"\x06config\x18\x01 \x01(\v2\x1c.aggregator.AwaitNode.ConfigR\x06config\x1a\xc3\x01\n" +
 	"\x06Config\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1c\n" +
 	"\tapprovers\x18\x02 \x03(\tR\tapprovers\x12\x16\n" +
 	"\x06prompt\x18\x03 \x01(\tR\x06prompt\x12'\n" +
-	"\x0ftimeout_seconds\x18\x04 \x01(\rR\x0etimeoutSeconds\x1a4\n" +
+	"\x0ftimeout_seconds\x18\x04 \x01(\rR\x0etimeoutSeconds\x12@\n" +
+	"\vchain_event\x18\x05 \x01(\v2\x1f.aggregator.EventTrigger.ConfigR\n" +
+	"chainEvent\x1a4\n" +
 	"\x06Output\x12*\n" +
 	"\x04data\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x04data\"\x96\x02\n" +
 	"\n" +
@@ -11117,43 +11132,44 @@ var file_avs_proto_depIdxs = []int32{
 	4,   // 150: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
 	145, // 151: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
 	145, // 152: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
-	145, // 153: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
-	130, // 154: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	145, // 155: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	145, // 156: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	3,   // 157: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	145, // 158: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	5,   // 159: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
-	145, // 160: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	145, // 161: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	145, // 162: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	98,  // 163: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	94,  // 164: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	96,  // 165: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	102, // 166: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	104, // 167: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	108, // 168: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	119, // 169: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	116, // 170: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	111, // 171: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	125, // 172: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	122, // 173: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	132, // 174: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	134, // 175: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	136, // 176: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	127, // 177: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
-	145, // 178: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 179: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 180: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	145, // 181: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 182: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	145, // 183: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	145, // 184: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	185, // [185:185] is the sub-list for method output_type
-	185, // [185:185] is the sub-list for method input_type
-	185, // [185:185] is the sub-list for extension type_name
-	185, // [185:185] is the sub-list for extension extendee
-	0,   // [0:185] is the sub-list for field type_name
+	101, // 153: aggregator.AwaitNode.Config.chain_event:type_name -> aggregator.EventTrigger.Config
+	145, // 154: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
+	130, // 155: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	145, // 156: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	145, // 157: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	3,   // 158: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	145, // 159: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	5,   // 160: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
+	145, // 161: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	145, // 162: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	145, // 163: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	98,  // 164: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	94,  // 165: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	96,  // 166: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	102, // 167: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	104, // 168: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	108, // 169: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	119, // 170: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	116, // 171: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	111, // 172: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	125, // 173: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	122, // 174: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	132, // 175: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	134, // 176: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	136, // 177: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	127, // 178: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
+	145, // 179: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 180: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 181: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 182: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 183: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	145, // 184: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	145, // 185: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	186, // [186:186] is the sub-list for method output_type
+	186, // [186:186] is the sub-list for method input_type
+	186, // [186:186] is the sub-list for extension type_name
+	186, // [186:186] is the sub-list for extension extendee
+	0,   // [0:186] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -34,6 +34,7 @@ enum NodeType {
   NODE_TYPE_FILTER = 8;          // Filter node
   NODE_TYPE_LOOP = 9;            // Loop node
   NODE_TYPE_BALANCE = 10;        // Balance node for retrieving wallet token balances
+  NODE_TYPE_AWAIT = 11;          // Suspendable node: pause until a signal arrives (durable execution)
 }
 
 // ExecutionTier defines value-capture pricing groups for on-chain execution nodes.
@@ -584,7 +585,26 @@ message BalanceNode {
     google.protobuf.Value data = 1;
   }
 
-  // Include Config as field 
+  // Include Config as field
+  Config config = 1;
+}
+
+// AwaitNode pauses the workflow until a signal arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
+// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
+// (cross-chain Await) and timer wakes follow.
+message AwaitNode {
+  message Config {
+    // External-signal wake parameters.
+    string channel = 1;             // "telegram" | "api"
+    repeated string approvers = 2;  // authorized parties; empty ⇒ the workflow owner
+    string prompt = 3;              // shown to the approver
+    uint32 timeout_seconds = 4;     // safety bound; 0 ⇒ server default (never an unbounded wait)
+  }
+  message Output {
+    // The delivered signal (decision + payload), readable by downstream steps.
+    google.protobuf.Value data = 1;
+  }
   Config config = 1;
 }
 
@@ -707,6 +727,8 @@ message TaskNode {
     CustomCodeNode    custom_code = 18;
     // Get token balances for a wallet address
     BalanceNode       balance = 19;
+    // Pause until a signal arrives (durable execution)
+    AwaitNode         await = 20;
   }
 }
 

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -595,11 +595,17 @@ message BalanceNode {
 // (cross-chain Await) and timer wakes follow.
 message AwaitNode {
   message Config {
-    // External-signal wake parameters.
+    // External-signal wake parameters (human-approval flavor). Used when chain_event
+    // is unset.
     string channel = 1;             // "telegram" | "api"
     repeated string approvers = 2;  // authorized parties; empty ⇒ the workflow owner
     string prompt = 3;              // shown to the approver
     uint32 timeout_seconds = 4;     // safety bound; 0 ⇒ server default (never an unbounded wait)
+    // Chain-event wake (cross-chain flavor). When set, the Await pauses until an
+    // operator covering chain_event.chain_id observes this event — a mid-workflow
+    // EventTrigger (e.g. a bridge arrival on chain B). Reuses the event-trigger
+    // machinery; mutually exclusive with the external-signal fields above.
+    EventTrigger.Config chain_event = 5;
   }
   message Output {
     // The delivered signal (decision + payload), readable by downstream steps.

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -589,10 +589,11 @@ message BalanceNode {
   Config config = 1;
 }
 
-// AwaitNode pauses the workflow until a signal arrives (durable execution — see
-// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
-// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
-// (cross-chain Await) and timer wakes follow.
+// AwaitNode pauses the workflow until a wake arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). Two mutually-exclusive flavors: external-signal (human
+// approval — the gateway delivers an approve/reject, e.g. from Telegram) and
+// chain-event (cross-chain Await — an operator observes an on-chain event). Timer
+// wakes follow.
 message AwaitNode {
   message Config {
     // External-signal wake parameters (human-approval flavor). Used when chain_event

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -370,6 +370,9 @@ enum ExecutionStatus {
   reserved 4;
   reserved "EXECUTION_STATUS_PARTIAL_SUCCESS";
   EXECUTION_STATUS_ERROR = 5;
+  // Durable execution: the execution is suspended mid-workflow, waiting for a
+  // signal (chain event, external approval, or timer) to advance. Non-terminal.
+  EXECUTION_STATUS_WAITING = 6;
 }
 
 
@@ -723,6 +726,13 @@ message Execution {
   Fee execution_fee = 7;            // Flat platform fee charged {amount, unit: "USD"}
   repeated NodeCOGS cogs = 9;      // Per-node actual gas/API costs {fee: {amount, unit: "WEI"}}
   ValueFee value_fee = 10;         // Value-capture fee charged (post-paid) {fee: {amount, unit: "PERCENTAGE"}}
+
+  // Durable execution (suspend/resume). Set only while status == WAITING; cleared
+  // on resume to a terminal status. The accumulated `steps` above carry each
+  // completed step's output, so they are the resumable state — these fields just
+  // mark where/why the execution is parked.
+  string resume_node_id = 11;  // the suspended step; execution resumes at its successors
+  string wait_reason    = 12;  // debug/human label for why it is waiting
 
   message Step {
     string id = 1;


### PR DESCRIPTION
Promotes `staging` → `main`. Headline: the **durable execution engine** — workflows can now pause mid-execution and resume later, exactly-once, surviving aggregator restarts.

## Storage / migration
`make storage-check` vs `origin/main`: **✅ no breaking storage changes** (additive-only — new `ckpt:`/`wake:` keys, additive proto fields, reserved enum slots). No migration required.

## What's in this release

### Durable execution engine (the feature)
A new `await` node parks a workflow until a wake arrives, then resumes against the same smart wallet — built incrementally across:
- **#643** — durable core: re-entrant Kahn scheduler with dry-replay resume, vars snapshot/restore (secrets excluded), wake registry.
- **#644** — the suspend → checkpoint → `Advance()` → finalize cycle (checkpoint-based, not replay — on-chain side effects never re-run).
- **#645** — the `Await` node + signal intake + full OpenAPI/REST surface.
- **#646** — the **human-approval transport**: `POST /executions/{id}:signal` (owner-auth), so a Telegram bot / API client approves or rejects a money-moving step.
- **#647** — the **cross-chain wake**: an `Await` can pause until an operator observes an on-chain event (e.g. a bridge arrival), reusing the existing event-trigger machinery; plus hardening (create-time operator-coverage validation, operator deregistration, timeout sweep).
- **#648** — surface `WAITING` over REST (was masked as `pending` on `:getStatus`/`:stream`/`:trigger`); collapsed three duplicate status mappers into one with a drift-guard test.

Both wake sources — **human approval** and **chain event** — work end-to-end, exactly-once, restart-durable.

### Docs
- `PLAN_DURABLE_EXECUTION.md` (design-of-record) + `PLAN_CROSS_CHAIN_SEQUENCING.md` (appendices).
- `SDK_HANDOFF_DURABLE_EXECUTION.md` — as-built contract for the ava-sdk-js team.
- Chain-decoupling description cleanups (stale workflow-level/loop-inherited chainId, ChainIdQuery).

## API surface (additive)
- New node type `await` (`AwaitNodeConfig`: external-signal `channel`/`approvers`/`prompt` **or** `chainEvent`; `timeoutSeconds`).
- New op `POST /executions/{id}:signal` (`SignalExecutionRequest`).
- `ExecutionStatus` enum gains `waiting` (non-terminal).

**SDK note:** the spec is published from `main` after this merges — ava-sdk-js should re-run `openapi-download` + `types-gen` to pick up `AwaitNode`, `signalExecution`, and the `waiting` status. See `SDK_HANDOFF_DURABLE_EXECUTION.md`.

## Verification
Per-PR review (Copilot + a thorough human re-review on #648), all green. taskengine + aggregator suites pass; storage-check clean.
