### PR TITLE
fix: reject zero-address ERC-20 token in withdraw path (Sentry EIGENLAYER-AVS-1J)

### DIFF
--- a/aggregator/rest/handlers_wallets.go
+++ b/aggregator/rest/handlers_wallets.go
@@ -185,9 +185,19 @@ func (s *Server) WithdrawWallet(ctx echo.Context, address generated.EthereumAddr
 		return badRequest("WITHDRAW_BAD_RECIPIENT", "Invalid recipient address",
 			"recipientAddress must be a valid 0x-prefixed hex address.")
 	}
-	if body.Token != "ETH" && !common.IsHexAddress(body.Token) {
-		return badRequest("WITHDRAW_BAD_TOKEN", "Invalid token",
-			"token must be the literal \"ETH\" or a valid 0x-prefixed ERC-20 address.")
+	if body.Token != "ETH" {
+		if !common.IsHexAddress(body.Token) {
+			return badRequest("WITHDRAW_BAD_TOKEN", "Invalid token",
+				"token must be the literal \"ETH\" or a valid 0x-prefixed ERC-20 address.")
+		}
+		// The zero address passes IsHexAddress but is never an ERC-20 —
+		// balanceOf on it fails downstream with the opaque "no contract
+		// code at given address" (Sentry EIGENLAYER-AVS-1J). Reject it here
+		// as a 400. Native withdrawals use the literal "ETH".
+		if common.HexToAddress(body.Token) == (common.Address{}) {
+			return badRequest("WITHDRAW_BAD_TOKEN", "Invalid token",
+				"token cannot be the zero address; use the literal \"ETH\" to withdraw native currency.")
+		}
 	}
 	if body.Amount != "max" {
 		amt, ok := new(big.Int).SetString(body.Amount, 10)

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/allegro/bigcache/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -275,10 +277,31 @@ func (r *RpcServer) ExecuteWithdraw(ctx context.Context, user *model.User, paylo
 		if !common.IsHexAddress(payload.Token) {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid token address format: %q", payload.Token)
 		}
+		tokenAddr := common.HexToAddress(payload.Token)
+		// The zero address is never a valid ERC-20. It passes IsHexAddress,
+		// so guard explicitly — otherwise GetTokenBalance calls balanceOf on
+		// it and fails with the opaque "no contract code at given address".
+		// This path is reachable via gRPC (not only the REST handler), so
+		// don't assume upstream validation. Native withdrawals use "ETH".
+		if tokenAddr == (common.Address{}) {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"token cannot be the zero address on chain %d; use \"ETH\" to withdraw native currency", requestedChainID)
+		}
 		// Validate the token balance.
-		tokenBalance, balanceErr := chainReader.GetTokenBalance(ctx, common.HexToAddress(payload.Token), *smartWalletAddress)
+		tokenBalance, balanceErr := chainReader.GetTokenBalance(ctx, tokenAddr, *smartWalletAddress)
 		if balanceErr != nil {
-			return nil, status.Errorf(codes.Internal, "failed to get token balance: %v", balanceErr)
+			// "no contract code at given address" means the token isn't
+			// deployed on this chain (wrong chainId, or a non-token address) —
+			// a client error, not a server fault. Return FailedPrecondition
+			// (HTTP 400) so it doesn't page Sentry as a 500, and include the
+			// token + chain so the event is self-diagnosable without
+			// cross-referencing gateway logs (Sentry EIGENLAYER-AVS-1J).
+			if errors.Is(balanceErr, bind.ErrNoCode) || strings.Contains(balanceErr.Error(), "no contract code at given address") {
+				return nil, status.Errorf(codes.FailedPrecondition,
+					"token %s has no contract code on chain %d — verify the token address and chainId", payload.Token, requestedChainID)
+			}
+			return nil, status.Errorf(codes.Internal,
+				"failed to get token balance for token %s on chain %d: %v", payload.Token, requestedChainID, balanceErr)
 		}
 		if withdrawAll {
 			if tokenBalance.Cmp(big.NewInt(0)) == 0 {

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -200,6 +200,12 @@ func (d *directChainStateReader) GetBalance(ctx context.Context, addr common.Add
 }
 
 func (d *directChainStateReader) GetTokenBalance(ctx context.Context, token, owner common.Address) (*big.Int, error) {
+	// The zero address is never an ERC-20 contract; balanceOf on it fails
+	// with the opaque "no contract code at given address". Reject up front
+	// so callers get an actionable error (Sentry EIGENLAYER-AVS-1J).
+	if token == (common.Address{}) {
+		return nil, fmt.Errorf("token address is the zero address, not an ERC-20 contract")
+	}
 	contract, err := erc20.NewErc20(token, d.client)
 	if err != nil {
 		return nil, fmt.Errorf("erc20 binding for %s: %w", token.Hex(), err)

--- a/core/taskengine/chain_state_reader_test.go
+++ b/core/taskengine/chain_state_reader_test.go
@@ -490,6 +490,22 @@ func TestWorkerChainStateReader_GetTokenBalance_Malformed(t *testing.T) {
 	}
 }
 
+// TestDirectChainStateReader_GetTokenBalance_ZeroAddress: the zero address is
+// never an ERC-20; balanceOf on it fails with the opaque "no contract code at
+// given address" (Sentry EIGENLAYER-AVS-1J). The reader must reject it up
+// front without dialing the chain, so a nil client is safe here.
+func TestDirectChainStateReader_GetTokenBalance_ZeroAddress(t *testing.T) {
+	r := NewDirectChainStateReader(nil, 11155111)
+	owner := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	_, err := r.GetTokenBalance(context.Background(), common.Address{}, owner)
+	if err == nil {
+		t.Fatalf("expected zero-address token to be rejected")
+	}
+	if !strings.Contains(err.Error(), "zero address") {
+		t.Fatalf("error should mention zero address, got: %v", err)
+	}
+}
+
 // TestWorkerChainStateReader_GetSmartWalletAddress: owner/factory are
 // hex-encoded and the salt serializes as a base-10 string; a valid hex
 // address round-trips back.

--- a/worker/server.go
+++ b/worker/server.go
@@ -563,6 +563,13 @@ func (s *Server) GetTokenBalance(ctx context.Context, req *avsproto.WorkerGetTok
 	if !common.IsHexAddress(req.OwnerAddress) {
 		return nil, fmt.Errorf("invalid owner address %q", req.OwnerAddress)
 	}
+	// The zero address passes IsHexAddress but is never an ERC-20 contract;
+	// balanceOf on it fails with "no contract code at given address". Reject
+	// it explicitly so the caller gets an actionable error rather than an
+	// opaque RPC failure (Sentry EIGENLAYER-AVS-1J).
+	if common.HexToAddress(req.TokenAddress) == (common.Address{}) {
+		return nil, fmt.Errorf("token address is the zero address, not an ERC-20 contract")
+	}
 	token, err := erc20.NewErc20(common.HexToAddress(req.TokenAddress), s.worker.rpcClient)
 	if err != nil {
 		return nil, fmt.Errorf("erc20 binding for %s: %w", req.TokenAddress, err)

--- a/worker/server_test.go
+++ b/worker/server_test.go
@@ -1,0 +1,27 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestServer_GetTokenBalance_ZeroAddress: the worker rejects a zero-address
+// token before dialing the chain, so a Server with no wired worker is enough
+// to exercise the guard. Without it, balanceOf on the zero address fails with
+// the opaque "no contract code at given address" (Sentry EIGENLAYER-AVS-1J)
+// on the worker-routed withdraw path.
+func TestServer_GetTokenBalance_ZeroAddress(t *testing.T) {
+	s := &Server{}
+	req := &avsproto.WorkerGetTokenBalanceReq{
+		TokenAddress: "0x0000000000000000000000000000000000000000",
+		OwnerAddress: "0x1234567890123456789012345678901234567890",
+	}
+	if _, err := s.GetTokenBalance(context.Background(), req); err == nil {
+		t.Fatalf("expected zero-address token to be rejected")
+	} else if !strings.Contains(err.Error(), "zero address") {
+		t.Fatalf("error should mention zero address, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

A production withdraw request with `token = 0x0000…0000` (the zero address) surfaced as **Sentry [EIGENLAYER-AVS-1J](https://ava-protocol.sentry.io/issues/7508446815)** — `REST handler error … failed to get token balance: no contract code at given address`, returned as HTTP **500**.

Root cause: the zero address passes `common.IsHexAddress`, so it slipped past the surface validation into the ERC-20 branch, where `balanceOf` on `0x0` fails with go-ethereum's `ErrNoCode`. That's a deterministic **client** error (a non-contract token, or a token/chain mismatch), but it was returned as `codes.Internal` → 500 → paged Sentry.

Gateway logs confirmed the traffic: self-withdraw, Sepolia (11155111), `token = 0x0`, `amount = 1` wei, one call using the `0x…dEaD` burn address as the wallet — i.e. E2E/probe traffic, not a real user.

## Changes

- **REST handler + `ExecuteWithdraw`**: reject the zero-address token as **400** (native withdrawals use the literal `"ETH"`).
- **`ExecuteWithdraw`**: reclassify `"no contract code"` (`bind.ErrNoCode` or the flattened worker-gRPC string) → `FailedPrecondition` (**400**) so it no longer pages Sentry as a 500, and enrich the error with `token` + `chainId` so the event is self-diagnosable straight from Sentry (the original event recorded neither).
- **Defense-in-depth sweep**: guard both `GetTokenBalance` implementations (direct `chain_state_reader` + `worker/server`) against the zero address, since each is reachable independently via gRPC. Left `engine.go:4087` untouched — there a zero-address token legitimately means native ETH.
- **Regression tests** for the direct-reader and worker guards.

## Test

```
go test ./worker/ -run TestServer_GetTokenBalance_ZeroAddress -count=1            # ok
go test ./core/taskengine/ -run 'TestDirectChainStateReader_GetTokenBalance_ZeroAddress' -count=1   # ok
go test ./core/taskengine/ -run 'TestWorkerChainStateReader_GetTokenBalance' -count=1               # ok (no regression)
go build ./aggregator/... ./worker/... ./core/taskengine/...                       # ok
```

No storage/model/proto changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)