### PR TITLE
fix: node nil-config panics, REST 5xx Sentry grouping, detail leak

### DIFF
--- a/aggregator/rest/handlers_nodes_nil_config_test.go
+++ b/aggregator/rest/handlers_nodes_nil_config_test.go
@@ -1,0 +1,64 @@
+package rest
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+)
+
+// runNodeCtx builds the Echo context POST /api/v1/nodes:run would arrive with
+// after the JWT middleware ran — an authenticated user and a JSON body. The
+// engine is never reached for these cases: node mapping fails first.
+func runNodeCtx(body string) echo.Context {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes:run", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c := e.NewContext(req, httptest.NewRecorder())
+	c.Set("auth.user", &restmw.AuthenticatedUser{Subject: testPartnerSubject})
+	return c
+}
+
+// A node posted with `"config": null` must come back as a 400 with a
+// NODES_BAD_NODE code. It used to panic inside OpenAPIToProtoNode; the panic
+// was caught by Echo's recover middleware and re-surfaced as a 500, which is
+// what Sentry recorded as EIGENLAYER-AVS-29 (the panic) plus the generic
+// "REST handler error" 5xx log line (EIGENLAYER-AVS-2A / -1J).
+//
+// customCode and loop are the two variants whose mapping arm reads through
+// the Config pointer directly; the rest already errored cleanly.
+func TestRunNodeRejectsNilConfigWithoutPanicking(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"customCodeNullConfig", `{"node":{"id":"n1","type":"customCode","config":null}}`},
+		{"customCodeMissingConfig", `{"node":{"id":"n1","type":"customCode"}}`},
+		{"loopNullConfig", `{"node":{"id":"n1","type":"loop","config":null}}`},
+		{"loopMissingConfig", `{"node":{"id":"n1","type":"loop"}}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("RunNode panicked on %s: %v", tc.body, r)
+				}
+			}()
+
+			err := s.RunNode(runNodeCtx(tc.body))
+			assertHTTPStatus(t, err, http.StatusBadRequest)
+			if code := err.(*restmw.HTTPError).Code; code != "NODES_BAD_NODE" {
+				t.Fatalf("expected NODES_BAD_NODE, got %s", code)
+			}
+		})
+	}
+}

--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -153,6 +153,9 @@ func OpenAPIToProtoNode(in generated.Node) (*avsproto.TaskNode, error) {
 		if err != nil {
 			return nil, fmt.Errorf("node %s: decode CustomCodeNode: %w", in.Id, err)
 		}
+		if v.Config == nil {
+			return nil, fmt.Errorf("node %s: CustomCodeNode missing config", in.Id)
+		}
 		// CustomCodeNode_Config.Lang is a proto enum whose wire form
 		// (LANG_JAVASCRIPT) doesn't match the OpenAPI wire form
 		// (javascript), so it's mapped explicitly rather than through

--- a/aggregator/rest/mapping/node.go
+++ b/aggregator/rest/mapping/node.go
@@ -122,6 +122,9 @@ func OpenAPIToProtoNode(in generated.Node) (*avsproto.TaskNode, error) {
 		if err != nil {
 			return nil, fmt.Errorf("node %s: decode LoopNode: %w", in.Id, err)
 		}
+		if v.Config == nil {
+			return nil, fmt.Errorf("node %s: LoopNode missing config", in.Id)
+		}
 		// LoopNode.Config.Runner is a nested Node — recurse so its
 		// discriminated union survives the round-trip. The runner lives
 		// on the proto LoopNode (oneof), not on LoopNode_Config.

--- a/aggregator/rest/mapping/node_nil_config_test.go
+++ b/aggregator/rest/mapping/node_nil_config_test.go
@@ -1,0 +1,74 @@
+package mapping
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+)
+
+// Every Node variant's OpenAPI Config is a `*Config` with `omitempty`, so a
+// caller that POSTs `"config": null` — or omits the field entirely — reaches
+// OpenAPIToProtoNode with a nil Config. The customCode and loop arms read
+// through that pointer directly (the other nine hand it to jsonRetargetProto,
+// which marshals a nil pointer to `null` and lets protojson reject it), so
+// they panicked instead of returning a 400. The panic surfaced as a 500 via
+// Echo's recover middleware — Sentry EIGENLAYER-AVS-29.
+//
+// This table covers every variant so a future arm that dereferences Config
+// without a nil check is caught here rather than in production.
+func TestOpenAPIToProtoNodeNilConfigIsRejectedNotPanic(t *testing.T) {
+	variants := []string{
+		"ethTransfer",
+		"contractWrite",
+		"contractRead",
+		"graphqlQuery",
+		"restApi",
+		"branch",
+		"filter",
+		"loop",
+		"customCode",
+		"balance",
+		"await",
+	}
+
+	for _, variant := range variants {
+		t.Run(variant, func(t *testing.T) {
+			for _, body := range []string{
+				`{"id":"n1","type":"` + variant + `","config":null}`, // explicit null
+				`{"id":"n1","type":"` + variant + `"}`,               // config omitted
+			} {
+				var node generated.Node
+				require.NoError(t, json.Unmarshal([]byte(body), &node))
+
+				require.NotPanics(t, func() {
+					out, err := OpenAPIToProtoNode(node)
+					assert.Error(t, err, "a node with no config must be rejected: %s", body)
+					assert.Nil(t, out)
+				}, "payload must not panic: %s", body)
+			}
+		})
+	}
+}
+
+// The nil-config rejection must name the offending node so the 400 the caller
+// receives is actionable rather than an opaque decode failure.
+func TestOpenAPIToProtoNodeNilConfigErrorNamesNode(t *testing.T) {
+	for variant, want := range map[string]string{
+		"customCode": "CustomCodeNode missing config",
+		"loop":       "LoopNode missing config",
+	} {
+		t.Run(variant, func(t *testing.T) {
+			var node generated.Node
+			require.NoError(t, json.Unmarshal([]byte(`{"id":"bad-node","type":"`+variant+`","config":null}`), &node))
+
+			_, err := OpenAPIToProtoNode(node)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "bad-node")
+			assert.Contains(t, err.Error(), want)
+		})
+	}
+}

--- a/aggregator/rest/middleware/problem.go
+++ b/aggregator/rest/middleware/problem.go
@@ -23,6 +23,12 @@ type Problem struct {
 	Code     string `json:"code,omitempty"`
 }
 
+// genericServerErrorDetail replaces any 5xx Problem detail the code didn't
+// deliberately author for the caller. Server-side failure text is internal
+// state and stays in the logs and Sentry; the client correlates via the
+// request id carried in Problem.Instance.
+const genericServerErrorDetail = "An internal error occurred while processing this request."
+
 // HTTPError is a typed error a handler can return to control the
 // Problem fields directly. Anything else (echo.HTTPError, plain errors)
 // gets best-effort-mapped to a Problem by ProblemErrorHandler.
@@ -80,6 +86,13 @@ func ProblemErrorHandler(logger sdklogging.Logger) echo.HTTPErrorHandler {
 			Type:     "about:blank",
 		}
 
+		// A typed *HTTPError carries a Detail a handler author wrote for the
+		// caller ("this aggregator has no smart-wallet config for the
+		// requested chain"). Every other branch carries whatever text the
+		// failure happened to produce internally, which must not be echoed
+		// back on a 5xx — see the clamp below.
+		detailIsAuthored := false
+
 		var typed *HTTPError
 		var echoErr *echo.HTTPError
 		switch {
@@ -88,6 +101,7 @@ func ProblemErrorHandler(logger sdklogging.Logger) echo.HTTPErrorHandler {
 			p.Code = typed.Code
 			p.Title = typed.Title
 			p.Detail = typed.Detail
+			detailIsAuthored = true
 		case errors.As(err, &echoErr):
 			p.Status = echoErr.Code
 			p.Title = http.StatusText(echoErr.Code)
@@ -125,6 +139,17 @@ func ProblemErrorHandler(logger sdklogging.Logger) echo.HTTPErrorHandler {
 				"method", c.Request().Method,
 				"request_id", p.Instance,
 				"error", err)
+		}
+
+		// An unauthored 5xx Detail is raw internal state — a panic message
+		// ("runtime error: invalid memory address or nil pointer
+		// dereference"), an engine error chain, a driver string. The log
+		// call above and its Sentry event keep the full text; the caller
+		// gets a fixed line plus the request id in `instance`, which is
+		// what correlates the two. 4xx details are unchanged: those
+		// describe the caller's own input and are meant to be actionable.
+		if p.Status >= 500 && !detailIsAuthored {
+			p.Detail = genericServerErrorDetail
 		}
 
 		// Defer to Echo's standard response writing with our shape +

--- a/aggregator/rest/middleware/problem.go
+++ b/aggregator/rest/middleware/problem.go
@@ -110,12 +110,21 @@ func ProblemErrorHandler(logger sdklogging.Logger) echo.HTTPErrorHandler {
 		}
 
 		if logger != nil && p.Status >= 500 {
+			// `err` is passed as an error value, not err.Error(). pkg/logger's
+			// SentryLogger uses the first error-typed tag as the captured
+			// exception and only falls back to wrapping the message string
+			// when there is none — so passing a string made every 5xx from
+			// every route report as the same `*errors.errorString: REST
+			// handler error`, collapsing unrelated root causes into one
+			// Sentry issue (EIGENLAYER-AVS-1J / -2A). Passing the error
+			// itself makes Sentry group on the actual failure.
 			logger.Error("REST handler error",
 				"status", p.Status,
 				"path", c.Request().URL.Path,
+				"route", c.Path(),
 				"method", c.Request().Method,
 				"request_id", p.Instance,
-				"error", err.Error())
+				"error", err)
 		}
 
 		// Defer to Echo's standard response writing with our shape +

