### PR TITLE
feat(aggregator): Gas Manager sponsorship webhook (FeeLedger credit gate)

### DIFF
--- a/aggregator/gas_manager_webhook.go
+++ b/aggregator/gas_manager_webhook.go
@@ -1,0 +1,266 @@
+package aggregator
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Alchemy Gas Manager "custom rules" webhook.
+//
+// Gas Manager POSTs here before sponsoring a UserOp; our answer decides
+// whether the treasury pays for it. This is the enforcement point for the
+// FeeLedger credit limit — without it FeeLedger is retrospective accounting
+// and an owner past their limit keeps getting sponsored.
+//
+// Two properties this handler must hold, both easy to break by accident:
+//
+//  1. It is mounted OUTSIDE the /api/v1 group. That group requires a JWT and
+//     applies the shared rate limiter. Alchemy sends neither a token nor a
+//     predictable request rate, so mounting it there would return 401/429 —
+//     which Gas Manager reads as "deny", silently disabling sponsorship for
+//     every user. The failure is global and looks like a chain problem.
+//
+//  2. It fails CLOSED. Every error path returns approved=false. This is the
+//     opposite of the executor's pre-execution credit check, which logs and
+//     proceeds on a ledger error: there, failing open costs one unmetered
+//     execution; here it would hand out unlimited sponsored gas for as long as
+//     the fault lasts.
+//
+// The response is always HTTP 200 carrying an explicit {"approved": bool}. A
+// non-200 also denies (the policy has "Sponsor on error or timeout" off), but
+// then our deliberate denial is indistinguishable from a crash in the logs.
+
+const gasManagerWebhookPath = "/webhooks/gas-manager"
+
+// gasManagerWebhookRequest is Alchemy's request body. userOperation's shape
+// varies by EntryPoint version, so only `sender` is decoded — it is the one
+// field present in both v0.6 and v0.7 and the only one this decision needs.
+type gasManagerWebhookRequest struct {
+	UserOperation struct {
+		Sender string `json:"sender"`
+	} `json:"userOperation"`
+	PolicyID    string `json:"policyId"`
+	ChainID     int64  `json:"chainId"`
+	WebhookData string `json:"webhookData"`
+}
+
+type gasManagerWebhookResponse struct {
+	Approved bool `json:"approved"`
+}
+
+// gasManagerWebhookConfig carries the deployment-supplied settings. Sourced
+// from the environment rather than the YAML because both values are secrets
+// that Railway already delivers that way.
+type gasManagerWebhookConfig struct {
+	// PolicyID is the Gas Manager policy this gateway answers for. A request
+	// quoting any other policy is refused: it means either a misconfigured
+	// dashboard or someone else's policy pointed at our endpoint.
+	PolicyID string
+	// Secret, when set, must appear as the request's webhookData. Defence in
+	// depth — the endpoint is unauthenticated by necessity (see above), and
+	// this keeps it from being a freely queryable oracle over ledger state.
+	// Empty disables the check so the webhook can be brought up before the
+	// sponsorship caller is taught to send it.
+	Secret string
+}
+
+func gasManagerWebhookConfigFromEnv() gasManagerWebhookConfig {
+	return gasManagerWebhookConfig{
+		PolicyID: strings.TrimSpace(os.Getenv("ALCHEMY_GAS_POLICY_ID")),
+		Secret:   strings.TrimSpace(os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
+	}
+}
+
+// ownerOfSmartWallet resolves a smart-wallet address back to its owner EOA.
+//
+// Wallet records are keyed `w:<chain>:<owner>:<wallet>` — owner first — so
+// there is no direct reverse index. This scans the chain's key space and
+// matches on the trailing segment, using the key-only iterator so values are
+// never loaded. Linear in wallets-per-chain, which is fine at current scale
+// (hundreds); if that stops being true, add a `wowner:<chain>:<wallet>`
+// index rather than making this smarter.
+func ownerOfSmartWallet(db storage.Storage, chainID int64, wallet common.Address) (common.Address, bool, error) {
+	prefix := []byte(fmt.Sprintf("w:%d:", chainID))
+	want := strings.ToLower(wallet.Hex())
+
+	var owner common.Address
+	var found bool
+	err := db.IterateKeysOnly(prefix, func(key []byte) error {
+		// w : chain : owner : wallet
+		parts := strings.Split(string(key), ":")
+		if len(parts) != 4 {
+			return nil
+		}
+		if parts[3] != want {
+			return nil
+		}
+		owner = common.HexToAddress(parts[2])
+		found = true
+		return nil
+	})
+	if err != nil {
+		return common.Address{}, false, err
+	}
+	return owner, found, nil
+}
+
+// registerGasManagerWebhook mounts the webhook on the unauthenticated router.
+func (agg *Aggregator) registerGasManagerWebhook(e *echo.Echo) {
+	cfg := gasManagerWebhookConfigFromEnv()
+	if cfg.PolicyID == "" {
+		// Without a policy id every request would be refused, which is worse
+		// than not serving the route: an operator who set the URL in the
+		// dashboard would see all sponsorship denied with no clue why.
+		agg.logger.Warn("gas manager webhook not mounted: ALCHEMY_GAS_POLICY_ID is unset",
+			"path", gasManagerWebhookPath)
+		return
+	}
+	if cfg.Secret == "" {
+		agg.logger.Warn("gas manager webhook mounted without GAS_MANAGER_WEBHOOK_SECRET; endpoint is unauthenticated beyond the policy id check",
+			"path", gasManagerWebhookPath)
+	}
+	e.POST(gasManagerWebhookPath, func(c echo.Context) error {
+		return agg.handleGasManagerWebhook(c, cfg)
+	})
+	agg.logger.Info("gas manager webhook mounted", "path", gasManagerWebhookPath)
+}
+
+// deny logs why sponsorship was refused and returns the 200/false body.
+// Reasons are logged rather than returned: the caller is Alchemy, and telling
+// an arbitrary POSTer *why* it was refused leaks ledger and config state.
+func (agg *Aggregator) deny(c echo.Context, reason string, kv ...interface{}) error {
+	agg.logger.Warn("gas sponsorship denied: "+reason, kv...)
+	return c.JSON(http.StatusOK, gasManagerWebhookResponse{Approved: false})
+}
+
+func (agg *Aggregator) handleGasManagerWebhook(c echo.Context, cfg gasManagerWebhookConfig) error {
+	var req gasManagerWebhookRequest
+	if err := c.Bind(&req); err != nil {
+		return agg.deny(c, "malformed request body", "error", err)
+	}
+
+	if subtle.ConstantTimeCompare([]byte(req.PolicyID), []byte(cfg.PolicyID)) != 1 {
+		return agg.deny(c, "unexpected policy id", "policy_id", req.PolicyID)
+	}
+	if cfg.Secret != "" &&
+		subtle.ConstantTimeCompare([]byte(req.WebhookData), []byte(cfg.Secret)) != 1 {
+		return agg.deny(c, "webhookData did not match the configured secret")
+	}
+
+	sender := strings.TrimSpace(req.UserOperation.Sender)
+	if !common.IsHexAddress(sender) {
+		return agg.deny(c, "userOperation.sender is not an address", "sender", sender)
+	}
+	wallet := common.HexToAddress(sender)
+
+	if agg.db == nil {
+		return agg.deny(c, "storage unavailable")
+	}
+
+	owner, found, err := ownerOfSmartWallet(agg.db, req.ChainID, wallet)
+	if err != nil {
+		return agg.deny(c, "owner lookup failed", "wallet", wallet.Hex(), "error", err)
+	}
+	if !found {
+		// An unknown sender is not ours to sponsor. This is the check that
+		// stops the policy from funding wallets created outside this gateway.
+		return agg.deny(c, "sender is not a known smart wallet",
+			"wallet", wallet.Hex(), "chain_id", req.ChainID)
+	}
+
+	withinLimit, outstanding, err := agg.ownerWithinCreditLimit(owner)
+	if err != nil {
+		return agg.deny(c, "credit check failed", "owner", owner.Hex(), "error", err)
+	}
+	if !withinLimit {
+		return agg.deny(c, "owner is over their credit limit",
+			"owner", owner.Hex(), "outstanding_wei", outstanding.String())
+	}
+
+	return c.JSON(http.StatusOK, gasManagerWebhookResponse{Approved: true})
+}
+
+// ownerWithinCreditLimit checks the owner's outstanding value fees against the
+// configured limit on EVERY known chain, not just the one the UserOp targets.
+// Fees accrue per execution chain (`fl:<chain>:<owner>`), so gating only the
+// requesting chain would let an owner who is over their limit on Base keep
+// drawing sponsorship on Ethereum.
+func (agg *Aggregator) ownerWithinCreditLimit(owner common.Address) (bool, *big.Int, error) {
+	if agg.config == nil || agg.config.FeeRates == nil {
+		return false, big.NewInt(0), fmt.Errorf("fee configuration unavailable")
+	}
+	ledger := taskengine.NewFeeLedger(agg.db, agg.logger)
+
+	// A zero limit means "block on any outstanding balance". USD limits need
+	// the price service to convert; when that is unavailable we cannot make a
+	// safe judgement, so we fail closed rather than guessing.
+	creditLimitWei := big.NewInt(0)
+	if limitUSD := agg.config.FeeRates.CreditLimitUSD; limitUSD > 0 {
+		if agg.priceService == nil {
+			return false, big.NewInt(0), fmt.Errorf("price service unavailable for USD credit limit")
+		}
+		converted, err := taskengine.ConvertUSDToWei(limitUSD, agg.priceService, agg.chainIDInt64())
+		if err != nil {
+			return false, big.NewInt(0), fmt.Errorf("converting credit limit to wei: %w", err)
+		}
+		creditLimitWei = converted
+	}
+
+	worstOutstanding := big.NewInt(0)
+	for _, chainID := range agg.knownFeeChainIDs() {
+		within, outstanding, err := ledger.CheckCreditLimit(chainID, owner, creditLimitWei)
+		if err != nil {
+			return false, worstOutstanding, fmt.Errorf("chain %d: %w", chainID, err)
+		}
+		if outstanding != nil && outstanding.Cmp(worstOutstanding) > 0 {
+			worstOutstanding = outstanding
+		}
+		if !within {
+			return false, outstanding, nil
+		}
+	}
+	return true, worstOutstanding, nil
+}
+
+// chainIDInt64 returns the gateway's default chain, used only to price the USD
+// credit limit.
+func (agg *Aggregator) chainIDInt64() int64 {
+	if agg.chainID != nil {
+		return agg.chainID.Int64()
+	}
+	return 0
+}
+
+// knownFeeChainIDs lists every chain this gateway serves, so the credit check
+// cannot be bypassed by switching chains.
+func (agg *Aggregator) knownFeeChainIDs() []int64 {
+	seen := map[int64]struct{}{}
+	out := []int64{}
+	add := func(id int64) {
+		if id <= 0 {
+			return
+		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	add(agg.chainIDInt64())
+	if agg.config != nil {
+		for _, chain := range agg.config.Chains {
+			add(chain.SmartWallet.ChainID)
+		}
+	}
+	return out
+}

--- a/aggregator/gas_manager_webhook_test.go
+++ b/aggregator/gas_manager_webhook_test.go
@@ -1,0 +1,239 @@
+package aggregator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+)
+
+const (
+	testPolicyID = "bf905871-55d7-4197-a020-000000000000"
+	testSecret   = "s3cr3t-webhook-token"
+)
+
+func newWebhookAggregator(t *testing.T) (*Aggregator, func()) {
+	t.Helper()
+	db := testutil.TestMustDB()
+	agg := &Aggregator{
+		logger: testutil.GetLogger(),
+		db:     db,
+		config: &config.Config{
+			FeeRates: &config.FeeRatesConfig{CreditLimitUSD: 0},
+		},
+	}
+	return agg, func() { db.Close() }
+}
+
+// post drives the handler directly so the test covers the decision logic
+// rather than Echo's routing.
+func post(t *testing.T, agg *Aggregator, cfg gasManagerWebhookConfig, body string) (int, bool) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, gasManagerWebhookPath, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	if err := agg.handleGasManagerWebhook(e.NewContext(req, rec), cfg); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	var resp gasManagerWebhookResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding response %q: %v", rec.Body.String(), err)
+	}
+	return rec.Code, resp.Approved
+}
+
+func bodyFor(sender string, chainID int64, policyID, webhookData string) string {
+	return fmt.Sprintf(
+		`{"userOperation":{"sender":%q},"policyId":%q,"chainId":%d,"webhookData":%q}`,
+		sender, policyID, chainID, webhookData)
+}
+
+// storeWallet writes a wallet record so the reverse lookup can find it.
+func storeWallet(t *testing.T, agg *Aggregator, chainID int64, owner, wallet common.Address) {
+	t.Helper()
+	key := taskengine.WalletStorageKey(chainID, owner, wallet.Hex())
+	if err := agg.db.Set([]byte(key), []byte("{}")); err != nil {
+		t.Fatalf("seeding wallet: %v", err)
+	}
+}
+
+// Every rejection path must answer 200 with approved:false. A non-200 would
+// also deny at the platform level, but then a deliberate refusal is
+// indistinguishable from a crash.
+func TestGasManagerWebhook_DeniesAndAlwaysAnswers200(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID, Secret: testSecret}
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"malformed body", `{not json`},
+		{"wrong policy id", bodyFor(wallet.Hex(), 11155111, "someone-elses-policy", testSecret)},
+		{"empty policy id", bodyFor(wallet.Hex(), 11155111, "", testSecret)},
+		{"wrong webhook secret", bodyFor(wallet.Hex(), 11155111, testPolicyID, "guessed")},
+		{"missing webhook secret", bodyFor(wallet.Hex(), 11155111, testPolicyID, "")},
+		{"sender not an address", bodyFor("not-an-address", 11155111, testPolicyID, testSecret)},
+		{"sender empty", bodyFor("", 11155111, testPolicyID, testSecret)},
+		{"unknown smart wallet", bodyFor("0x000000000000000000000000000000000000dEaD", 11155111, testPolicyID, testSecret)},
+		{"known wallet but wrong chain", bodyFor(wallet.Hex(), 8453, testPolicyID, testSecret)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, approved := post(t, agg, cfg, tt.body)
+			if status != http.StatusOK {
+				t.Errorf("status = %d, want 200 (a non-200 hides the reason from logs)", status)
+			}
+			if approved {
+				t.Error("approved = true, want false — this path must fail closed")
+			}
+		})
+	}
+}
+
+func TestGasManagerWebhook_ApprovesKnownWalletWithinLimit(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID, Secret: testSecret}
+	status, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), 11155111, testPolicyID, testSecret))
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !approved {
+		t.Error("approved = false, want true for a known wallet with no outstanding fees")
+	}
+}
+
+// An empty configured secret disables the check, so the webhook can be brought
+// up before the sponsorship caller is taught to send webhookData. It must not
+// accidentally start accepting *any* secret when one IS configured — covered
+// by the deny table above.
+func TestGasManagerWebhook_EmptySecretSkipsTheCheck(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0xc60e71bd0f2e6d8832fea1a2d56091c48493c788")
+	wallet := common.HexToAddress("0x71c8f4d7d5291edcb3a081802e7efb2788bd232e")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID, Secret: ""}
+	_, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), 11155111, testPolicyID, "anything at all"))
+	if !approved {
+		t.Error("approved = false; an empty configured secret should skip the comparison")
+	}
+}
+
+// Storage faults must deny rather than pass through.
+func TestGasManagerWebhook_DeniesWhenStorageUnavailable(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+	agg.db = nil
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID}
+	status, approved := post(t, agg, cfg,
+		bodyFor("0x981e18d5aade83620a6bd21990b5da0c797e1e5b", 11155111, testPolicyID, ""))
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if approved {
+		t.Error("approved = true with no storage; must fail closed")
+	}
+}
+
+// A USD credit limit needs the price service to convert to wei. Without it we
+// cannot judge the limit, and guessing would mean sponsoring an owner who may
+// be far past it.
+func TestGasManagerWebhook_DeniesWhenUSDLimitCannotBePriced(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+	agg.config.FeeRates.CreditLimitUSD = 20 // > 0 requires the price service
+	agg.priceService = nil
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID}
+	_, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), 11155111, testPolicyID, ""))
+	if approved {
+		t.Error("approved = true without a way to price the credit limit; must fail closed")
+	}
+}
+
+func TestOwnerOfSmartWallet(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	other := common.HexToAddress("0xc60e71bd0f2e6d8832fea1a2d56091c48493c788")
+	storeWallet(t, agg, 11155111, owner, wallet)
+	storeWallet(t, agg, 11155111, other, common.HexToAddress("0x71c8f4d7d5291edcb3a081802e7efb2788bd232e"))
+	// Same wallet address on another chain, different owner — CREATE2 makes
+	// this genuinely possible, and the lookup must not cross chains.
+	storeWallet(t, agg, 8453, other, wallet)
+
+	t.Run("resolves owner on the requested chain", func(t *testing.T) {
+		got, found, err := ownerOfSmartWallet(agg.db, 11155111, wallet)
+		if err != nil || !found {
+			t.Fatalf("found=%v err=%v", found, err)
+		}
+		if got != owner {
+			t.Errorf("owner = %s, want %s", got.Hex(), owner.Hex())
+		}
+	})
+
+	t.Run("same wallet on another chain resolves to that chain's owner", func(t *testing.T) {
+		got, found, err := ownerOfSmartWallet(agg.db, 8453, wallet)
+		if err != nil || !found {
+			t.Fatalf("found=%v err=%v", found, err)
+		}
+		if got != other {
+			t.Errorf("owner = %s, want %s — lookup leaked across chains", got.Hex(), other.Hex())
+		}
+	})
+
+	t.Run("unknown wallet is not found", func(t *testing.T) {
+		_, found, err := ownerOfSmartWallet(agg.db, 11155111,
+			common.HexToAddress("0x000000000000000000000000000000000000dEaD"))
+		if err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		if found {
+			t.Error("found = true for a wallet that was never stored")
+		}
+	})
+
+	t.Run("case-insensitive on the sender address", func(t *testing.T) {
+		_, found, err := ownerOfSmartWallet(agg.db, 11155111,
+			common.HexToAddress(strings.ToUpper(strings.TrimPrefix(wallet.Hex(), "0x"))))
+		if err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		if !found {
+			t.Error("found = false; sender casing should not matter")
+		}
+	})
+}

