### PR TITLE
feat(aa): Modular Account v2 execution calldata encoding

### DIFF
--- a/core/chainio/aa/ma_v2.go
+++ b/core/chainio/aa/ma_v2.go
@@ -1,0 +1,116 @@
+package aa
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Execution calldata encoding for Alchemy Modular Account v2.
+//
+// How this differs from the v0.6 SimpleAccount encoding in aa.go, verified
+// against the deployed SemiModularAccountBytecode implementation
+// (0x000000000000c5A9089039570Dd36455b5C07383):
+//
+//	execute(address,uint256,bytes)                      0xb61d27f6  present — unchanged
+//	executeBatch((address,uint256,bytes)[])             0x34fcd5be  present — MA v2 form
+//	executeBatch(address[],bytes[])                     0x18dfb3c7  ABSENT  — v0.6 form
+//	executeBatchWithValues(address[],uint256[],bytes[]) 0xc3ff72fc  ABSENT  — our fork's
+//
+// Two consequences worth stating plainly:
+//
+//   - `execute` carries over byte-for-byte. Single-call encoding needs no
+//     migration at all.
+//   - `executeBatchWithValues` was a function we added to our SimpleAccount
+//     fork so a batch could carry a per-call ETH value. MA v2's `executeBatch`
+//     does that natively, so the fork function has no successor and needs
+//     none. This is what retires the sponsor-then-reimburse-from-wallet trick
+//     (avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §3.2).
+const (
+	SelectorExecuteMAv2      = "0xb61d27f6"
+	SelectorExecuteBatchMAv2 = "0x34fcd5be"
+)
+
+// Call is one entry in an MA v2 batch. Field order and names must match the
+// on-chain tuple — the ABI encoder maps by the `abi` tag, and a reordering
+// here would produce calldata that decodes to different arguments rather than
+// failing loudly.
+type Call struct {
+	Target common.Address `abi:"target"`
+	Value  *big.Int       `abi:"value"`
+	Data   []byte         `abi:"data"`
+}
+
+const modularAccountABIJSON = `[
+  {"type":"function","name":"execute","stateMutability":"payable",
+   "inputs":[{"name":"target","type":"address"},{"name":"value","type":"uint256"},{"name":"data","type":"bytes"}],
+   "outputs":[{"name":"result","type":"bytes"}]},
+  {"type":"function","name":"executeBatch","stateMutability":"payable",
+   "inputs":[{"name":"calls","type":"tuple[]","components":[
+     {"name":"target","type":"address"},{"name":"value","type":"uint256"},{"name":"data","type":"bytes"}]}],
+   "outputs":[{"name":"results","type":"bytes[]"}]}
+]`
+
+var (
+	modularAccountABIOnce sync.Once
+	modularAccountABI     abi.ABI
+	modularAccountABIErr  error
+)
+
+func ensureModularAccountABI() (abi.ABI, error) {
+	modularAccountABIOnce.Do(func() {
+		modularAccountABI, modularAccountABIErr = abi.JSON(strings.NewReader(modularAccountABIJSON))
+	})
+	return modularAccountABI, modularAccountABIErr
+}
+
+// PackExecuteMAv2 encodes a single call. Identical on the wire to the v0.6
+// PackExecute; kept as its own symbol so call sites read unambiguously and so
+// the v0.6 helper can be deleted at cutover without touching these.
+func PackExecuteMAv2(target common.Address, value *big.Int, data []byte) ([]byte, error) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		value = big.NewInt(0)
+	}
+	if data == nil {
+		data = []byte{}
+	}
+	return parsed.Pack("execute", target, value, data)
+}
+
+// PackExecuteBatchMAv2 encodes an atomic batch. Every call carries its own ETH
+// value, which is what makes the v0.6 executeBatchWithValues workaround
+// unnecessary.
+//
+// A nil Value or Data is normalised to zero/empty rather than rejected: the
+// common batch entry is a contract call with no ETH attached, and forcing
+// callers to spell that out invites big.NewInt(0) boilerplate at every site.
+// An empty batch IS rejected — it encodes fine and burns gas doing nothing,
+// which is never what the caller meant.
+func PackExecuteBatchMAv2(calls []Call) ([]byte, error) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, err
+	}
+	if len(calls) == 0 {
+		return nil, fmt.Errorf("executeBatch requires at least one call")
+	}
+	normalised := make([]Call, len(calls))
+	for i, c := range calls {
+		if c.Value == nil {
+			c.Value = big.NewInt(0)
+		}
+		if c.Data == nil {
+			c.Data = []byte{}
+		}
+		normalised[i] = c
+	}
+	return parsed.Pack("executeBatch", normalised)
+}

