### PR TITLE
feat: gas sponsorship webhook, EntryPoint v0.7 + MA v2 encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,11 +278,22 @@ operator-default: build
 ## to the caller's terminal/pane; callers that want files redirect (dev-stack →
 ## logs/, start.sh → tee). Each sources .env.local so the
 ## ${SEPOLIA_BUNDLER_URL} / ${BASE_SEPOLIA_BUNDLER_URL} refs in the YAML resolve.
-.PHONY: run-gateway run-worker-sepolia run-worker-base-sepolia run-operator-sepolia
+.PHONY: run-gateway run-worker-sepolia run-worker-ethereum run-worker-base run-worker-base-sepolia run-operator-sepolia
 run-gateway:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap aggregator --config=config/gateway.yaml
 run-worker-sepolia:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-sepolia.yaml
+# MAINNET workers — move REAL funds, pay REAL gas (no paymaster). Need these in
+# .env.local: ETHEREUM_RPC_URL/WS, BASE_RPC_URL/WS, MAINNET_CONTROLLER_PRIVATE_KEY.
+# No *_BUNDLER_URL: every chain runs bundler_provider: alchemy, which derives the
+# endpoint from ALCHEMY_API_KEY and never reads bundler_url — the self-hosted
+# Voltaire tunnels these used to need are retired. start.sh skips these two panes
+# when the mainnet vars are absent, so a Sepolia-only stack still boots.
+run-worker-ethereum:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-ethereum.yaml
+run-worker-base:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base.yaml
+# Retired from the default local stack (see studio scripts/start.sh); kept runnable.
 run-worker-base-sepolia:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base-sepolia.yaml
 run-operator-sepolia:

--- a/aggregator/gas_manager_webhook.go
+++ b/aggregator/gas_manager_webhook.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -110,13 +111,22 @@ func ownerOfSmartWallet(db storage.Storage, chainID int64, wallet common.Address
 		}
 		owner = common.HexToAddress(parts[2])
 		found = true
-		return nil
+		// Stop at the first match. A non-nil error is the iterator's only
+		// break signal, so this sentinel is swallowed below. Without it the
+		// scan walks the chain's entire key space on every sponsorship
+		// request, and any duplicate key would silently decide the owner by
+		// iteration order.
+		return errStopIterating
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, errStopIterating) {
 		return common.Address{}, false, err
 	}
 	return owner, found, nil
 }