--- a/aggregator/http_server.go
+++ b/aggregator/http_server.go
@@ -166,6 +166,12 @@ func (agg *Aggregator) startHttpServer(ctx context.Context, extraMounts []HTTPMo
 		return c.HTMLBlob(http.StatusOK, buf.Bytes())
 	})
 
+	// Alchemy Gas Manager custom-rules webhook. Deliberately on this router
+	// and not the /api/v1 group — that group's JWT and rate-limit middleware
+	// would reject Alchemy, and Gas Manager reads any non-200 as "deny
+	// sponsorship". See gas_manager_webhook.go.
+	agg.registerGasManagerWebhook(e)
+
 	// Register debug endpoints only if not in production
 	if os.Getenv("APP_ENV") != "production" {
 		// Debug endpoints to validate Sentry wiring from a running instance


### PR DESCRIPTION
Adds the Alchemy Gas Manager custom-rules webhook. Gas Manager POSTs before sponsoring a UserOp; this handler decides whether the treasury pays.

**This is time-sensitive.** The webhook URL is already configured in the Alchemy dashboard, and the endpoint does not exist yet — `POST /webhooks/gas-manager` returns 404. Because the policy correctly has *Sponsor on error or timeout* OFF, Gas Manager reads that as "deny", so **sponsorship is currently refused on that policy** until this ships.

## Why it exists

It is the enforcement point for the `FeeLedger` credit limit. Without it, `FeeLedger` is retrospective accounting — an owner past their limit keeps drawing sponsorship and the balance just grows.

## Three details that are easy to get wrong

**Mounted outside `/api/v1`.** That group applies JWT auth and the shared rate limiter. Alchemy sends neither a token nor a predictable request rate, so a handler mounted there returns 401/429 — which Gas Manager also reads as "deny". Same global outage as the 404, but harder to diagnose because it looks like a chain fault.

**Fails closed on every path**, deliberately opposite to the executor's pre-execution credit check (`core/taskengine/executor.go`), which logs and proceeds on a ledger error. There, failing open costs one unmetered execution. Here it would hand out unlimited sponsored gas for as long as the fault lasts. A USD credit limit with no price service to convert it is therefore a denial, not a skip.

**Credit is checked across every known chain**, not just the requesting one. Fees accrue per execution chain (`fl:<chain>:<owner>`), so gating only the requested chain would let an owner over their limit on Base keep drawing on Ethereum — the same reasoning the executor already uses.

Also: unknown senders are refused. With policy access control set to `None`, that is the only thing stopping the policy from funding wallets created outside this gateway.

## Notes

Responses are always HTTP 200 with an explicit `{"approved": bool}`. A non-200 denies too, but then a deliberate refusal is indistinguishable from a crash in the logs.

Wallet→owner resolution scans `w:<chain>:` with the key-only iterator, since records are keyed owner-first with no reverse index. Linear in wallets-per-chain — fine at current scale (161); add a `wowner:` index if that changes.

## Deploying

Two Railway vars on `gateway`:

- `ALCHEMY_GAS_POLICY_ID` — required. **Without it the route is not mounted at all**, which is intentional: a mounted route refusing everything looks identical to a broken chain, whereas an unmounted route 404s loudly.
- `GAS_MANAGER_WEBHOOK_SECRET` — optional. When unset the check is skipped, so the endpoint can come up before the sponsorship caller is taught to send `webhookData`.

## Tests

18 subtests. The deny table covers malformed body, wrong/empty policy id, wrong/missing secret, non-address sender, unknown wallet, and right-wallet-wrong-chain. `TestOwnerOfSmartWallet` covers the CREATE2 case where the same wallet address exists on two chains under different owners.

Context: `avs-infra/Smart_Wallet_MA_v2_Spend_Policy.md` §4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
