### PR TITLE
fix: raise MaxActiveWorkflowsPerOwner to 1000 after measuring real demand

### DIFF
--- a/core/taskengine/limits.go
+++ b/core/taskengine/limits.go
@@ -74,7 +74,22 @@ const (
 	// ceilings structurally cannot reach: N leaked tasks cost N times the
 	// per-task cap. Counts only *active* (Enabled) tasks, so completed and
 	// cancelled ones never accumulate against an owner.
-	MaxActiveWorkflowsPerOwner = 100
+	//
+	// Sized from a measurement, not a guess. The first value here was 100,
+	// chosen with no data; the ava-sdk-js v4 suite then failed 30 of 48 suites
+	// against a local gateway with 132 rejections, because a single full run
+	// creates ~105 workflows under one EOA (gateway log, 7.7-minute window) and
+	// per-test cleanup lags creation enough that the live count crosses 100
+	// mid-run. 1000 leaves ~10x headroom over that observed peak.
+	//
+	// A loose bound is the right trade here. This cap is only a backstop
+	// against mass *creation*: DefaultMaxExecution already stops any single
+	// leaked task after 51,840 runs and the interval floors bound its rate, so
+	// the per-task ceilings do the real work. Against that, being too tight is
+	// the more damaging failure — it is the one ceiling evaluated against an
+	// owner's *current* state, so an owner already over it is locked out of
+	// creating anything, with no grandfathering.
+	MaxActiveWorkflowsPerOwner = 1000
 
 	// MaxLoopIterations bounds fan-out *within* a single execution, which the
 	// trigger floors cannot reach: a REST node inside a Loop runs once per


### PR DESCRIPTION
## The bug

`MaxActiveWorkflowsPerOwner = 100`, shipped in #673, is too low. Running the ava-sdk-js v4 suite against a local gateway:

```
Test Suites: 30 failed, 2 skipped, 16 passed, 46 of 48
Tests:       68 failed, 6 skipped, 256 passed
132 x  APIError: owner already has 100 active workflows, the maximum is 100
```

I flagged this constant on #673 as *"the one constant chosen without data, and the only one that can break an existing user rather than a new workflow — there is no grandfathering."* That is exactly how it failed.

## Not a leftover-backlog artifact

The obvious explanation would be workflows accumulating across runs. Ruled out: I counted the owner's active workflows down to **1** across all 13 smart wallets, re-ran from that clean state, and it failed the same way with 132 rejections.

The gateway log gives the real number — **~105 successful creates inside a 7.7-minute window under a single EOA** (162 attempts including rejections). Per-test cleanup lags creation enough that the live Enabled count crosses 100 mid-run. Nothing in the SDK is misbehaving; the suite's volume is legitimate and the constant made it illegal.

## The fix

`MaxActiveWorkflowsPerOwner = 1000`, with the measurement recorded at the constant so nobody has to rediscover it.

~10x headroom over the observed peak. A loose bound is the right trade: this cap is only a backstop against mass *creation*, because `DefaultMaxExecution` already stops any single leaked task after 51,840 runs and the interval floors bound its rate. The per-task ceilings do the real work. Against that, too tight is the more damaging direction, for the grandfathering reason above.

## Verification

Same gateway, same suite, only the constant changed:

| | before | after |
|---|---|---|
| Suites | 30 failed / 16 passed | **3 failed / 43 passed** |
| Tests | 256 passed | **321 passed** |
| Cap rejections | 132 | **0** |

The 3 remaining failures were unrelated and are since resolved — two were transient operator-coverage errors from my own mid-run aggregator restart (the operator log confirms it monitors chain 11155111 normally), and one was an httpbin outage fixed separately in [ava-sdk-js#235](https://github.com/AvaProtocol/ava-sdk-js/pull/235). Re-running those three: 17/17 pass.

## Why CI missed it

`TestCheckActiveWorkflowQuota` exercises the cap *mechanism* against a synthetic task map — it asserts that the boundary rejects, that matching is case-insensitive, that owners are isolated. It cannot exercise the cap *value*, because it never generates real client volume. All 18 checks on #673 were green.

Only running a real client against a real gateway surfaced this. Worth remembering for the other constants in `limits.go`: their mechanisms are unit-tested, their values are not.

## Note for whoever deploys this

`/health` reports `version: 4.5.2` on a binary built from `35b74c6`, because `-ldflags` takes semver from `version.go` and nothing re-bumped it after #673 merged. **The version string cannot tell you whether the ceilings are deployed** — probe behaviourally (create a `* * * * *` cron and expect a 400) or bump the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
