### PR TITLE
fix(rest): constrain AwaitNodeConfig.channel to enum [telegram, api]

### DIFF
--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -21,6 +21,12 @@ const (
 	AwaitNodeTypeAwait AwaitNodeType = "await"
 )
 
+// Defines values for AwaitNodeConfigChannel.
+const (
+	Api      AwaitNodeConfigChannel = "api"
+	Telegram AwaitNodeConfigChannel = "telegram"
+)
+
 // Defines values for BalanceNodeType.
 const (
 	Balance BalanceNodeType = "balance"
@@ -300,7 +306,7 @@ type AwaitNodeConfig struct {
 	ChainEvent *EventTriggerConfig `json:"chainEvent,omitempty"`
 
 	// Channel External-signal flavor — signal channel: `telegram` or `api`.
-	Channel *string `json:"channel,omitempty"`
+	Channel *AwaitNodeConfigChannel `json:"channel,omitempty"`
 
 	// Prompt External-signal flavor — message shown to the approver.
 	Prompt *string `json:"prompt,omitempty"`
@@ -308,6 +314,9 @@ type AwaitNodeConfig struct {
 	// TimeoutSeconds Safety bound; 0 = server default (the wait is never unbounded).
 	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
+
+// AwaitNodeConfigChannel External-signal flavor — signal channel: `telegram` or `api`.
+type AwaitNodeConfigChannel string
 
 // BalanceNode defines model for BalanceNode.
 type BalanceNode struct {

--- a/aggregator/rest/mapping/node_test.go
+++ b/aggregator/rest/mapping/node_test.go
@@ -164,7 +164,7 @@ func TestNodeRoundTrip_PerNodeChainId(t *testing.T) {
 // round-trip (OpenAPI → proto → OpenAPI), so the SDK/studio can put it in a workflow.
 func TestNodeRoundTrip_Await(t *testing.T) {
 	typ := generated.AwaitNodeTypeAwait
-	channel := "telegram"
+	channel := generated.Telegram
 	approvers := []string{"0xowner"}
 	prompt := "approve the transfer?"
 	timeout := int64(3600)
@@ -193,7 +193,7 @@ func TestNodeRoundTrip_Await(t *testing.T) {
 	v, err := rt.AsAwaitNode()
 	require.NoError(t, err)
 	require.NotNil(t, v.Config.Channel)
-	assert.Equal(t, "telegram", *v.Config.Channel)
+	assert.Equal(t, generated.Telegram, *v.Config.Channel)
 	require.NotNil(t, v.Config.TimeoutSeconds)
 	assert.Equal(t, int64(3600), *v.Config.TimeoutSeconds)
 }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -771,6 +771,7 @@ components:
       properties:
         channel:
           type: string
+          enum: [telegram, api]
           description: 'External-signal flavor — signal channel: `telegram` or `api`.'
         approvers:
           type: array


### PR DESCRIPTION
## Constrain `AwaitNodeConfig.channel` to `enum: [telegram, api]`

The external-signal `channel` field on `AwaitNodeConfig` was declared `type: string` with the valid values only in prose:

```yaml
channel:
  type: string
  description: 'External-signal flavor — signal channel: `telegram` or `api`.'
```

So `make rest-gen` emitted `Channel *string`, and every generated client (Go + the SDK's `openapi-typescript`) got an unconstrained `string`. A consumer building `AwaitNodeConfig` directly (not via a builder) could pass `"webhook"` and only learn it's invalid from a 400 at the server.

### Fix
Add the enum (mirroring how `SignalExecutionRequest.decision` already does it):

```yaml
channel:
  type: string
  enum: [telegram, api]
```

`make rest-gen` then emits a typed `AwaitNodeConfigChannel` (`Api` / `Telegram`) and `Channel *AwaitNodeConfigChannel`, making the constraint machine-checkable everywhere — and the regenerated SDK type becomes `channel?: "telegram" | "api"` instead of `channel?: string`.

### Changes
- `api/openapi.yaml`: add `enum: [telegram, api]` to `channel`.
- `aggregator/rest/generated/types.gen.go` (regenerated): `Channel *string` → `*AwaitNodeConfigChannel` + the `Api`/`Telegram` consts.
- `aggregator/rest/mapping/node_test.go`: round-trip test uses `generated.Telegram` for the tightened type.

### Verification
- `make rest-gen` clean.
- `go build ./aggregator/rest/... ./core/taskengine/...` — passes (the `.Channel` references in taskengine are on the proto/internal structs, unaffected).
- `go test ./aggregator/rest/...` — green (`TestNodeRoundTrip_Await` updated).

Additive, server-side enforcement already rejected non-`{telegram,api}` values; this just surfaces the constraint in the contract + generated types. Surfaced in @claude's review of [ava-sdk-js#227](https://github.com/AvaProtocol/ava-sdk-js/pull/227).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