--- a/core/chainio/aa/ma_v2_test.go
+++ b/core/chainio/aa/ma_v2_test.go
@@ -1,0 +1,165 @@
+package aa
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+var (
+	targetA = common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	targetB = common.HexToAddress("0x71c8f4d7d5291edcb3a081802e7efb2788bd232e")
+)
+
+// The selectors are the contract's, not ours. These were read off the deployed
+// SemiModularAccountBytecode implementation
+// (0x000000000000c5A9089039570Dd36455b5C07383) — if a change here flips one,
+// the calldata stops being callable rather than merely being encoded oddly.
+func TestMAv2Selectors(t *testing.T) {
+	single, err := PackExecuteMAv2(targetA, big.NewInt(1), []byte{0xde, 0xad})
+	if err != nil {
+		t.Fatalf("PackExecuteMAv2: %v", err)
+	}
+	if got := hexutil.Encode(single[:4]); got != SelectorExecuteMAv2 {
+		t.Errorf("execute selector = %s, want %s", got, SelectorExecuteMAv2)
+	}
+
+	batch, err := PackExecuteBatchMAv2([]Call{{Target: targetA, Value: big.NewInt(1), Data: []byte{0xde}}})
+	if err != nil {
+		t.Fatalf("PackExecuteBatchMAv2: %v", err)
+	}
+	if got := hexutil.Encode(batch[:4]); got != SelectorExecuteBatchMAv2 {
+		t.Errorf("executeBatch selector = %s, want %s", got, SelectorExecuteBatchMAv2)
+	}
+
+	// v0.6's executeBatch(address[],bytes[]) is 0x18dfb3c7 and is NOT on the
+	// MA v2 implementation. Encoding against the old shape would produce
+	// calldata no MA v2 account can dispatch.
+	if hexutil.Encode(batch[:4]) == "0x18dfb3c7" {
+		t.Error("encoded the v0.6 executeBatch shape")
+	}
+}
+
+func TestPackExecuteMAv2RoundTrip(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	data := []byte{0xb6, 0x1d, 0x27, 0xf6, 0x01}
+	packed, err := PackExecuteMAv2(targetA, big.NewInt(12345), data)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	args, err := parsed.Methods["execute"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	if args[0].(common.Address) != targetA {
+		t.Errorf("target = %v, want %v", args[0], targetA)
+	}
+	if args[1].(*big.Int).Cmp(big.NewInt(12345)) != 0 {
+		t.Errorf("value = %v, want 12345", args[1])
+	}
+	if !bytes.Equal(args[2].([]byte), data) {
+		t.Errorf("data = %x, want %x", args[2], data)
+	}
+}
+
+func TestPackExecuteBatchMAv2RoundTrip(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	calls := []Call{
+		{Target: targetA, Value: big.NewInt(0), Data: []byte{0x01, 0x02}},
+		{Target: targetB, Value: big.NewInt(999), Data: []byte{0x03}},
+	}
+	packed, err := PackExecuteBatchMAv2(calls)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	args, err := parsed.Methods["executeBatch"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	decoded, ok := args[0].([]struct {
+		Target common.Address `json:"target"`
+		Value  *big.Int       `json:"value"`
+		Data   []byte         `json:"data"`
+	})
+	if !ok {
+		t.Fatalf("unexpected decoded type %T", args[0])
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("len = %d, want 2", len(decoded))
+	}
+	if decoded[0].Target != targetA || decoded[1].Target != targetB {
+		t.Errorf("targets round-tripped wrong: %v, %v", decoded[0].Target, decoded[1].Target)
+	}
+	if decoded[1].Value.Cmp(big.NewInt(999)) != 0 {
+		t.Errorf("per-call value lost: got %v want 999", decoded[1].Value)
+	}
+	if !bytes.Equal(decoded[0].Data, []byte{0x01, 0x02}) || !bytes.Equal(decoded[1].Data, []byte{0x03}) {
+		t.Error("call data round-tripped wrong")
+	}
+}
+
+// The v0.6 PackExecuteBatchWithValues hand-rolls its ABI encoding, with a
+// comment attributing that to a go-ethereum bug encoding empty []byte in a
+// dynamic array. This pins down whether the same workaround is needed for MA
+// v2's tuple[] — if it encodes and round-trips cleanly, the manual encoder
+// does not need to be carried forward.
+func TestPackExecuteBatchMAv2HandlesEmptyCallData(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	calls := []Call{
+		{Target: targetA, Value: big.NewInt(1_000_000), Data: []byte{}}, // plain ETH transfer
+		{Target: targetB, Value: big.NewInt(0), Data: []byte{0xab}},
+		{Target: targetA, Value: big.NewInt(0), Data: nil}, // nil, not just empty
+	}
+	packed, err := PackExecuteBatchMAv2(calls)
+	if err != nil {
+		t.Fatalf("pack with empty call data: %v", err)
+	}
+	args, err := parsed.Methods["executeBatch"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack with empty call data: %v", err)
+	}
+	decoded := args[0].([]struct {
+		Target common.Address `json:"target"`
+		Value  *big.Int       `json:"value"`
+		Data   []byte         `json:"data"`
+	})
+	if len(decoded) != 3 {
+		t.Fatalf("len = %d, want 3", len(decoded))
+	}
+	if len(decoded[0].Data) != 0 || len(decoded[2].Data) != 0 {
+		t.Errorf("empty call data did not survive: %x / %x", decoded[0].Data, decoded[2].Data)
+	}
+	if decoded[0].Value.Cmp(big.NewInt(1_000_000)) != 0 {
+		t.Errorf("value on an empty-data call was lost: %v", decoded[0].Value)
+	}
+}
+
+func TestPackExecuteBatchMAv2Normalisation(t *testing.T) {
+	t.Run("nil value and data are normalised", func(t *testing.T) {
+		if _, err := PackExecuteBatchMAv2([]Call{{Target: targetA}}); err != nil {
+			t.Errorf("nil Value/Data should be accepted: %v", err)
+		}
+	})
+	t.Run("nil value on single execute is normalised", func(t *testing.T) {
+		if _, err := PackExecuteMAv2(targetA, nil, nil); err != nil {
+			t.Errorf("nil value/data should be accepted: %v", err)
+		}
+	})
+	t.Run("empty batch is rejected", func(t *testing.T) {
+		if _, err := PackExecuteBatchMAv2(nil); err == nil {
+			t.Error("expected an error for an empty batch — it encodes fine and burns gas doing nothing")
+		}
+	})
+}


### PR DESCRIPTION
Second increment of the MA v2 / EntryPoint v0.7 migration. Additive — nothing calls it yet, so no runtime risk. Stacked on #678.

## Selectors were verified, not assumed

Read off the deployed `SemiModularAccountBytecode` implementation (`0x000000000000c5A9089039570Dd36455b5C07383`):

| Signature | Selector | On MA v2 |
|---|---|---|
| `execute(address,uint256,bytes)` | `0xb61d27f6` | present |
| `executeBatch((address,uint256,bytes)[])` | `0x34fcd5be` | present |
| `executeBatch(address[],bytes[])` | `0x18dfb3c7` | **absent** — v0.6 form |
| `executeBatchWithValues(address[],uint256[],bytes[])` | `0xc3ff72fc` | **absent** — our fork's |

Two consequences:

**`execute` carries over byte-for-byte.** Single-call encoding needs no migration at all — same selector, same arguments.

**`executeBatchWithValues` has no successor and needs none.** We added it to our SimpleAccount fork so a batch could carry a per-call ETH value; MA v2's `executeBatch` does that natively. This is the thing that retires the sponsor-then-reimburse-from-wallet trick (`avs-infra/Smart_Wallet_MA_v2_Spend_Policy.md` §3.2).

## The empty-bytes workaround does not need carrying forward

`PackExecuteBatchWithValues` hand-rolls its ABI encoding, with a comment blaming a go-ethereum bug encoding empty `[]byte` inside a dynamic array. `TestPackExecuteBatchMAv2HandlesEmptyCallData` pins down that MA v2's `tuple[]` encodes and round-trips empty *and* nil call data correctly — including a plain ETH transfer with value but no data — so the manual encoder stays behind with v0.6.

## Small deliberate choices

`nil` Value/Data normalise to zero/empty, because the common batch entry is a contract call with no ETH and forcing `big.NewInt(0)` at every site buys nothing. Empty batches are rejected: they encode fine and burn gas doing nothing, which is never what the caller meant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
