### PR TITLE
feat(config): alchemy_api_secret; correct webhook sponsorship claims

### DIFF
--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -60,6 +60,14 @@ tenderly_access_key: ""
 #     gas; which also means
 #   - configuring the webhook URL in Alchemy BEFORE this gateway is deployed
 #     and configured will refuse every sponsorship on that policy.
+# An Alchemy ACCESS KEY (alcht_...), NOT the app api key above. The app key
+# authorises RPC/bundler traffic; this authorises the account-level admin APIs
+# at manage.g.alchemy.com — Gas Manager policy config and spend stats.
+# Create it at dashboard.alchemy.com -> Security -> Create Access Key (team
+# level, not inside an app; needs billing/team admin). Scope it Gas Manager
+# READ ONLY: a read/write key can delete the policy that funds sponsorship.
+alchemy_api_secret: ""
+
 gas_manager_policy_id: ""
 # Echoed back as the request's webhookData. The webhook cannot sit behind the
 # REST JWT (Alchemy has no token), so this is its only caller authentication.

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -132,6 +132,13 @@ type Config struct {
 	// Moralis Web3 Data API key for token price lookup (optional)
 	MoralisApiKey string `yaml:"moralis_api_key"`
 
+	// AlchemyAPISecret is an Alchemy ACCESS KEY (alcht_...), distinct from
+	// alchemy_api_key: the app key authorises RPC and bundler traffic, while
+	// this authorises the account-level admin APIs at manage.g.alchemy.com —
+	// notably the Gas Manager policy and spend endpoints. Scope it Gas Manager
+	// READ; a read/write key can delete the policy that funds sponsorship.
+	AlchemyAPISecret string `yaml:"alchemy_api_secret"`
+
 	// GasManagerPolicyID is the Alchemy Gas Manager policy this gateway
 	// answers sponsorship questions for. The Gas Manager "custom rules"
 	// webhook is only mounted when this is set — a mounted route that
@@ -389,7 +396,8 @@ type ConfigRaw struct {
 	// Moralis Web3 Data API key for token price lookup (optional)
 	MoralisApiKey string `yaml:"moralis_api_key"`
 
-	// Alchemy Gas Manager sponsorship webhook (optional; see Config)
+	// Alchemy Gas Manager sponsorship webhook + admin API (optional; see Config)
+	AlchemyAPISecret        string `yaml:"alchemy_api_secret"`
 	GasManagerPolicyID      string `yaml:"gas_manager_policy_id"`
 	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
 
@@ -664,7 +672,8 @@ func NewConfig(configFilePath string) (*Config, error) {
 		// Pass through Moralis API key (from YAML or environment variable)
 		MoralisApiKey: firstNonEmpty(configRaw.MoralisApiKey, os.Getenv("MORALIS_API_KEY")),
 
-		// Gas Manager sponsorship webhook (from YAML or environment variable)
+		// Gas Manager sponsorship webhook + admin API (from YAML or environment)
+		AlchemyAPISecret:        firstNonEmpty(configRaw.AlchemyAPISecret, os.Getenv("ALCHEMY_API_SECRET")),
 		GasManagerPolicyID:      firstNonEmpty(configRaw.GasManagerPolicyID, os.Getenv("ALCHEMY_GAS_POLICY_ID")),
 		GasManagerWebhookSecret: firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
 

--- a/pkg/erc4337/preset/builder_v07.go
+++ b/pkg/erc4337/preset/builder_v07.go
@@ -277,10 +277,19 @@ type sponsorshipResultV07 struct {
 // RequestSponsorshipV07 fills the paymaster fields (and the gas values Gas
 // Manager prices alongside them) from a Gas Manager policy.
 //
-// The policy's own rules apply here, including the custom-rules webhook, so a
-// denial surfaces as an RPC error rather than an unsponsored operation. That
-// is the intended shape: an operation that silently fell back to self-funded
-// would drain the account.
+// Verified against the live Sepolia policy: an MA v2 operation comes back with
+// a real paymaster (0x2cc0c798…) and priced gas.
+//
+// Whatever the policy enforces applies here — spend caps and, once configured,
+// the custom-rules webhook — and a denial surfaces as an RPC error rather than
+// an unsponsored operation. That is the shape we want: an operation that
+// silently fell back to self-funded would drain the account instead.
+//
+// Note the webhook is NOT currently configured on the policy (webhookRules is
+// null), so nothing consults the gateway's FeeLedger gate today and any sender
+// reaching the policy is sponsored within its caps. Enabling it is what makes
+// the credit limit bind — and it also means MA v2 wallets must be registered
+// in gateway storage first, or the webhook will refuse every one of them.
 func RequestSponsorshipV07(ctx context.Context, client *rpc.Client, op *userop.UserOperationV07, entryPoint common.Address, req SponsorshipRequestV07) error {
 	if client == nil {
 		return fmt.Errorf("nil bundler client")


### PR DESCRIPTION
Two things, both unlocked by finally being able to query the Gas Manager admin API.

## 1. `alchemy_api_secret`

An Alchemy **access key** (`alcht_…`), a different credential class from `alchemy_api_key`: the app key authorises RPC and bundler traffic, this one authorises the account-level admin APIs at `manage.g.alchemy.com` — the only way to read policy config and spend. Same YAML-with-env-fallback path as every other credential here, paired with an avs-infra change adding it to `gateway-railway.yaml`. `ALCHEMY_API_SECRET` is set on the gateway service.

Documented as **Gas Manager READ ONLY**. A read/write key can delete the policy that funds sponsorship, and this ends up as a Railway var on a long-running service.

**Nothing reads it yet.** It is plumbing for balance/spend monitoring — the gap that let the v0.6 paymaster deposits drain unnoticed.

## 2. Correction: the webhook was never the blocker

#687 claimed sponsorship was blocked because the gateway's custom-rules webhook denies MA v2 senders. **That was wrong**, and I stated it in both the PR body and a commit message.

The policy's `webhookRules` is **null** — the webhook URL was never set in the dashboard, so Alchemy has never called this gateway. What I actually observed was calling our own endpoint directly and getting `{"approved":false}`, which is correct for an unknown sender but irrelevant when nothing is consulting it.

**Sponsorship in fact works.** `alchemy_requestGasAndPaymasterAndData` returns a real paymaster for an MA v2 operation on Sepolia:

```
execute -> 0x0000…0001  : SPONSORED paymaster=0x2cc0c7981D846b9F2a16276556f6e8cb52BfB633
execute -> 0x82F2Dd9a…  : SPONSORED paymaster=0x2cc0c7981D846b9F2a16276556f6e8cb52BfB633
```

The earlier `execution reverted` was malformed shell quoting on my side, not a policy or account failure.

So **MA v2 wallet registration is not a prerequisite for sponsorship today**. It becomes one the moment the webhook is enabled — which is also the moment the FeeLedger credit limit starts binding at all. Recorded in the config comments next to the keys it concerns, rather than left as tribal knowledge.

## What the policy actually looks like

```
status               active
maxSpendUsd          500      (balance is $100, so the balance is the real ceiling)
maxSpendPerSenderUsd 20
maxSpendPerUoUsd     2
senderAllowlist      null
webhookRules         null
sponsorshipExpiryMs  600000
```

Spend to date: `signaturesMined: 0`, `usdMined: 0` — the $100 is untouched, consistent with both landed UserOps being self-funded.

Worth stating plainly: with `senderAllowlist` **and** `webhookRules` both null, any sender reaching this policy is sponsored within its caps, and the API key is the only gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
