### PR TITLE
fix: durable-exec review follow-ups — checkpoint atomicity, branch resume, await validation

### DIFF
--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1787,6 +1787,12 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		return nil, err
 	}
 
+	// Reject an Await with an invalid config (the two flavors are mutually exclusive;
+	// exactly one is required) before it can persist and fail only at execution time.
+	if err := n.validateAwaitConfigs(task); err != nil {
+		return nil, err
+	}
+
 	// Reject a chain-event Await whose chain no operator currently covers — a wait
 	// that nothing could ever fire would never resume.
 	if err := n.validateAwaitOperatorCoverage(task); err != nil {

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -676,9 +676,9 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 		runTaskErr = vm.Run()
 	}
 
-	// Durable execution: a Suspendable step (Await / HumanApproval) may have paused
-	// the run. Checkpoint and return WAITING instead of finalizing. Inert today — no
-	// current node calls requestSuspend, so PendingSuspend is always nil.
+	// Durable execution: an Await node may have paused the run via requestSuspend.
+	// Checkpoint and return WAITING instead of finalizing; the execution resumes later
+	// via DeliverSignal/Advance (human approval) or an operator chain-event wake.
 	if susp := vm.PendingSuspend(); susp != nil {
 		return x.checkpointSuspendedExecution(task, execution, vm, susp)
 	}
@@ -836,25 +836,34 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	if err := persistCheckpoint(x.db, execution.Id, snapshot); err != nil {
 		return nil, fmt.Errorf("persist checkpoint: %w", err)
 	}
