### PR TITLE
fix(config): skip per-chain paymaster probe when no paymaster is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ operator-default: build
 ## to the caller's terminal/pane; callers that want files redirect (dev-stack →
 ## logs/, start.sh → tee). Each sources .env.local so the
 ## ${SEPOLIA_BUNDLER_URL} / ${BASE_SEPOLIA_BUNDLER_URL} refs in the YAML resolve.
-.PHONY: run-gateway run-worker-sepolia run-worker-ethereum run-worker-base run-worker-base-sepolia run-operator-sepolia
+.PHONY: run-gateway run-worker-sepolia run-worker-ethereum run-worker-base run-worker-base-sepolia run-operator-sepolia run-operator-ethereum
 run-gateway:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap aggregator --config=config/gateway.yaml
 run-worker-sepolia:
@@ -298,6 +298,11 @@ run-worker-base-sepolia:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base-sepolia.yaml
 run-operator-sepolia:
 	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap operator --config=config/operator-sepolia.yaml
+# Second operator, registered against the Ethereum mainnet AVS. Binds its
+# metrics/node-api on 9091/9011 because operator-sepolia already holds
+# 9090/9010 — running both with the stock ports fails on bind, not on config.
+run-operator-ethereum:
+	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap operator --config=config/operator-ethereum.yaml
 
 ## dev-gateway / dev-worker-* / dev-operator-sepolia: build once, then run a single
 ## process in the foreground (standalone use), streaming to logs/<svc>.log.

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -1055,7 +1055,18 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 	// connectivity-only rollout (e.g. BNB Phase 0.5 in avs-infra/chains/),
 	// where wallet ops are intentionally disabled and the paymaster_address
 	// is a placeholder.
-	if chainCfg.SmartWallet.BundlerConfigured() && chainCfg.SmartWallet.EthRpcUrl != "" {
+	//
+	// Also skip when no paymaster is configured at all. Omitting
+	// paymaster_address is a supported configuration — the chain runs
+	// unsponsored and the smart wallet pays its own gas — so probing here
+	// would call owner() on the zero address and fail the boot for a chain
+	// that never wanted a paymaster. The top-level probe above has always
+	// had this guard; the per-chain path did not, which only became
+	// reachable once chains moved to bundler_provider: alchemy. Before that,
+	// an unsponsored chain typically had an empty bundler_url, so
+	// BundlerConfigured() was false and the probe was skipped by accident.
+	hasPaymaster := chainCfg.SmartWallet.PaymasterAddress != (common.Address{})
+	if hasPaymaster && chainCfg.SmartWallet.BundlerConfigured() && chainCfg.SmartWallet.EthRpcUrl != "" {
 		rpcClient, err := ethclient.Dial(chainCfg.SmartWallet.EthRpcUrl)
 		if err != nil {
 			return nil, fmt.Errorf("dial RPC %s for chain %s (chain_id=%d): %w",


### PR DESCRIPTION
Found while bringing the local stack up with all three chains (Sepolia + Ethereum + Base mainnet).

## The bug

A chain that omits `paymaster_address` is a supported configuration — it runs unsponsored and the smart wallet pays its own gas. `config.go` even says so explicitly:

> chains that omit it run without a paymaster and rely on the smart wallet's own balance for gas.

But the **per-chain** probe never checked for that. It called `owner()` on the zero address and panicked the entire gateway at boot:

```
chain ethereum (chain_id=1): paymaster 0x0000…0000 is unreachable on RPC
… (owner() call failed: abi: attempting to unmarshal an empty string while arguments are expected)
```

The **top-level** probe has always guarded on a non-zero paymaster (`config.SmartWallet.PaymasterAddress != (common.Address{})`). The per-chain path only guarded on `BundlerConfigured() && EthRpcUrl != ""`.

## Why it surfaced now

It was unreachable until chains moved to `bundler_provider: alchemy`. Before that, an unsponsored chain typically had an empty `bundler_url`, so `BundlerConfigured()` returned false and the probe was skipped — by accident, not design. Once the endpoint is derived from `ALCHEMY_API_KEY`, `BundlerConfigured()` is always true, and any paymaster-less chain fails to boot.

This also explains something in the production config: BNB carries a `paymaster_address` placeholder it never calls, with a comment saying the probe would otherwise fail. That workaround exists because of this bug and can be dropped once this lands.

It matters for what's next, too: Arbitrum, Hyperliquid, and Robinhood are planned as connectivity-only chains with no paymaster (`avs-infra/Alchemy_Stack_Migration_And_Chain_Expansion.md` §7). Each would have needed the same placebo placeholder.

## Verified

Gateway boots with all three chains, zero panics:

```
Parsed chain config  chain_id: 11155111  bundler_provider: alchemy  paymaster_owner: 0x72b9fcC9…
Parsed chain config  chain_id: 1         bundler_provider: alchemy  paymaster_owner: 0x0000…0000
Parsed chain config  chain_id: 8453      bundler_provider: alchemy  paymaster_owner: 0x0000…0000
Gateway mode enabled {"num_chains": 3, "default_chain_id": 11155111}
```

Sepolia still probes and resolves its paymaster owner, so the check is skipped only where there is genuinely nothing to probe.

## Also here

`run-operator-ethereum`, so the local stack can run both operators (paired with a studio `start.sh` change adding the second pane). It binds metrics/node-api on **9091/9011** — `operator-sepolia` holds 9090/9010, and running both on the stock ports fails on bind rather than on config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
