### PR TITLE
chore(makefile): add run-worker-ethereum / run-worker-base targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,11 +278,22 @@ operator-default: build
 ## to the caller's terminal/pane; callers that want files redirect (dev-stack →
 ## logs/, start.sh → tee). Each sources .env.local so the
 ## ${SEPOLIA_BUNDLER_URL} / ${BASE_SEPOLIA_BUNDLER_URL} refs in the YAML resolve.
-.PHONY: run-gateway run-worker-sepolia run-worker-base-sepolia run-operator-sepolia
+.PHONY: run-gateway run-worker-sepolia run-worker-ethereum run-worker-base run-worker-base-sepolia run-operator-sepolia
 run-gateway:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap aggregator --config=config/gateway.yaml
 run-worker-sepolia:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-sepolia.yaml
+# MAINNET workers — move REAL funds, pay REAL gas (no paymaster). Need these in
+# .env.local: ETHEREUM_RPC_URL/WS, BASE_RPC_URL/WS, MAINNET_CONTROLLER_PRIVATE_KEY.
+# No *_BUNDLER_URL: every chain runs bundler_provider: alchemy, which derives the
+# endpoint from ALCHEMY_API_KEY and never reads bundler_url — the self-hosted
+# Voltaire tunnels these used to need are retired. start.sh skips these two panes
+# when the mainnet vars are absent, so a Sepolia-only stack still boots.
+run-worker-ethereum:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-ethereum.yaml
+run-worker-base:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base.yaml
+# Retired from the default local stack (see studio scripts/start.sh); kept runnable.
 run-worker-base-sepolia:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base-sepolia.yaml
 run-operator-sepolia:


### PR DESCRIPTION
`studio/scripts/start.sh` invokes `make run-worker-ethereum` and `make run-worker-base` for the Ethereum and Base panes of the local stack. Those targets don't exist, so the mainnet path of that script fails on a missing target.

Same build-free exec pattern as the existing `run-*` targets, which stay the single source of truth for each local process's config + `.env.local` sourcing.

## Comment rewritten against the current setup

The mainnet comment as originally drafted said these need `ETHEREUM_BUNDLER_URL` / `BASE_BUNDLER_URL` and "a reachable bundler (SSH tunnel / hosted)". Both are stale, and it's the same stale guidance that made `start.sh` demand seven env vars when only five are real:

- No `*_BUNDLER_URL` is needed — every chain runs `bundler_provider: alchemy`, which derives the endpoint from `ALCHEMY_API_KEY` and never reads `bundler_url`.
- The self-hosted Voltaire SSH tunnels it referred to are retired.

The comment now also notes that `start.sh` skips these two panes when the mainnet vars are absent, so a Sepolia-only stack still boots.

## Verified

All six `run-*` targets resolve to configs that exist on disk:

| Target | Config |
|---|---|
| `run-gateway` | `config/gateway.yaml` |
| `run-worker-sepolia` | `config/worker-sepolia.yaml` |
| `run-worker-ethereum` | `config/worker-ethereum.yaml` |
| `run-worker-base` | `config/worker-base.yaml` |
| `run-worker-base-sepolia` | `config/worker-base-sepolia.yaml` |
| `run-operator-sepolia` | `config/operator-sepolia.yaml` |

Note those configs are gitignored, so a fresh clone needs them created before the targets run — pre-existing for every `run-*` target, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
