### PR TITLE
feat: correct + idempotent single-node contractWrite execution

### DIFF
--- a/PLAN_AGENT_ONDEMAND_ACTIONS.md
+++ b/PLAN_AGENT_ONDEMAND_ACTIONS.md
@@ -64,6 +64,18 @@ The "gap of the preview→confirm→execute contract" is exactly the set of dive
 | G6 | Runner **salt not propagated** on the `nodes:run` real path (validates salt 0–4, sets only `aa_sender`) | Correctness (edge) | **P2** | [run_node_immediately.go:2731](core/taskengine/run_node_immediately.go#L2731) |
 | G7 | **No execution fee** wired on `nodes:run` (nil `executionFeeWei`) | Product/pricing | **P2 — decision** | (fee set only in `executor.go`) |
 
+### Implementation status (2026-07-12, branch `feat/ondemand-single-node-execution`)
+
+| Gap | Status | Commit |
+| --- | --- | --- |
+| G1 native value passthrough | ✅ **done + tested** | `fix(taskengine): correct single-node contractWrite real execution` |
+| G2 typed identity (userOpHash + normalized status) | ✅ **done + tested** (via receipt fields, no proto change) | same |
+| G3 pending ≠ failure | ✅ **done + tested** | same |
+| G6 runner salt propagation | ✅ **done** | same |
+| G5 idempotency | ✅ **done + tested** (Idempotency-Key header, no proto change) | `feat(taskengine): idempotent nodes:run via Idempotency-Key header` |
+| G4 atomic batching | ⛔ **deferred** — shares the Execute loop with deployed workflows and interleaves with the reimbursement wrapper; restrict chat execution to single-call actions until revisited | — |
+| G7 fee posture | 🟡 **fee-free for v1** (analysis below); revisit monetization separately | — |
+
 ### G1 — Native `value` is dropped on execute (P0, breaks the example)
 
 The real path packs the smart-wallet call with a **hardcoded zero value**:
@@ -94,7 +106,9 @@ A mined real result carries a `Receipt` **map** with `transactionHash` and the s
 `SendUserOp` blocks up to ~2 minutes polling for the receipt and can return a **UserOp with no receipt** (still pending). In that branch the result is `status:"pending"`, `transactionHash:"pending"` ([vm_runner_contract_write.go:1022-1030](core/taskengine/vm_runner_contract_write.go#L1022)), and success is computed as `receipt != nil && receipt.Status == 1 && userOpInnerSuccess` ([:1087](core/taskengine/vm_runner_contract_write.go#L1087)) → **`success=false`**. So a swap that *will* land but hasn't yet is reported identically to a swap that *failed*. And because `nodes:run` is stateless, there is **no way to re-poll** that UserOp's status afterward.
 **Fix**: (a) surface a distinct `pending` status in the typed result (G2) so studio doesn't render pending as failure; (b) provide a way to resolve a pending UserOp — either a lightweight status lookup keyed by `userOpHash`, or have studio poll chain/bundler with the returned `userOpHash`. Minimum viable: make `pending` unambiguous in the response.
 
-### G4 — Non-atomic approve+swap (P1, reliability)
+### G4 — Non-atomic approve+swap (P1, reliability) — DEFERRED
+
+> **Decision: deferred.** The `Execute` loop is shared with deployed workflows and the fix interleaves with the reimbursement wrapper (which decodes a *single* `execute`, not a batch), so this is a behavior change with real blast radius, not a local fix. Until it lands, **restrict chat execution to single-call actions** (do the `approve` as its own confirmed action, or use tokens already approved). Design notes retained below.
 
 `Execute` loops over `methodCalls` ([vm_runner_contract_write.go:1526](core/taskengine/vm_runner_contract_write.go#L1526)); each real method calls `executeRealUserOpTransaction` independently ([:643](core/taskengine/vm_runner_contract_write.go#L643)) → **one UserOp per method**, and the loop **does not stop on a failed method** ("Don't fail the entire execution for individual method failures", [:1729](core/taskengine/vm_runner_contract_write.go#L1729)). So approve+swap = two sequential UserOps; if approve lands and swap fails, `computeWriteStepSuccess` reports the *step* as failed while the **approve is already on-chain** — a partial side effect the preview (single atomic Tenderly sim with allowance injection) never showed. This is both a fidelity gap and a footgun.
 **Fix**: when a node has multiple `methodCalls` and `is_simulated=false`, batch them into **one `executeBatch` UserOp** via the existing `aa.PackExecuteBatch` / `PackExecuteBatchWithValues` ([core/chainio/aa/aa.go:206](core/chainio/aa/aa.go#L206)) — atomic, one gas estimate, one signature. Keep per-method sequential as a fallback. Until this lands, restrict chat execution to single-call actions (or accept the approve-then-swap risk with a guard).
@@ -108,9 +122,19 @@ A mined real result carries a `Receipt` **map** with `transactionHash` and the s
 The run-node path validates the runner across **salts 0–4** and computes `matchedSalt`, but then sets only `aa_sender` and **discards the salt** ([run_node_immediately.go:2731](core/taskengine/run_node_immediately.go#L2731)) — `aa_salt` is never set on this path (it *is* set on the deployed-task path, [executor.go:491](core/taskengine/executor.go#L491), and in `runContractWrite` from `vm.task`, [vm.go:1658](core/taskengine/vm.go#L1658), but `vm.task` is nil for `nodes:run`). The real send reads `aa_salt` ([vm_runner_contract_write.go:756](core/taskengine/vm_runner_contract_write.go#L756)) and, absent it, defaults to salt 0. For the overwhelmingly common **salt:0** runner this is fine; for a runner at salt 1–4 the sender override and the auto-deploy salt/initCode diverge → wrong/failed deploy.
 **Fix**: carry `matchedSalt` into `aa_salt` on the `nodes:run` path (mirror `executor.go`). Cheap; removes a latent multi-wallet bug.
 
-### G7 — Execution fee posture (P2, decision not bug)
+### G7 — Execution fee posture (P2, decision — resolved: fee-free for v1)
 
-The deployed-task executor adds a platform `executionFeeWei` batch transfer ([executor.go:356-368]); the `nodes:run` path leaves it nil, so **on-demand actions are gas-sponsored but fee-free** today. Decide explicitly: charge a fee on on-demand executes (wire it like the executor) or document them as free. Pure product/pricing.
+The deployed-task executor adds a platform `executionFeeWei` batch transfer ([executor.go:356-368]); the `nodes:run` path leaves it nil, so **on-demand actions are gas-sponsored but fee-free** today.
+
+**Decision for v1: keep on-demand executes fee-free.** Ship the capability; don't couple monetization to correctness. Monetization is a separate, deliberate design. The analysis that informs that later design:
+
+**Does batching a fee into the UserOp add significant gas?** No — *if batched*, which is already how `wrapWithReimbursement` works (it appends `executionFeeWei` as an extra `executeBatchWithValues` entry, `builder.go:499-503`). The marginal cost of a fee is one extra batch op = a value-transfer CALL to an existing recipient (~9,000 gas) + the extra batch entry's calldata (~3 words ≈ 1,500 gas) + minor loop/decode overhead ≈ **~10–15k gas**. Against a Uniswap `exactInputSingle` (~120–180k) inside a full UserOp (~250–400k with EntryPoint verification), that's **~3–6%**. The expensive alternative is a *separate* fee UserOp — a whole extra EntryPoint verification + preVerificationGas + base ≈ 60–100k+ gas. So **batching is the efficient path**; a separate fee tx is not.
+
+**Would charging on every tx raise user cost?** Yes, two components: (1) the fee amount itself (revenue, a direct cost), and (2) the ~10–15k marginal gas — borne by the user because the paymaster sponsors then the wallet reimburses. For **micro trades** a *flat* per-tx fee (+ the fixed gas overhead) is a large % of a small swap; a **bps fee** scales with size and is the better "charge on every tx" shape. Batched into the existing reimbursement op, a bps fee is the lowest-friction option and needs no new signature.
+
+**Coinbase x402 as a micro-fee rail?** x402 revives HTTP 402: the client hits an endpoint, gets payment requirements, pays with stablecoin (USDC, typically Base) by signing an EIP-3009 `transferWithAuthorization`, retries with an `X-PAYMENT` header, and a *facilitator* verifies + settles on-chain. The **payer pays no gas directly** (the facilitator submits settlement; USDC transfer gas on Base is sub-cent), so it's effectively gasless-for-payer and purpose-built for **agent/API micropayments** — conceptually a good fit for "charge $X per chat action," stable-denominated and decoupled from the swap's gas.
+- **Friction against our model:** x402 reintroduces a **user signature** (the EIP-3009 authorization), which conflicts with the delegated model where the aggregator signs and the user doesn't sign per-tx — unless the fund-authorization/session-key layer also authorizes the x402 payment. It's also Base/USDC-centric today and adds a facilitator dependency.
+- **Recommendation:** for a wallet/ETH-denominated fee, **batch a bps fee into the existing reimbursement UserOp** (cheap, no new signature, works today). Treat **x402 as a separate, deliberate rail** specifically for the agent/chat surface if/when per-action USDC micropayments are desired — its own project, not part of this backend correctness work.
 
 ---
 
@@ -130,14 +154,14 @@ The deployed-task executor adds a platform `executionFeeWei` batch transfer ([ex
 
 ---
 
-## 6. Suggested backend sequencing
+## 6. Backend sequencing (status)
 
-1. **G1 (value passthrough)** + **G2 (typed result incl. return value)** + **G3 (pending status)** — the P0 set that makes a single real swap *work and be reconcilable*. Ship together; they're the whole "execute returns something studio can trust."
-2. **G4 (atomic batch)** — makes approve+swap a reliable market order.
-3. **G5 (idempotency)** — safety before chat drives real executes at volume.
-4. **G6 (salt)**, **G7 (fee decision)** — cleanup/decisions.
+1. ✅ **G1 + G2 + G3 + G6** — shipped: a single real execute is correct (value forwarded), reconcilable (userOpHash + normalized `confirmed`/`pending`/`failed`), pending is not failure, and non-zero-salt runners resolve. (commit `fix(taskengine): correct single-node contractWrite real execution`)
+2. ✅ **G5 (idempotency)** — shipped: `Idempotency-Key` header dedupes retries/double-clicks. (commit `feat(taskengine): idempotent nodes:run via Idempotency-Key header`)
+3. ⛔ **G4 (atomic batch)** — deferred (shared-loop blast radius). Chat execution restricted to single-call actions meanwhile.
+4. 🟡 **G7 (fee)** — fee-free for v1; monetization is a separate design (see G7 analysis).
 
-Each is independently shippable; **G1 alone is a small, standalone correctness fix worth landing regardless.** Deferred (later hardening): server-side spend/fund-authorization policy.
+Deferred (later hardening): server-side spend/fund-authorization policy; atomic multi-call batching (G4); fee monetization (G7).
 
 ---
 

--- a/PLAN_AGENT_ONDEMAND_ACTIONS.md
+++ b/PLAN_AGENT_ONDEMAND_ACTIONS.md
@@ -74,7 +74,7 @@ The "gap of the preview→confirm→execute contract" is exactly the set of dive
 | G6 runner salt propagation | ✅ **done** | same |
 | G5 idempotency | ✅ **done + tested** (Idempotency-Key header, no proto change) | `feat(taskengine): idempotent nodes:run via Idempotency-Key header` |
 | G4 atomic batching | ⛔ **deferred** — shares the Execute loop with deployed workflows and interleaves with the reimbursement wrapper; restrict chat execution to single-call actions until revisited | — |
-| G7 fee posture | 🟡 **fee-free for v1** (analysis below); revisit monetization separately | — |
+| G7 fee posture | ✅ **decided: fee-free for v1** (confirmed 2026-07-12); monetization revisited separately (analysis below) | — |
 
 ### G1 — Native `value` is dropped on execute (P0, breaks the example)
 
@@ -159,7 +159,7 @@ The deployed-task executor adds a platform `executionFeeWei` batch transfer ([ex
 1. ✅ **G1 + G2 + G3 + G6** — shipped: a single real execute is correct (value forwarded), reconcilable (userOpHash + normalized `confirmed`/`pending`/`failed`), pending is not failure, and non-zero-salt runners resolve. (commit `fix(taskengine): correct single-node contractWrite real execution`)
 2. ✅ **G5 (idempotency)** — shipped: `Idempotency-Key` header dedupes retries/double-clicks. (commit `feat(taskengine): idempotent nodes:run via Idempotency-Key header`)
 3. ⛔ **G4 (atomic batch)** — deferred (shared-loop blast radius). Chat execution restricted to single-call actions meanwhile.
-4. 🟡 **G7 (fee)** — fee-free for v1; monetization is a separate design (see G7 analysis).
+4. ✅ **G7 (fee)** — decided fee-free for v1 (confirmed); monetization is a separate design (see G7 analysis).
 
 Deferred (later hardening): server-side spend/fund-authorization policy; atomic multi-call batching (G4); fee monetization (G7).
 

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -59,7 +59,11 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		req.Erc20Overrides = openAPIERC20OverridesToProto(*body.Erc20Overrides)
 	}
 
-	resp, err := s.engine.RunNodeImmediatelyRPCWithContext(ctx.Request().Context(), user, req)
+	// A caller-supplied Idempotency-Key (Stripe-style header) makes a retried or
+	// double-submitted execute safe: the same key returns the first result instead
+	// of broadcasting a second UserOp. Absent the header, behavior is unchanged.
+	idempotencyKey := ctx.Request().Header.Get("Idempotency-Key")
+	resp, err := s.engine.RunNodeImmediatelyRPCIdempotent(ctx.Request().Context(), user, req, idempotencyKey)
 	if err != nil {
 		return err
 	}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/oklog/ulid/v2"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -305,6 +306,12 @@ type Engine struct {
 	// fixed set of mutexes bounds memory — the same executionID always maps to the
 	// same shard, so concurrent resumes of one execution serialize. See executionMutex.
 	executionMutexes [executionLockShards]sync.Mutex
+
+	// Collapses concurrent nodes:run requests that carry the same Idempotency-Key
+	// so a retried/double-clicked Confirm can't broadcast a second UserOp. Works
+	// with a persistent TTL cache (see runNodeImmediatelyIdempotent) that also
+	// dedupes sequential retries after the first request has completed.
+	idempotencyGroup singleflight.Group
 }
 
 // executionLockShards bounds the per-execution resume locks to a fixed set of mutexes.

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -309,7 +309,7 @@ type Engine struct {
 
 	// Collapses concurrent nodes:run requests that carry the same Idempotency-Key
 	// so a retried/double-clicked Confirm can't broadcast a second UserOp. Works
-	// with a persistent TTL cache (see runNodeImmediatelyIdempotent) that also
+	// with a persistent TTL cache (see RunNodeImmediatelyRPCIdempotent) that also
 	// dedupes sequential retries after the first request has completed.
 	idempotencyGroup singleflight.Group
 }

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -3038,15 +3038,15 @@ func idempotencyCacheKey(subject, clientKey string) []byte {
 // the caller may safely retry. Polling a pending UserOp's final status is a
 // separate concern — reuse of the same key returns the cached pending result.
 func (n *Engine) RunNodeImmediatelyRPCIdempotent(ctx context.Context, user *model.User, req *avsproto.RunNodeWithInputsReq, idempotencyKey string) (*avsproto.RunNodeWithInputsResp, error) {
-	if idempotencyKey == "" {
+	// Idempotency needs a distinct authenticated subject to scope the cache key.
+	// A partner-assertion (simulate-only) caller can resolve to the zero address;
+	// deduping those would let one caller's key cross-replay another's result, so
+	// skip idempotency when there is no real subject. Safe by construction: real
+	// executes (fund-moving) always carry a non-zero authenticated owner.
+	if idempotencyKey == "" || user == nil || user.Address == (common.Address{}) {
 		return n.RunNodeImmediatelyRPCWithContext(ctx, user, req)
 	}
-
-	subject := ""
-	if user != nil {
-		subject = user.Address.Hex()
-	}
-	cacheKey := idempotencyCacheKey(subject, idempotencyKey)
+	cacheKey := idempotencyCacheKey(user.Address.Hex(), idempotencyKey)
 
 	// Fast path: a prior completed result still within the TTL window.
 	if resp := n.readIdempotentResponse(cacheKey); resp != nil {
@@ -3081,15 +3081,25 @@ func (n *Engine) readIdempotentResponse(cacheKey []byte) *avsproto.RunNodeWithIn
 		return nil
 	}
 	raw, err := n.db.GetKey(cacheKey)
-	if err != nil || len(raw) < 8 {
+	if err != nil {
+		return nil // not found
+	}
+	if len(raw) < 8 {
+		_ = n.db.Delete(cacheKey) // corrupt/short entry — drop it
 		return nil
 	}
 	ts := int64(binary.BigEndian.Uint64(raw[:8]))
 	if time.Since(time.Unix(0, ts)) > idempotencyTTL {
-		return nil // expired; a fresh request is allowed to re-execute
+		// Expired: best-effort delete so stale keys don't accumulate unbounded,
+		// then let the fresh request re-execute.
+		_ = n.db.Delete(cacheKey)
+		return nil
 	}
 	resp := &avsproto.RunNodeWithInputsResp{}
 	if err := proto.Unmarshal(raw[8:], resp); err != nil {
+		// Corrupt payload: drop it so the next request re-executes and repopulates
+		// cleanly instead of failing to decode forever.
+		_ = n.db.Delete(cacheKey)
 		return nil
 	}
 	return resp

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2650,12 +2650,19 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 					return nil, fmt.Errorf("failed to list wallets for owner %s: %w", vm.TaskOwner.Hex(), err)
 				}
 				var chosenSender common.Address
-				var matchedSalt *big.Int // Track matched salt for debug logging
+				var matchedSalt *big.Int // Matched wallet salt; propagated to aa_salt so the real UserOp path derives/deploys the correct sender for non-zero salts
 				walletExists := false
 				for _, w := range resp.GetItems() {
 					if strings.EqualFold(w.GetAddress(), runnerStr) {
 						chosenSender = common.HexToAddress(w.GetAddress())
 						walletExists = true
+						// Capture the wallet's salt so a runner at salt 1-4 deploys/derives
+						// under its own salt rather than defaulting to salt 0.
+						if saltStr := w.GetSalt(); saltStr != "" {
+							if parsedSalt, ok := new(big.Int).SetString(saltStr, 10); ok {
+								matchedSalt = parsedSalt
+							}
+						}
 						break
 					}
 				}
@@ -2729,6 +2736,14 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 				}
 
 				vm.AddVar("aa_sender", chosenSender.Hex())
+				// Propagate the resolved salt so the real UserOp path (aa_salt) derives
+				// and auto-deploys the runner under its own salt. Absent this, a runner
+				// at salt 1-4 would fall back to salt 0 and mismatch its initCode/sender.
+				// For the common salt:0 runner this is a no-op (big.NewInt(0) resolves
+				// identically to the default).
+				if matchedSalt != nil {
+					vm.AddVar("aa_salt", matchedSalt)
+				}
 			} else {
 				return nil, fmt.Errorf("settings must be an object for %s", nodeType)
 			}

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2,6 +2,9 @@ package taskengine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -18,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -3003,6 +3007,110 @@ func (n *Engine) detectNodeTypeFromStep(step *avsproto.Execution_Step) string {
 // RunNodeImmediatelyRPC handles the RPC interface for immediate node execution
 func (n *Engine) RunNodeImmediatelyRPC(user *model.User, req *avsproto.RunNodeWithInputsReq) (*avsproto.RunNodeWithInputsResp, error) {
 	return n.RunNodeImmediatelyRPCWithContext(context.Background(), user, req)
+}
+
+// idempotencyTTL bounds how long a completed nodes:run result stays replayable
+// under the same Idempotency-Key. Sized to comfortably cover a Confirm retry (a
+// real UserOp send blocks up to ~2 min) without pinning results indefinitely.
+const idempotencyTTL = 15 * time.Minute
+
+// idempotencyCachePrefix namespaces persisted nodes:run responses in storage.
+const idempotencyCachePrefix = "idem:noderun:"
+
+// idempotencyCacheKey derives a bounded, collision-resistant storage key from the
+// authenticated subject and the client-supplied key. Scoping by subject prevents
+// one caller's idempotency key from colliding with another's.
+func idempotencyCacheKey(subject, clientKey string) []byte {
+	sum := sha256.Sum256([]byte(subject + "\x00" + clientKey))
+	return []byte(idempotencyCachePrefix + hex.EncodeToString(sum[:]))
+}
+
+// RunNodeImmediatelyRPCIdempotent runs a single node, deduplicating by
+// idempotencyKey so a retried or double-submitted request (e.g. a chat Confirm)
+// does not execute — and broadcast — a second UserOp. An empty key preserves the
+// plain non-idempotent behavior.
+//
+// Two layers cooperate: singleflight collapses requests that are in flight
+// concurrently (a double-click), and a persistent TTL cache returns the prior
+// result for a request that arrives after the first has completed (a retry).
+// Only a definitive response (err == nil, which includes an on-chain failure or
+// a still-pending UserOp) is cached; a transport/engine error caches nothing so
+// the caller may safely retry. Polling a pending UserOp's final status is a
+// separate concern — reuse of the same key returns the cached pending result.
+func (n *Engine) RunNodeImmediatelyRPCIdempotent(ctx context.Context, user *model.User, req *avsproto.RunNodeWithInputsReq, idempotencyKey string) (*avsproto.RunNodeWithInputsResp, error) {
+	if idempotencyKey == "" {
+		return n.RunNodeImmediatelyRPCWithContext(ctx, user, req)
+	}
+
+	subject := ""
+	if user != nil {
+		subject = user.Address.Hex()
+	}
+	cacheKey := idempotencyCacheKey(subject, idempotencyKey)
+
+	// Fast path: a prior completed result still within the TTL window.
+	if resp := n.readIdempotentResponse(cacheKey); resp != nil {
+		return resp, nil
+	}
+
+	// Collapse concurrent duplicates: only the singleflight leader executes.
+	v, err, _ := n.idempotencyGroup.Do(string(cacheKey), func() (interface{}, error) {
+		// Re-check under the leader in case a racing request completed and cached
+		// between our fast-path miss and acquiring the singleflight slot.
+		if resp := n.readIdempotentResponse(cacheKey); resp != nil {
+			return resp, nil
+		}
+		resp, runErr := n.RunNodeImmediatelyRPCWithContext(ctx, user, req)
+		if runErr != nil {
+			return nil, runErr
+		}
+		n.writeIdempotentResponse(cacheKey, resp)
+		return resp, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, _ := v.(*avsproto.RunNodeWithInputsResp)
+	return resp, nil
+}
+
+// readIdempotentResponse returns a cached response if one exists and is within
+// the TTL; otherwise nil. Stored as [8-byte big-endian unix-nano ts][proto bytes].
+func (n *Engine) readIdempotentResponse(cacheKey []byte) *avsproto.RunNodeWithInputsResp {
+	if n.db == nil {
+		return nil
+	}
+	raw, err := n.db.GetKey(cacheKey)
+	if err != nil || len(raw) < 8 {
+		return nil
+	}
+	ts := int64(binary.BigEndian.Uint64(raw[:8]))
+	if time.Since(time.Unix(0, ts)) > idempotencyTTL {
+		return nil // expired; a fresh request is allowed to re-execute
+	}
+	resp := &avsproto.RunNodeWithInputsResp{}
+	if err := proto.Unmarshal(raw[8:], resp); err != nil {
+		return nil
+	}
+	return resp
+}
+
+// writeIdempotentResponse persists a completed response for TTL-bounded replay.
+// Best-effort: a store failure only means a later retry re-executes.
+func (n *Engine) writeIdempotentResponse(cacheKey []byte, resp *avsproto.RunNodeWithInputsResp) {
+	if n.db == nil || resp == nil {
+		return
+	}
+	payload, err := proto.Marshal(resp)
+	if err != nil {
+		return
+	}
+	buf := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint64(buf[:8], uint64(time.Now().UnixNano()))
+	copy(buf[8:], payload)
+	if err := n.db.Set(cacheKey, buf); err != nil && n.logger != nil {
+		n.logger.Warn("RunNodeImmediately: failed to persist idempotent response", "error", err)
+	}
 }
 
 // RunNodeImmediatelyRPCWithContext is RunNodeImmediatelyRPC with a

--- a/core/taskengine/run_node_immediately_idempotency_test.go
+++ b/core/taskengine/run_node_immediately_idempotency_test.go
@@ -72,6 +72,16 @@ func TestRunNodeImmediatelyIdempotency(t *testing.T) {
 	resp5, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, otherUser, customCodeReq("return 'second'"), "confirm-key-1")
 	require.NoError(t, err)
 	assert.False(t, proto.Equal(resp1, resp5), "idempotency cache must be scoped per authenticated subject")
+
+	// Zero-address subject (e.g. a partner-assertion simulate caller) must NOT
+	// dedupe — otherwise two indistinguishable callers sharing a key would
+	// cross-replay. Same key, different nodes → the second still executes.
+	zeroUser := &model.User{} // Address is the zero value
+	zresp1, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, zeroUser, customCodeReq("return 'first'"), "shared-key")
+	require.NoError(t, err)
+	zresp2, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, zeroUser, customCodeReq("return 'second'"), "shared-key")
+	require.NoError(t, err)
+	assert.False(t, proto.Equal(zresp1, zresp2), "a zero-address subject must not dedupe (avoids cross-caller replay)")
 }
 
 // The cache key is deterministic and scoped, and entries older than the TTL are

--- a/core/taskengine/run_node_immediately_idempotency_test.go
+++ b/core/taskengine/run_node_immediately_idempotency_test.go
@@ -1,0 +1,105 @@
+package taskengine
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// customCodeReq builds a single-node RunNodeWithInputs request whose customCode
+// node returns the given constant, so distinct sources produce distinct results.
+func customCodeReq(source string) *avsproto.RunNodeWithInputsReq {
+	return &avsproto.RunNodeWithInputsReq{
+		Node: &avsproto.TaskNode{
+			Id:   "cc1",
+			Name: "cc1",
+			Type: avsproto.NodeType_NODE_TYPE_CUSTOM_CODE,
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{
+						Lang:   avsproto.Lang_LANG_JAVASCRIPT,
+						Source: source,
+					},
+				},
+			},
+		},
+	}
+}
+
+// G5: a retried or double-submitted nodes:run carrying the same Idempotency-Key
+// must replay the first result instead of executing (and broadcasting) again.
+func TestRunNodeImmediatelyIdempotency(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	engine := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+	user := &model.User{Address: common.HexToAddress("0x1111111111111111111111111111111111111111")}
+	ctx := context.Background()
+
+	// First call under key K executes node A ("first").
+	resp1, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, user, customCodeReq("return 'first'"), "confirm-key-1")
+	require.NoError(t, err)
+	require.True(t, resp1.GetSuccess(), "customCode node should execute successfully")
+
+	// Same key, a DIFFERENT node ("second"): must return node A's cached result,
+	// proving the second execution was short-circuited by idempotency.
+	resp2, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, user, customCodeReq("return 'second'"), "confirm-key-1")
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(resp1, resp2), "same Idempotency-Key must replay the first result, not re-execute")
+
+	// No key: never dedupes — executes node B, giving a result different from A.
+	resp3, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, user, customCodeReq("return 'second'"), "")
+	require.NoError(t, err)
+	assert.False(t, proto.Equal(resp1, resp3), "an empty key must not dedupe")
+
+	// Different key: executes node B (not a replay of key K's result).
+	resp4, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, user, customCodeReq("return 'second'"), "confirm-key-2")
+	require.NoError(t, err)
+	assert.False(t, proto.Equal(resp1, resp4), "a different key must not replay another key's result")
+
+	// Subject scoping: another user with the SAME key must not see the result.
+	otherUser := &model.User{Address: common.HexToAddress("0x2222222222222222222222222222222222222222")}
+	resp5, err := engine.RunNodeImmediatelyRPCIdempotent(ctx, otherUser, customCodeReq("return 'second'"), "confirm-key-1")
+	require.NoError(t, err)
+	assert.False(t, proto.Equal(resp1, resp5), "idempotency cache must be scoped per authenticated subject")
+}
+
+// The cache key is deterministic and scoped, and entries older than the TTL are
+// ignored so a stale key is allowed to re-execute.
+func TestIdempotencyCacheKeyAndTTL(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	engine := New(db, testutil.GetAggregatorConfig(), nil, testutil.GetLogger())
+
+	kA := idempotencyCacheKey("0xA", "k")
+	assert.Equal(t, string(kA), string(idempotencyCacheKey("0xA", "k")), "key derivation must be deterministic")
+	assert.NotEqual(t, string(kA), string(idempotencyCacheKey("0xB", "k")), "different subject must yield a different key")
+	assert.NotEqual(t, string(kA), string(idempotencyCacheKey("0xA", "k2")), "different client key must yield a different key")
+
+	// Fresh entry round-trips.
+	resp := &avsproto.RunNodeWithInputsResp{Success: true}
+	engine.writeIdempotentResponse(kA, resp)
+	got := engine.readIdempotentResponse(kA)
+	require.NotNil(t, got)
+	assert.True(t, got.GetSuccess())
+
+	// An entry older than the TTL is ignored (a fresh request may re-execute).
+	expiredKey := idempotencyCacheKey("0xA", "expired")
+	payload, err := proto.Marshal(resp)
+	require.NoError(t, err)
+	buf := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint64(buf[:8], uint64(time.Now().Add(-idempotencyTTL-time.Minute).UnixNano()))
+	copy(buf[8:], payload)
+	require.NoError(t, db.Set(expiredKey, buf))
+	assert.Nil(t, engine.readIdempotentResponse(expiredKey), "entry older than the TTL must be treated as absent")
+}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -640,11 +640,11 @@ func (r *ContractWriteProcessor) executeMethodCall(
 		"contract", contractAddress.Hex(),
 		"method", methodName)
 
-	return r.executeRealUserOpTransaction(ctx, contractAddress, callData, methodName, parsedABI, t0)
+	return r.executeRealUserOpTransaction(ctx, contractAddress, callData, methodName, parsedABI, node, t0)
 }
 
 // executeRealUserOpTransaction executes a real UserOp transaction for contract writes
-func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Context, contractAddress common.Address, callData string, methodName string, parsedABI *abi.ABI, startTime time.Time) *avsproto.ContractWriteNode_MethodResult {
+func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Context, contractAddress common.Address, callData string, methodName string, parsedABI *abi.ABI, node *avsproto.ContractWriteNode, startTime time.Time) *avsproto.ContractWriteNode_MethodResult {
 	r.vm.logger.Info("🔍 REAL USEROP DEBUG - Starting real UserOp transaction execution",
 		"contract_address", contractAddress.Hex(),
 		"method_name", methodName,
@@ -660,6 +660,27 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 
 	// Convert hex calldata to bytes
 	callDataBytes := common.FromHex(callData)
+
+	// Resolve the native ETH value to send with this call (payable methods / native-in
+	// swaps such as wrapping ETH or an ETH-in Uniswap swap). The simulation path already
+	// honors node.Config.Value via extractTransactionValue; the real path must match it,
+	// otherwise a call that previews correctly executes with 0 wei and reverts/no-ops.
+	transactionValue := big.NewInt(0)
+	if rawValue := r.extractTransactionValue(node); rawValue != "" && rawValue != "0" {
+		parsedValue, parseErr := bigint.Parse(rawValue)
+		if parseErr != nil || parsedValue.Sign() < 0 {
+			r.vm.logger.Error("🚨 DEPLOYED WORKFLOW ERROR: Invalid transaction value",
+				"raw_value", rawValue,
+				"method_name", methodName,
+				"error", parseErr)
+			return &avsproto.ContractWriteNode_MethodResult{
+				Success:    false,
+				Error:      fmt.Sprintf("invalid transaction value %q: must be a non-negative wei integer", rawValue),
+				MethodName: methodName,
+			}
+		}
+		transactionValue = parsedValue
+	}
 
 	// 🔍 PRE-FLIGHT VALIDATION: Check for common failure scenarios before gas estimation
 	if validationErr := r.validateTransactionBeforeGasEstimation(methodName, callData, callDataBytes, contractAddress); validationErr != nil {
@@ -679,13 +700,13 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 	// Create smart wallet execute calldata: execute(target, value, data)
 	executionLogBuilder.WriteString(fmt.Sprintf("Packing smart wallet execute calldata...\n"))
 	executionLogBuilder.WriteString(fmt.Sprintf("  Target contract: %s\n", contractAddress.Hex()))
-	executionLogBuilder.WriteString(fmt.Sprintf("  ETH value: 0\n"))
+	executionLogBuilder.WriteString(fmt.Sprintf("  ETH value: %s wei\n", transactionValue.String()))
 	executionLogBuilder.WriteString(fmt.Sprintf("  Method calldata: %d bytes\n", len(callDataBytes)))
 
 	smartWalletCallData, err := aa.PackExecute(
-		contractAddress, // target contract
-		big.NewInt(0),   // ETH value (0 for contract calls)
-		callDataBytes,   // contract method calldata
+		contractAddress,  // target contract
+		transactionValue, // ETH value to send with the call (0 for non-payable calls)
+		callDataBytes,    // contract method calldata
 	)
 	if err != nil {
 		executionLogBuilder.WriteString(fmt.Sprintf("CALLDATA PACKING FAILED: %v\n", err))
@@ -1085,8 +1106,28 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 	// For AA transactions, check both receipt status AND UserOp inner success
 	// For regular transactions, just check receipt status
 	success := receipt != nil && receipt.Status == 1 && userOpInnerSuccess
+
+	// A UserOp that the bundler accepted but that hasn't been mined within the
+	// send timeout is PENDING, not failed — the on-chain outcome is still
+	// undecided and can be resolved later via userOpHash. Distinguishing this
+	// from an outright failure is essential for the chat preview→confirm→execute
+	// flow, where rendering a slow-but-successful swap as an error is wrong.
+	pending := receipt == nil && userOp != nil
+
+	// executionStatus is the unambiguous, machine-readable outcome clients should
+	// branch on (instead of interpreting the EVM hex `status`): "confirmed"
+	// (mined + inner success), "pending" (submitted, awaiting confirmation), or
+	// "failed" (submission or on-chain failure).
+	executionStatus := "failed"
+	switch {
+	case success:
+		executionStatus = "confirmed"
+	case pending:
+		executionStatus = "pending"
+	}
+
 	errorMsg := ""
-	if !success {
+	if !success && !pending {
 		if receipt == nil {
 			errorMsg = "No transaction receipt received"
 		} else if receipt.Status != 1 {
@@ -1097,9 +1138,23 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 		}
 	}
 
+	// Stamp the normalized status onto the receipt the client reads, and ensure
+	// the UserOp hash is present on the mined branch too (the pending branch
+	// already sets it) so callers always have a handle to the submitted UserOp.
+	if receiptMap != nil {
+		receiptMap["executionStatus"] = executionStatus
+		if _, hasHash := receiptMap["userOpHash"]; !hasHash && userOp != nil && r.smartWalletConfig != nil {
+			receiptMap["userOpHash"] = userOp.GetUserOpHash(r.smartWalletConfig.EntrypointAddress, big.NewInt(r.smartWalletConfig.ChainID)).Hex()
+		}
+		if v, err := structpb.NewValue(receiptMap); err == nil {
+			receiptValue = v
+		}
+	}
+
 	r.vm.logger.Info("🎯 DEPLOYED WORKFLOW: Final transaction result",
 		"method_name", methodName,
 		"success", success,
+		"execution_status", executionStatus,
 		"error_msg", errorMsg,
 		"has_receipt_value", receiptValue != nil)
 
@@ -1109,7 +1164,7 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 		Success:    success,
 		Error:      errorMsg,
 		Receipt:    receiptValue,
-		Value:      nil, // Real transactions don't return values directly
+		Value:      nil, // Real transactions don't return values directly; decoded events carry outputs
 	}
 }
 
@@ -1225,8 +1280,10 @@ func (r *ContractWriteProcessor) convertTenderlyResultToFlexibleFormat(result *C
 	// Note: blockNumber/blockHash default to placeholders here and can be
 	// overridden by the caller with real chain context when available.
 	receiptStatus := "0x1" // Default to success
+	simExecutionStatus := "confirmed"
 	if !result.Success {
 		receiptStatus = "0x0" // Set to failure if transaction failed
+		simExecutionStatus = "failed"
 	}
 
 	// Prepare logs from Tenderly simulation result
@@ -1249,6 +1306,7 @@ func (r *ContractWriteProcessor) convertTenderlyResultToFlexibleFormat(result *C
 		"cumulativeGasUsed": r.getGasUsedWithFallback(result, StandardGasCostHex),
 		"effectiveGasPrice": r.getEffectiveGasPriceWithFallback(result),
 		"status":            receiptStatus,                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        // Success/failure status based on actual result
+		"executionStatus":   simExecutionStatus,                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   // Normalized outcome, uniform with the real path ("confirmed"/"failed")
 		"logsBloom":         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", // Empty logs bloom
 		"logs":              receiptLogs,                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          // Logs from Tenderly simulation
 		"type":              "0x2",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                // EIP-1559 transaction type

--- a/core/taskengine/vm_runner_contract_write_ondemand_test.go
+++ b/core/taskengine/vm_runner_contract_write_ondemand_test.go
@@ -1,0 +1,185 @@
+package taskengine
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wellFormedUserOp returns a UserOperation with every big.Int/byte field populated
+// so GetUserOpHash / PackForSignature don't panic in unit tests.
+func wellFormedUserOp(sender common.Address) *userop.UserOperation {
+	return &userop.UserOperation{
+		Sender:               sender,
+		Nonce:                big.NewInt(0),
+		InitCode:             []byte{},
+		CallData:             []byte{},
+		CallGasLimit:         big.NewInt(0),
+		VerificationGasLimit: big.NewInt(0),
+		PreVerificationGas:   big.NewInt(0),
+		MaxFeePerGas:         big.NewInt(0),
+		MaxPriorityFeePerGas: big.NewInt(0),
+		PaymasterAndData:     []byte{},
+		Signature:            []byte{},
+	}
+}
+
+// ondemandTestConfig builds a smart-wallet config sufficient to drive the real
+// UserOp path in-process. PaymasterAddress is left zero so shouldUsePaymaster()
+// short-circuits to self-funded (no bundler gas estimation needed under the mock).
+func ondemandTestConfig() *config.SmartWalletConfig {
+	return &config.SmartWalletConfig{
+		EntrypointAddress: common.HexToAddress(config.DefaultEntrypointAddressHex),
+		FactoryAddress:    common.HexToAddress("0x0000000000000000000000000000000000009999"),
+		ChainID:           11155111,
+	}
+}
+
+func minedReceipt(status uint64) *types.Receipt {
+	return &types.Receipt{
+		Status:            status,
+		TxHash:            common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000ab"),
+		BlockHash:         common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000de"),
+		BlockNumber:       big.NewInt(100),
+		TransactionIndex:  0,
+		GasUsed:           21000,
+		CumulativeGasUsed: 21000,
+		EffectiveGasPrice: big.NewInt(1_000_000_000),
+		Type:              2,
+	}
+}
+
+// G2/G3: createRealTransactionResult must expose an unambiguous executionStatus
+// (confirmed/failed/pending) plus a userOpHash, so the chat preview→confirm→execute
+// flow can tell a mined success from a revert from a still-pending UserOp instead
+// of collapsing pending into failure.
+func TestCreateRealTransactionResultExecutionStatus(t *testing.T) {
+	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	runner := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	contractAddr := common.HexToAddress("0x1c7d4b196cb0c7b01d743fbc6116a902379c7238")
+	swConfig := ondemandTestConfig()
+
+	vm, err := NewVMWithData(nil, nil, swConfig, nil)
+	require.NoError(t, err)
+	vm.AddVar("aa_sender", runner.Hex())
+
+	processor := NewContractWriteProcessor(vm, nil, swConfig, owner)
+	userOp := wellFormedUserOp(runner)
+
+	receiptMapOf := func(t *testing.T, mr *avsproto.ContractWriteNode_MethodResult) map[string]any {
+		require.NotNil(t, mr.Receipt)
+		m, ok := mr.Receipt.AsInterface().(map[string]any)
+		require.True(t, ok)
+		return m
+	}
+
+	t.Run("mined success -> confirmed", func(t *testing.T) {
+		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(1))
+		assert.True(t, mr.Success)
+		assert.Empty(t, mr.Error)
+		rm := receiptMapOf(t, mr)
+		assert.Equal(t, "confirmed", rm["executionStatus"])
+		assert.NotEmpty(t, rm["userOpHash"], "mined result must carry a userOpHash")
+	})
+
+	t.Run("mined revert -> failed", func(t *testing.T) {
+		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(0))
+		assert.False(t, mr.Success)
+		assert.NotEmpty(t, mr.Error)
+		rm := receiptMapOf(t, mr)
+		assert.Equal(t, "failed", rm["executionStatus"])
+	})
+
+	t.Run("submitted but not mined -> pending, not failure", func(t *testing.T) {
+		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, nil)
+		assert.False(t, mr.Success, "pending is not confirmed-success")
+		assert.Empty(t, mr.Error, "pending must not be reported as an error")
+		rm := receiptMapOf(t, mr)
+		assert.Equal(t, "pending", rm["executionStatus"])
+		assert.Equal(t, "pending", rm["transactionHash"])
+		assert.NotEmpty(t, rm["userOpHash"], "pending result must carry a userOpHash to poll")
+	})
+}
+
+// G1: the real UserOp path must forward the node's native ETH value into the
+// packed execute(target, value, data) calldata, matching the simulation path.
+// It previously hardcoded 0, so a payable call (e.g. wrapping ETH or an ETH-in
+// swap) previewed correctly then executed with 0 wei.
+func TestContractWriteRealPathForwardsNativeValue(t *testing.T) {
+	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	runner := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	contractAddr := common.HexToAddress("0x1c7d4b196cb0c7b01d743fbc6116a902379c7238")
+	swConfig := ondemandTestConfig()
+
+	// A valid ERC20 transfer calldata (>= 4 bytes) — the inner call is irrelevant
+	// here; we only assert on the value word of the outer execute() wrapper.
+	transferCallData := "0xa9059cbb000000000000000000000000e0f7d11fd714674722d325cd86062a5f1882e13a00000000000000000000000000000000000000000000000000000000000003e8"
+
+	// run executes a single real contractWrite method call with the given config
+	// value and returns the value word decoded from the packed execute() calldata.
+	run := func(t *testing.T, valueWei string) *big.Int {
+		vm, err := NewVMWithData(nil, nil, swConfig, nil)
+		require.NoError(t, err)
+		vm.AddVar("aa_sender", runner.Hex())
+
+		processor := NewContractWriteProcessor(vm, nil, swConfig, owner)
+
+		var capturedCallData []byte
+		processor.sendUserOpFunc = func(
+			_ *config.SmartWalletConfig,
+			_ common.Address,
+			callData []byte,
+			_ *preset.VerifyingPaymasterRequest,
+			_ *common.Address,
+			_ *big.Int,
+			_ *big.Int,
+			_ logger.Logger,
+		) (*userop.UserOperation, *types.Receipt, error) {
+			capturedCallData = callData
+			return wellFormedUserOp(runner), minedReceipt(1), nil
+		}
+
+		cfg := &avsproto.ContractWriteNode_Config{
+			ContractAddress: contractAddr.Hex(),
+			ChainId:         swConfig.ChainID,
+		}
+		if valueWei != "" {
+			cfg.Value = &valueWei
+		}
+		node := &avsproto.ContractWriteNode{Config: cfg}
+
+		callData := transferCallData
+		methodCall := &avsproto.ContractWriteNode_MethodCall{
+			MethodName: "transfer",
+			CallData:   &callData,
+		}
+
+		mr := processor.executeMethodCall(context.Background(), nil, "", contractAddr, methodCall, false, node)
+		require.NotNil(t, mr)
+
+		// execute(address dest, uint256 value, bytes data): after the 4-byte
+		// selector, word 0 is dest and word 1 (bytes 36:68) is the ETH value.
+		require.GreaterOrEqual(t, len(capturedCallData), 68, "expected packed execute(target,value,data) calldata")
+		return new(big.Int).SetBytes(capturedCallData[36:68])
+	}
+
+	t.Run("config value is forwarded", func(t *testing.T) {
+		got := run(t, "1230000000000000000") // 1.23 ETH
+		assert.Equal(t, "1230000000000000000", got.String())
+	})
+
+	t.Run("unset value defaults to zero", func(t *testing.T) {
+		got := run(t, "")
+		assert.Equal(t, "0", got.String())
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.48.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
@@ -144,7 +145,6 @@ require (
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.14.0 // indirect


### PR DESCRIPTION
Makes on-demand single-node (`POST /nodes:run`) `contractWrite` execution correct and safe for the studio chat agent's preview→confirm→execute flow — the backend half of `PLAN_AGENT_ONDEMAND_ACTIONS.md`.

## What shipped

- **G1 — native ETH value passthrough.** The real UserOp path packed `execute(target, value, data)` with a hardcoded `0`, so a payable / native-ETH call previewed correctly then executed with 0 wei. Now forwards `node.Config.Value` (matching the simulation path).
- **G2/G3 — reconcilable, honest results.** The real result now carries a normalized `executionStatus` (`confirmed` / `pending` / `failed`) plus a `userOpHash` on every branch. A bundler-accepted-but-not-yet-mined UserOp reads as **pending, not failure** (a slow-but-successful swap is no longer rendered as an error). The same `executionStatus` is added to the Tenderly simulation receipt so preview and execute expose one shape.
- **G5 — idempotency.** A Stripe-style `Idempotency-Key` header on `/nodes:run` dedupes retries/double-clicks so a re-sent Confirm can't broadcast a second UserOp: `singleflight` collapses concurrent duplicates, a persistent 15m TTL cache replays completed results, scoped per subject. No proto/OpenAPI change.
- **G6 — runner salt propagation.** The `nodes:run` path set only `aa_sender`, so a runner at salt 1–4 fell back to salt 0 and mismatched its initCode/sender. Now propagates the resolved salt to `aa_salt` (no-op for the common salt:0).

## Decisions (documented in the plan)

- **G4 (atomic approve+swap): deferred** — the `Execute` loop is shared with deployed workflows and interleaves with the reimbursement wrapper; chat execution stays single-call until revisited.
- **G7 (fee): fee-free for v1** (confirmed); monetization is a separate design (gas/x402 analysis in the plan).
- Server-side spend/fund-authorization policy remains deferred to a later hardening pass.

## Tests

Hermetic unit tests: native value passthrough + execution-status (`vm_runner_contract_write_ondemand_test.go`); idempotency dedup, subject scoping, key determinism, TTL expiry (`run_node_immediately_idempotency_test.go`). `go vet` clean; contract-write and run-node suites green.

Remaining work is client-side (ava-sdk-js + studio) and tracked in `PLAN_AGENT_ONDEMAND_ACTIONS.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)