### PR TITLE
fix(rest): surface contractWrite per-method receipt in nodes:run response

### DIFF
--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -127,8 +127,21 @@ func runNodeRespToOpenAPI(in *avsproto.RunNodeWithInputsResp) generated.RunNodeR
 		out.ErrorCode = &code
 	}
 	if md := in.GetMetadata(); md != nil {
-		if v, ok := md.AsInterface().(map[string]interface{}); ok && v != nil {
-			out.Metadata = &v
+		switch v := md.AsInterface().(type) {
+		case map[string]interface{}:
+			if v != nil {
+				out.Metadata = &v
+			}
+		case []interface{}:
+			// Some node types (notably contractWrite) produce a per-method
+			// results array as metadata. RunNodeResponse.metadata is an object,
+			// so a bare array was previously dropped here — taking the per-method
+			// receipts (executionStatus, userOpHash, transactionHash) with it.
+			// Wrap it under "results" so those actually reach the client.
+			if len(v) > 0 {
+				wrapped := map[string]interface{}{"results": v}
+				out.Metadata = &wrapped
+			}
 		}
 	}
 	if ec := in.GetExecutionContext(); ec != nil {

--- a/aggregator/rest/handlers_nodes_test.go
+++ b/aggregator/rest/handlers_nodes_test.go
@@ -1,0 +1,57 @@
+package rest
+
+import (
+	"testing"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// contractWrite surfaces its per-method results (including the receipt with
+// executionStatus / userOpHash / transactionHash) as an ARRAY-typed metadata.
+// runNodeRespToOpenAPI must wrap that array under "results" so the client can
+// read it — a bare array used to be silently dropped, taking the receipts with it.
+func TestRunNodeRespToOpenAPISurfacesContractWriteReceiptArray(t *testing.T) {
+	results := []interface{}{
+		map[string]interface{}{
+			"methodName": "exactInputSingle",
+			"success":    true,
+			"receipt": map[string]interface{}{
+				"executionStatus": "confirmed",
+				"userOpHash":      "0xuserop",
+				"transactionHash": "0xtx",
+			},
+		},
+	}
+	md, err := structpb.NewValue(results)
+	require.NoError(t, err)
+
+	out := runNodeRespToOpenAPI(&avsproto.RunNodeWithInputsResp{Success: true, Metadata: md})
+
+	require.NotNil(t, out.Metadata, "array metadata must be surfaced, not dropped")
+	m := *out.Metadata
+	arr, ok := m["results"].([]interface{})
+	require.True(t, ok, "array metadata must be wrapped under 'results'")
+	require.Len(t, arr, 1)
+	first := arr[0].(map[string]interface{})
+	receipt := first["receipt"].(map[string]interface{})
+	assert.Equal(t, "confirmed", receipt["executionStatus"])
+	assert.Equal(t, "0xuserop", receipt["userOpHash"])
+	assert.Equal(t, "0xtx", receipt["transactionHash"])
+}
+
+// Map-typed metadata (e.g. ethTransfer's gasUsed/transactionHash) must keep
+// surfacing as-is, without the "results" wrapper.
+func TestRunNodeRespToOpenAPIMapMetadataStillForwarded(t *testing.T) {
+	md, err := structpb.NewValue(map[string]interface{}{"transactionHash": "0xabc", "gasUsed": "21000"})
+	require.NoError(t, err)
+
+	out := runNodeRespToOpenAPI(&avsproto.RunNodeWithInputsResp{Success: true, Metadata: md})
+
+	require.NotNil(t, out.Metadata)
+	m := *out.Metadata
+	assert.Equal(t, "0xabc", m["transactionHash"])
+	assert.Nil(t, m["results"], "map metadata is forwarded as-is, not wrapped")
+}


### PR DESCRIPTION
## Problem

The G2/G3 execution-status fields shipped in #659 (`executionStatus`, `userOpHash`, `transactionHash` on a `contractWrite` method receipt) **never reach the client via `nodes:run`**.

`contractWrite` produces its per-method results — including the receipt — as an **array**-typed metadata ([node_output_handlers.go](core/taskengine/node_output_handlers.go)). But `runNodeRespToOpenAPI` only forwarded **map**-typed metadata, so the array (and every per-method receipt with it) was silently dropped from the REST response.

Confirmed by asymmetry: `ethTransfer` returns metadata as a *map*, and its SDK test reads `result.metadata.transactionHash` — that works. `contractWrite`'s is an *array*, so nothing surfaced; no client could read a receipt/txHash from a `nodes.run` contractWrite response. It stayed latent because `nodes.run` is simulate-only in practice and only `output.data` is asserted.

## Fix

Wrap array-typed metadata under `"results"` so it fits the object-typed `RunNodeResponse.metadata` and reaches the client as:

```
metadata.results[].receipt.{executionStatus, userOpHash, transactionHash}
```

Surgical and safe: it only affects metadata that was **previously dropped** (arrays), so there are no existing consumers to break. Map-typed metadata (`ethTransfer`) is unchanged.

## Why now

Unblocks the `ava-sdk-js` execution-status accessor and completes the G2/G3 work end-to-end for the studio preview→confirm→execute flow.

## Tests

`aggregator/rest/handlers_nodes_test.go` — array metadata is wrapped under `results` (receipt fields present); map metadata still forwarded as-is. `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