-	// 2. Armed markers: the wake subscription...
+	// 2. Armed markers — the wake subscription AND the WAITING execution record are
+	//    written ATOMICALLY in one batch. As separate writes, a crash between them
+	//    could leave a wake pointing at an execution that was never persisted: the
+	//    internal-trigger sync would then watch and fire a wake that can never resume.
+	//    (The checkpoint above stays a separate prior write — it's resume data with no
+	//    wake referencing it, so a partial write is an inert orphan.)
+	batch := map[string][]byte{}
 	if susp.Wake != nil {
 		// Bind the wake to its task so a chain-event notify / boot re-arm can resolve
 		// the task (executions are stored task-scoped; no global exec→task index).
 		susp.Wake.TaskID = task.Id
-		if err := persistWakeSubscription(x.db, execution.Id, susp.Wake); err != nil {
-			return nil, fmt.Errorf("persist wake: %w", err)
+		if err := susp.Wake.Validate(); err != nil {
+			return nil, fmt.Errorf("validate wake: %w", err)
 		}
+		wakeBytes, err := marshalWake(susp.Wake)
+		if err != nil {
+			return nil, fmt.Errorf("marshal wake: %w", err)
+		}
+		batch[string(wakeSubscriptionKey(execution.Id))] = wakeBytes
 	}
-	// ...and the WAITING execution record.
 	mo := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
 	execBytes, err := mo.Marshal(execution)
 	if err != nil {
 		return nil, fmt.Errorf("marshal suspended execution: %w", err)
 	}
-	if err := x.db.BatchWrite(map[string][]byte{
-		string(TaskExecutionKey(task, execution.Id)): execBytes,
-	}); err != nil {
-		return nil, fmt.Errorf("persist suspended execution: %w", err)
+	batch[string(TaskExecutionKey(task, execution.Id))] = execBytes
+	if err := x.db.BatchWrite(batch); err != nil {
+		return nil, fmt.Errorf("persist suspended execution + wake: %w", err)
 	}
 
 	if x.logger != nil {

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -40,6 +40,43 @@ func (n *Engine) validateAwaitOperatorCoverage(task *model.Workflow) error {
 	return nil
 }
 
+// validateAwaitConfigs rejects, at create time, an Await node with an invalid config:
+// the external-signal flavor (a channel) and the chain-event flavor are mutually
+// exclusive, and exactly one must be set (an external-signal Await requires a channel).
+// Without this an invalid Await would persist and only fail later at execution in
+// runAwait / WakeSubscription.Validate. Runs in every mode (it's a config error, not a
+// coverage condition).
+func (n *Engine) validateAwaitConfigs(task *model.Workflow) error {
+	if task == nil {
+		return nil
+	}
+	for _, node := range task.Nodes {
+		await := node.GetAwait()
+		if await == nil {
+			continue
+		}
+		cfg := await.GetConfig()
+		if cfg == nil {
+			return status.Errorf(codes.InvalidArgument, "await node %s has no config", node.GetId())
+		}
+		hasChainEvent := cfg.GetChainEvent() != nil
+		hasExternalFields := cfg.GetChannel() != "" || len(cfg.GetApprovers()) > 0 || cfg.GetPrompt() != ""
+		if hasChainEvent && hasExternalFields {
+			return status.Errorf(codes.InvalidArgument,
+				"await node %s sets both an external-signal field and chain_event; they are mutually exclusive", node.GetId())
+		}
+		if hasChainEvent {
+			continue // chain-event flavor is valid
+		}
+		// External-signal flavor — channel is required (approvers/prompt alone is invalid).
+		if cfg.GetChannel() == "" {
+			return status.Errorf(codes.InvalidArgument,
+				"await node %s requires either an external-signal 'channel' or 'chain_event'", node.GetId())
+		}
+	}
+	return nil
+}
+
 // deregisterInternalTrigger tells operators to stop watching a consumed internal
 // trigger (the wake it stood for is gone). If the execution re-suspended on a new
 // chain-event wake, the next sync re-registers it (DeleteTask also untracks it).
@@ -126,6 +163,17 @@ func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
 	out := make([]*model.Workflow, 0, len(wakes))
 	for executionID, wake := range wakes {
 		if wake.Kind != WakeChainEvent || wake.ChainEvent == nil {
+			continue
+		}
+		// GC a wake whose workflow has been deleted (e.g. DELETE /workflows/{id})
+		// instead of streaming an internal trigger that can never resume — otherwise
+		// operators keep watching it until the timeout sweep eventually clears it.
+		// NotFound only; a transient/corrupt error preserves the state for recovery.
+		if _, err := n.GetWorkflowByID(wake.TaskID); err != nil {
+			if status.Code(err) == codes.NotFound {
+				_ = deleteCheckpoint(n.db, executionID)
+				_ = deleteWakeSubscription(n.db, executionID)
+			}
 			continue
 		}
 		id := internalTriggerTaskID(executionID)

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1062,6 +1062,18 @@ func (v *VM) runKahnScheduler() error {
 			seedQueue = append(seedQueue, nodeID)
 		}
 	}
+	// On resume, a branch-target node that already ran in a prior leg must also be
+	// fast-forwarded so its completion propagates to its successors — the Branch
+	// runtime (which is what normally schedules a target) does not re-run on resume,
+	// and the phantom predCount keeps the target from ever reaching the queue via the
+	// predCount path. Without this, a completed Branch-before-Await prefix would leave
+	// the await's successors permanently unschedulable. Fresh runs have empty
+	// `completed`, so this adds nothing there.
+	for nodeID := range completed {
+		if branchTargets[nodeID] {
+			seedQueue = append(seedQueue, nodeID)
+		}
+	}
 	seedVisited := make(map[string]bool)
 	for len(seedQueue) > 0 {
 		nodeID := seedQueue[0]

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -570,6 +570,112 @@ func TestValidateAwaitOperatorCoverage(t *testing.T) {
 	require.NoError(t, n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{Channel: "telegram"})))
 }
 
+// TestAwaitNode_ResumeThroughBranchTarget guards the resume scheduler: when the
+// completed prefix runs through a Branch-selected node before the Await, that branch
+// target must be fast-forwarded on resume so the Await's successors become schedulable.
+// Without the fix the workflow resumes to a dead frontier and ccAfter never runs.
+func TestAwaitNode_ResumeThroughBranchTarget(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	branch := &avsproto.TaskNode{
+		Id: "br", Name: "br",
+		TaskType: &avsproto.TaskNode_Branch{Branch: &avsproto.BranchNode{
+			Config: &avsproto.BranchNode_Config{
+				Conditions: []*avsproto.BranchNode_Condition{{Id: "a1", Type: "if", Expression: "true"}},
+			},
+		}},
+	}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "branch-await-wf", Trigger: trigger,
+		Nodes: []*avsproto.TaskNode{branch, customCodeNode("ccTarget"), await, customCodeNode("ccAfter")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "br"},
+			{Id: "e1", Source: "br.a1", Target: "ccTarget"}, // branch-condition edge → branch target
+			{Id: "e2", Source: "ccTarget", Target: "wait"},
+			{Id: "e3", Source: "wait", Target: "ccAfter"},
+		},
+	}}
+
+	// Leg 1 — branch selects ccTarget, it runs, the Await suspends.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	require.NotNil(t, vm1.PendingSuspend(), "suspended at the Await")
+	assert.Contains(t, executedNodeIDs(vm1), "ccTarget", "the branch target ran in leg 1")
+
+	const execID = "exec-branch-await"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+
+	// Leg 2 — resume; ccAfter (downstream of the Await, past the completed branch target) must run.
+	payload, err := structpb.NewValue(map[string]any{"decision": "approve"})
+	require.NoError(t, err)
+	out, err := executor.DeliverSignal(task, &Signal{ExecutionID: execID, Kind: WakeExternalSignal, Decision: "approve", Payload: payload})
+	require.NoError(t, err)
+	var ids []string
+	for _, s := range out.Steps {
+		ids = append(ids, s.Id)
+	}
+	assert.Contains(t, ids, "ccAfter", "resume must schedule the Await's successor past the completed branch target")
+	assert.NotEqual(t, avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING, out.Status, "resumed to terminal")
+}
+
+// TestValidateAwaitConfigs proves invalid Await configs are rejected at create time
+// (the XOR + required-flavor rule), not deferred to execution.
+func TestValidateAwaitConfigs(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	awaitTask := func(c *avsproto.AwaitNode_Config) *model.Workflow {
+		return &model.Workflow{Task: &avsproto.Task{Nodes: []*avsproto.TaskNode{{
+			Id: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+			TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{Config: c}},
+		}}}}
+	}
+
+	require.NoError(t, n.validateAwaitConfigs(awaitTask(&avsproto.AwaitNode_Config{Channel: "telegram"})), "external-signal valid")
+	require.NoError(t, n.validateAwaitConfigs(awaitTask(&avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453)})), "chain-event valid")
+
+	for _, bad := range []*avsproto.AwaitNode_Config{
+		{Channel: "telegram", ChainEvent: chainEventConfig(8453)}, // both flavors
+		{},                  // neither flavor
+		{Prompt: "approve?"}, // external fields but no channel
+	} {
+		err := n.validateAwaitConfigs(awaitTask(bad))
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	}
+}
+
+// TestPendingChainEventTriggers_GCsOrphanedWake proves a chain-event wake whose
+// workflow was deleted is GC'd (not streamed) at sync time, so operators stop watching
+// promptly instead of waiting for the timeout sweep.
+func TestPendingChainEventTriggers_GCsOrphanedWake(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	require.NoError(t, persistWakeSubscription(db, "exec-orphan", &WakeSubscription{
+		Kind: WakeChainEvent, TaskID: "deleted-wf", ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
+	}))
+	assert.Empty(t, n.pendingChainEventTriggers(), "an orphaned wake (deleted workflow) is not streamed")
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err)
+	assert.Nil(t, wakes["exec-orphan"], "the orphaned wake is GC'd")
+}
+
 // TestInternalTrigger_SyncAndRoute proves the operator-transport seam: a chain-event
 // wake surfaces as a synthetic event-trigger "task" (pendingChainEventTriggers) that
 // the operator sync streams, and an internal-trigger id round-trips so the notify
