### PR TITLE
feat(erc4337): EntryPoint v0.7 packed UserOperation type and hashing

### DIFF
--- a/core/chainio/aa/ma_v2.go
+++ b/core/chainio/aa/ma_v2.go
@@ -1,0 +1,116 @@
+package aa
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Execution calldata encoding for Alchemy Modular Account v2.
+//
+// How this differs from the v0.6 SimpleAccount encoding in aa.go, verified
+// against the deployed SemiModularAccountBytecode implementation
+// (0x000000000000c5A9089039570Dd36455b5C07383):
+//
+//	execute(address,uint256,bytes)                      0xb61d27f6  present — unchanged
+//	executeBatch((address,uint256,bytes)[])             0x34fcd5be  present — MA v2 form
+//	executeBatch(address[],bytes[])                     0x18dfb3c7  ABSENT  — v0.6 form
+//	executeBatchWithValues(address[],uint256[],bytes[]) 0xc3ff72fc  ABSENT  — our fork's
+//
+// Two consequences worth stating plainly:
+//
+//   - `execute` carries over byte-for-byte. Single-call encoding needs no
+//     migration at all.
+//   - `executeBatchWithValues` was a function we added to our SimpleAccount
+//     fork so a batch could carry a per-call ETH value. MA v2's `executeBatch`
+//     does that natively, so the fork function has no successor and needs
+//     none. This is what retires the sponsor-then-reimburse-from-wallet trick
+//     (avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §3.2).
+const (
+	SelectorExecuteMAv2      = "0xb61d27f6"
+	SelectorExecuteBatchMAv2 = "0x34fcd5be"
+)
+
+// Call is one entry in an MA v2 batch. Field order and names must match the
+// on-chain tuple — the ABI encoder maps by the `abi` tag, and a reordering
+// here would produce calldata that decodes to different arguments rather than
+// failing loudly.
+type Call struct {
+	Target common.Address `abi:"target"`
+	Value  *big.Int       `abi:"value"`
+	Data   []byte         `abi:"data"`
+}
+
+const modularAccountABIJSON = `[
+  {"type":"function","name":"execute","stateMutability":"payable",
+   "inputs":[{"name":"target","type":"address"},{"name":"value","type":"uint256"},{"name":"data","type":"bytes"}],
+   "outputs":[{"name":"result","type":"bytes"}]},
+  {"type":"function","name":"executeBatch","stateMutability":"payable",
+   "inputs":[{"name":"calls","type":"tuple[]","components":[
+     {"name":"target","type":"address"},{"name":"value","type":"uint256"},{"name":"data","type":"bytes"}]}],
+   "outputs":[{"name":"results","type":"bytes[]"}]}
+]`
+
+var (
+	modularAccountABIOnce sync.Once
+	modularAccountABI     abi.ABI
+	modularAccountABIErr  error
+)
+
+func ensureModularAccountABI() (abi.ABI, error) {
+	modularAccountABIOnce.Do(func() {
+		modularAccountABI, modularAccountABIErr = abi.JSON(strings.NewReader(modularAccountABIJSON))
+	})
+	return modularAccountABI, modularAccountABIErr
+}
+
+// PackExecuteMAv2 encodes a single call. Identical on the wire to the v0.6
+// PackExecute; kept as its own symbol so call sites read unambiguously and so
+// the v0.6 helper can be deleted at cutover without touching these.
+func PackExecuteMAv2(target common.Address, value *big.Int, data []byte) ([]byte, error) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		value = big.NewInt(0)
+	}
+	if data == nil {
+		data = []byte{}
+	}
+	return parsed.Pack("execute", target, value, data)
+}
+
+// PackExecuteBatchMAv2 encodes an atomic batch. Every call carries its own ETH
+// value, which is what makes the v0.6 executeBatchWithValues workaround
+// unnecessary.
+//
+// A nil Value or Data is normalised to zero/empty rather than rejected: the
+// common batch entry is a contract call with no ETH attached, and forcing
+// callers to spell that out invites big.NewInt(0) boilerplate at every site.
+// An empty batch IS rejected — it encodes fine and burns gas doing nothing,
+// which is never what the caller meant.
+func PackExecuteBatchMAv2(calls []Call) ([]byte, error) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, err
+	}
+	if len(calls) == 0 {
+		return nil, fmt.Errorf("executeBatch requires at least one call")
+	}
+	normalised := make([]Call, len(calls))
+	for i, c := range calls {
+		if c.Value == nil {
+			c.Value = big.NewInt(0)
+		}
+		if c.Data == nil {
+			c.Data = []byte{}
+		}
+		normalised[i] = c
+	}
+	return parsed.Pack("executeBatch", normalised)
+}