--- a/aggregator/rest/middleware/problem_test.go
+++ b/aggregator/rest/middleware/problem_test.go
@@ -1,0 +1,151 @@
+package middleware
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+)
+
+// recordingLogger captures Error() calls so a test can assert what reached
+// the log — and therefore what SentryLogger would have captured.
+type recordingLogger struct {
+	sdklogging.Logger
+	msgs []string
+	tags [][]any
+}
+
+func (l *recordingLogger) Error(msg string, tags ...any) {
+	l.msgs = append(l.msgs, msg)
+	l.tags = append(l.tags, tags)
+}
+
+func (l *recordingLogger) loggedError(t *testing.T) error {
+	t.Helper()
+	if len(l.tags) != 1 {
+		t.Fatalf("expected exactly one Error() call, got %d", len(l.tags))
+	}
+	for i := 0; i+1 < len(l.tags[0]); i += 2 {
+		if l.tags[0][i] == "error" {
+			err, ok := l.tags[0][i+1].(error)
+			if !ok {
+				t.Fatalf("the `error` tag must carry an error value (SentryLogger only "+
+					"adopts error-typed tags as the exception), got %T", l.tags[0][i+1])
+			}
+			return err
+		}
+	}
+	t.Fatal("no `error` tag logged")
+	return nil
+}
+
+func serveErr(logger sdklogging.Logger, handlerErr error) (*httptest.ResponseRecorder, Problem) {
+	e := echo.New()
+	e.HTTPErrorHandler = ProblemErrorHandler(logger)
+	e.GET("/x", func(c echo.Context) error { return handlerErr })
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	var p Problem
+	_ = json.Unmarshal(rec.Body.Bytes(), &p)
+	return rec, p
+}
+
+// A 5xx whose detail the code never authored — the panic text Echo's recover
+// middleware hands back, an engine error chain — must not be echoed to the
+// caller, while the full error still reaches the log and Sentry.
+func TestProblemClampsUnauthored5xxDetail(t *testing.T) {
+	internal := errors.New("runtime error: invalid memory address or nil pointer dereference")
+	logger := &recordingLogger{}
+
+	rec, p := serveErr(logger, internal)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+	if p.Detail != genericServerErrorDetail {
+		t.Fatalf("expected clamped detail, got %q", p.Detail)
+	}
+	if strings.Contains(rec.Body.String(), "nil pointer dereference") {
+		t.Fatalf("internal error text leaked to client: %s", rec.Body.String())
+	}
+	if got := logger.loggedError(t); !errors.Is(got, internal) {
+		t.Fatalf("log must keep the original error, got %v", got)
+	}
+}
+
+// gRPC codes that map to 5xx carry engine-authored messages, not
+// caller-authored ones, so they are clamped too.
+func TestProblemClampsGRPCInternalDetail(t *testing.T) {
+	rec, p := serveErr(nil, status.Error(codes.Internal, "badger: key not found in vault shard 3"))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+	if p.Detail != genericServerErrorDetail {
+		t.Fatalf("expected clamped detail, got %q", p.Detail)
+	}
+	if strings.Contains(rec.Body.String(), "vault shard") {
+		t.Fatalf("engine internals leaked to client: %s", rec.Body.String())
+	}
+}
+
+// A handler that deliberately builds a 5xx *HTTPError wrote its Detail for
+// the caller — those stay, or operators lose the "this instance isn't
+// configured for that chain" class of message.
+func TestProblemKeepsAuthored5xxDetail(t *testing.T) {
+	const detail = "This aggregator instance has no smart-wallet config for the requested chain."
+	rec, p := serveErr(nil, &HTTPError{
+		Status: http.StatusServiceUnavailable,
+		Code:   "FEES_UNAVAILABLE",
+		Title:  "Fee estimator not configured",
+		Detail: detail,
+	})
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	if p.Detail != detail {
+		t.Fatalf("authored detail must survive, got %q", p.Detail)
+	}
+	if p.Code != "FEES_UNAVAILABLE" {
+		t.Fatalf("expected FEES_UNAVAILABLE, got %q", p.Code)
+	}
+}
+
+// 4xx details describe the caller's own input and must stay actionable —
+// this is the path the nil-config node payload now takes.
+func TestProblemKeeps4xxDetail(t *testing.T) {
+	const detail = "node n1: CustomCodeNode missing config"
+	_, p := serveErr(nil, &HTTPError{
+		Status: http.StatusBadRequest,
+		Code:   "NODES_BAD_NODE",
+		Title:  "Invalid node payload",
+		Detail: detail,
+	})
+
+	if p.Detail != detail {
+		t.Fatalf("4xx detail must survive, got %q", p.Detail)
+	}
+}
+
+// 4xx mapped from a gRPC code is also caller-facing and must not be clamped.
+func TestProblemKeepsGRPCInvalidArgumentDetail(t *testing.T) {
+	_, p := serveErr(nil, status.Error(codes.InvalidArgument, "chainId is required"))
+
+	if p.Status != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", p.Status)
+	}
+	if p.Detail != "chainId is required" {
+		t.Fatalf("4xx gRPC detail must survive, got %q", p.Detail)
+	}
+}