@@ -588,9 +694,13 @@ func TestInternalTrigger_SyncAndRoute(t *testing.T) {
 	_, ok = parseInternalTriggerTaskID("01HZY8M0000000000000000000")
 	assert.False(t, ok, "a normal task id is not an internal trigger")
 
+	// A real workflow backs the wake — pendingChainEventTriggers GCs wakes whose task is gone.
+	created, err := n.CreateWorkflow(testutil.TestUser1(), testutil.RestTask())
+	require.NoError(t, err)
+
 	// A persisted chain-event wake surfaces as a synthetic single-shot event trigger.
 	require.NoError(t, persistWakeSubscription(db, execID, &WakeSubscription{
-		Kind: WakeChainEvent, TaskID: "wf-1", ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
+		Kind: WakeChainEvent, TaskID: created.Id, ChainEvent: chainEventConfig(8453), TimeoutAt: 1 << 40,
 	}))
 	// An external-signal wake must NOT surface (it's not operator-watched).
 	require.NoError(t, persistWakeSubscription(db, "exec-ext-1", &WakeSubscription{

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -1549,10 +1549,11 @@ func (x *BalanceNode) GetConfig() *BalanceNode_Config {
 	return nil
 }
 
-// AwaitNode pauses the workflow until a signal arrives (durable execution — see
-// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
-// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
-// (cross-chain Await) and timer wakes follow.
+// AwaitNode pauses the workflow until a wake arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). Two mutually-exclusive flavors: external-signal (human
+// approval — the gateway delivers an approve/reject, e.g. from Telegram) and
+// chain-event (cross-chain Await — an operator observes an on-chain event). Timer
+// wakes follow.
 type AwaitNode struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Config        *AwaitNode_Config      `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -589,10 +589,11 @@ message BalanceNode {
   Config config = 1;
 }
 
-// AwaitNode pauses the workflow until a signal arrives (durable execution — see
-// PLAN_DURABLE_EXECUTION.md). v1 ships the external-signal flavor (human approval:
-// the gateway delivers an approve/reject, e.g. from Telegram). chain-event
-// (cross-chain Await) and timer wakes follow.
+// AwaitNode pauses the workflow until a wake arrives (durable execution — see
+// PLAN_DURABLE_EXECUTION.md). Two mutually-exclusive flavors: external-signal (human
+// approval — the gateway delivers an approve/reject, e.g. from Telegram) and
+// chain-event (cross-chain Await — an operator observes an on-chain event). Timer
+// wakes follow.
 message AwaitNode {
   message Config {
     // External-signal wake parameters (human-approval flavor). Used when chain_event


### PR DESCRIPTION
Addresses all **6 Copilot findings** from the release PR #649 review, on staging so #649 promotes clean.

| # | Fix |
|---|---|
| 2 | **checkpoint atomicity** — wake + WAITING exec written in one BatchWrite (a crash between separate writes could orphan a wake watching an unpersisted exec) |
| 3 | **branch resume** — fast-forward a *completed* branch-target on resume; a Branch-before-Await prefix previously left the await’s successors unschedulable (regression test proves it) |
| 4 | **create validation** — `validateAwaitConfigs` rejects an invalid Await (XOR + required flavor) at CreateWorkflow with `InvalidArgument`, not at execution |
| 5 | **orphan GC** — `pendingChainEventTriggers` GCs a chain-event wake whose workflow was deleted instead of streaming an unresumable trigger |
| 1, 6 | stale comments (executor suspend-path, AwaitNode proto) |

New tests: `TestAwaitNode_ResumeThroughBranchTarget` (fails without the #3 fix), `TestValidateAwaitConfigs`, `TestPendingChainEventTriggers_GCsOrphanedWake`. storage-check clean; taskengine + aggregator green (113s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)