### PR TITLE
docs: change-doc for Alchemy bundler rollout (cuts v4.4.0 pre-release)

### DIFF
--- a/docs/changes/20260720-alchemy-bundler-provider.md
+++ b/docs/changes/20260720-alchemy-bundler-provider.md
@@ -1,0 +1,36 @@
+# Alchemy bundler routing via `bundler_provider`
+
+**Date:** 2026-07-20
+
+## Summary
+
+Adds a per-chain `bundler_provider` switch (`alchemy` | `self_hosted`, default
+`alchemy`) so UserOps can be relayed through Alchemy's Rundler instead of the
+self-hosted Voltaire bundler, with no change to the paymaster (still our
+per-chain `VerifyingPaymaster`, per-chain deposits — only the relay moves).
+
+## What changed
+
+- `SmartWalletConfig` gains `BundlerProvider` + `AlchemyAPIKey`;
+  `ActiveBundlerURL()` resolves the endpoint (alchemy URL derived from
+  `AlchemyAPIKey` + a chainId→subdomain map; `self_hosted` uses `bundler_url`).
+  The alchemy path never falls back to `bundler_url` — a missing key or unmapped
+  chain is a hard error (fail closed). `BundlerConfigured()` replaces the old
+  `bundler_url != ""` connectivity-only guard.
+- Two ERC-4337 portability fixes for Rundler: `eth_simulateUserOperation` (a
+  Voltaire-only method) is now best-effort; and verification gas is taken from
+  the real estimate rather than the 1M default, which tripped Rundler's
+  verification-gas-limit-efficiency floor.
+- Subdomain map covers Ethereum (1), Base (8453), Sepolia (11155111),
+  Base-Sepolia (84532), BNB (56 → `bnb-mainnet`).
+
+## Rollout
+
+Config ships via `avs-infra` (`sync-configs.sh --apply`) separately from the
+code release. Every wallet-op chain sets `bundler_provider` explicitly and
+`ALCHEMY_API_KEY` is a Railway sealed var. BNB stays `self_hosted` until it has a
+real deployed + funded paymaster on BNB mainnet (its config paymaster is a
+placeholder today, so making `BundlerConfigured()` true would fail the fatal
+startup paymaster probe).
+
+Validated end-to-end on Sepolia: a real UserOp lands through both providers.


### PR DESCRIPTION
Trigger PR to run semantic-release on `main`.

**Why:** #664's code was landed on `main` via a direct `git rebase staging` + push, which fires no `pull_request: closed` event — so `release-on-pr-close.yml` (publishes only from `main`, only on PR-merge) never ran and no version/tag was cut (main is still v4.3.0).

**Effect:** merging this to `main` runs the release workflow → `go-semantic-release` evaluates commits since v4.3.0, finds the `feat: bundler_provider` commit (b061b1c), and cuts a **v4.4.0 pre-release**. Payload is a genuine change-doc for the rollout.

**Next after merge:** dispatch `publish-prod-docker.yml` with the new `v4.4.0-...` tag to build + deploy the prod image (Railway flips to Alchemy on the 4 EVM chains; BNB stays self_hosted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