--- a/core/chainio/aa/ma_v2_test.go
+++ b/core/chainio/aa/ma_v2_test.go
@@ -1,0 +1,165 @@
+package aa
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+var (
+	targetA = common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	targetB = common.HexToAddress("0x71c8f4d7d5291edcb3a081802e7efb2788bd232e")
+)
+
+// The selectors are the contract's, not ours. These were read off the deployed
+// SemiModularAccountBytecode implementation
+// (0x000000000000c5A9089039570Dd36455b5C07383) — if a change here flips one,
+// the calldata stops being callable rather than merely being encoded oddly.
+func TestMAv2Selectors(t *testing.T) {
+	single, err := PackExecuteMAv2(targetA, big.NewInt(1), []byte{0xde, 0xad})
+	if err != nil {
+		t.Fatalf("PackExecuteMAv2: %v", err)
+	}
+	if got := hexutil.Encode(single[:4]); got != SelectorExecuteMAv2 {
+		t.Errorf("execute selector = %s, want %s", got, SelectorExecuteMAv2)
+	}
+
+	batch, err := PackExecuteBatchMAv2([]Call{{Target: targetA, Value: big.NewInt(1), Data: []byte{0xde}}})
+	if err != nil {
+		t.Fatalf("PackExecuteBatchMAv2: %v", err)
+	}
+	if got := hexutil.Encode(batch[:4]); got != SelectorExecuteBatchMAv2 {
+		t.Errorf("executeBatch selector = %s, want %s", got, SelectorExecuteBatchMAv2)
+	}
+
+	// v0.6's executeBatch(address[],bytes[]) is 0x18dfb3c7 and is NOT on the
+	// MA v2 implementation. Encoding against the old shape would produce
+	// calldata no MA v2 account can dispatch.
+	if hexutil.Encode(batch[:4]) == "0x18dfb3c7" {
+		t.Error("encoded the v0.6 executeBatch shape")
+	}
+}
+
+func TestPackExecuteMAv2RoundTrip(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	data := []byte{0xb6, 0x1d, 0x27, 0xf6, 0x01}
+	packed, err := PackExecuteMAv2(targetA, big.NewInt(12345), data)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	args, err := parsed.Methods["execute"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	if args[0].(common.Address) != targetA {
+		t.Errorf("target = %v, want %v", args[0], targetA)
+	}
+	if args[1].(*big.Int).Cmp(big.NewInt(12345)) != 0 {
+		t.Errorf("value = %v, want 12345", args[1])
+	}
+	if !bytes.Equal(args[2].([]byte), data) {
+		t.Errorf("data = %x, want %x", args[2], data)
+	}
+}
+
+func TestPackExecuteBatchMAv2RoundTrip(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	calls := []Call{
+		{Target: targetA, Value: big.NewInt(0), Data: []byte{0x01, 0x02}},
+		{Target: targetB, Value: big.NewInt(999), Data: []byte{0x03}},
+	}
+	packed, err := PackExecuteBatchMAv2(calls)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	args, err := parsed.Methods["executeBatch"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	decoded, ok := args[0].([]struct {
+		Target common.Address `json:"target"`
+		Value  *big.Int       `json:"value"`
+		Data   []byte         `json:"data"`
+	})
+	if !ok {
+		t.Fatalf("unexpected decoded type %T", args[0])
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("len = %d, want 2", len(decoded))
+	}
+	if decoded[0].Target != targetA || decoded[1].Target != targetB {
+		t.Errorf("targets round-tripped wrong: %v, %v", decoded[0].Target, decoded[1].Target)
+	}
+	if decoded[1].Value.Cmp(big.NewInt(999)) != 0 {
+		t.Errorf("per-call value lost: got %v want 999", decoded[1].Value)
+	}
+	if !bytes.Equal(decoded[0].Data, []byte{0x01, 0x02}) || !bytes.Equal(decoded[1].Data, []byte{0x03}) {
+		t.Error("call data round-tripped wrong")
+	}
+}
+
+// The v0.6 PackExecuteBatchWithValues hand-rolls its ABI encoding, with a
+// comment attributing that to a go-ethereum bug encoding empty []byte in a
+// dynamic array. This pins down whether the same workaround is needed for MA
+// v2's tuple[] — if it encodes and round-trips cleanly, the manual encoder
+// does not need to be carried forward.
+func TestPackExecuteBatchMAv2HandlesEmptyCallData(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	calls := []Call{
+		{Target: targetA, Value: big.NewInt(1_000_000), Data: []byte{}}, // plain ETH transfer
+		{Target: targetB, Value: big.NewInt(0), Data: []byte{0xab}},
+		{Target: targetA, Value: big.NewInt(0), Data: nil}, // nil, not just empty
+	}
+	packed, err := PackExecuteBatchMAv2(calls)
+	if err != nil {
+		t.Fatalf("pack with empty call data: %v", err)
+	}
+	args, err := parsed.Methods["executeBatch"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack with empty call data: %v", err)
+	}
+	decoded := args[0].([]struct {
+		Target common.Address `json:"target"`
+		Value  *big.Int       `json:"value"`
+		Data   []byte         `json:"data"`
+	})
+	if len(decoded) != 3 {
+		t.Fatalf("len = %d, want 3", len(decoded))
+	}
+	if len(decoded[0].Data) != 0 || len(decoded[2].Data) != 0 {
+		t.Errorf("empty call data did not survive: %x / %x", decoded[0].Data, decoded[2].Data)
+	}
+	if decoded[0].Value.Cmp(big.NewInt(1_000_000)) != 0 {
+		t.Errorf("value on an empty-data call was lost: %v", decoded[0].Value)
+	}
+}
+
+func TestPackExecuteBatchMAv2Normalisation(t *testing.T) {
+	t.Run("nil value and data are normalised", func(t *testing.T) {
+		if _, err := PackExecuteBatchMAv2([]Call{{Target: targetA}}); err != nil {
+			t.Errorf("nil Value/Data should be accepted: %v", err)
+		}
+	})
+	t.Run("nil value on single execute is normalised", func(t *testing.T) {
+		if _, err := PackExecuteMAv2(targetA, nil, nil); err != nil {
+			t.Errorf("nil value/data should be accepted: %v", err)
+		}
+	})
+	t.Run("empty batch is rejected", func(t *testing.T) {
+		if _, err := PackExecuteBatchMAv2(nil); err == nil {
+			t.Error("expected an error for an empty batch — it encodes fine and burns gas doing nothing")
+		}
+	})
+}

--- a/pkg/erc4337/userop/v07.go
+++ b/pkg/erc4337/userop/v07.go
@@ -1,0 +1,192 @@
+package userop
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// EntryPoint v0.7 splits the v0.6 UserOperation into two shapes that are easy
+// to confuse:
+//
+//   - the *unpacked* form, which is what travels on the JSON-RPC wire
+//     (eth_sendUserOperation, eth_estimateUserOperationGas). Factory and
+//     paymaster each become their own fields.
+//   - the *packed* form (PackedUserOperation), which is what the EntryPoint
+//     contract hashes and executes. Gas limits and fees are squeezed into
+//     bytes32 pairs, and factory/paymaster collapse back into initCode and
+//     paymasterAndData.
+//
+// UserOperationV07 models the unpacked form because that is what callers build
+// and what the bundler consumes; Pack* produce the packed encoding on demand.
+//
+// This is deliberately a separate type from the v0.6 UserOperation rather than
+// a set of extra fields on it. The two hashing schemes are incompatible, and a
+// single struct carrying both would make it possible to sign under the wrong
+// one -- an error that only shows up as an on-chain AA24 revert.
+type UserOperationV07 struct {
+	Sender   common.Address `json:"sender"`
+	Nonce    *big.Int       `json:"nonce"`
+	CallData []byte         `json:"callData"`
+
+	// Factory is nil once the account is deployed. When set, Factory and
+	// FactoryData together form the v0.6-style initCode.
+	Factory     *common.Address `json:"factory,omitempty"`
+	FactoryData []byte          `json:"factoryData,omitempty"`
+
+	CallGasLimit         *big.Int `json:"callGasLimit"`
+	VerificationGasLimit *big.Int `json:"verificationGasLimit"`
+	PreVerificationGas   *big.Int `json:"preVerificationGas"`
+	MaxFeePerGas         *big.Int `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *big.Int `json:"maxPriorityFeePerGas"`
+
+	// Paymaster is nil for an unsponsored operation. The three paymaster
+	// fields are only meaningful when it is set.
+	Paymaster                     *common.Address `json:"paymaster,omitempty"`
+	PaymasterVerificationGasLimit *big.Int        `json:"paymasterVerificationGasLimit,omitempty"`
+	PaymasterPostOpGasLimit       *big.Int        `json:"paymasterPostOpGasLimit,omitempty"`
+	PaymasterData                 []byte          `json:"paymasterData,omitempty"`
+
+	Signature []byte `json:"signature"`
+}
+
+// packUint128Pair encodes two values into a single bytes32, high first. Values
+// wider than 128 bits are rejected rather than silently truncated: a truncated
+// gas limit still produces a well-formed UserOp that fails much later, on
+// chain, with no indication of where the number was lost.
+func packUint128Pair(high, low *big.Int, highName, lowName string) ([32]byte, error) {
+	var out [32]byte
+	for _, f := range []struct {
+		v    *big.Int
+		name string
+	}{{high, highName}, {low, lowName}} {
+		if f.v == nil {
+			return out, fmt.Errorf("%s is nil", f.name)
+		}
+		if f.v.Sign() < 0 {
+			return out, fmt.Errorf("%s is negative", f.name)
+		}
+		if f.v.BitLen() > 128 {
+			return out, fmt.Errorf("%s overflows uint128 (%d bits)", f.name, f.v.BitLen())
+		}
+	}
+	high.FillBytes(out[0:16])
+	low.FillBytes(out[16:32])
+	return out, nil
+}
+
+// AccountGasLimits packs verificationGasLimit into the high 16 bytes and
+// callGasLimit into the low 16, per ERC-4337 v0.7.
+func (op *UserOperationV07) AccountGasLimits() ([32]byte, error) {
+	return packUint128Pair(op.VerificationGasLimit, op.CallGasLimit,
+		"verificationGasLimit", "callGasLimit")
+}
+
+// GasFees packs maxPriorityFeePerGas into the high 16 bytes and maxFeePerGas
+// into the low 16. Note the ordering is priority-then-max, which is the
+// reverse of how the fields are usually written out.
+func (op *UserOperationV07) GasFees() ([32]byte, error) {
+	return packUint128Pair(op.MaxPriorityFeePerGas, op.MaxFeePerGas,
+		"maxPriorityFeePerGas", "maxFeePerGas")
+}
+
+// InitCode returns factory ++ factoryData, or empty when the account already
+// exists.
+func (op *UserOperationV07) InitCode() []byte {
+	if op.Factory == nil {
+		return []byte{}
+	}
+	return append(op.Factory.Bytes(), op.FactoryData...)
+}
+
+// PaymasterAndData returns paymaster ++ verificationGasLimit(16) ++
+// postOpGasLimit(16) ++ data, or empty when the operation is unsponsored.
+func (op *UserOperationV07) PaymasterAndData() ([]byte, error) {
+	if op.Paymaster == nil {
+		return []byte{}, nil
+	}
+	limits, err := packUint128Pair(
+		op.PaymasterVerificationGasLimit, op.PaymasterPostOpGasLimit,
+		"paymasterVerificationGasLimit", "paymasterPostOpGasLimit")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, common.AddressLength+32+len(op.PaymasterData))
+	out = append(out, op.Paymaster.Bytes()...)
+	out = append(out, limits[:]...)
+	out = append(out, op.PaymasterData...)
+	return out, nil
+}
+
+var (
+	bytes32Ty, _ = abi.NewType("bytes32", "", nil)
+	addressTy, _ = abi.NewType("address", "", nil)
+	uint256Ty, _ = abi.NewType("uint256", "", nil)
+)
+
+// PackForSignature returns the ABI encoding the EntryPoint hashes to produce
+// the inner half of the userOpHash. Dynamic fields appear as their keccak
+// digests, and signature is excluded -- it is what gets computed over this.
+func (op *UserOperationV07) PackForSignature() ([]byte, error) {
+	accountGasLimits, err := op.AccountGasLimits()
+	if err != nil {
+		return nil, err
+	}
+	gasFees, err := op.GasFees()
+	if err != nil {
+		return nil, err
+	}
+	paymasterAndData, err := op.PaymasterAndData()
+	if err != nil {
+		return nil, err
+	}
+	if op.Nonce == nil {
+		return nil, fmt.Errorf("nonce is nil")
+	}
+	if op.PreVerificationGas == nil {
+		return nil, fmt.Errorf("preVerificationGas is nil")
+	}
+
+	args := abi.Arguments{
+		{Type: addressTy}, {Type: uint256Ty}, {Type: bytes32Ty}, {Type: bytes32Ty},
+		{Type: bytes32Ty}, {Type: uint256Ty}, {Type: bytes32Ty}, {Type: bytes32Ty},
+	}
+	return args.Pack(
+		op.Sender,
+		op.Nonce,
+		toBytes32(crypto.Keccak256(op.InitCode())),
+		toBytes32(crypto.Keccak256(op.CallData)),
+		accountGasLimits,
+		op.PreVerificationGas,
+		gasFees,
+		toBytes32(crypto.Keccak256(paymasterAndData)),
+	)
+}
+
+// GetUserOpHash returns the hash the account signs, binding the operation to a
+// specific EntryPoint and chain so a signature cannot be replayed across
+// either.
+func (op *UserOperationV07) GetUserOpHash(entryPoint common.Address, chainID *big.Int) (common.Hash, error) {
+	if chainID == nil {
+		return common.Hash{}, fmt.Errorf("chainID is nil")
+	}
+	inner, err := op.PackForSignature()
+	if err != nil {
+		return common.Hash{}, err
+	}
+	args := abi.Arguments{{Type: bytes32Ty}, {Type: addressTy}, {Type: uint256Ty}}
+	outer, err := args.Pack(toBytes32(crypto.Keccak256(inner)), entryPoint, chainID)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return common.BytesToHash(crypto.Keccak256(outer)), nil
+}
+
+func toBytes32(b []byte) [32]byte {
+	var out [32]byte
+	copy(out[:], b)
+	return out
+}

--- a/pkg/erc4337/userop/v07_test.go
+++ b/pkg/erc4337/userop/v07_test.go
@@ -1,0 +1,226 @@
+package userop
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// EntryPoint v0.7, same address on every chain.
+var entryPointV07 = common.HexToAddress("0x0000000071727De22E5E9d8BAf0edAc6f37da032")
+
+// sepoliaChainID is the chain the expected hashes below were read from. The
+// hash binds to the chain id, so these vectors are only valid for it.
+var sepoliaChainID = big.NewInt(11155111)
+
+func addr(s string) *common.Address { a := common.HexToAddress(s); return &a }
+
+// The expected hashes are not hand-computed. Each was read from the deployed
+// EntryPoint v0.7 on Sepolia via
+//
+//	cast call 0x0000000071727De22E5E9d8BAf0edAc6f37da032 \
+//	  'getUserOpHash((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes))(bytes32)' ...
+//
+// so the contract itself is the oracle. Regenerate them the same way if the
+// packing ever needs to change.
+func TestGetUserOpHash_MatchesDeployedEntryPoint(t *testing.T) {
+	tests := []struct {
+		name string
+		op   UserOperationV07
+		want string
+	}{
+		{
+			name: "all zero",
+			op: UserOperationV07{
+				Sender:               common.HexToAddress("0x0"),
+				Nonce:                big.NewInt(0),
+				CallData:             []byte{},
+				CallGasLimit:         big.NewInt(0),
+				VerificationGasLimit: big.NewInt(0),
+				PreVerificationGas:   big.NewInt(0),
+				MaxFeePerGas:         big.NewInt(0),
+				MaxPriorityFeePerGas: big.NewInt(0),
+			},
+			want: "0xc2ae9ba70cf313be10ea729190547ac0dfa49cb6501877a84bec112f30781863",
+		},
+		{
+			name: "deployed account, unsponsored",
+			op: UserOperationV07{
+				Sender:               common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b"),
+				Nonce:                big.NewInt(7),
+				CallData:             hexutil.MustDecode("0xb61d27f6000000000000000000000000c60e71bd0f2e6d8832fea1a2d56091c48493c788"),
+				VerificationGasLimit: big.NewInt(100000),
+				CallGasLimit:         big.NewInt(200000),
+				PreVerificationGas:   big.NewInt(21000),
+				MaxPriorityFeePerGas: big.NewInt(1000000000),
+				MaxFeePerGas:         big.NewInt(2000000000),
+			},
+			want: "0x3ba23f9f10cdf7dbf0ff7b13c995fe26151e5cdbb50ad5e8ead961d011a695a3",
+		},
+		{
+			name: "counterfactual account with paymaster",
+			op: UserOperationV07{
+				Sender:                        common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0"),
+				Nonce:                         big.NewInt(3),
+				Factory:                       addr("0x00000000000017c61b5bEe81050EC8eFc9c6fecd"),
+				FactoryData:                   hexutil.MustDecode("0xdeadbeef"),
+				CallData:                      hexutil.MustDecode("0xdeadbeefcafe"),
+				VerificationGasLimit:          big.NewInt(500000),
+				CallGasLimit:                  big.NewInt(1000000),
+				PreVerificationGas:            big.NewInt(50000),
+				MaxPriorityFeePerGas:          big.NewInt(100000000),
+				MaxFeePerGas:                  big.NewInt(50000000000),
+				Paymaster:                     addr("0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f"),
+				PaymasterVerificationGasLimit: big.NewInt(100000),
+				PaymasterPostOpGasLimit:       big.NewInt(50000),
+				PaymasterData:                 hexutil.MustDecode("0xc0ffee"),
+			},
+			want: "0x118de0f4dd62e075f2f21139965356f851435c00c5c3c24ccefd7429ada1f607",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.op.GetUserOpHash(entryPointV07, sepoliaChainID)
+			if err != nil {
+				t.Fatalf("GetUserOpHash: %v", err)
+			}
+			if got.Hex() != tt.want {
+				t.Errorf("hash mismatch\n got %s\nwant %s", got.Hex(), tt.want)
+			}
+		})
+	}
+}
+
+func TestGetUserOpHash_BindsToChainAndEntryPoint(t *testing.T) {
+	op := UserOperationV07{
+		Sender: common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b"),
+		Nonce:  big.NewInt(7), CallData: []byte{},
+		CallGasLimit: big.NewInt(1), VerificationGasLimit: big.NewInt(1),
+		PreVerificationGas: big.NewInt(1), MaxFeePerGas: big.NewInt(1),
+		MaxPriorityFeePerGas: big.NewInt(1),
+	}
+	base, err := op.GetUserOpHash(entryPointV07, sepoliaChainID)
+	if err != nil {
+		t.Fatalf("base: %v", err)
+	}
+	otherChain, err := op.GetUserOpHash(entryPointV07, big.NewInt(1))
+	if err != nil {
+		t.Fatalf("otherChain: %v", err)
+	}
+	otherEP, err := op.GetUserOpHash(common.HexToAddress("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"), sepoliaChainID)
+	if err != nil {
+		t.Fatalf("otherEP: %v", err)
+	}
+	if base == otherChain {
+		t.Error("hash did not change with chain id — signatures would replay across chains")
+	}
+	if base == otherEP {
+		t.Error("hash did not change with entrypoint — signatures would replay across entrypoints")
+	}
+}
+
+func TestPackedFieldOrdering(t *testing.T) {
+	op := UserOperationV07{
+		VerificationGasLimit: big.NewInt(0x1111),
+		CallGasLimit:         big.NewInt(0x2222),
+		MaxPriorityFeePerGas: big.NewInt(0x3333),
+		MaxFeePerGas:         big.NewInt(0x4444),
+	}
+	agl, err := op.AccountGasLimits()
+	if err != nil {
+		t.Fatalf("AccountGasLimits: %v", err)
+	}
+	// verificationGasLimit occupies the high 16 bytes, callGasLimit the low.
+	if want := "0x0000000000000000000000000000111100000000000000000000000000002222"; hexutil.Encode(agl[:]) != want {
+		t.Errorf("accountGasLimits\n got %s\nwant %s", hexutil.Encode(agl[:]), want)
+	}
+	gf, err := op.GasFees()
+	if err != nil {
+		t.Fatalf("GasFees: %v", err)
+	}
+	// maxPriorityFeePerGas is the HIGH half — the reverse of the usual reading order.
+	if want := "0x0000000000000000000000000000333300000000000000000000000000004444"; hexutil.Encode(gf[:]) != want {
+		t.Errorf("gasFees\n got %s\nwant %s", hexutil.Encode(gf[:]), want)
+	}
+}
+
+func TestPackRejectsOversizedAndNilValues(t *testing.T) {
+	tooBig := new(big.Int).Lsh(big.NewInt(1), 128) // 2^128, one past uint128
+
+	t.Run("overflow is an error, not a truncation", func(t *testing.T) {
+		op := UserOperationV07{VerificationGasLimit: tooBig, CallGasLimit: big.NewInt(1)}
+		if _, err := op.AccountGasLimits(); err == nil {
+			t.Fatal("expected overflow error, got nil — value would be silently truncated")
+		}
+	})
+
+	t.Run("nil is an error", func(t *testing.T) {
+		op := UserOperationV07{VerificationGasLimit: nil, CallGasLimit: big.NewInt(1)}
+		if _, err := op.AccountGasLimits(); err == nil {
+			t.Fatal("expected nil error, got nil")
+		}
+	})
+
+	t.Run("hash surfaces the packing error", func(t *testing.T) {
+		op := UserOperationV07{
+			Sender: common.HexToAddress("0x1"), Nonce: big.NewInt(0), CallData: []byte{},
+			VerificationGasLimit: tooBig, CallGasLimit: big.NewInt(1),
+			PreVerificationGas: big.NewInt(0),
+			MaxFeePerGas:       big.NewInt(1), MaxPriorityFeePerGas: big.NewInt(1),
+		}
+		if _, err := op.GetUserOpHash(entryPointV07, sepoliaChainID); err == nil {
+			t.Fatal("expected error to propagate out of GetUserOpHash")
+		}
+	})
+}
+
+func TestInitCodeAndPaymasterAndData(t *testing.T) {
+	t.Run("nil factory yields empty initCode", func(t *testing.T) {
+		op := UserOperationV07{}
+		if got := op.InitCode(); len(got) != 0 {
+			t.Errorf("expected empty initCode, got %s", hexutil.Encode(got))
+		}
+	})
+	t.Run("factory concatenates with data", func(t *testing.T) {
+		op := UserOperationV07{
+			Factory:     addr("0x00000000000017c61b5bEe81050EC8eFc9c6fecd"),
+			FactoryData: hexutil.MustDecode("0xdeadbeef"),
+		}
+		want := "0x00000000000017c61b5bee81050ec8efc9c6fecddeadbeef"
+		if got := hexutil.Encode(op.InitCode()); got != want {
+			t.Errorf("initCode\n got %s\nwant %s", got, want)
+		}
+	})
+	t.Run("nil paymaster yields empty paymasterAndData", func(t *testing.T) {
+		op := UserOperationV07{}
+		got, err := op.PaymasterAndData()
+		if err != nil {
+			t.Fatalf("PaymasterAndData: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %s", hexutil.Encode(got))
+		}
+	})
+	t.Run("paymaster packs address then two gas limits then data", func(t *testing.T) {
+		op := UserOperationV07{
+			Paymaster:                     addr("0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f"),
+			PaymasterVerificationGasLimit: big.NewInt(100000),
+			PaymasterPostOpGasLimit:       big.NewInt(50000),
+			PaymasterData:                 hexutil.MustDecode("0xc0ffee"),
+		}
+		got, err := op.PaymasterAndData()
+		if err != nil {
+			t.Fatalf("PaymasterAndData: %v", err)
+		}
+		want := "0xf023ea291f5beda4bf59bbdc9004f1d18be19d6f" +
+			"000000000000000000000000000186a0" +
+			"0000000000000000000000000000c350" +
+			"c0ffee"
+		if hexutil.Encode(got) != want {
+			t.Errorf("paymasterAndData\n got %s\nwant %s", hexutil.Encode(got), want)
+		}
+	})
+}


### PR DESCRIPTION
First increment of the MA v2 / EntryPoint v0.7 migration (`avs-infra/Alchemy_Stack_Migration_And_Chain_Expansion.md` W1). Additive — nothing calls it yet, so it carries no runtime risk. The builder and MA v2 execution ABI land on top of it.

## Separate type, not extra fields on v0.6

`UserOperationV07` sits alongside the existing `UserOperation` rather than extending it. The two hashing schemes are incompatible, and one struct carrying both sets of fields would make it possible to sign under the wrong one — a mistake that surfaces only as an on-chain `AA24` revert, far from where it was made.

## Unpacked wire form, packed on demand

v0.7 has two shapes that are easy to confuse. The type models the *unpacked* form (factory and paymaster as their own fields), which is what `eth_sendUserOperation` and `eth_estimateUserOperationGas` carry. `PackForSignature` produces the packed encoding the EntryPoint actually hashes.

## The expected hashes are not hand-computed

Each was read from the deployed EntryPoint v0.7 on Sepolia:

```
cast call 0x0000000071727De22E5E9d8BAf0edAc6f37da032 \
  'getUserOpHash((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes))(bytes32)' ...
```

so the contract itself is the oracle. Three shapes covered: all-zero, deployed-and-unsponsored, and counterfactual-with-paymaster. Regenerate the same way if the packing ever needs to change.

## Gas packing rejects rather than truncates

`nil`, negative, and `>uint128` values are errors. A silently truncated gas limit still produces a well-formed UserOp — it just fails much later, on chain, with no indication of where the number was lost.

Two ordering details the tests pin down, both easy to invert: `accountGasLimits` is verificationGasLimit-then-callGasLimit, and `gasFees` is maxPriorityFeePerGas-then-maxFeePerGas — the reverse of how those two are usually written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
