### PR TITLE
fix: parseUnit macro implements ethers parseUnits scaling with fractional support

### DIFF
--- a/core/taskengine/macros/exp.go
+++ b/core/taskengine/macros/exp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -59,7 +60,7 @@ func readContractData(contractAddress string, data string, method string, contra
 }
 
 // QueryContract
-//const taskCondition = `cmp(chainlinkPrice("0x694AA1769357215DE4FAC081bf1f309aDC325306"), parseUnit("262199799820", 8)) > 1`
+//const taskCondition = `cmp(chainlinkPrice("0x694AA1769357215DE4FAC081bf1f309aDC325306"), parseUnit("2621.99", 8)) > 1`
 
 func chainlinkLatestRoundData(tokenPair string) *big.Int {
 	output, err := QueryContract(
@@ -115,22 +116,35 @@ func BigLt(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) < 0
 }
 
-// ParseUnit converts a decimal string into a fixed-point integer scaled by
-// 10^decimals, matching the ethers.js parseUnits(value, decimals) convention.
-// It accepts a fractional component (e.g. ParseUnit("2621.99", 8) == 262199000000),
-// which is what task-condition expressions need to build a price threshold to
-// compare against chainlinkPrice(). A fraction with more digits than `decimals`
-// or a negative value is rejected.
-func ParseUnit(val string, decimal uint) *big.Int {
-	parts := strings.SplitN(val, ".", 2)
+// parseUnitRe matches a non-negative decimal number with an optional fractional
+// part (e.g. "2621", "2621.99", "2621."). Validating the shape up front rejects
+// signs, a leading "+" in the fraction, hex, and other malformed input that
+// big.Int.SetString would otherwise silently accept. A bare ".5" (empty whole
+// part) is intentionally rejected; task thresholds are written with a leading 0.
+var parseUnitRe = regexp.MustCompile(`^[0-9]+(\.[0-9]*)?$`)
 
-	whole, ok := new(big.Int).SetString(parts[0], 10)
-	if !ok {
-		panic(fmt.Errorf("Parse error: %s", val))
+// parseUnitMaxDecimals caps 10^decimals so a user-supplied `decimal` can't force
+// the aggregator/operator to materialize a huge integer. 10^78 ≈ 2^259, beyond
+// anything on-chain needs (uint256 tops out near 10^77).
+const parseUnitMaxDecimals = 78
+
+// ParseUnit converts a non-negative decimal string into a fixed-point integer
+// scaled by 10^decimals, matching the ethers.js parseUnits(value, decimals)
+// convention. It accepts a fractional component (e.g. ParseUnit("2621.99", 8) ==
+// 262199000000), which is what task-condition expressions need to build a price
+// threshold to compare against chainlinkPrice(). Input that is not a non-negative
+// decimal, a fraction with more digits than `decimals` (over-precision), or
+// `decimals` beyond the on-chain range is rejected.
+func ParseUnit(val string, decimal uint) *big.Int {
+	if !parseUnitRe.MatchString(val) {
+		panic(fmt.Errorf("Parse error: %q is not a non-negative decimal number", val))
 	}
-	if whole.Sign() < 0 {
-		panic(fmt.Errorf("Parse error: negative value not supported: %s", val))
+	if decimal > parseUnitMaxDecimals {
+		panic(fmt.Errorf("Parse error: decimals %d out of range (max %d)", decimal, parseUnitMaxDecimals))
 	}
+
+	parts := strings.SplitN(val, ".", 2)
+	whole, _ := new(big.Int).SetString(parts[0], 10) // regex guarantees a valid non-negative integer
 
 	scale := new(big.Int).Exp(big.NewInt(10), new(big.Int).SetUint64(uint64(decimal)), nil)
 	result := new(big.Int).Mul(whole, scale)
@@ -141,10 +155,7 @@ func ParseUnit(val string, decimal uint) *big.Int {
 		if uint(len(frac)) > decimal {
 			panic(fmt.Errorf("Parse error: fractional part %q exceeds %d decimals in %q", frac, decimal, val))
 		}
-		fracVal, ok := new(big.Int).SetString(frac+strings.Repeat("0", int(decimal)-len(frac)), 10)
-		if !ok || fracVal.Sign() < 0 {
-			panic(fmt.Errorf("Parse error: %s", val))
-		}
+		fracVal, _ := new(big.Int).SetString(frac+strings.Repeat("0", int(decimal)-len(frac)), 10)
 		result.Add(result, fracVal)
 	}
 

--- a/core/taskengine/macros/exp.go
+++ b/core/taskengine/macros/exp.go
@@ -115,14 +115,40 @@ func BigLt(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) < 0
 }
 
+// ParseUnit converts a decimal string into a fixed-point integer scaled by
+// 10^decimals, matching the ethers.js parseUnits(value, decimals) convention.
+// It accepts a fractional component (e.g. ParseUnit("2621.99", 8) == 262199000000),
+// which is what task-condition expressions need to build a price threshold to
+// compare against chainlinkPrice(). A fraction with more digits than `decimals`
+// or a negative value is rejected.
 func ParseUnit(val string, decimal uint) *big.Int {
-	b, ok := ethmath.ParseBig256(val)
+	parts := strings.SplitN(val, ".", 2)
+
+	whole, ok := new(big.Int).SetString(parts[0], 10)
 	if !ok {
 		panic(fmt.Errorf("Parse error: %s", val))
 	}
+	if whole.Sign() < 0 {
+		panic(fmt.Errorf("Parse error: negative value not supported: %s", val))
+	}
 
-	r := big.NewInt(0)
-	return r.Div(b, big.NewInt(int64(decimal)))
+	scale := new(big.Int).Exp(big.NewInt(10), new(big.Int).SetUint64(uint64(decimal)), nil)
+	result := new(big.Int).Mul(whole, scale)
+
+	// Add the fractional component, right-padded to `decimals` digits.
+	if len(parts) == 2 && parts[1] != "" {
+		frac := parts[1]
+		if uint(len(frac)) > decimal {
+			panic(fmt.Errorf("Parse error: fractional part %q exceeds %d decimals in %q", frac, decimal, val))
+		}
+		fracVal, ok := new(big.Int).SetString(frac+strings.Repeat("0", int(decimal)-len(frac)), 10)
+		if !ok || fracVal.Sign() < 0 {
+			panic(fmt.Errorf("Parse error: %s", val))
+		}
+		result.Add(result, fracVal)
+	}
+
+	return result
 }
 
 func ToBigInt(val string) *big.Int {

--- a/core/taskengine/macros/parseunit_test.go
+++ b/core/taskengine/macros/parseunit_test.go
@@ -15,13 +15,25 @@ func TestParseUnit(t *testing.T) {
 	if got := ParseUnit("1", 8); got.Cmp(e8) != 0 { // integer scaling
 		t.Fatalf("ParseUnit(1, 8) = %s, want %s", got, e8)
 	}
-	// Over-precision must be rejected.
-	func() {
-		defer func() {
-			if recover() == nil {
-				t.Fatal("ParseUnit(1.999, 2) expected panic on over-precision")
-			}
+
+	// Malformed or out-of-range input must be rejected, not silently coerced.
+	for _, bad := range []struct {
+		val     string
+		decimal uint
+	}{
+		{"1.999", 2}, // over-precision
+		{"-0.5", 8},  // negative with a "-0" whole part
+		{"-1.5", 8},  // negative
+		{"1.+5", 8},  // malformed fraction (leading +)
+		{"1", 1000},  // decimals out of range
+	} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("ParseUnit(%q, %d) expected panic, got none", bad.val, bad.decimal)
+				}
+			}()
+			ParseUnit(bad.val, bad.decimal)
 		}()
-		ParseUnit("1.999", 2)
-	}()
+	}
 }

--- a/core/taskengine/macros/parseunit_test.go
+++ b/core/taskengine/macros/parseunit_test.go
@@ -1,0 +1,27 @@
+package macros
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestParseUnit(t *testing.T) {
+	e8 := new(big.Int).Exp(big.NewInt(10), big.NewInt(8), nil)
+
+	// The regression: divide-by-decimal gave 327; ethers parseUnits gives 262199000000.
+	if got, want := ParseUnit("2621.99", 8), big.NewInt(262199000000); got.Cmp(want) != 0 {
+		t.Fatalf("ParseUnit(2621.99, 8) = %s, want %s", got, want)
+	}
+	if got := ParseUnit("1", 8); got.Cmp(e8) != 0 { // integer scaling
+		t.Fatalf("ParseUnit(1, 8) = %s, want %s", got, e8)
+	}
+	// Over-precision must be rejected.
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("ParseUnit(1.999, 2) expected panic on over-precision")
+			}
+		}()
+		ParseUnit("1.999", 2)
+	}()
+}