+
+// errStopIterating breaks out of IterateKeysOnly early. It never escapes
+// ownerOfSmartWallet.
+var errStopIterating = errors.New("stop iterating")
 
 // registerGasManagerWebhook mounts the webhook on the unauthenticated router.
 func (agg *Aggregator) registerGasManagerWebhook(e *echo.Echo) {

--- a/aggregator/gas_manager_webhook.go
+++ b/aggregator/gas_manager_webhook.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -58,9 +57,11 @@ type gasManagerWebhookResponse struct {
 	Approved bool `json:"approved"`
 }
 
-// gasManagerWebhookConfig carries the deployment-supplied settings. Sourced
-// from the environment rather than the YAML because both values are secrets
-// that Railway already delivers that way.
+// gasManagerWebhookConfig carries the deployment-supplied settings. Both come
+// from the gateway config (`gas_manager_policy_id`, `gas_manager_webhook_secret`),
+// which resolves them from YAML with an environment fallback — the same path
+// `moralis_api_key` and `alchemy_api_key` take, so a deployment configures
+// them in one place rather than two.
 type gasManagerWebhookConfig struct {
 	// PolicyID is the Gas Manager policy this gateway answers for. A request
 	// quoting any other policy is refused: it means either a misconfigured
@@ -74,10 +75,13 @@ type gasManagerWebhookConfig struct {
 	Secret string
 }
 
-func gasManagerWebhookConfigFromEnv() gasManagerWebhookConfig {
+func (agg *Aggregator) gasManagerWebhookConfig() gasManagerWebhookConfig {
+	if agg.config == nil {
+		return gasManagerWebhookConfig{}
+	}
 	return gasManagerWebhookConfig{
-		PolicyID: strings.TrimSpace(os.Getenv("ALCHEMY_GAS_POLICY_ID")),
-		Secret:   strings.TrimSpace(os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
+		PolicyID: strings.TrimSpace(agg.config.GasManagerPolicyID),
+		Secret:   strings.TrimSpace(agg.config.GasManagerWebhookSecret),
 	}
 }
 
@@ -116,17 +120,17 @@ func ownerOfSmartWallet(db storage.Storage, chainID int64, wallet common.Address
 
 // registerGasManagerWebhook mounts the webhook on the unauthenticated router.
 func (agg *Aggregator) registerGasManagerWebhook(e *echo.Echo) {
-	cfg := gasManagerWebhookConfigFromEnv()
+	cfg := agg.gasManagerWebhookConfig()
 	if cfg.PolicyID == "" {
 		// Without a policy id every request would be refused, which is worse
 		// than not serving the route: an operator who set the URL in the
 		// dashboard would see all sponsorship denied with no clue why.
-		agg.logger.Warn("gas manager webhook not mounted: ALCHEMY_GAS_POLICY_ID is unset",
+		agg.logger.Warn("gas manager webhook not mounted: gas_manager_policy_id is unset (env ALCHEMY_GAS_POLICY_ID)",
 			"path", gasManagerWebhookPath)
 		return
 	}
 	if cfg.Secret == "" {
-		agg.logger.Warn("gas manager webhook mounted without GAS_MANAGER_WEBHOOK_SECRET; endpoint is unauthenticated beyond the policy id check",
+		agg.logger.Warn("gas manager webhook mounted without gas_manager_webhook_secret (env GAS_MANAGER_WEBHOOK_SECRET); endpoint is unauthenticated beyond the policy id check",
 			"path", gasManagerWebhookPath)
 	}
 	e.POST(gasManagerWebhookPath, func(c echo.Context) error {

--- a/aggregator/gas_manager_webhook.go
+++ b/aggregator/gas_manager_webhook.go
@@ -1,0 +1,266 @@
+package aggregator
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Alchemy Gas Manager "custom rules" webhook.
+//
+// Gas Manager POSTs here before sponsoring a UserOp; our answer decides
+// whether the treasury pays for it. This is the enforcement point for the
+// FeeLedger credit limit — without it FeeLedger is retrospective accounting
+// and an owner past their limit keeps getting sponsored.
+//
+// Two properties this handler must hold, both easy to break by accident:
+//
+//  1. It is mounted OUTSIDE the /api/v1 group. That group requires a JWT and
+//     applies the shared rate limiter. Alchemy sends neither a token nor a
+//     predictable request rate, so mounting it there would return 401/429 —
+//     which Gas Manager reads as "deny", silently disabling sponsorship for
+//     every user. The failure is global and looks like a chain problem.
+//
+//  2. It fails CLOSED. Every error path returns approved=false. This is the
+//     opposite of the executor's pre-execution credit check, which logs and
+//     proceeds on a ledger error: there, failing open costs one unmetered
+//     execution; here it would hand out unlimited sponsored gas for as long as
+//     the fault lasts.
+//
+// The response is always HTTP 200 carrying an explicit {"approved": bool}. A
+// non-200 also denies (the policy has "Sponsor on error or timeout" off), but
+// then our deliberate denial is indistinguishable from a crash in the logs.
+
+const gasManagerWebhookPath = "/webhooks/gas-manager"
+
+// gasManagerWebhookRequest is Alchemy's request body. userOperation's shape
+// varies by EntryPoint version, so only `sender` is decoded — it is the one
+// field present in both v0.6 and v0.7 and the only one this decision needs.
+type gasManagerWebhookRequest struct {
+	UserOperation struct {
+		Sender string `json:"sender"`
+	} `json:"userOperation"`
+	PolicyID    string `json:"policyId"`
+	ChainID     int64  `json:"chainId"`
+	WebhookData string `json:"webhookData"`
+}
+
+type gasManagerWebhookResponse struct {
+	Approved bool `json:"approved"`
+}
+
+// gasManagerWebhookConfig carries the deployment-supplied settings. Sourced
+// from the environment rather than the YAML because both values are secrets
+// that Railway already delivers that way.
+type gasManagerWebhookConfig struct {
+	// PolicyID is the Gas Manager policy this gateway answers for. A request
+	// quoting any other policy is refused: it means either a misconfigured
+	// dashboard or someone else's policy pointed at our endpoint.
+	PolicyID string
+	// Secret, when set, must appear as the request's webhookData. Defence in
+	// depth — the endpoint is unauthenticated by necessity (see above), and
+	// this keeps it from being a freely queryable oracle over ledger state.
+	// Empty disables the check so the webhook can be brought up before the
+	// sponsorship caller is taught to send it.
+	Secret string
+}
+
+func gasManagerWebhookConfigFromEnv() gasManagerWebhookConfig {
+	return gasManagerWebhookConfig{
+		PolicyID: strings.TrimSpace(os.Getenv("ALCHEMY_GAS_POLICY_ID")),
+		Secret:   strings.TrimSpace(os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
+	}
+}
+
+// ownerOfSmartWallet resolves a smart-wallet address back to its owner EOA.
+//
+// Wallet records are keyed `w:<chain>:<owner>:<wallet>` — owner first — so
+// there is no direct reverse index. This scans the chain's key space and
+// matches on the trailing segment, using the key-only iterator so values are
+// never loaded. Linear in wallets-per-chain, which is fine at current scale
+// (hundreds); if that stops being true, add a `wowner:<chain>:<wallet>`
+// index rather than making this smarter.
+func ownerOfSmartWallet(db storage.Storage, chainID int64, wallet common.Address) (common.Address, bool, error) {
+	prefix := []byte(fmt.Sprintf("w:%d:", chainID))
+	want := strings.ToLower(wallet.Hex())
+
+	var owner common.Address
+	var found bool
+	err := db.IterateKeysOnly(prefix, func(key []byte) error {
+		// w : chain : owner : wallet
+		parts := strings.Split(string(key), ":")
+		if len(parts) != 4 {
+			return nil
+		}
+		if parts[3] != want {
+			return nil
+		}
+		owner = common.HexToAddress(parts[2])
+		found = true
+		return nil
+	})
+	if err != nil {
+		return common.Address{}, false, err
+	}
+	return owner, found, nil
+}
+
+// registerGasManagerWebhook mounts the webhook on the unauthenticated router.
+func (agg *Aggregator) registerGasManagerWebhook(e *echo.Echo) {
+	cfg := gasManagerWebhookConfigFromEnv()
+	if cfg.PolicyID == "" {
+		// Without a policy id every request would be refused, which is worse
+		// than not serving the route: an operator who set the URL in the
+		// dashboard would see all sponsorship denied with no clue why.
+		agg.logger.Warn("gas manager webhook not mounted: ALCHEMY_GAS_POLICY_ID is unset",
+			"path", gasManagerWebhookPath)
+		return
+	}
+	if cfg.Secret == "" {
+		agg.logger.Warn("gas manager webhook mounted without GAS_MANAGER_WEBHOOK_SECRET; endpoint is unauthenticated beyond the policy id check",
+			"path", gasManagerWebhookPath)
+	}
+	e.POST(gasManagerWebhookPath, func(c echo.Context) error {
+		return agg.handleGasManagerWebhook(c, cfg)
+	})
+	agg.logger.Info("gas manager webhook mounted", "path", gasManagerWebhookPath)
+}
+
+// deny logs why sponsorship was refused and returns the 200/false body.
+// Reasons are logged rather than returned: the caller is Alchemy, and telling
+// an arbitrary POSTer *why* it was refused leaks ledger and config state.
+func (agg *Aggregator) deny(c echo.Context, reason string, kv ...interface{}) error {
+	agg.logger.Warn("gas sponsorship denied: "+reason, kv...)
+	return c.JSON(http.StatusOK, gasManagerWebhookResponse{Approved: false})
+}
+
+func (agg *Aggregator) handleGasManagerWebhook(c echo.Context, cfg gasManagerWebhookConfig) error {
+	var req gasManagerWebhookRequest
+	if err := c.Bind(&req); err != nil {
+		return agg.deny(c, "malformed request body", "error", err)
+	}
+
+	if subtle.ConstantTimeCompare([]byte(req.PolicyID), []byte(cfg.PolicyID)) != 1 {
+		return agg.deny(c, "unexpected policy id", "policy_id", req.PolicyID)
+	}
+	if cfg.Secret != "" &&
+		subtle.ConstantTimeCompare([]byte(req.WebhookData), []byte(cfg.Secret)) != 1 {
+		return agg.deny(c, "webhookData did not match the configured secret")
+	}
+
+	sender := strings.TrimSpace(req.UserOperation.Sender)
+	if !common.IsHexAddress(sender) {
+		return agg.deny(c, "userOperation.sender is not an address", "sender", sender)
+	}
+	wallet := common.HexToAddress(sender)
+
+	if agg.db == nil {
+		return agg.deny(c, "storage unavailable")
+	}
+
+	owner, found, err := ownerOfSmartWallet(agg.db, req.ChainID, wallet)
+	if err != nil {
+		return agg.deny(c, "owner lookup failed", "wallet", wallet.Hex(), "error", err)
+	}
+	if !found {
+		// An unknown sender is not ours to sponsor. This is the check that
+		// stops the policy from funding wallets created outside this gateway.
+		return agg.deny(c, "sender is not a known smart wallet",
+			"wallet", wallet.Hex(), "chain_id", req.ChainID)
+	}
+
+	withinLimit, outstanding, err := agg.ownerWithinCreditLimit(owner)
+	if err != nil {
+		return agg.deny(c, "credit check failed", "owner", owner.Hex(), "error", err)
+	}
+	if !withinLimit {
+		return agg.deny(c, "owner is over their credit limit",
+			"owner", owner.Hex(), "outstanding_wei", outstanding.String())
+	}
+
+	return c.JSON(http.StatusOK, gasManagerWebhookResponse{Approved: true})
+}
+
+// ownerWithinCreditLimit checks the owner's outstanding value fees against the
+// configured limit on EVERY known chain, not just the one the UserOp targets.
+// Fees accrue per execution chain (`fl:<chain>:<owner>`), so gating only the
+// requesting chain would let an owner who is over their limit on Base keep
+// drawing sponsorship on Ethereum.
+func (agg *Aggregator) ownerWithinCreditLimit(owner common.Address) (bool, *big.Int, error) {
+	if agg.config == nil || agg.config.FeeRates == nil {
+		return false, big.NewInt(0), fmt.Errorf("fee configuration unavailable")
+	}
+	ledger := taskengine.NewFeeLedger(agg.db, agg.logger)
+
+	// A zero limit means "block on any outstanding balance". USD limits need
+	// the price service to convert; when that is unavailable we cannot make a
+	// safe judgement, so we fail closed rather than guessing.
+	creditLimitWei := big.NewInt(0)
+	if limitUSD := agg.config.FeeRates.CreditLimitUSD; limitUSD > 0 {
+		if agg.priceService == nil {
+			return false, big.NewInt(0), fmt.Errorf("price service unavailable for USD credit limit")
+		}
+		converted, err := taskengine.ConvertUSDToWei(limitUSD, agg.priceService, agg.chainIDInt64())
+		if err != nil {
+			return false, big.NewInt(0), fmt.Errorf("converting credit limit to wei: %w", err)
+		}
+		creditLimitWei = converted
+	}
+
+	worstOutstanding := big.NewInt(0)
+	for _, chainID := range agg.knownFeeChainIDs() {
+		within, outstanding, err := ledger.CheckCreditLimit(chainID, owner, creditLimitWei)
+		if err != nil {
+			return false, worstOutstanding, fmt.Errorf("chain %d: %w", chainID, err)
+		}
+		if outstanding != nil && outstanding.Cmp(worstOutstanding) > 0 {
+			worstOutstanding = outstanding
+		}
+		if !within {
+			return false, outstanding, nil
+		}
+	}
+	return true, worstOutstanding, nil
+}
+
+// chainIDInt64 returns the gateway's default chain, used only to price the USD
+// credit limit.
+func (agg *Aggregator) chainIDInt64() int64 {
+	if agg.chainID != nil {
+		return agg.chainID.Int64()
+	}
+	return 0
+}
+
+// knownFeeChainIDs lists every chain this gateway serves, so the credit check
+// cannot be bypassed by switching chains.
+func (agg *Aggregator) knownFeeChainIDs() []int64 {
+	seen := map[int64]struct{}{}
+	out := []int64{}
+	add := func(id int64) {
+		if id <= 0 {
+			return
+		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	add(agg.chainIDInt64())
+	if agg.config != nil {
+		for _, chain := range agg.config.Chains {
+			add(chain.SmartWallet.ChainID)
+		}
+	}
+	return out
+}

--- a/aggregator/gas_manager_webhook.go
+++ b/aggregator/gas_manager_webhook.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
@@ -143,9 +144,16 @@ func (agg *Aggregator) registerGasManagerWebhook(e *echo.Echo) {
 		agg.logger.Warn("gas manager webhook mounted without gas_manager_webhook_secret (env GAS_MANAGER_WEBHOOK_SECRET); endpoint is unauthenticated beyond the policy id check",
 			"path", gasManagerWebhookPath)
 	}
+	// Body cap. This route sits outside /api/v1 and so outside that group's
+	// middleware, which means nothing else bounds request size here. A Gas
+	// Manager payload is one UserOp plus three short fields; 64 KiB is orders
+	// of magnitude of headroom. Deliberately no rate limit: throttling this
+	// route would return 429 to Alchemy, which reads as "deny" and turns a
+	// traffic spike into a sponsorship outage. The policy-id check runs before
+	// any storage access, so an unauthenticated caller cannot reach the scan.
 	e.POST(gasManagerWebhookPath, func(c echo.Context) error {
 		return agg.handleGasManagerWebhook(c, cfg)
-	})
+	}, middleware.BodyLimit("64K"))
 	agg.logger.Info("gas manager webhook mounted", "path", gasManagerWebhookPath)
 }
 
@@ -230,8 +238,18 @@ func (agg *Aggregator) ownerWithinCreditLimit(owner common.Address) (bool, *big.
 		creditLimitWei = converted
 	}
 
+	// An empty chain list would make the loop below a no-op and return
+	// "within limit" for everyone — a fail-OPEN in the one function whose
+	// entire job is to fail closed. It means the aggregator has no chain
+	// context (uninitialised, or mounted before init populated it), which is
+	// never a state in which we can vouch for an owner's balance.
+	chainIDs := agg.knownFeeChainIDs()
+	if len(chainIDs) == 0 {
+		return false, big.NewInt(0), fmt.Errorf("no known chains: cannot evaluate credit limit")
+	}
+
 	worstOutstanding := big.NewInt(0)
-	for _, chainID := range agg.knownFeeChainIDs() {
+	for _, chainID := range chainIDs {
 		within, outstanding, err := ledger.CheckCreditLimit(chainID, owner, creditLimitWei)
 		if err != nil {
 			return false, worstOutstanding, fmt.Errorf("chain %d: %w", chainID, err)

--- a/aggregator/gas_manager_webhook_test.go
+++ b/aggregator/gas_manager_webhook_test.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,17 +22,35 @@ const (
 	testSecret   = "s3cr3t-webhook-token"
 )
 
+const testChainID = int64(11155111)
+
+// newWebhookAggregator builds an aggregator with a real chain context.
+//
+// The chain id matters more than it looks: ownerWithinCreditLimit iterates
+// knownFeeChainIDs(), so an aggregator with none would skip the ledger read
+// entirely and every test would pass without ever exercising the credit gate.
 func newWebhookAggregator(t *testing.T) (*Aggregator, func()) {
 	t.Helper()
 	db := testutil.TestMustDB()
 	agg := &Aggregator{
-		logger: testutil.GetLogger(),
-		db:     db,
+		logger:  testutil.GetLogger(),
+		db:      db,
+		chainID: big.NewInt(testChainID),
 		config: &config.Config{
 			FeeRates: &config.FeeRatesConfig{CreditLimitUSD: 0},
 		},
 	}
 	return agg, func() { db.Close() }
+}
+
+// Guards the harness itself. If this regresses to an empty list, every
+// approval assertion below becomes vacuous — the ledger would never be read.
+func TestWebhookHarnessHasChainContext(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+	if got := agg.knownFeeChainIDs(); len(got) == 0 {
+		t.Fatal("harness has no known chains — credit-limit assertions would not exercise the ledger")
+	}
 }
 
 // post drives the handler directly so the test covers the decision logic
@@ -123,6 +142,102 @@ func TestGasManagerWebhook_ApprovesKnownWalletWithinLimit(t *testing.T) {
 	}
 	if !approved {
 		t.Error("approved = false, want true for a known wallet with no outstanding fees")
+	}
+}
+
+// The behaviour the whole feature exists for: an owner carrying outstanding
+// value fees above their credit limit must not get sponsored gas. Seeds a real
+// FeeLedger record rather than stubbing, so this exercises the same
+// CheckCreditLimit path production takes.
+func TestGasManagerWebhook_DeniesOwnerOverCreditLimit(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, testChainID, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID}
+	body := bodyFor(wallet.Hex(), testChainID, testPolicyID, "")
+
+	// Clean ledger → approved. Establishes that the denial below is caused by
+	// the fee, not by some unrelated rejection earlier in the handler.
+	if _, approved := post(t, agg, cfg, body); !approved {
+		t.Fatal("precondition: expected approval with an empty ledger")
+	}
+
+	ledger := taskengine.NewFeeLedger(agg.db, agg.logger)
+	if err := ledger.RecordValueFee(&taskengine.FeeRecord{
+		ExecutionID:    "exec-over-limit",
+		TaskID:         "task-over-limit",
+		Owner:          owner.Hex(),
+		Tier:           "EXECUTION_TIER_1",
+		TierPercentage: "0.03",
+		TxValueWei:     "1000000000000000000",
+		FeeAmountWei:   "300000000000000", // outstanding > 0, limit is 0
+		Timestamp:      1,
+		ChainID:        testChainID,
+	}); err != nil {
+		t.Fatalf("seeding fee record: %v", err)
+	}
+
+	status, approved := post(t, agg, cfg, body)
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if approved {
+		t.Error("approved = true for an owner over their credit limit — the credit gate is not being enforced")
+	}
+}
+
+// Fees accrue per execution chain, so an owner over their limit on one chain
+// must not be able to draw sponsorship by requesting on another.
+func TestGasManagerWebhook_CreditLimitIsNotBypassableCrossChain(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+	otherChain := int64(8453)
+	agg.config.Chains = []*config.ChainConfig{
+		{ChainID: otherChain, SmartWallet: &config.SmartWalletConfig{ChainID: otherChain}},
+	}
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, testChainID, owner, wallet)
+
+	// Debt sits on the OTHER chain; the request comes in on testChainID.
+	ledger := taskengine.NewFeeLedger(agg.db, agg.logger)
+	if err := ledger.RecordValueFee(&taskengine.FeeRecord{
+		ExecutionID: "exec-other-chain", TaskID: "task-other-chain",
+		Owner: owner.Hex(), Tier: "EXECUTION_TIER_1", TierPercentage: "0.03",
+		TxValueWei: "1000000000000000000", FeeAmountWei: "300000000000000",
+		Timestamp: 1, ChainID: otherChain,
+	}); err != nil {
+		t.Fatalf("seeding fee record: %v", err)
+	}
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID}
+	_, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), testChainID, testPolicyID, ""))
+	if approved {
+		t.Error("approved = true — debt on another chain was not counted, so the limit is bypassable by switching chains")
+	}
+}
+
+// An aggregator with no chain context cannot vouch for anyone's balance. The
+// loop over known chains would otherwise be a no-op and approve unconditionally.
+func TestGasManagerWebhook_DeniesWithNoChainContext(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+	agg.chainID = nil
+	agg.config.Chains = nil
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, testChainID, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID}
+	_, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), testChainID, testPolicyID, ""))
+	if approved {
+		t.Error("approved = true with no known chains; must fail closed")
 	}
 }
 

--- a/aggregator/gas_manager_webhook_test.go
+++ b/aggregator/gas_manager_webhook_test.go
@@ -1,0 +1,239 @@
+package aggregator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+)
+
+const (
+	testPolicyID = "bf905871-55d7-4197-a020-000000000000"
+	testSecret   = "s3cr3t-webhook-token"
+)
+
+func newWebhookAggregator(t *testing.T) (*Aggregator, func()) {
+	t.Helper()
+	db := testutil.TestMustDB()
+	agg := &Aggregator{
+		logger: testutil.GetLogger(),
+		db:     db,
+		config: &config.Config{
+			FeeRates: &config.FeeRatesConfig{CreditLimitUSD: 0},
+		},
+	}
+	return agg, func() { db.Close() }
+}
+
+// post drives the handler directly so the test covers the decision logic
+// rather than Echo's routing.
+func post(t *testing.T, agg *Aggregator, cfg gasManagerWebhookConfig, body string) (int, bool) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, gasManagerWebhookPath, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	if err := agg.handleGasManagerWebhook(e.NewContext(req, rec), cfg); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	var resp gasManagerWebhookResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding response %q: %v", rec.Body.String(), err)
+	}
+	return rec.Code, resp.Approved
+}
+
+func bodyFor(sender string, chainID int64, policyID, webhookData string) string {
+	return fmt.Sprintf(
+		`{"userOperation":{"sender":%q},"policyId":%q,"chainId":%d,"webhookData":%q}`,
+		sender, policyID, chainID, webhookData)
+}
+
+// storeWallet writes a wallet record so the reverse lookup can find it.
+func storeWallet(t *testing.T, agg *Aggregator, chainID int64, owner, wallet common.Address) {
+	t.Helper()
+	key := taskengine.WalletStorageKey(chainID, owner, wallet.Hex())
+	if err := agg.db.Set([]byte(key), []byte("{}")); err != nil {
+		t.Fatalf("seeding wallet: %v", err)
+	}
+}
+
+// Every rejection path must answer 200 with approved:false. A non-200 would
+// also deny at the platform level, but then a deliberate refusal is
+// indistinguishable from a crash.
+func TestGasManagerWebhook_DeniesAndAlwaysAnswers200(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID, Secret: testSecret}
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"malformed body", `{not json`},
+		{"wrong policy id", bodyFor(wallet.Hex(), 11155111, "someone-elses-policy", testSecret)},
+		{"empty policy id", bodyFor(wallet.Hex(), 11155111, "", testSecret)},
+		{"wrong webhook secret", bodyFor(wallet.Hex(), 11155111, testPolicyID, "guessed")},
+		{"missing webhook secret", bodyFor(wallet.Hex(), 11155111, testPolicyID, "")},
+		{"sender not an address", bodyFor("not-an-address", 11155111, testPolicyID, testSecret)},
+		{"sender empty", bodyFor("", 11155111, testPolicyID, testSecret)},
+		{"unknown smart wallet", bodyFor("0x000000000000000000000000000000000000dEaD", 11155111, testPolicyID, testSecret)},
+		{"known wallet but wrong chain", bodyFor(wallet.Hex(), 8453, testPolicyID, testSecret)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, approved := post(t, agg, cfg, tt.body)
+			if status != http.StatusOK {
+				t.Errorf("status = %d, want 200 (a non-200 hides the reason from logs)", status)
+			}
+			if approved {
+				t.Error("approved = true, want false — this path must fail closed")
+			}
+		})
+	}
+}
+
+func TestGasManagerWebhook_ApprovesKnownWalletWithinLimit(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID, Secret: testSecret}
+	status, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), 11155111, testPolicyID, testSecret))
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !approved {
+		t.Error("approved = false, want true for a known wallet with no outstanding fees")
+	}
+}
+
+// An empty configured secret disables the check, so the webhook can be brought
+// up before the sponsorship caller is taught to send webhookData. It must not
+// accidentally start accepting *any* secret when one IS configured — covered
+// by the deny table above.
+func TestGasManagerWebhook_EmptySecretSkipsTheCheck(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0xc60e71bd0f2e6d8832fea1a2d56091c48493c788")
+	wallet := common.HexToAddress("0x71c8f4d7d5291edcb3a081802e7efb2788bd232e")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID, Secret: ""}
+	_, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), 11155111, testPolicyID, "anything at all"))
+	if !approved {
+		t.Error("approved = false; an empty configured secret should skip the comparison")
+	}
+}
+
+// Storage faults must deny rather than pass through.
+func TestGasManagerWebhook_DeniesWhenStorageUnavailable(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+	agg.db = nil
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID}
+	status, approved := post(t, agg, cfg,
+		bodyFor("0x981e18d5aade83620a6bd21990b5da0c797e1e5b", 11155111, testPolicyID, ""))
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if approved {
+		t.Error("approved = true with no storage; must fail closed")
+	}
+}
+
+// A USD credit limit needs the price service to convert to wei. Without it we
+// cannot judge the limit, and guessing would mean sponsoring an owner who may
+// be far past it.
+func TestGasManagerWebhook_DeniesWhenUSDLimitCannotBePriced(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+	agg.config.FeeRates.CreditLimitUSD = 20 // > 0 requires the price service
+	agg.priceService = nil
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	storeWallet(t, agg, 11155111, owner, wallet)
+
+	cfg := gasManagerWebhookConfig{PolicyID: testPolicyID}
+	_, approved := post(t, agg, cfg, bodyFor(wallet.Hex(), 11155111, testPolicyID, ""))
+	if approved {
+		t.Error("approved = true without a way to price the credit limit; must fail closed")
+	}
+}
+
+func TestOwnerOfSmartWallet(t *testing.T) {
+	agg, cleanup := newWebhookAggregator(t)
+	defer cleanup()
+
+	owner := common.HexToAddress("0x72d841f43241957b558097a5110a8ed68c6fd88c")
+	wallet := common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	other := common.HexToAddress("0xc60e71bd0f2e6d8832fea1a2d56091c48493c788")
+	storeWallet(t, agg, 11155111, owner, wallet)
+	storeWallet(t, agg, 11155111, other, common.HexToAddress("0x71c8f4d7d5291edcb3a081802e7efb2788bd232e"))
+	// Same wallet address on another chain, different owner — CREATE2 makes
+	// this genuinely possible, and the lookup must not cross chains.
+	storeWallet(t, agg, 8453, other, wallet)
+
+	t.Run("resolves owner on the requested chain", func(t *testing.T) {
+		got, found, err := ownerOfSmartWallet(agg.db, 11155111, wallet)
+		if err != nil || !found {
+			t.Fatalf("found=%v err=%v", found, err)
+		}
+		if got != owner {
+			t.Errorf("owner = %s, want %s", got.Hex(), owner.Hex())
+		}
+	})
+
+	t.Run("same wallet on another chain resolves to that chain's owner", func(t *testing.T) {
+		got, found, err := ownerOfSmartWallet(agg.db, 8453, wallet)
+		if err != nil || !found {
+			t.Fatalf("found=%v err=%v", found, err)
+		}
+		if got != other {
+			t.Errorf("owner = %s, want %s — lookup leaked across chains", got.Hex(), other.Hex())
+		}
+	})
+
+	t.Run("unknown wallet is not found", func(t *testing.T) {
+		_, found, err := ownerOfSmartWallet(agg.db, 11155111,
+			common.HexToAddress("0x000000000000000000000000000000000000dEaD"))
+		if err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		if found {
+			t.Error("found = true for a wallet that was never stored")
+		}
+	})
+
+	t.Run("case-insensitive on the sender address", func(t *testing.T) {
+		_, found, err := ownerOfSmartWallet(agg.db, 11155111,
+			common.HexToAddress(strings.ToUpper(strings.TrimPrefix(wallet.Hex(), "0x"))))
+		if err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		if !found {
+			t.Error("found = false; sender casing should not matter")
+		}
+	})
+}