### PR DESCRIPTION
## Summary

Investigation of Sentry EIGENLAYER-AVS-29 / -2A / -1J. They turn out to be **one real defect plus a grouping artifact**, so this PR fixes the defect, de-aliases the grouping, and closes the information leak the panic exposed.

## 1. Nil-config panic — EIGENLAYER-AVS-29

Every node variant's OpenAPI `Config` is a `*Config` with `omitempty`, so `"config": null` — or an omitted `config` — reaches `OpenAPIToProtoNode` as nil on **any** of the eleven variants.

Probing all eleven: nine hand the nil to `jsonRetargetProto`, which marshals it to `null` and lets protojson reject it cleanly. **Two panic — `customCode` and `loop`.** The original fix guarded only `customCode`; the `loop` arm dereferenced `v.Config.Runner` with the identical exposure.

It is also reachable from both workflow-create paths, not just `POST /nodes:run` — `handlers_workflows.go` and `mapping/workflow.go` call the same mapper.

Both arms now return a named error that flows through `badRequest`, so the caller gets a 400 instead of a 500.

## 2. Sentry grouping — EIGENLAYER-AVS-2A / -1J

`ProblemErrorHandler` logged `"error", err.Error()` — a **string**. `pkg/logger`'s `SentryLogger.captureToSentry` only adopts an *error-typed* tag as the captured exception and otherwise wraps the message, so every 5xx from every REST route reported as the same `*errors.errorString: REST handler error`.

