### PR TITLE
fix: durable-exec deep-review follow-ups — exactly-once, corrupt-record resilience, MaxExecution

### DIFF
--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -291,7 +291,7 @@ type AwaitNodeType string
 // `chainEvent` to pause until an operator observes that on-chain event, e.g. a
 // bridge arrival on another chain). Exactly one flavor must be configured.
 type AwaitNodeConfig struct {
-	// Approvers External-signal flavor — authorized approver identities. Empty = the workflow owner.
+	// Approvers External-signal flavor — authorized approver identities. Empty = the workflow owner. NOTE (v1): not yet enforced — the signal endpoint authorizes by workflow ownership only, so the owner can always approve regardless of this list. Delegated-approver enforcement (Telegram binding) is a follow-up; do not rely on this field for security yet.
 	Approvers *[]string `json:"approvers,omitempty"`
 
 	// ChainEvent Chain-event flavor — the on-chain event to wait for (a mid-workflow

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -775,7 +775,12 @@ components:
         approvers:
           type: array
           items: { type: string }
-          description: External-signal flavor — authorized approver identities. Empty = the workflow owner.
+          description: >-
+            External-signal flavor — authorized approver identities. Empty = the
+            workflow owner. NOTE (v1): not yet enforced — the signal endpoint
+            authorizes by workflow ownership only, so the owner can always approve
+            regardless of this list. Delegated-approver enforcement (Telegram binding)
+            is a follow-up; do not rely on this field for security yet.
         prompt:
           type: string
           description: External-signal flavor — message shown to the approver.

--- a/core/taskengine/durable.go
+++ b/core/taskengine/durable.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -371,7 +372,7 @@ func persistWakeSubscription(db storage.Storage, execID string, sub *WakeSubscri
 // loadAllWakeSubscriptions scans the registry — the boot re-arm entrypoint. The
 // engine uses the result to re-register chain waits to operators, reload timers,
 // and GC entries whose execution is no longer WAITING.
-func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription, error) {
+func loadAllWakeSubscriptions(db storage.Storage, logger ...sdklogging.Logger) (map[string]*WakeSubscription, error) {
 	items, err := db.GetByPrefix([]byte(wakeSubscriptionPrefix))
 	if err != nil {
 		return nil, err
@@ -379,14 +380,19 @@ func loadAllWakeSubscriptions(db storage.Storage) (map[string]*WakeSubscription,
 	out := make(map[string]*WakeSubscription, len(items))
 	for _, it := range items {
 		execID := strings.TrimPrefix(string(it.Key), wakeSubscriptionPrefix)
-		sub, err := unmarshalWake(it.Value)
-		if err != nil {
-			return nil, fmt.Errorf("load wake %s: %w", execID, err)
+		sub, uErr := unmarshalWake(it.Value)
+		if uErr == nil {
+			// Re-validate on load to catch a partially-written / version-mismatched record.
+			uErr = sub.Validate()
 		}
-		// Re-validate on load: a corrupted or partially-written record gets a clear
-		// error path here rather than surfacing as hard-to-debug behavior later.
-		if err := sub.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid wake %s: %w", execID, err)
+		if uErr != nil {
+			// Skip a corrupt/invalid record — do NOT abort the whole scan. One bad
+			// record must never block every timeout sweep and chain-event re-arm on
+			// each periodic tick (it would silently freeze durable execution).
+			if len(logger) > 0 && logger[0] != nil {
+				logger[0].Error("skipping corrupt wake record", "exec_id", execID, "error", uErr)
+			}
+			continue
 		}
 		out[execID] = sub
 	}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -300,6 +300,29 @@ type Engine struct {
 	pendingNotifications map[string][]PendingNotification // operatorAddr -> list of notifications
 	notificationMutex    *sync.RWMutex
 	notificationTicker   *time.Ticker
+
+	// Per-execution serialization for durable resume (exactly-once). Sharded so a
+	// fixed set of mutexes bounds memory — the same executionID always maps to the
+	// same shard, so concurrent resumes of one execution serialize. See executionMutex.
+	executionMutexes [executionLockShards]sync.Mutex
+}
+
+// executionLockShards bounds the per-execution resume locks to a fixed set of mutexes.
+const executionLockShards = 256
+
+// executionMutex returns the lock guarding resume of executionID. Holding it across
+// the load-status → run → write-terminal sequence makes durable resume exactly-once:
+// a second concurrent signal (two approvers, a duplicate operator notify) blocks, then
+// finds the execution already terminal and no-ops — so an on-chain ContractWrite /
+// ETHTransfer in the resumed leg can never run twice.
+func (n *Engine) executionMutex(executionID string) *sync.Mutex {
+	// FNV-1a — allocation-free, deterministic (same id → same shard).
+	var h uint32 = 2166136261
+	for i := 0; i < len(executionID); i++ {
+		h ^= uint32(executionID[i])
+		h *= 16777619
+	}
+	return &n.executionMutexes[h%executionLockShards]
 }
 
 // create a new task engine using given storage, config and queue
@@ -4350,6 +4373,10 @@ func (n *Engine) SignalExecution(user *model.User, workflowID, executionID, deci
 	if err != nil {
 		return nil, err // GetWorkflow returns codes.NotFound for a missing/non-owned workflow
 	}
+	// Serialize concurrent resumes of this execution (exactly-once — see executionMutex).
+	mu := n.executionMutex(executionID)
+	mu.Lock()
+	defer mu.Unlock()
 	executor := NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
 	exec, err := executor.DeliverSignal(task, &Signal{
 		ExecutionID: executionID,
@@ -4564,6 +4591,10 @@ func (n *Engine) DeleteWorkflowByUser(user *model.User, taskID string) (*avsprot
 			Id:      taskID,
 		}, nil
 	}
+
+	// GC durable state of any suspended (WAITING) execution this task owned, so its
+	// checkpoint/wake — and any operator internal trigger — don't outlive the workflow.
+	n.gcDurableStateForTask(taskID)
 
 	n.logger.Info("📢 Starting operator notifications", "task_id", taskID)
 	n.notifyOperatorsTaskOperation(taskID, avsproto.MessageOp_DeleteTask)

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -862,8 +862,34 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 		return nil, fmt.Errorf("marshal suspended execution: %w", err)
 	}
 	batch[string(TaskExecutionKey(task, execution.Id))] = execBytes
+
+	// Count this run toward MaxExecution at suspend time — a suspended execution is a
+	// run in progress, so the limit must not be bypassed (nor a new execution fire)
+	// while it waits. ExecutionCount was already incremented in RunTask; persist the
+	// task now, in the same atomic batch. The resume in Advance does NOT re-count.
+	initialTaskStatus := task.Status
+	if task.MaxExecution > 0 && task.ExecutionCount >= task.MaxExecution {
+		task.SetCompleted()
+	}
+	if task.ExpiredAt > 0 && time.Now().UnixMilli() >= task.ExpiredAt {
+		task.SetCompleted()
+	}
+	taskJSON, err := task.ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal suspended task: %w", err)
+	}
+	batch[string(WorkflowStorageKey(task.Id, task.Status))] = taskJSON
+	batch[string(TaskUserKey(task))] = []byte(fmt.Sprintf("%d", task.Status))
+
 	if err := x.db.BatchWrite(batch); err != nil {
-		return nil, fmt.Errorf("persist suspended execution + wake: %w", err)
+		return nil, fmt.Errorf("persist suspended execution + wake + task: %w", err)
+	}
+	// If MaxExecution/expiry flipped the task to a terminal status, drop the stale
+	// status-keyed record (mirrors RunTask's normal finalize).
+	if task.Status != initialTaskStatus {
+		if err := x.db.Delete(WorkflowStorageKey(task.Id, initialTaskStatus)); err != nil && x.logger != nil {
+			x.logger.Warn("failed to delete stale task status key after suspend", "task_id", task.Id, "error", err)
+		}
 	}
 
 	if x.logger != nil {
@@ -875,8 +901,17 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 
 // DeliverSignal is the signal-intake entrypoint: a gateway approve/reject endpoint
 // or operator internal-trigger calls this to wake a suspended execution. It
-// validates the signal and advances the execution. (Authorization of the signal
-// against the wait's approvers is a follow-up — see the approval security model.)
+// validates the signal and advances the execution.
+//
+// SECURITY (v1, must close before delegated approval ships): the wake's `Approvers`
+// list is NOT yet enforced — the engine relies on the caller having authorized the
+// signal (SignalExecution gates on workflow ownership, so today only the owner can
+// signal). Consequently the signal `Payload` is owner-trusted; because a downstream
+// node may template `{{await.data.*}}` into JS source, an UNtrusted payload could
+// inject code. That is safe while only the owner (who already controls the workflow
+// source) can signal. When delegated approvers are enforced, the payload must be
+// treated as untrusted data (escaped / passed as a runtime value, not into source).
+// See the approval security model in PLAN_DURABLE_EXECUTION.md.
 func (x *WorkflowExecutor) DeliverSignal(task *model.Workflow, signal *Signal) (*avsproto.Execution, error) {
 	if err := signal.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid signal: %w", err)

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -882,7 +882,8 @@ func (x *WorkflowExecutor) checkpointSuspendedExecution(task *model.Workflow, ex
 	batch[string(TaskUserKey(task))] = []byte(fmt.Sprintf("%d", task.Status))
 
 	if err := x.db.BatchWrite(batch); err != nil {
-		return nil, fmt.Errorf("persist suspended execution + wake + task: %w", err)
+		// The batch always holds the execution + task, and the wake when present.
+		return nil, fmt.Errorf("persist suspended execution state: %w", err)
 	}
 	// If MaxExecution/expiry flipped the task to a terminal status, drop the stale
 	// status-keyed record (mirrors RunTask's normal finalize).

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -55,6 +55,12 @@ func (n *Engine) validateAwaitConfigs(task *model.Workflow) error {
 		if await == nil {
 			continue
 		}
+		// An Await whose name is a reserved system var would, on resume, overwrite that
+		// var (the delivered signal is set under the node's name) — reject it at create.
+		if reservedSystemVarNames[node.GetName()] {
+			return status.Errorf(codes.InvalidArgument,
+				"await node name %q collides with a reserved system variable; rename it", node.GetName())
+		}
 		cfg := await.GetConfig()
 		if cfg == nil {
 			return status.Errorf(codes.InvalidArgument, "await node %s has no config", node.GetId())
@@ -84,11 +90,34 @@ func (n *Engine) deregisterInternalTrigger(executionID string) {
 	n.notifyOperatorsTaskOperation(internalTriggerTaskID(executionID), avsproto.MessageOp_DeleteTask)
 }
 
+// gcDurableStateForTask removes the durable state (checkpoint + wake, plus the operator
+// internal trigger for chain-event waits) of every suspended execution belonging to
+// taskID. Called when a workflow is deleted so a WAITING execution's wake doesn't
+// linger until the timeout sweep — and so external-signal waits (which the sync-time GC
+// never sees) are cleaned up promptly too.
+func (n *Engine) gcDurableStateForTask(taskID string) {
+	wakes, err := loadAllWakeSubscriptions(n.db, n.logger)
+	if err != nil {
+		n.logger.Error("gc durable state for deleted task: load wakes", "task_id", taskID, "error", err)
+		return
+	}
+	for executionID, wake := range wakes {
+		if wake.TaskID != taskID {
+			continue
+		}
+		_ = deleteCheckpoint(n.db, executionID)
+		_ = deleteWakeSubscription(n.db, executionID)
+		if wake.Kind == WakeChainEvent {
+			n.deregisterInternalTrigger(executionID)
+		}
+	}
+}
+
 // sweepExpiredWaits fails WAITING executions whose wake timed out (a stuck bridge, an
 // approver who never responded) and GCs their durable state. Runs on the periodic
 // scan loop, so a wait whose timeout passed while no operator was up still resolves.
 func (n *Engine) sweepExpiredWaits() {
-	wakes, err := loadAllWakeSubscriptions(n.db)
+	wakes, err := loadAllWakeSubscriptions(n.db, n.logger)
 	if err != nil {
 		n.logger.Error("sweep expired waits: load wakes", "error", err)
 		return
@@ -114,8 +143,14 @@ func (n *Engine) sweepExpiredWaits() {
 		if executor == nil {
 			executor = NewExecutor(n.ResolveSmartWalletConfig(n.defaultChainID()), n.db, n.logger, n, n.priceService)
 		}
-		if _, err := executor.ExpireWait(task, executionID); err != nil {
-			n.logger.Error("sweep expired waits: expire", "execution_id", executionID, "error", err)
+		// Serialize against a concurrent resume of the same execution (exactly-once):
+		// a signal landing as the sweep expires must not double-finalize.
+		mu := n.executionMutex(executionID)
+		mu.Lock()
+		_, expireErr := executor.ExpireWait(task, executionID)
+		mu.Unlock()
+		if expireErr != nil {
+			n.logger.Error("sweep expired waits: expire", "execution_id", executionID, "error", expireErr)
 			continue
 		}
 		// Deregistration only applies to chain-event waits (operator-watched triggers).
@@ -155,7 +190,7 @@ func parseInternalTriggerTaskID(taskID string) (executionID string, ok bool) {
 // them with zero new transport. Re-derived from storage on every sync, so a boot or
 // operator reconnect re-arms every live wait for free.
 func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
-	wakes, err := loadAllWakeSubscriptions(n.db)
+	wakes, err := loadAllWakeSubscriptions(n.db, n.logger)
 	if err != nil {
 		n.logger.Error("internal-trigger sync: load wake subscriptions", "error", err)
 		return nil
@@ -200,6 +235,13 @@ func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
 // A duplicate or late fire is a safe no-op — the wake is gone once resumed, and
 // Advance only acts on a still-WAITING execution.
 func (n *Engine) deliverChainEventWake(executionID string, payload *avsproto.NotifyTriggersReq) (*ExecutionState, error) {
+	// Serialize against any other resume of this execution (a duplicate operator notify
+	// or a concurrent external signal) so the load-wake → run sequence is exactly-once.
+	// The gate read below must be inside the lock: the loser then finds no wake and no-ops.
+	mu := n.executionMutex(executionID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	wake, err := loadWakeSubscription(n.db, executionID)
 	if err != nil {
 		// No pending wait — already resumed, timed out, or GC'd. Nothing to do.

--- a/core/taskengine/internal_trigger.go
+++ b/core/taskengine/internal_trigger.go
@@ -208,6 +208,10 @@ func (n *Engine) pendingChainEventTriggers() []*model.Workflow {
 			if status.Code(err) == codes.NotFound {
 				_ = deleteCheckpoint(n.db, executionID)
 				_ = deleteWakeSubscription(n.db, executionID)
+				n.logger.Warn("gc orphaned wake: workflow gone", "execution_id", executionID, "task_id", wake.TaskID)
+			} else {
+				// Transient/corrupt error — preserve the state, but surface it (mirrors sweepExpiredWaits).
+				n.logger.Error("internal-trigger sync: resolve task for wake", "execution_id", executionID, "task_id", wake.TaskID, "error", err)
 			}
 			continue
 		}

--- a/core/taskengine/vm_resume_test.go
+++ b/core/taskengine/vm_resume_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -568,6 +569,123 @@ func TestValidateAwaitOperatorCoverage(t *testing.T) {
 
 	// External-signal Await has no chain → allowed regardless of operators.
 	require.NoError(t, n.validateAwaitOperatorCoverage(awaitNode(&avsproto.AwaitNode_Config{Channel: "telegram"})))
+}
+
+// TestDeliverChainEventWake_ConcurrentExactlyOnce proves the per-execution lock makes
+// resume exactly-once: two concurrent chain-event wakes for the same execution resume
+// it exactly once (the other no-ops), so an on-chain step in the resumed leg can't run
+// twice.
+func TestDeliverChainEventWake_ConcurrentExactlyOnce(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	n := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{ChainEvent: chainEventConfig(8453), TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "concurrent-wf", Trigger: trigger, Status: avsproto.TaskStatus_Enabled,
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await, customCodeNode("cc2")},
+		Edges: []*avsproto.TaskEdge{
+			{Id: "e0", Source: "t", Target: "cc1"}, {Id: "e1", Source: "cc1", Target: "wait"}, {Id: "e2", Source: "wait", Target: "cc2"},
+		},
+	}}
+	// Store the task so GetWorkflowByID resolves it from the wake's TaskID.
+	taskJSON, err := task.ToJSON()
+	require.NoError(t, err)
+	require.NoError(t, db.Set(WorkflowStorageKey(task.Id, avsproto.TaskStatus_Enabled), taskJSON))
+
+	// Build the WAITING execution.
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	require.NotNil(t, vm1.PendingSuspend())
+	const execID = "exec-concurrent"
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: execID, StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+
+	// Fire two concurrent wakes for the same execution.
+	var wg sync.WaitGroup
+	results := make([]string, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			state, _ := n.deliverChainEventWake(execID, &avsproto.NotifyTriggersReq{})
+			if state != nil {
+				results[idx] = state.Status
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	delivered := 0
+	for _, s := range results {
+		if s == "wake_delivered" {
+			delivered++
+		}
+	}
+	assert.Equal(t, 1, delivered, "exactly one concurrent wake resumes the execution; the other no-ops")
+}
+
+// TestLoadAllWakeSubscriptions_SkipsCorrupt proves one corrupt wake record does not
+// abort the whole scan — otherwise a single bad record would freeze every timeout
+// sweep and chain-event re-arm permanently.
+func TestLoadAllWakeSubscriptions_SkipsCorrupt(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	require.NoError(t, persistWakeSubscription(db, "good", &WakeSubscription{
+		Kind: WakeExternalSignal, TaskID: "wf", External: &ExternalSignalSpec{Channel: "telegram"}, TimeoutAt: 1 << 40,
+	}))
+	require.NoError(t, db.Set(wakeSubscriptionKey("bad"), []byte("{not valid json")))
+
+	wakes, err := loadAllWakeSubscriptions(db)
+	require.NoError(t, err, "a corrupt record must not fail the scan")
+	assert.NotNil(t, wakes["good"], "the healthy wake still loads")
+	assert.Nil(t, wakes["bad"], "the corrupt wake is skipped")
+}
+
+// TestCheckpoint_CountsTowardMaxExecution proves a suspended run counts toward
+// MaxExecution at suspend time (the task is completed), so a MaxExecution=1 workflow
+// that suspends does not fire again while it waits.
+func TestCheckpoint_CountsTowardMaxExecution(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	executor := &WorkflowExecutor{db: db, logger: testutil.GetLogger(), smartWalletConfig: &config.SmartWalletConfig{}}
+
+	trigger := &avsproto.TaskTrigger{Id: "t", Name: "t", TriggerType: &avsproto.TaskTrigger_Manual{}}
+	await := &avsproto.TaskNode{
+		Id: "wait", Name: "wait", Type: avsproto.NodeType_NODE_TYPE_AWAIT,
+		TaskType: &avsproto.TaskNode_Await{Await: &avsproto.AwaitNode{
+			Config: &avsproto.AwaitNode_Config{Channel: "telegram", TimeoutSeconds: 3600},
+		}},
+	}
+	task := &model.Workflow{Task: &avsproto.Task{
+		Id: "maxexec-wf", Trigger: trigger,
+		MaxExecution: 1, ExecutionCount: 1, Status: avsproto.TaskStatus_Enabled, // RunTask already incremented the count
+		Nodes: []*avsproto.TaskNode{customCodeNode("cc1"), await},
+		Edges: []*avsproto.TaskEdge{{Id: "e0", Source: "t", Target: "cc1"}, {Id: "e1", Source: "cc1", Target: "wait"}},
+	}}
+
+	vm1, err := NewVMWithData(task, nil, &config.SmartWalletConfig{}, nil)
+	require.NoError(t, err)
+	vm1.WithDb(db).WithLogger(testutil.GetLogger())
+	require.NoError(t, vm1.Compile())
+	require.NoError(t, vm1.Run())
+	require.NotNil(t, vm1.PendingSuspend())
+
+	_, err = executor.checkpointSuspendedExecution(task, &avsproto.Execution{Id: "e1", StartAt: 1}, vm1, vm1.PendingSuspend())
+	require.NoError(t, err)
+	assert.Equal(t, avsproto.TaskStatus_Completed, task.Status,
+		"MaxExecution=1 task is Completed at suspend so it won't fire again while waiting")
 }
 
 // TestAwaitNode_ResumeThroughBranchTarget guards the resume scheduler: when the


### PR DESCRIPTION
Addresses the **6 findings from Claude's deeper review of #649** (the release PR). Stacked on #651 (Copilot fixes) so this PR shows only these changes; retarget to staging once #651 merges.

| # | Sev | Fix |
|---|---|---|
| 1 | HIGH | **exactly-once** — per-execution sharded lock serializes resume (SignalExecution / deliverChainEventWake / sweep); concurrent signals no longer double-run on-chain steps. Proven by a `-race` concurrency test |
| 2 | HIGH | **resilience** — `loadAllWakeSubscriptions` skips a corrupt record instead of aborting (one bad record no longer freezes all sweeps/re-arms) |
| 4 | MED | **MaxExecution** counted at suspend (task persisted in the atomic batch) so a suspended `MaxExecution=1` workflow can't fire again |
| 3 | — | **delete GC** — `DeleteWorkflowByUser` cleans durable state of WAITING executions (incl. external-signal waits) |
| 5,6 | MED | **security caveats** — `Approvers` not-yet-enforced + signal payload owner-trusted (OpenAPI + code) |
| minor | — | reject an Await named a reserved system var |

New tests: `TestDeliverChainEventWake_ConcurrentExactlyOnce` (-race), `TestLoadAllWakeSubscriptions_SkipsCorrupt`, `TestCheckpoint_CountsTowardMaxExecution`. storage-check clean; taskengine + aggregator green (133s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)