### PR TITLE
ci: move unit test workflow back to GitHub-hosted runners

### DIFF
--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   check-changes:
     name: Check Changed Files
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -78,7 +78,7 @@ jobs:
     name: Lint
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
@@ -122,7 +122,7 @@ jobs:
     name: Unit Test
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Moves the **Run Unit Tests** workflow (`run-test-on-pr.yml`) back to standard GitHub-hosted runners (`ubuntu-latest`), partially reverting the Blacksmith migration from #505 (commit `690bbc0`).

## Why

Almost every job in this workflow finishes in well under a minute:

| Job | Rough duration |
|---|---|
| Check Changed Files | 28s |
| Lint | 31s |
| Unit Test matrix (11 of 13 packages) | 30–53s each |
| Unit Test (pkg/erc4337/preset) | ~3m |
| Unit Test (core/taskengine) | ~4m |

On jobs this short, Blacksmith's faster 4-vCPU hardware has almost no room to cut wall-clock time, but each of the ~15 parallel jobs still bills at the 4-vCPU per-minute rate on every push. Standard 2-core GitHub runners handle these just as well.

The whole workflow uses a single runner type — the matrix is intentionally **not** split across runner types, so the two longer packages (`core/taskengine`, `pkg/erc4337/preset`) move along with the rest.

## What stays on Blacksmith

The Docker image publish workflows (`publish-dev-docker.yml`, `publish-prod-docker.yml`, ~4–5 min builds) remain on `blacksmith-4vcpu-ubuntu-2404`, where the faster hardware genuinely reduces build time. `claude.yml`, `claude-code-review.yml`, `release-on-pr-close.yml`, and `token-catalog-drift.yml` were already on `ubuntu-latest` and are untouched.

## Changes

- `.github/workflows/run-test-on-pr.yml`: `runs-on: blacksmith-4vcpu-ubuntu-2404` → `runs-on: ubuntu-latest` for the `check-changes`, `lint`, and `test` jobs (3 lines)

No Blacksmith-specific actions (e.g. `useblacksmith/setup-go`) are used in this workflow, so the runner label is the only change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un7opV3NNydU4EEHD4pjAV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Un7opV3NNydU4EEHD4pjAV)_