--- a/aggregator/http_server.go
+++ b/aggregator/http_server.go
@@ -166,6 +166,12 @@ func (agg *Aggregator) startHttpServer(ctx context.Context, extraMounts []HTTPMo
 		return c.HTMLBlob(http.StatusOK, buf.Bytes())
 	})
 
+	// Alchemy Gas Manager custom-rules webhook. Deliberately on this router
+	// and not the /api/v1 group — that group's JWT and rate-limit middleware
+	// would reject Alchemy, and Gas Manager reads any non-200 as "deny
+	// sponsorship". See gas_manager_webhook.go.
+	agg.registerGasManagerWebhook(e)
+
 	// Register debug endpoints only if not in production
 	if os.Getenv("APP_ENV") != "production" {
 		// Debug endpoints to validate Sentry wiring from a running instance

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -47,6 +47,25 @@ tenderly_account: ""
 tenderly_project: ""
 tenderly_access_key: ""
 
+# Optional: Alchemy Gas Manager sponsorship webhook.
+#
+# gas_manager_policy_id is the policy this gateway answers sponsorship
+# questions for. The webhook at POST /webhooks/gas-manager is mounted ONLY
+# when this is set — leaving it empty is the normal local-dev state, and the
+# route then 404s rather than silently refusing every sponsorship.
+#
+# Two things to know before pointing a real Gas Manager policy at a gateway:
+#   - the policy's "Sponsor on error or timeout" must stay OFF, so an
+#     unreachable gateway denies sponsorship instead of handing out unlimited
+#     gas; which also means
+#   - configuring the webhook URL in Alchemy BEFORE this gateway is deployed
+#     and configured will refuse every sponsorship on that policy.
+gas_manager_policy_id: ""
+# Echoed back as the request's webhookData. The webhook cannot sit behind the
+# REST JWT (Alchemy has no token), so this is its only caller authentication.
+# Empty disables the check.
+gas_manager_webhook_secret: ""
+
 # Top-level smart_wallet — required by the aa package globals (factory +
 # entrypoint), the startup paymaster probe, and any cmd tool that takes
 # the aggregator's default chain context. Points at Sepolia to match the

--- a/core/chainio/aa/ma_v2.go
+++ b/core/chainio/aa/ma_v2.go
@@ -1,0 +1,116 @@
+package aa
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Execution calldata encoding for Alchemy Modular Account v2.
+//
+// How this differs from the v0.6 SimpleAccount encoding in aa.go, verified
+// against the deployed SemiModularAccountBytecode implementation
+// (0x000000000000c5A9089039570Dd36455b5C07383):
+//
+//	execute(address,uint256,bytes)                      0xb61d27f6  present — unchanged
+//	executeBatch((address,uint256,bytes)[])             0x34fcd5be  present — MA v2 form
+//	executeBatch(address[],bytes[])                     0x18dfb3c7  ABSENT  — v0.6 form
+//	executeBatchWithValues(address[],uint256[],bytes[]) 0xc3ff72fc  ABSENT  — our fork's
+//
+// Two consequences worth stating plainly:
+//
+//   - `execute` carries over byte-for-byte. Single-call encoding needs no
+//     migration at all.
+//   - `executeBatchWithValues` was a function we added to our SimpleAccount
+//     fork so a batch could carry a per-call ETH value. MA v2's `executeBatch`
+//     does that natively, so the fork function has no successor and needs
+//     none. This is what retires the sponsor-then-reimburse-from-wallet trick
+//     (avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §3.2).
+const (
+	SelectorExecuteMAv2      = "0xb61d27f6"
+	SelectorExecuteBatchMAv2 = "0x34fcd5be"
+)
+
+// Call is one entry in an MA v2 batch. Field order and names must match the
+// on-chain tuple — the ABI encoder maps by the `abi` tag, and a reordering
+// here would produce calldata that decodes to different arguments rather than
+// failing loudly.
+type Call struct {
+	Target common.Address `abi:"target"`
+	Value  *big.Int       `abi:"value"`
+	Data   []byte         `abi:"data"`
+}
+
+const modularAccountABIJSON = `[
+  {"type":"function","name":"execute","stateMutability":"payable",
+   "inputs":[{"name":"target","type":"address"},{"name":"value","type":"uint256"},{"name":"data","type":"bytes"}],
+   "outputs":[{"name":"result","type":"bytes"}]},
+  {"type":"function","name":"executeBatch","stateMutability":"payable",
+   "inputs":[{"name":"calls","type":"tuple[]","components":[
+     {"name":"target","type":"address"},{"name":"value","type":"uint256"},{"name":"data","type":"bytes"}]}],
+   "outputs":[{"name":"results","type":"bytes[]"}]}
+]`
+
+var (
+	modularAccountABIOnce sync.Once
+	modularAccountABI     abi.ABI
+	modularAccountABIErr  error
+)
+
+func ensureModularAccountABI() (abi.ABI, error) {
+	modularAccountABIOnce.Do(func() {
+		modularAccountABI, modularAccountABIErr = abi.JSON(strings.NewReader(modularAccountABIJSON))
+	})
+	return modularAccountABI, modularAccountABIErr
+}
+
+// PackExecuteMAv2 encodes a single call. Identical on the wire to the v0.6
+// PackExecute; kept as its own symbol so call sites read unambiguously and so
+// the v0.6 helper can be deleted at cutover without touching these.
+func PackExecuteMAv2(target common.Address, value *big.Int, data []byte) ([]byte, error) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		value = big.NewInt(0)
+	}
+	if data == nil {
+		data = []byte{}
+	}
+	return parsed.Pack("execute", target, value, data)
+}
+
+// PackExecuteBatchMAv2 encodes an atomic batch. Every call carries its own ETH
+// value, which is what makes the v0.6 executeBatchWithValues workaround
+// unnecessary.
+//
+// A nil Value or Data is normalised to zero/empty rather than rejected: the
+// common batch entry is a contract call with no ETH attached, and forcing
+// callers to spell that out invites big.NewInt(0) boilerplate at every site.
+// An empty batch IS rejected — it encodes fine and burns gas doing nothing,
+// which is never what the caller meant.
+func PackExecuteBatchMAv2(calls []Call) ([]byte, error) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, err
+	}
+	if len(calls) == 0 {
+		return nil, fmt.Errorf("executeBatch requires at least one call")
+	}
+	normalised := make([]Call, len(calls))
+	for i, c := range calls {
+		if c.Value == nil {
+			c.Value = big.NewInt(0)
+		}
+		if c.Data == nil {
+			c.Data = []byte{}
+		}
+		normalised[i] = c
+	}
+	return parsed.Pack("executeBatch", normalised)
+}

