### PR TITLE
fix: validate chainlink feed freshness in price macros

### DIFF
--- a/core/taskengine/macros/chainlink_test.go
+++ b/core/taskengine/macros/chainlink_test.go
@@ -1,0 +1,58 @@
+package macros
+
+import (
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestValidateChainlinkRound(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	maxAge := time.Hour
+	tenMinAgo := big.NewInt(now.Add(-10 * time.Minute).Unix())
+	twoHoursAgo := big.NewInt(now.Add(-2 * time.Hour).Unix())
+	price := big.NewInt(262199000000)
+
+	// Fresh, complete round: the answer passes through unchanged.
+	got, err := validateChainlinkRound(chainlinkRound{
+		roundID: big.NewInt(100), answer: price, updatedAt: tenMinAgo, answeredInRound: big.NewInt(100),
+	}, maxAge, now)
+	if err != nil {
+		t.Fatalf("fresh round: unexpected error: %v", err)
+	}
+	if got.Cmp(price) != 0 {
+		t.Fatalf("fresh round: answer = %s, want %s", got, price)
+	}
+
+	// Each unhealthy round must be rejected; the answer must never leak through.
+	bad := []struct {
+		name  string
+		round chainlinkRound
+	}{
+		{"stale: updated 2h ago, max 1h", chainlinkRound{big.NewInt(100), price, twoHoursAgo, big.NewInt(100)}},
+		{"negative price", chainlinkRound{big.NewInt(100), big.NewInt(-1), tenMinAgo, big.NewInt(100)}},
+		{"zero price", chainlinkRound{big.NewInt(100), big.NewInt(0), tenMinAgo, big.NewInt(100)}},
+		{"round not complete (updatedAt 0)", chainlinkRound{big.NewInt(100), price, big.NewInt(0), big.NewInt(100)}},
+		{"carried-over answer (answeredInRound < roundId)", chainlinkRound{big.NewInt(100), price, tenMinAgo, big.NewInt(99)}},
+		{"nil answer", chainlinkRound{big.NewInt(100), nil, tenMinAgo, big.NewInt(100)}},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := validateChainlinkRound(tt.round, maxAge, now); err == nil {
+				t.Fatalf("expected error, got answer %s", got)
+			}
+		})
+	}
+}
+
+func TestChainlinkMaxAge(t *testing.T) {
+	if d := chainlinkMaxAge(nil); d != chainlinkDefaultMaxAge {
+		t.Fatalf("no arg: got %s, want default %s", d, chainlinkDefaultMaxAge)
+	}
+	if d := chainlinkMaxAge([]int{0}); d != chainlinkDefaultMaxAge {
+		t.Fatalf("zero arg: got %s, want default %s", d, chainlinkDefaultMaxAge)
+	}
+	if d := chainlinkMaxAge([]int{3600}); d != time.Hour {
+		t.Fatalf("explicit arg: got %s, want 1h", d)
+	}
+}

