### PR TITLE
refactor(config): source Gas Manager webhook settings from gateway config

### DIFF
--- a/aggregator/gas_manager_webhook.go
+++ b/aggregator/gas_manager_webhook.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -58,9 +57,11 @@ type gasManagerWebhookResponse struct {
 	Approved bool `json:"approved"`
 }
 
-// gasManagerWebhookConfig carries the deployment-supplied settings. Sourced
-// from the environment rather than the YAML because both values are secrets
-// that Railway already delivers that way.
+// gasManagerWebhookConfig carries the deployment-supplied settings. Both come
+// from the gateway config (`gas_manager_policy_id`, `gas_manager_webhook_secret`),
+// which resolves them from YAML with an environment fallback — the same path
+// `moralis_api_key` and `alchemy_api_key` take, so a deployment configures
+// them in one place rather than two.
 type gasManagerWebhookConfig struct {
 	// PolicyID is the Gas Manager policy this gateway answers for. A request
 	// quoting any other policy is refused: it means either a misconfigured
@@ -74,10 +75,13 @@ type gasManagerWebhookConfig struct {
 	Secret string
 }
 
-func gasManagerWebhookConfigFromEnv() gasManagerWebhookConfig {
+func (agg *Aggregator) gasManagerWebhookConfig() gasManagerWebhookConfig {
+	if agg.config == nil {
+		return gasManagerWebhookConfig{}
+	}
 	return gasManagerWebhookConfig{
-		PolicyID: strings.TrimSpace(os.Getenv("ALCHEMY_GAS_POLICY_ID")),
-		Secret:   strings.TrimSpace(os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
+		PolicyID: strings.TrimSpace(agg.config.GasManagerPolicyID),
+		Secret:   strings.TrimSpace(agg.config.GasManagerWebhookSecret),
 	}
 }
 
@@ -116,17 +120,17 @@ func ownerOfSmartWallet(db storage.Storage, chainID int64, wallet common.Address
 
 // registerGasManagerWebhook mounts the webhook on the unauthenticated router.
 func (agg *Aggregator) registerGasManagerWebhook(e *echo.Echo) {
-	cfg := gasManagerWebhookConfigFromEnv()
+	cfg := agg.gasManagerWebhookConfig()
 	if cfg.PolicyID == "" {
 		// Without a policy id every request would be refused, which is worse
 		// than not serving the route: an operator who set the URL in the
 		// dashboard would see all sponsorship denied with no clue why.
-		agg.logger.Warn("gas manager webhook not mounted: ALCHEMY_GAS_POLICY_ID is unset",
+		agg.logger.Warn("gas manager webhook not mounted: gas_manager_policy_id is unset (env ALCHEMY_GAS_POLICY_ID)",
 			"path", gasManagerWebhookPath)
 		return
 	}
 	if cfg.Secret == "" {
-		agg.logger.Warn("gas manager webhook mounted without GAS_MANAGER_WEBHOOK_SECRET; endpoint is unauthenticated beyond the policy id check",
+		agg.logger.Warn("gas manager webhook mounted without gas_manager_webhook_secret (env GAS_MANAGER_WEBHOOK_SECRET); endpoint is unauthenticated beyond the policy id check",
 			"path", gasManagerWebhookPath)
 	}
 	e.POST(gasManagerWebhookPath, func(c echo.Context) error {

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -47,6 +47,25 @@ tenderly_account: ""
 tenderly_project: ""
 tenderly_access_key: ""
 
+# Optional: Alchemy Gas Manager sponsorship webhook.
+#
+# gas_manager_policy_id is the policy this gateway answers sponsorship
+# questions for. The webhook at POST /webhooks/gas-manager is mounted ONLY
+# when this is set — leaving it empty is the normal local-dev state, and the
+# route then 404s rather than silently refusing every sponsorship.
+#
+# Two things to know before pointing a real Gas Manager policy at a gateway:
+#   - the policy's "Sponsor on error or timeout" must stay OFF, so an
+#     unreachable gateway denies sponsorship instead of handing out unlimited
+#     gas; which also means
+#   - configuring the webhook URL in Alchemy BEFORE this gateway is deployed
+#     and configured will refuse every sponsorship on that policy.
+gas_manager_policy_id: ""
+# Echoed back as the request's webhookData. The webhook cannot sit behind the
+# REST JWT (Alchemy has no token), so this is its only caller authentication.
+# Empty disables the check.
+gas_manager_webhook_secret: ""
+
 # Top-level smart_wallet — required by the aa package globals (factory +
 # entrypoint), the startup paymaster probe, and any cmd tool that takes
 # the aggregator's default chain context. Points at Sepolia to match the

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -132,6 +132,20 @@ type Config struct {
 	// Moralis Web3 Data API key for token price lookup (optional)
 	MoralisApiKey string `yaml:"moralis_api_key"`
 
+	// GasManagerPolicyID is the Alchemy Gas Manager policy this gateway
+	// answers sponsorship questions for. The Gas Manager "custom rules"
+	// webhook is only mounted when this is set — a mounted route that
+	// refuses everything is indistinguishable from a broken chain in the
+	// dashboard, whereas an unmounted route 404s loudly.
+	GasManagerPolicyID string `yaml:"gas_manager_policy_id"`
+
+	// GasManagerWebhookSecret, when set, must be echoed as the webhook
+	// request's webhookData. The webhook cannot sit behind the REST JWT
+	// (Alchemy has no token), so this is its only caller authentication.
+	// Optional so the endpoint can be brought up before the sponsorship
+	// caller is taught to send it.
+	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
+
 	// Fee rates configuration for task execution pricing
 	FeeRates *FeeRatesConfig
 
@@ -374,6 +388,10 @@ type ConfigRaw struct {
 
 	// Moralis Web3 Data API key for token price lookup (optional)
 	MoralisApiKey string `yaml:"moralis_api_key"`
+
+	// Alchemy Gas Manager sponsorship webhook (optional; see Config)
+	GasManagerPolicyID      string `yaml:"gas_manager_policy_id"`
+	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
 
 	// Fee structure: execution_fee + COGS + value tiers
 	// Pointer fields: nil = use default, explicit 0.0 = free tier
@@ -645,6 +663,10 @@ func NewConfig(configFilePath string) (*Config, error) {
 
 		// Pass through Moralis API key (from YAML or environment variable)
 		MoralisApiKey: firstNonEmpty(configRaw.MoralisApiKey, os.Getenv("MORALIS_API_KEY")),
+
+		// Gas Manager sponsorship webhook (from YAML or environment variable)
+		GasManagerPolicyID:      firstNonEmpty(configRaw.GasManagerPolicyID, os.Getenv("ALCHEMY_GAS_POLICY_ID")),
+		GasManagerWebhookSecret: firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
 
 		// Initialize fee rates - use defaults if no YAML config provided
 		FeeRates: loadFeeRatesFromConfig(configRaw.FeeRates),


### PR DESCRIPTION
Follow-up to #677. The webhook read `ALCHEMY_GAS_POLICY_ID` and `GAS_MANAGER_WEBHOOK_SECRET` via `os.Getenv` directly, which is out of step with every other credential in this gateway — `alchemy_api_key`, `moralis_api_key`, and `tenderly_access_key` are all YAML fields resolved with an environment fallback. That split meant configuring the same service in two places, and it is why the setting was missing from the gateway configs entirely.

Adds `gas_manager_policy_id` and `gas_manager_webhook_secret` as top-level config fields following the `moralis_api_key` pattern (YAML first, env fallback), so the existing env vars keep working unchanged while `AP_CONFIG_YAML` becomes the primary source.

Paired with an avs-infra change adding both keys to `railway/configs/gateway-railway.yaml`.

## Verified parsing

| Config | Env | Result |
|---|---|---|
| `gateway-railway.yaml` | unset | parses; both empty → route not mounted → 404s loudly |
| `gateway-railway.yaml` | policy id set | parses; value resolves |
| `gateway.example.yaml` | n/a | parses; both empty |

The unset case matters: an unresolved `${VAR}` that left literal text behind would break YAML parsing at boot, and an empty-but-parsing value is what makes a half-configured deploy fail visibly instead of silently denying every sponsorship.

## Documented hazard

`gateway.example.yaml` now spells out the ordering trap, because it already bit us once: the policy correctly has *Sponsor on error or timeout* OFF, so Gas Manager reads any non-200 as "deny". Setting the webhook URL in Alchemy **before** the gateway is deployed and configured refuses every sponsorship on that policy. Deploy first, verify the endpoint answers 200, then set the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