That is a catch-all bucket, not a single bug. It explains why -1J looked like it "regressed" after the withdraw fix in #670: unrelated 500s keep landing in it. Passing the error itself lets Sentry group on the real failure; the matched route is added as a tag for filtering.

Two corrections to the original triage worth recording:
- "Check `handlers_nodes.go` for other error paths returning non-nil errors" would find nothing — mapping failures return `badRequest` (400) and the handler only logs at `>= 500`, so the panic was the only path that could produce those events.
- The "0-user events suggest probing/fuzzing" read isn't needed; `config: null` is what a normal SDK client sends for a partially-built node.

**-1J will not go quiet after this deploy.** The grouping change means new 5xx events split into per-error issues instead, so it should be resolved and the real ones allowed to surface separately.

## 3. Internal error text in 5xx bodies

`p.Detail = err.Error()` meant a recovered panic returned its runtime message to the caller:

```json
{"status":500,"detail":"runtime error: invalid memory address or nil pointer dereference"}
```

Same for gRPC codes mapping to 5xx, where the engine's `st.Message()` was forwarded verbatim.

The clamp is **selective, not blanket**. Four handlers deliberately build 5xx `HTTPError`s with caller-appropriate wording — "This aggregator instance has no smart-wallet config for the requested chain", "Withdraw service not configured" — and a blanket clamp would have deleted exactly the messages an operator needs. So a typed `*HTTPError` detail is treated as authored and survives; everything else on a 5xx is replaced. 4xx is untouched in every branch, including the gRPC-mapped `InvalidArgument` path.

The full error still reaches the log and Sentry; `instance` carries the request id correlating the generic client response to it.

## Tests

- `mapping/node_nil_config_test.go` — all eleven variants × (null config, omitted config), asserting no panic and a named error.
- `handlers_nodes_nil_config_test.go` — `POST /nodes:run` returns 400 / `NODES_BAD_NODE` for `customCode` and `loop`.
- `middleware/problem_test.go` — first tests for this package. Both directions of the clamp, plus an assertion that the `error` tag is still an error *value* (what makes the Sentry de-aliasing hold).

`go build ./...` and `go test ./aggregator/...` pass.

Sentry: EIGENLAYER-AVS-29 (fixed), EIGENLAYER-AVS-2A (should stop), EIGENLAYER-AVS-1J (grouping artifact — resolve, don't expect silence).