### PR DESCRIPTION
## What

Fix the `parseUnit` expression builtin, which computed `value / decimals` instead
of scaling by `10^decimals`. Reimplemented to match the ethers.js
`parseUnits(value, decimals)` convention, including fractional input.

Closes #656.

## Why

`parseUnit` is exposed to users in task-condition expressions — the documented use
is building a fixed-point price threshold to compare against `chainlinkPrice(...)`,
which returns an 8-decimal integer. The old implementation divided by the raw
decimal *count*:

```go
r.Div(b, big.NewInt(int64(decimal)))   // parseUnit("2621", 8) -> 327
```

So every threshold was wrong by orders of magnitude (and lossy, from integer
division). Conditions fired when they shouldn't or never fired — silent, incorrect
automation with no error surfaced. On top of that, the function couldn't accept a
fractional value like `"2621.99"` at all (it used `ParseBig256`, integer-only), so
it was unusable for the price thresholds it exists to build.

## What changed

`ParseUnit` now:
- scales by `10^decimals` (`parseUnit("2621", 8)` → `262100000000`)
- accepts a fractional component, right-padded to `decimals` (`parseUnit("2621.99", 8)` → `262199000000`)
- rejects over-precision (fraction longer than `decimals`), negatives, and non-numeric input

| Call | Before | After |
|------|--------|-------|
| `parseUnit("2621", 8)`    | `327`      | `262100000000` |
| `parseUnit("2621.99", 8)` | panic      | `262199000000` |
| `parseUnit("100", 6)`     | `16`       | `100000000` |

## Tests

Added `TestParseUnit` (pure unit test, no RPC): the regression assertion
(`2621.99 → 262199000000`), integer scaling, and the over-precision rejection.

## Compatibility

No callers or tests depended on the old output — the only reference was a
commented-out example. Behavior now matches the ethers `parseUnits` semantics the
name implies.