--- a/core/chainio/aa/ma_v2_test.go
+++ b/core/chainio/aa/ma_v2_test.go
@@ -1,0 +1,165 @@
+package aa
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+var (
+	targetA = common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b")
+	targetB = common.HexToAddress("0x71c8f4d7d5291edcb3a081802e7efb2788bd232e")
+)
+
+// The selectors are the contract's, not ours. These were read off the deployed
+// SemiModularAccountBytecode implementation
+// (0x000000000000c5A9089039570Dd36455b5C07383) — if a change here flips one,
+// the calldata stops being callable rather than merely being encoded oddly.
+func TestMAv2Selectors(t *testing.T) {
+	single, err := PackExecuteMAv2(targetA, big.NewInt(1), []byte{0xde, 0xad})
+	if err != nil {
+		t.Fatalf("PackExecuteMAv2: %v", err)
+	}
+	if got := hexutil.Encode(single[:4]); got != SelectorExecuteMAv2 {
+		t.Errorf("execute selector = %s, want %s", got, SelectorExecuteMAv2)
+	}
+
+	batch, err := PackExecuteBatchMAv2([]Call{{Target: targetA, Value: big.NewInt(1), Data: []byte{0xde}}})
+	if err != nil {
+		t.Fatalf("PackExecuteBatchMAv2: %v", err)
+	}
+	if got := hexutil.Encode(batch[:4]); got != SelectorExecuteBatchMAv2 {
+		t.Errorf("executeBatch selector = %s, want %s", got, SelectorExecuteBatchMAv2)
+	}
+
+	// v0.6's executeBatch(address[],bytes[]) is 0x18dfb3c7 and is NOT on the
+	// MA v2 implementation. Encoding against the old shape would produce
+	// calldata no MA v2 account can dispatch.
+	if hexutil.Encode(batch[:4]) == "0x18dfb3c7" {
+		t.Error("encoded the v0.6 executeBatch shape")
+	}
+}
+
+func TestPackExecuteMAv2RoundTrip(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	data := []byte{0xb6, 0x1d, 0x27, 0xf6, 0x01}
+	packed, err := PackExecuteMAv2(targetA, big.NewInt(12345), data)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	args, err := parsed.Methods["execute"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	if args[0].(common.Address) != targetA {
+		t.Errorf("target = %v, want %v", args[0], targetA)
+	}
+	if args[1].(*big.Int).Cmp(big.NewInt(12345)) != 0 {
+		t.Errorf("value = %v, want 12345", args[1])
+	}
+	if !bytes.Equal(args[2].([]byte), data) {
+		t.Errorf("data = %x, want %x", args[2], data)
+	}
+}
+
+func TestPackExecuteBatchMAv2RoundTrip(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	calls := []Call{
+		{Target: targetA, Value: big.NewInt(0), Data: []byte{0x01, 0x02}},
+		{Target: targetB, Value: big.NewInt(999), Data: []byte{0x03}},
+	}
+	packed, err := PackExecuteBatchMAv2(calls)
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	args, err := parsed.Methods["executeBatch"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	decoded, ok := args[0].([]struct {
+		Target common.Address `json:"target"`
+		Value  *big.Int       `json:"value"`
+		Data   []byte         `json:"data"`
+	})
+	if !ok {
+		t.Fatalf("unexpected decoded type %T", args[0])
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("len = %d, want 2", len(decoded))
+	}
+	if decoded[0].Target != targetA || decoded[1].Target != targetB {
+		t.Errorf("targets round-tripped wrong: %v, %v", decoded[0].Target, decoded[1].Target)
+	}
+	if decoded[1].Value.Cmp(big.NewInt(999)) != 0 {
+		t.Errorf("per-call value lost: got %v want 999", decoded[1].Value)
+	}
+	if !bytes.Equal(decoded[0].Data, []byte{0x01, 0x02}) || !bytes.Equal(decoded[1].Data, []byte{0x03}) {
+		t.Error("call data round-tripped wrong")
+	}
+}
+
+// The v0.6 PackExecuteBatchWithValues hand-rolls its ABI encoding, with a
+// comment attributing that to a go-ethereum bug encoding empty []byte in a
+// dynamic array. This pins down whether the same workaround is needed for MA
+// v2's tuple[] — if it encodes and round-trips cleanly, the manual encoder
+// does not need to be carried forward.
+func TestPackExecuteBatchMAv2HandlesEmptyCallData(t *testing.T) {
+	parsed, err := ensureModularAccountABI()
+	if err != nil {
+		t.Fatalf("abi: %v", err)
+	}
+	calls := []Call{
+		{Target: targetA, Value: big.NewInt(1_000_000), Data: []byte{}}, // plain ETH transfer
+		{Target: targetB, Value: big.NewInt(0), Data: []byte{0xab}},
+		{Target: targetA, Value: big.NewInt(0), Data: nil}, // nil, not just empty
+	}
+	packed, err := PackExecuteBatchMAv2(calls)
+	if err != nil {
+		t.Fatalf("pack with empty call data: %v", err)
+	}
+	args, err := parsed.Methods["executeBatch"].Inputs.Unpack(packed[4:])
+	if err != nil {
+		t.Fatalf("unpack with empty call data: %v", err)
+	}
+	decoded := args[0].([]struct {
+		Target common.Address `json:"target"`
+		Value  *big.Int       `json:"value"`
+		Data   []byte         `json:"data"`
+	})
+	if len(decoded) != 3 {
+		t.Fatalf("len = %d, want 3", len(decoded))
+	}
+	if len(decoded[0].Data) != 0 || len(decoded[2].Data) != 0 {
+		t.Errorf("empty call data did not survive: %x / %x", decoded[0].Data, decoded[2].Data)
+	}
+	if decoded[0].Value.Cmp(big.NewInt(1_000_000)) != 0 {
+		t.Errorf("value on an empty-data call was lost: %v", decoded[0].Value)
+	}
+}
+
+func TestPackExecuteBatchMAv2Normalisation(t *testing.T) {
+	t.Run("nil value and data are normalised", func(t *testing.T) {
+		if _, err := PackExecuteBatchMAv2([]Call{{Target: targetA}}); err != nil {
+			t.Errorf("nil Value/Data should be accepted: %v", err)
+		}
+	})
+	t.Run("nil value on single execute is normalised", func(t *testing.T) {
+		if _, err := PackExecuteMAv2(targetA, nil, nil); err != nil {
+			t.Errorf("nil value/data should be accepted: %v", err)
+		}
+	})
+	t.Run("empty batch is rejected", func(t *testing.T) {
+		if _, err := PackExecuteBatchMAv2(nil); err == nil {
+			t.Error("expected an error for an empty batch — it encodes fine and burns gas doing nothing")
+		}
+	})
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -132,6 +132,20 @@ type Config struct {
 	// Moralis Web3 Data API key for token price lookup (optional)
 	MoralisApiKey string `yaml:"moralis_api_key"`
 
+	// GasManagerPolicyID is the Alchemy Gas Manager policy this gateway
+	// answers sponsorship questions for. The Gas Manager "custom rules"
+	// webhook is only mounted when this is set — a mounted route that
+	// refuses everything is indistinguishable from a broken chain in the
+	// dashboard, whereas an unmounted route 404s loudly.
+	GasManagerPolicyID string `yaml:"gas_manager_policy_id"`
+
+	// GasManagerWebhookSecret, when set, must be echoed as the webhook
+	// request's webhookData. The webhook cannot sit behind the REST JWT
+	// (Alchemy has no token), so this is its only caller authentication.
+	// Optional so the endpoint can be brought up before the sponsorship
+	// caller is taught to send it.
+	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
+
 	// Fee rates configuration for task execution pricing
 	FeeRates *FeeRatesConfig
 
@@ -374,6 +388,10 @@ type ConfigRaw struct {
 
 	// Moralis Web3 Data API key for token price lookup (optional)
 	MoralisApiKey string `yaml:"moralis_api_key"`
+
+	// Alchemy Gas Manager sponsorship webhook (optional; see Config)
+	GasManagerPolicyID      string `yaml:"gas_manager_policy_id"`
+	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
 
 	// Fee structure: execution_fee + COGS + value tiers
 	// Pointer fields: nil = use default, explicit 0.0 = free tier
@@ -645,6 +663,10 @@ func NewConfig(configFilePath string) (*Config, error) {
 
 		// Pass through Moralis API key (from YAML or environment variable)
 		MoralisApiKey: firstNonEmpty(configRaw.MoralisApiKey, os.Getenv("MORALIS_API_KEY")),
+
+		// Gas Manager sponsorship webhook (from YAML or environment variable)
+		GasManagerPolicyID:      firstNonEmpty(configRaw.GasManagerPolicyID, os.Getenv("ALCHEMY_GAS_POLICY_ID")),
+		GasManagerWebhookSecret: firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
 
 		// Initialize fee rates - use defaults if no YAML config provided
 		FeeRates: loadFeeRatesFromConfig(configRaw.FeeRates),

--- a/pkg/erc4337/userop/v07.go
+++ b/pkg/erc4337/userop/v07.go
@@ -143,11 +143,21 @@ func (op *UserOperationV07) PackForSignature() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if op.Nonce == nil {
-		return nil, fmt.Errorf("nonce is nil")
-	}
-	if op.PreVerificationGas == nil {
-		return nil, fmt.Errorf("preVerificationGas is nil")
+	// Nonce and preVerificationGas are packed as raw uint256 rather than
+	// through packUint128Pair, so they miss its guards. A negative value would
+	// two's-complement into an enormous uint256 and produce a hash over
+	// arguments nobody intended, rather than failing — the same class of
+	// silently-wrong calldata every other numeric field here rejects.
+	for _, f := range []struct {
+		v    *big.Int
+		name string
+	}{{op.Nonce, "nonce"}, {op.PreVerificationGas, "preVerificationGas"}} {
+		if f.v == nil {
+			return nil, fmt.Errorf("%s is nil", f.name)
+		}
+		if f.v.Sign() < 0 {
+			return nil, fmt.Errorf("%s is negative", f.name)
+		}
 	}
 
 	args := abi.Arguments{

--- a/pkg/erc4337/userop/v07.go
+++ b/pkg/erc4337/userop/v07.go
@@ -1,0 +1,192 @@
+package userop
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// EntryPoint v0.7 splits the v0.6 UserOperation into two shapes that are easy
+// to confuse:
+//
+//   - the *unpacked* form, which is what travels on the JSON-RPC wire
+//     (eth_sendUserOperation, eth_estimateUserOperationGas). Factory and
+//     paymaster each become their own fields.
+//   - the *packed* form (PackedUserOperation), which is what the EntryPoint
+//     contract hashes and executes. Gas limits and fees are squeezed into
+//     bytes32 pairs, and factory/paymaster collapse back into initCode and
+//     paymasterAndData.
+//
+// UserOperationV07 models the unpacked form because that is what callers build
+// and what the bundler consumes; Pack* produce the packed encoding on demand.
+//
+// This is deliberately a separate type from the v0.6 UserOperation rather than
+// a set of extra fields on it. The two hashing schemes are incompatible, and a
+// single struct carrying both would make it possible to sign under the wrong
+// one -- an error that only shows up as an on-chain AA24 revert.
+type UserOperationV07 struct {
+	Sender   common.Address `json:"sender"`
+	Nonce    *big.Int       `json:"nonce"`
+	CallData []byte         `json:"callData"`
+
+	// Factory is nil once the account is deployed. When set, Factory and
+	// FactoryData together form the v0.6-style initCode.
+	Factory     *common.Address `json:"factory,omitempty"`
+	FactoryData []byte          `json:"factoryData,omitempty"`
+
+	CallGasLimit         *big.Int `json:"callGasLimit"`
+	VerificationGasLimit *big.Int `json:"verificationGasLimit"`
+	PreVerificationGas   *big.Int `json:"preVerificationGas"`
+	MaxFeePerGas         *big.Int `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *big.Int `json:"maxPriorityFeePerGas"`
+
+	// Paymaster is nil for an unsponsored operation. The three paymaster
+	// fields are only meaningful when it is set.
+	Paymaster                     *common.Address `json:"paymaster,omitempty"`
+	PaymasterVerificationGasLimit *big.Int        `json:"paymasterVerificationGasLimit,omitempty"`
+	PaymasterPostOpGasLimit       *big.Int        `json:"paymasterPostOpGasLimit,omitempty"`
+	PaymasterData                 []byte          `json:"paymasterData,omitempty"`
+
+	Signature []byte `json:"signature"`
+}
+
+// packUint128Pair encodes two values into a single bytes32, high first. Values
+// wider than 128 bits are rejected rather than silently truncated: a truncated
+// gas limit still produces a well-formed UserOp that fails much later, on
+// chain, with no indication of where the number was lost.
+func packUint128Pair(high, low *big.Int, highName, lowName string) ([32]byte, error) {
+	var out [32]byte
+	for _, f := range []struct {
+		v    *big.Int
+		name string
+	}{{high, highName}, {low, lowName}} {
+		if f.v == nil {
+			return out, fmt.Errorf("%s is nil", f.name)
+		}
+		if f.v.Sign() < 0 {
+			return out, fmt.Errorf("%s is negative", f.name)
+		}
+		if f.v.BitLen() > 128 {
+			return out, fmt.Errorf("%s overflows uint128 (%d bits)", f.name, f.v.BitLen())
+		}
+	}
+	high.FillBytes(out[0:16])
+	low.FillBytes(out[16:32])
+	return out, nil
+}
+
+// AccountGasLimits packs verificationGasLimit into the high 16 bytes and
+// callGasLimit into the low 16, per ERC-4337 v0.7.
+func (op *UserOperationV07) AccountGasLimits() ([32]byte, error) {
+	return packUint128Pair(op.VerificationGasLimit, op.CallGasLimit,
+		"verificationGasLimit", "callGasLimit")
+}
+
+// GasFees packs maxPriorityFeePerGas into the high 16 bytes and maxFeePerGas
+// into the low 16. Note the ordering is priority-then-max, which is the
+// reverse of how the fields are usually written out.
+func (op *UserOperationV07) GasFees() ([32]byte, error) {
+	return packUint128Pair(op.MaxPriorityFeePerGas, op.MaxFeePerGas,
+		"maxPriorityFeePerGas", "maxFeePerGas")
+}
+
+// InitCode returns factory ++ factoryData, or empty when the account already
+// exists.
+func (op *UserOperationV07) InitCode() []byte {
+	if op.Factory == nil {
+		return []byte{}
+	}
+	return append(op.Factory.Bytes(), op.FactoryData...)
+}
+
+// PaymasterAndData returns paymaster ++ verificationGasLimit(16) ++
+// postOpGasLimit(16) ++ data, or empty when the operation is unsponsored.
+func (op *UserOperationV07) PaymasterAndData() ([]byte, error) {
+	if op.Paymaster == nil {
+		return []byte{}, nil
+	}
+	limits, err := packUint128Pair(
+		op.PaymasterVerificationGasLimit, op.PaymasterPostOpGasLimit,
+		"paymasterVerificationGasLimit", "paymasterPostOpGasLimit")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, common.AddressLength+32+len(op.PaymasterData))
+	out = append(out, op.Paymaster.Bytes()...)
+	out = append(out, limits[:]...)
+	out = append(out, op.PaymasterData...)
+	return out, nil
+}
+
+var (
+	bytes32Ty, _ = abi.NewType("bytes32", "", nil)
+	addressTy, _ = abi.NewType("address", "", nil)
+	uint256Ty, _ = abi.NewType("uint256", "", nil)
+)
+
+// PackForSignature returns the ABI encoding the EntryPoint hashes to produce
+// the inner half of the userOpHash. Dynamic fields appear as their keccak
+// digests, and signature is excluded -- it is what gets computed over this.
+func (op *UserOperationV07) PackForSignature() ([]byte, error) {
+	accountGasLimits, err := op.AccountGasLimits()
+	if err != nil {
+		return nil, err
+	}
+	gasFees, err := op.GasFees()
+	if err != nil {
+		return nil, err
+	}
+	paymasterAndData, err := op.PaymasterAndData()
+	if err != nil {
+		return nil, err
+	}
+	if op.Nonce == nil {
+		return nil, fmt.Errorf("nonce is nil")
+	}
+	if op.PreVerificationGas == nil {
+		return nil, fmt.Errorf("preVerificationGas is nil")
+	}
+
+	args := abi.Arguments{
+		{Type: addressTy}, {Type: uint256Ty}, {Type: bytes32Ty}, {Type: bytes32Ty},
+		{Type: bytes32Ty}, {Type: uint256Ty}, {Type: bytes32Ty}, {Type: bytes32Ty},
+	}
+	return args.Pack(
+		op.Sender,
+		op.Nonce,
+		toBytes32(crypto.Keccak256(op.InitCode())),
+		toBytes32(crypto.Keccak256(op.CallData)),
+		accountGasLimits,
+		op.PreVerificationGas,
+		gasFees,
+		toBytes32(crypto.Keccak256(paymasterAndData)),
+	)
+}
+
+// GetUserOpHash returns the hash the account signs, binding the operation to a
+// specific EntryPoint and chain so a signature cannot be replayed across
+// either.
+func (op *UserOperationV07) GetUserOpHash(entryPoint common.Address, chainID *big.Int) (common.Hash, error) {
+	if chainID == nil {
+		return common.Hash{}, fmt.Errorf("chainID is nil")
+	}
+	inner, err := op.PackForSignature()
+	if err != nil {
+		return common.Hash{}, err
+	}
+	args := abi.Arguments{{Type: bytes32Ty}, {Type: addressTy}, {Type: uint256Ty}}
+	outer, err := args.Pack(toBytes32(crypto.Keccak256(inner)), entryPoint, chainID)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return common.BytesToHash(crypto.Keccak256(outer)), nil
+}
+
+func toBytes32(b []byte) [32]byte {
+	var out [32]byte
+	copy(out[:], b)
+	return out
+}

--- a/pkg/erc4337/userop/v07_test.go
+++ b/pkg/erc4337/userop/v07_test.go
@@ -1,0 +1,226 @@
+package userop
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// EntryPoint v0.7, same address on every chain.
+var entryPointV07 = common.HexToAddress("0x0000000071727De22E5E9d8BAf0edAc6f37da032")
+
+// sepoliaChainID is the chain the expected hashes below were read from. The
+// hash binds to the chain id, so these vectors are only valid for it.
+var sepoliaChainID = big.NewInt(11155111)
+
+func addr(s string) *common.Address { a := common.HexToAddress(s); return &a }
+
+// The expected hashes are not hand-computed. Each was read from the deployed
+// EntryPoint v0.7 on Sepolia via
+//
+//	cast call 0x0000000071727De22E5E9d8BAf0edAc6f37da032 \
+//	  'getUserOpHash((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes))(bytes32)' ...
+//
+// so the contract itself is the oracle. Regenerate them the same way if the
+// packing ever needs to change.
+func TestGetUserOpHash_MatchesDeployedEntryPoint(t *testing.T) {
+	tests := []struct {
+		name string
+		op   UserOperationV07
+		want string
+	}{
+		{
+			name: "all zero",
+			op: UserOperationV07{
+				Sender:               common.HexToAddress("0x0"),
+				Nonce:                big.NewInt(0),
+				CallData:             []byte{},
+				CallGasLimit:         big.NewInt(0),
+				VerificationGasLimit: big.NewInt(0),
+				PreVerificationGas:   big.NewInt(0),
+				MaxFeePerGas:         big.NewInt(0),
+				MaxPriorityFeePerGas: big.NewInt(0),
+			},
+			want: "0xc2ae9ba70cf313be10ea729190547ac0dfa49cb6501877a84bec112f30781863",
+		},
+		{
+			name: "deployed account, unsponsored",
+			op: UserOperationV07{
+				Sender:               common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b"),
+				Nonce:                big.NewInt(7),
+				CallData:             hexutil.MustDecode("0xb61d27f6000000000000000000000000c60e71bd0f2e6d8832fea1a2d56091c48493c788"),
+				VerificationGasLimit: big.NewInt(100000),
+				CallGasLimit:         big.NewInt(200000),
+				PreVerificationGas:   big.NewInt(21000),
+				MaxPriorityFeePerGas: big.NewInt(1000000000),
+				MaxFeePerGas:         big.NewInt(2000000000),
+			},
+			want: "0x3ba23f9f10cdf7dbf0ff7b13c995fe26151e5cdbb50ad5e8ead961d011a695a3",
+		},
+		{
+			name: "counterfactual account with paymaster",
+			op: UserOperationV07{
+				Sender:                        common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0"),
+				Nonce:                         big.NewInt(3),
+				Factory:                       addr("0x00000000000017c61b5bEe81050EC8eFc9c6fecd"),
+				FactoryData:                   hexutil.MustDecode("0xdeadbeef"),
+				CallData:                      hexutil.MustDecode("0xdeadbeefcafe"),
+				VerificationGasLimit:          big.NewInt(500000),
+				CallGasLimit:                  big.NewInt(1000000),
+				PreVerificationGas:            big.NewInt(50000),
+				MaxPriorityFeePerGas:          big.NewInt(100000000),
+				MaxFeePerGas:                  big.NewInt(50000000000),
+				Paymaster:                     addr("0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f"),
+				PaymasterVerificationGasLimit: big.NewInt(100000),
+				PaymasterPostOpGasLimit:       big.NewInt(50000),
+				PaymasterData:                 hexutil.MustDecode("0xc0ffee"),
+			},
+			want: "0x118de0f4dd62e075f2f21139965356f851435c00c5c3c24ccefd7429ada1f607",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.op.GetUserOpHash(entryPointV07, sepoliaChainID)
+			if err != nil {
+				t.Fatalf("GetUserOpHash: %v", err)
+			}
+			if got.Hex() != tt.want {
+				t.Errorf("hash mismatch\n got %s\nwant %s", got.Hex(), tt.want)
+			}
+		})
+	}
+}
+
+func TestGetUserOpHash_BindsToChainAndEntryPoint(t *testing.T) {
+	op := UserOperationV07{
+		Sender: common.HexToAddress("0x981e18d5aade83620a6bd21990b5da0c797e1e5b"),
+		Nonce:  big.NewInt(7), CallData: []byte{},
+		CallGasLimit: big.NewInt(1), VerificationGasLimit: big.NewInt(1),
+		PreVerificationGas: big.NewInt(1), MaxFeePerGas: big.NewInt(1),
+		MaxPriorityFeePerGas: big.NewInt(1),
+	}
+	base, err := op.GetUserOpHash(entryPointV07, sepoliaChainID)
+	if err != nil {
+		t.Fatalf("base: %v", err)
+	}
+	otherChain, err := op.GetUserOpHash(entryPointV07, big.NewInt(1))
+	if err != nil {
+		t.Fatalf("otherChain: %v", err)
+	}
+	otherEP, err := op.GetUserOpHash(common.HexToAddress("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"), sepoliaChainID)
+	if err != nil {
+		t.Fatalf("otherEP: %v", err)
+	}
+	if base == otherChain {
+		t.Error("hash did not change with chain id — signatures would replay across chains")
+	}
+	if base == otherEP {
+		t.Error("hash did not change with entrypoint — signatures would replay across entrypoints")
+	}
+}
+
+func TestPackedFieldOrdering(t *testing.T) {
+	op := UserOperationV07{
+		VerificationGasLimit: big.NewInt(0x1111),
+		CallGasLimit:         big.NewInt(0x2222),
+		MaxPriorityFeePerGas: big.NewInt(0x3333),
+		MaxFeePerGas:         big.NewInt(0x4444),
+	}
+	agl, err := op.AccountGasLimits()
+	if err != nil {
+		t.Fatalf("AccountGasLimits: %v", err)
+	}
+	// verificationGasLimit occupies the high 16 bytes, callGasLimit the low.
+	if want := "0x0000000000000000000000000000111100000000000000000000000000002222"; hexutil.Encode(agl[:]) != want {
+		t.Errorf("accountGasLimits\n got %s\nwant %s", hexutil.Encode(agl[:]), want)
+	}
+	gf, err := op.GasFees()
+	if err != nil {
+		t.Fatalf("GasFees: %v", err)
+	}
+	// maxPriorityFeePerGas is the HIGH half — the reverse of the usual reading order.
+	if want := "0x0000000000000000000000000000333300000000000000000000000000004444"; hexutil.Encode(gf[:]) != want {
+		t.Errorf("gasFees\n got %s\nwant %s", hexutil.Encode(gf[:]), want)
+	}
+}
+
+func TestPackRejectsOversizedAndNilValues(t *testing.T) {
+	tooBig := new(big.Int).Lsh(big.NewInt(1), 128) // 2^128, one past uint128
+
+	t.Run("overflow is an error, not a truncation", func(t *testing.T) {
+		op := UserOperationV07{VerificationGasLimit: tooBig, CallGasLimit: big.NewInt(1)}
+		if _, err := op.AccountGasLimits(); err == nil {
+			t.Fatal("expected overflow error, got nil — value would be silently truncated")
+		}
+	})
+
+	t.Run("nil is an error", func(t *testing.T) {
+		op := UserOperationV07{VerificationGasLimit: nil, CallGasLimit: big.NewInt(1)}
+		if _, err := op.AccountGasLimits(); err == nil {
+			t.Fatal("expected nil error, got nil")
+		}
+	})
+
+	t.Run("hash surfaces the packing error", func(t *testing.T) {
+		op := UserOperationV07{
+			Sender: common.HexToAddress("0x1"), Nonce: big.NewInt(0), CallData: []byte{},
+			VerificationGasLimit: tooBig, CallGasLimit: big.NewInt(1),
+			PreVerificationGas: big.NewInt(0),
+			MaxFeePerGas:       big.NewInt(1), MaxPriorityFeePerGas: big.NewInt(1),
+		}
+		if _, err := op.GetUserOpHash(entryPointV07, sepoliaChainID); err == nil {
+			t.Fatal("expected error to propagate out of GetUserOpHash")
+		}
+	})
+}
+
+func TestInitCodeAndPaymasterAndData(t *testing.T) {
+	t.Run("nil factory yields empty initCode", func(t *testing.T) {
+		op := UserOperationV07{}
+		if got := op.InitCode(); len(got) != 0 {
+			t.Errorf("expected empty initCode, got %s", hexutil.Encode(got))
+		}
+	})
+	t.Run("factory concatenates with data", func(t *testing.T) {
+		op := UserOperationV07{
+			Factory:     addr("0x00000000000017c61b5bEe81050EC8eFc9c6fecd"),
+			FactoryData: hexutil.MustDecode("0xdeadbeef"),
+		}
+		want := "0x00000000000017c61b5bee81050ec8efc9c6fecddeadbeef"
+		if got := hexutil.Encode(op.InitCode()); got != want {
+			t.Errorf("initCode\n got %s\nwant %s", got, want)
+		}
+	})
+	t.Run("nil paymaster yields empty paymasterAndData", func(t *testing.T) {
+		op := UserOperationV07{}
+		got, err := op.PaymasterAndData()
+		if err != nil {
+			t.Fatalf("PaymasterAndData: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %s", hexutil.Encode(got))
+		}
+	})
+	t.Run("paymaster packs address then two gas limits then data", func(t *testing.T) {
+		op := UserOperationV07{
+			Paymaster:                     addr("0xf023eA291F5bEDA4Bf59BbDC9004F1d18be19D6f"),
+			PaymasterVerificationGasLimit: big.NewInt(100000),
+			PaymasterPostOpGasLimit:       big.NewInt(50000),
+			PaymasterData:                 hexutil.MustDecode("0xc0ffee"),
+		}
+		got, err := op.PaymasterAndData()
+		if err != nil {
+			t.Fatalf("PaymasterAndData: %v", err)
+		}
+		want := "0xf023ea291f5beda4bf59bbdc9004f1d18be19d6f" +
+			"000000000000000000000000000186a0" +
+			"0000000000000000000000000000c350" +
+			"c0ffee"
+		if hexutil.Encode(got) != want {
+			t.Errorf("paymasterAndData\n got %s\nwant %s", hexutil.Encode(got), want)
+		}
+	})
+}


### PR DESCRIPTION
Release PR: `staging` → `main`. Three merged PRs, all part of the Alchemy stack migration (`avs-infra/Alchemy_Stack_Migration_And_Chain_Expansion.md`).

## What's in it

**#677 — Gas Manager sponsorship webhook** (`POST /webhooks/gas-manager`). Alchemy Gas Manager asks, per UserOp, whether our treasury should pay; this handler answers from the `FeeLedger` credit limit. Without it `FeeLedger` is retrospective accounting — an owner past their limit keeps drawing sponsorship.

Three properties that are load-bearing and easy to break later:
- **Mounted outside `/api/v1`.** That group applies JWT auth and the shared rate limiter; Alchemy sends neither, so a handler there returns 401/429 — which Gas Manager reads as "deny", silently disabling sponsorship for every user in a way that looks like a chain fault.
- **Fails closed everywhere**, deliberately opposite to the executor's pre-execution credit check, which logs and proceeds. There, failing open costs one unmetered execution; here it would hand out unlimited sponsored gas for the duration of the fault.
- **Credit is checked across every known chain**, not just the requesting one — fees accrue per execution chain, so gating only the requested chain would let an owner over their limit on Base keep drawing on Ethereum.

**#678 — EntryPoint v0.7 packed UserOperation + hashing.** A separate type from the v0.6 `UserOperation`: the two hashing schemes are incompatible, and one struct carrying both would let a caller sign under the wrong one — a mistake that only surfaces as an on-chain `AA24` revert. Expected hashes in the tests were read from the deployed EntryPoint v0.7 on Sepolia via `getUserOpHash`, so the contract is the oracle rather than a hand-computed constant.

**#678 also carries MA v2 execution encoding** (`core/chainio/aa/ma_v2.go`). Selectors verified against the deployed `SemiModularAccountBytecode`: `execute` carries over byte-for-byte, while `executeBatchWithValues` — our SimpleAccount fork's function — is absent and needs no successor, since MA v2's `executeBatch` carries a per-call ETH value natively.

**#680 — config plumbing.** Moves the webhook settings from raw `os.Getenv` onto the same YAML-with-env-fallback path every other credential uses (`alchemy_api_key`, `moralis_api_key`, `tenderly_access_key`).

Everything here is **additive**. The v0.7 and MA v2 code has no callers yet; the webhook route is not mounted unless `gas_manager_policy_id` is set.

## Known-red tests — read before re-running

`pkg/erc4337/preset` and `core/taskengine` UserOp tests fail. Every failure has **one** distinct cause:

```
error sending transaction to bundler: revert reason : AA31 paymaster deposit too low
```

This is not a code regression. The v0.6 `VerifyingPaymaster` deposits were deliberately swept to zero on 2026-07-31 as part of retiring the v0.6 stack (`avs-infra` §8.4 Table B). All four chains read 0, down from 0.093/0.078/0.441/0.050 ETH the day before.

Affected: `TestSendUserOp`, `TestUserOpExecutionSuccessWithPaymaster`, `TestUserOpWithdrawalSkipsReimbursementWhenBalanceInsufficient`, `TestUserOpAtomicBatch_Sepolia`, `TestUserOpETHWithdrawal_Sepolia`. All exercise the v0.6 sponsored path this migration removes. Re-running them requires funding the Sepolia paymaster; they will be replaced by v0.7 tests as the builder lands.

Everything else passes and `go vet ./...` is clean.

## Deploying

The webhook route is **not mounted** unless `gas_manager_policy_id` resolves — intentional, since a mounted route refusing everything is indistinguishable from a broken chain, whereas an unmounted route 404s loudly. Two separate delivery paths:

1. `ALCHEMY_GAS_POLICY_ID` (and optionally `GAS_MANAGER_WEBHOOK_SECRET`) as Railway vars on `gateway`
2. `railway/sync-configs.sh gateway --apply` in avs-infra for the YAML keys — a code release does **not** push config

**Order matters.** The Gas Manager policy correctly has *Sponsor on error or timeout* OFF, so any non-200 reads as "deny". Setting the webhook URL in the Alchemy dashboard before this is deployed and configured refuses every sponsorship on that policy. Deploy → verify the endpoint answers 200 → then set the URL.

Validated locally against a running gateway: known wallet + correct policy + secret → `{"approved":true}`; wrong policy, wrong secret, unknown wallet, wrong chain, and malformed body all → `{"approved":false}` with HTTP 200; `/api/v1/webhooks/gas-manager` → 404, confirming it is not behind the JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