--- a/core/taskengine/macros/contract_test.go
+++ b/core/taskengine/macros/contract_test.go
@@ -1,6 +1,7 @@
 package macros
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -45,7 +46,12 @@ func TestExpression(t *testing.T) {
 	rpc := testutil.GetTestRPCURL()
 	SetRpc(rpc)
 
-	p, e := CompileExpression(`priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306")`)
+	// Pass the max-age override so these live-feed assertions don't flake when the
+	// Sepolia feed is stale (the case guarded against in the staleness logic). This
+	// also exercises the optional maxAgeSeconds argument through the expr path.
+	price := fmt.Sprintf(`priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306", %d)`, testNoStaleBound)
+
+	p, e := CompileExpression(price)
 	if e != nil {
 		t.Errorf("Compile expression error: %v", e)
 	}
@@ -61,12 +67,7 @@ func TestExpression(t *testing.T) {
 
 	t.Logf("Exp Run Result: %v", r.(*big.Int))
 
-	match, e := RunExpressionQuery(`
-		bigCmp(
-		  priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306"),
-		  toBigInt("2000")
-		) > 0
-	`)
+	match, e := RunExpressionQuery(fmt.Sprintf(`bigCmp(%s, toBigInt("2000")) > 0`, price))
 	if e != nil {
 		t.Errorf("Run expr error: %v %v", e, r)
 	}
@@ -74,12 +75,7 @@ func TestExpression(t *testing.T) {
 		t.Error("Evaluate error. Expected: true, received: false")
 	}
 
-	match, e = RunExpressionQuery(`
-		bigCmp(
-		  priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306"),
-		  toBigInt("9262391230023")
-		) > 0
-	`)
+	match, e = RunExpressionQuery(fmt.Sprintf(`bigCmp(%s, toBigInt("9262391230023")) > 0`, price))
 	if e != nil {
 		t.Errorf("Run expr error: %v %v", e, r)
 	}

--- a/core/taskengine/macros/exp.go
+++ b/core/taskengine/macros/exp.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -62,46 +63,92 @@ func readContractData(contractAddress string, data string, method string, contra
 // QueryContract
 //const taskCondition = `cmp(chainlinkPrice("0x694AA1769357215DE4FAC081bf1f309aDC325306"), parseUnit("2621.99", 8)) > 1`
 
-func chainlinkLatestRoundData(tokenPair string) *big.Int {
+// chainlinkDefaultMaxAge bounds how stale a feed's updatedAt may be before its
+// answer is rejected. Chainlink heartbeats vary by feed (ETH/USD ~1h, some feeds
+// up to 24h), so the default is deliberately loose to avoid rejecting a healthy
+// slow feed. Callers on a faster feed should pass an explicit max age in seconds.
+const chainlinkDefaultMaxAge = 24 * time.Hour
+
+// chainlinkRound is the decoded latestRoundData tuple:
+// (roundId, answer, startedAt, updatedAt, answeredInRound).
+type chainlinkRound struct {
+	roundID         *big.Int
+	answer          *big.Int
+	updatedAt       *big.Int
+	answeredInRound *big.Int
+}
+
+// validateChainlinkRound returns the round's answer, or an error if the round is
+// incomplete, reports a non-positive price, or is older than maxAge relative to
+// now. Keeping the checks separate from the RPC call makes them unit-testable
+// without a live feed. See https://docs.chain.link/data-feeds/api-reference.
+func validateChainlinkRound(r chainlinkRound, maxAge time.Duration, now time.Time) (*big.Int, error) {
+	if r.answer == nil || r.updatedAt == nil {
+		return nil, fmt.Errorf("incomplete round data")
+	}
+	if r.answer.Sign() <= 0 {
+		return nil, fmt.Errorf("invalid price %s: must be > 0", r.answer)
+	}
+	// updatedAt == 0 means the round has not been answered yet.
+	if r.updatedAt.Sign() == 0 {
+		return nil, fmt.Errorf("round not complete: updatedAt is 0")
+	}
+	// answeredInRound < roundId means the answer was carried over from an earlier
+	// round — a stalled feed on legacy aggregators.
+	if r.answeredInRound != nil && r.roundID != nil && r.answeredInRound.Cmp(r.roundID) < 0 {
+		return nil, fmt.Errorf("stale round: answeredInRound %s < roundId %s", r.answeredInRound, r.roundID)
+	}
+	updatedAt := time.Unix(r.updatedAt.Int64(), 0)
+	if age := now.Sub(updatedAt); age > maxAge {
+		return nil, fmt.Errorf("stale price: last updated %s ago, exceeds max age %s", age.Truncate(time.Second), maxAge)
+	}
+	return r.answer, nil
+}
+
+// chainlinkMaxAge resolves an optional caller-supplied max age (seconds) to a
+// duration, falling back to chainlinkDefaultMaxAge.
+func chainlinkMaxAge(maxAgeSeconds []int) time.Duration {
+	if len(maxAgeSeconds) > 0 && maxAgeSeconds[0] > 0 {
+		return time.Duration(maxAgeSeconds[0]) * time.Second
+	}
+	return chainlinkDefaultMaxAge
+}
+
+// bigFromABI safely extracts a *big.Int from an ABI-decoded value.
+func bigFromABI(v any) *big.Int {
+	b, _ := v.(*big.Int)
+	return b
+}
+
+// chainlinkLatestRoundData reads a Chainlink feed's latest round and returns its
+// price, panicking if the feed is unreachable or the round is stale or invalid.
+// The expr VM recovers the panic, so a bad feed fails the task loudly instead of
+// silently evaluating a condition against outdated or zero data. An optional
+// second argument overrides the staleness window (in seconds).
+func chainlinkLatestRoundData(tokenPair string, maxAgeSeconds ...int) *big.Int {
 	output, err := QueryContract(
 		rpcConn,
-		// https://docs.chain.link/data-feeds/price-feeds/addresses?network=ethereum&page=1&search=et#sepolia-testnet
-		// ETH-USD pair on sepolia
 		common.HexToAddress(tokenPair),
 		chainlinkABI,
 		"latestRoundData",
 	)
-
 	if err != nil {
 		panic(fmt.Errorf("Error when querying contract through rpc. contract: %s. error: %w", tokenPair, err))
 	}
-
-	// TODO: Check round and answer to prevent the case where chainlink down we
-	// may got outdated data
-	if len(output) < 2 || output[1] == nil {
-		return big.NewInt(0)
+	if len(output) < 5 {
+		panic(fmt.Errorf("chainlink feed %s: unexpected latestRoundData output (%d fields)", tokenPair, len(output)))
 	}
-	return output[1].(*big.Int)
-}
 
-func chainlinkLatestAnswer(tokenPair string) *big.Int {
-	output, err := QueryContract(
-		rpcConn,
-		// https://docs.chain.link/data-feeds/price-feeds/addresses?network=ethereum&page=1&search=et#sepolia-testnet
-		// ETH-USD pair on sepolia
-		common.HexToAddress(tokenPair),
-		chainlinkABI,
-		"latestAnswer",
-	)
-
+	answer, err := validateChainlinkRound(chainlinkRound{
+		roundID:         bigFromABI(output[0]),
+		answer:          bigFromABI(output[1]),
+		updatedAt:       bigFromABI(output[3]),
+		answeredInRound: bigFromABI(output[4]),
+	}, chainlinkMaxAge(maxAgeSeconds), time.Now())
 	if err != nil {
-		panic(fmt.Errorf("Error when querying contract through rpc. contract: %s. error: %w", tokenPair, err))
+		panic(fmt.Errorf("chainlink feed %s: %w", tokenPair, err))
 	}
-
-	if len(output) == 0 || output[0] == nil {
-		return big.NewInt(0)
-	}
-	return output[0].(*big.Int)
+	return answer
 }
 
 func BigCmp(a *big.Int, b *big.Int) (r int) {
@@ -176,11 +223,8 @@ func (bi *Builtin) ToBigInt(val string) *big.Int {
 	return ToBigInt(val)
 }
 
-func (bi *Builtin) ChainlinkLatestRoundData(tokenPair string) *big.Int {
-	return chainlinkLatestRoundData(tokenPair)
-}
-func (bi *Builtin) ChainlinkLatestAnswer(tokenPair string) *big.Int {
-	return chainlinkLatestAnswer(tokenPair)
+func (bi *Builtin) ChainlinkLatestRoundData(tokenPair string, maxAgeSeconds ...int) *big.Int {
+	return chainlinkLatestRoundData(tokenPair, maxAgeSeconds...)
 }
 
 func (bi *Builtin) BigCmp(a *big.Int, b *big.Int) (r int) {
@@ -207,8 +251,11 @@ var (
 		// macro to do IO from JS
 		"readContractData": readContractData,
 
-		"priceChainlink":           chainlinkLatestAnswer,
-		"chainlinkPrice":           chainlinkLatestAnswer,
+		// priceChainlink / chainlinkPrice historically used the deprecated
+		// latestAnswer (no round or timestamp, so staleness was undetectable).
+		// They now route through latestRoundData, which validates freshness.
+		"priceChainlink":           chainlinkLatestRoundData,
+		"chainlinkPrice":           chainlinkLatestRoundData,
 		"latestRoundDataChainlink": chainlinkLatestRoundData,
 
 		"bigCmp":    BigCmp,

--- a/core/taskengine/macros/exp_test.go
+++ b/core/taskengine/macros/exp_test.go
@@ -6,14 +6,18 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 )
 
+// testNoStaleBound is a max-age override (seconds) large enough that a live
+// testnet feed never reads as stale, so RPC-gated smoke tests don't flake on
+// Sepolia freshness. ~50 years, and kept under math.MaxInt32 so the untyped
+// constant is safe on 32-bit builds. Staleness logic itself is unit-tested in
+// chainlink_test.go.
+const testNoStaleBound = 50 * 365 * 24 * 3600
+
 func TestChainlinkLatestRoundData(t *testing.T) {
 	SetRpc(testutil.GetTestRPCURL())
 
 	// https://sepolia.etherscan.io/address/0x694AA1769357215DE4FAC081bf1f309aDC325306
-	// Sepolia ETH/USD. Pass a very large max age so this live-feed smoke test does
-	// not flake on a testnet feed that updates infrequently; staleness logic is
-	// covered by the unit tests in chainlink_test.go.
-	value := chainlinkLatestRoundData("0x694AA1769357215DE4FAC081bf1f309aDC325306", 100*365*24*3600)
+	value := chainlinkLatestRoundData("0x694AA1769357215DE4FAC081bf1f309aDC325306", testNoStaleBound)
 	if value == nil {
 		t.Errorf("fail to query chainlink answer. expect a value, got nil")
 	}

--- a/core/taskengine/macros/exp_test.go
+++ b/core/taskengine/macros/exp_test.go
@@ -6,11 +6,14 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 )
 
-func TestChainlinkLatestAnswer(t *testing.T) {
+func TestChainlinkLatestRoundData(t *testing.T) {
 	SetRpc(testutil.GetTestRPCURL())
 
-	// https://sepolia.etherscan.io/address/0x9aCb42Ac07C72cFc29Cd95d9DEaC807E93ada1F6#code
-	value := chainlinkLatestAnswer("0x694AA1769357215DE4FAC081bf1f309aDC325306")
+	// https://sepolia.etherscan.io/address/0x694AA1769357215DE4FAC081bf1f309aDC325306
+	// Sepolia ETH/USD. Pass a very large max age so this live-feed smoke test does
+	// not flake on a testnet feed that updates infrequently; staleness logic is
+	// covered by the unit tests in chainlink_test.go.
+	value := chainlinkLatestRoundData("0x694AA1769357215DE4FAC081bf1f309aDC325306", 100*365*24*3600)
 	if value == nil {
 		t.Errorf("fail to query chainlink answer. expect a value, got nil")
 	}


### PR DESCRIPTION
Closes #661.

The chainlink price macros returned the feed `answer` while discarding every
field that signals validity, so a stalled or down feed let price-conditioned
tasks evaluate against a frozen price. A failed round also read as `0`, and
`priceChainlink`/`chainlinkPrice` used the deprecated `latestAnswer`, which
carries no timestamp to check at all.

**Changes**
- Extract `validateChainlinkRound` (unit-testable without a live feed): rejects a
  stale (`updatedAt` older than max age), incomplete, carried-over, or
  non-positive round.
- Panic on an invalid round instead of returning a silent `0`, so the expr VM
  fails the task loudly rather than acting on bad data.
- Re-point `priceChainlink`/`chainlinkPrice` at `latestRoundData` and drop the
  deprecated `latestAnswer` path.
- Add an optional `maxAgeSeconds` argument to override the default 24h window:
  `latestRoundDataChainlink(feed)` or `latestRoundDataChainlink(feed, 3600)`.

**Decisions worth a look**
- Default max age is a loose 24h so healthy slow-heartbeat feeds aren't rejected;
  callers on faster feeds should pass an explicit window.
- The `latestAnswer` re-point is a behavior change flagged in #661 — same return
  value, but these now panic on a stale feed instead of silently returning a price.

**Tests:** `validateChainlinkRound` unit tests (6 rejection cases + fresh passes)
and `chainlinkMaxAge` default/override, all without RPC.

---

**⚠️ User-visible behavior change (SDK consumers)**

`priceChainlink` / `chainlinkPrice` previously returned a price unconditionally. They now route through `latestRoundData` and **panic on a round stale beyond the max age** (default 24h), which the expr VM surfaces as a task failure. A task using these on a feed stale >24h will now fail loudly instead of evaluating against a frozen price. Pass `priceChainlink(feed, maxAgeSeconds)` to tune the window.
