### PR TITLE
feat(taskengine): MA v2 wallet creation and registration

### DIFF
--- a/core/taskengine/wallet_ma_v2.go
+++ b/core/taskengine/wallet_ma_v2.go
@@ -1,0 +1,112 @@
+package taskengine
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Modular Account v2 wallet creation.
+//
+// MA v2 wallets reuse the existing record and index schema unchanged, because
+// `Factory` is already part of both the stored record and the `wsalt:` index
+// key. A v0.6 SimpleAccount at salt 0 and an MA v2 account at salt 0 for the
+// same owner therefore occupy different index slots and coexist without
+// collision — no migration, no separate keyspace, and ListWallets keeps
+// working on both.
+//
+// Registration is not bookkeeping. The Gas Manager sponsorship webhook
+// (aggregator/gas_manager_webhook.go) resolves a UserOperation's sender back
+// to an owner by scanning `w:<chain>:` and REFUSES senders it cannot find —
+// that refusal is the only thing stopping the policy from funding wallets
+// created outside this gateway, since policy access control is set to None.
+// An MA v2 wallet that is derived but never stored is therefore invisible to
+// sponsorship: every operation from it is denied, with a message about an
+// unknown sender rather than anything pointing at the missing record.
+
+// MAv2WalletFactory returns the factory address MA v2 wallets are recorded
+// under. Distinct from config.DefaultFactoryProxyAddressHex, which is the
+// v0.6 SimpleAccountFactory.
+func MAv2WalletFactory() common.Address { return aa.MAv2FactoryAddress() }
+
+// IsMAv2Wallet reports whether a stored record was created by the MA v2
+// factory, as opposed to the v0.6 SimpleAccountFactory.
+//
+// Records predating the factory field (Factory == nil) are v0.6 by
+// definition — MA v2 records have always carried it.
+func IsMAv2Wallet(wallet *model.SmartWallet) bool {
+	if wallet == nil || wallet.Factory == nil {
+		return false
+	}
+	return *wallet.Factory == MAv2WalletFactory()
+}
+
+// GetOrCreateMAv2Wallet derives the MA v2 account for (owner, salt) on the
+// given chain and persists its record, returning the existing one if it has
+// already been registered.
+//
+// Idempotent by address rather than by "did we just derive it": the address is
+// a pure function of (factory, owner, salt), so a second call for the same
+// tuple must return the same record instead of writing a duplicate or
+// resetting user-set flags like IsHidden.
+//
+// The address comes from the factory on-chain (see aa.GetSenderAddressMAv2)
+// rather than a local CREATE2 computation, so a derivation that drifts from
+// the contract fails loudly here instead of registering an address that will
+// never hold anything.
+func GetOrCreateMAv2Wallet(db storage.Storage, rpcConn *ethclient.Client, chainID int64, owner common.Address, salt *big.Int) (*model.SmartWallet, error) {
+	if db == nil {
+		return nil, fmt.Errorf("nil storage")
+	}
+	if salt == nil {
+		return nil, fmt.Errorf("salt is nil")
+	}
+	if salt.Sign() < 0 {
+		return nil, fmt.Errorf("salt must be non-negative, got %s", salt)
+	}
+	if owner == (common.Address{}) {
+		return nil, fmt.Errorf("owner is the zero address")
+	}
+
+	factory := MAv2WalletFactory()
+
+	// Prefer the (chain, owner, factory, salt) index over deriving again — it
+	// answers "has this been registered?" without an RPC round trip, and it is
+	// the same index StoreWallet maintains.
+	if existingAddr, err := LookupCanonicalWalletAddress(db, chainID, owner, factory, salt); err == nil {
+		if wallet, getErr := GetWallet(db, chainID, owner, existingAddr.Hex()); getErr == nil {
+			return wallet, nil
+		}
+		// Index present but the record is gone — fall through and rewrite it
+		// rather than returning a dangling reference.
+	}
+
+	derived, err := aa.GetSenderAddressMAv2ForFactory(rpcConn, owner, factory, salt)
+	if err != nil {
+		return nil, fmt.Errorf("deriving MA v2 wallet for owner %s salt %s on chain %d: %w",
+			owner.Hex(), salt, chainID, err)
+	}
+	if derived == nil || *derived == (common.Address{}) {
+		return nil, fmt.Errorf("factory %s returned the zero address for owner %s salt %s",
+			factory.Hex(), owner.Hex(), salt)
+	}
+
+	wallet := &model.SmartWallet{
+		Owner:    &owner,
+		Address:  derived,
+		Factory:  &factory,
+		Salt:     salt,
+		IsHidden: false,
+	}
+	if err := StoreWallet(db, chainID, owner, wallet); err != nil {
+		return nil, fmt.Errorf("storing MA v2 wallet %s for owner %s on chain %d: %w",
+			derived.Hex(), owner.Hex(), chainID, err)
+	}
+	return wallet, nil
+}

--- a/core/taskengine/wallet_ma_v2.go
+++ b/core/taskengine/wallet_ma_v2.go
@@ -1,9 +1,11 @@
 package taskengine
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
+	"github.com/dgraph-io/badger/v4"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
@@ -79,12 +81,30 @@ func GetOrCreateMAv2Wallet(db storage.Storage, rpcConn *ethclient.Client, chainI
 	// Prefer the (chain, owner, factory, salt) index over deriving again — it
 	// answers "has this been registered?" without an RPC round trip, and it is
 	// the same index StoreWallet maintains.
-	if existingAddr, err := LookupCanonicalWalletAddress(db, chainID, owner, factory, salt); err == nil {
-		if wallet, getErr := GetWallet(db, chainID, owner, existingAddr.Hex()); getErr == nil {
+	//
+	// Only a genuine "not recorded yet" may fall through to derive-and-store.
+	// Treating any read error as absence would re-register on a transient
+	// storage fault, and re-registration writes IsHidden:false — silently
+	// un-hiding a wallet the user had hidden. Idempotency here is only as good
+	// as the lookup it rests on.
+	existingAddr, err := LookupCanonicalWalletAddress(db, chainID, owner, factory, salt)
+	switch {
+	case err == nil:
+		wallet, getErr := GetWallet(db, chainID, owner, existingAddr.Hex())
+		if getErr == nil {
 			return wallet, nil
 		}
-		// Index present but the record is gone — fall through and rewrite it
-		// rather than returning a dangling reference.
+		if !errors.Is(getErr, badger.ErrKeyNotFound) {
+			return nil, fmt.Errorf("reading registered MA v2 wallet %s for owner %s on chain %d: %w",
+				existingAddr.Hex(), owner.Hex(), chainID, getErr)
+		}
+		// Index points at a record that is gone. Rewrite it rather than
+		// returning a dangling reference.
+	case errors.Is(err, badger.ErrKeyNotFound):
+		// Not registered yet — the expected path for a new wallet.
+	default:
+		return nil, fmt.Errorf("looking up MA v2 wallet index for owner %s salt %s on chain %d: %w",
+			owner.Hex(), salt, chainID, err)
 	}
 
 	derived, err := aa.GetSenderAddressMAv2ForFactory(rpcConn, owner, factory, salt)

--- a/core/taskengine/wallet_ma_v2_test.go
+++ b/core/taskengine/wallet_ma_v2_test.go
@@ -1,0 +1,175 @@
+package taskengine
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+const mav2TestChain = int64(11155111)
+
+func mav2Owner() common.Address {
+	return common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+}
+
+func TestIsMAv2Wallet(t *testing.T) {
+	mav2 := MAv2WalletFactory()
+	v06 := common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
+	owner, addr := mav2Owner(), common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
+
+	tests := []struct {
+		name   string
+		wallet *model.SmartWallet
+		want   bool
+	}{
+		{"MA v2 factory", &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &mav2}, true},
+		{"v0.6 factory", &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &v06}, false},
+		{"no factory recorded is v0.6 by definition", &model.SmartWallet{Owner: &owner, Address: &addr}, false},
+		{"nil wallet", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsMAv2Wallet(tt.wallet); got != tt.want {
+				t.Errorf("IsMAv2Wallet = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The factory address is what keeps MA v2 and v0.6 records from colliding in
+// the wsalt: index. If both used the same factory, registering an MA v2 wallet
+// at salt 0 would overwrite the v0.6 index entry for the same owner and salt,
+// silently repointing an existing user's canonical wallet.
+func TestMAv2AndV06IndexKeysDoNotCollide(t *testing.T) {
+	owner := mav2Owner()
+	salt := big.NewInt(0)
+	mav2Key := WalletBySaltKey(mav2TestChain, owner, MAv2WalletFactory(), salt)
+	v06Key := WalletBySaltKey(mav2TestChain, owner, common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834"), salt)
+
+	if string(mav2Key) == string(v06Key) {
+		t.Fatal("MA v2 and v0.6 index keys are identical; registering one would clobber the other")
+	}
+	if !strings.Contains(strings.ToLower(string(mav2Key)), strings.ToLower(MAv2WalletFactory().Hex()[2:])) {
+		t.Errorf("index key %q does not carry the factory address", mav2Key)
+	}
+}
+
+func TestGetOrCreateMAv2WalletGuards(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+	owner := mav2Owner()
+
+	tests := []struct {
+		name  string
+		db    interface{}
+		owner common.Address
+		salt  *big.Int
+	}{
+		{"nil salt", db, owner, nil},
+		{"negative salt", db, owner, big.NewInt(-1)},
+		{"zero owner", db, common.Address{}, big.NewInt(0)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// rpcConn is nil: every case here must fail on validation before
+			// any RPC is attempted, so a nil client can never be dereferenced.
+			if _, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, tt.owner, tt.salt); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+
+	t.Run("nil storage", func(t *testing.T) {
+		if _, err := GetOrCreateMAv2Wallet(nil, nil, mav2TestChain, owner, big.NewInt(0)); err == nil {
+			t.Error("expected an error for nil storage")
+		}
+	})
+}
+
+// The whole point of registration: the sponsorship webhook resolves a sender
+// back to an owner by scanning `w:<chain>:` and refuses anything it cannot
+// find. A record written under the MA v2 factory has to be discoverable by
+// that scan, or every sponsored operation from the wallet is denied as an
+// unknown sender.
+func TestMAv2RecordIsDiscoverableBySenderScan(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	owner := mav2Owner()
+	addr := common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
+	factory := MAv2WalletFactory()
+	wallet := &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &factory, Salt: big.NewInt(0)}
+
+	if err := StoreWallet(db, mav2TestChain, owner, wallet); err != nil {
+		t.Fatalf("StoreWallet: %v", err)
+	}
+
+	// Mirror the webhook's lookup: scan the chain prefix, match on the
+	// trailing wallet segment, read the owner out of the key.
+	prefix := []byte(fmt.Sprintf("w:%d:", mav2TestChain))
+	want := strings.ToLower(addr.Hex())
+	var foundOwner string
+	err := db.IterateKeysOnly(prefix, func(key []byte) error {
+		parts := strings.Split(string(key), ":")
+		if len(parts) == 4 && parts[3] == want {
+			foundOwner = parts[2]
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if foundOwner == "" {
+		t.Fatal("MA v2 wallet not found by the sender scan; sponsorship would deny it as an unknown sender")
+	}
+	if !strings.EqualFold(foundOwner, owner.Hex()) {
+		t.Errorf("scan resolved owner %s, want %s", foundOwner, owner.Hex())
+	}
+}
+
+// A second call for the same tuple must return the existing record rather than
+// writing a duplicate or resetting user-set flags.
+func TestMAv2RegistrationIsIdempotent(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer db.Close()
+
+	owner := mav2Owner()
+	addr := common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
+	factory := MAv2WalletFactory()
+	salt := big.NewInt(0)
+
+	first := &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &factory, Salt: salt, IsHidden: true}
+	if err := StoreWallet(db, mav2TestChain, owner, first); err != nil {
+		t.Fatalf("StoreWallet: %v", err)
+	}
+
+	// nil RPC: if the lookup path works, no derivation is attempted, so this
+	// returning successfully is itself the assertion that the index was used.
+	got, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, owner, salt)
+	if err != nil {
+		t.Fatalf("GetOrCreateMAv2Wallet on an already-registered wallet: %v", err)
+	}
+	if got.Address == nil || *got.Address != addr {
+		t.Errorf("address = %v, want %s", got.Address, addr.Hex())
+	}
+	if !got.IsHidden {
+		t.Error("IsHidden was reset; re-registration must not clobber user-set flags")
+	}
+}
+
+// Guards the assumption the whole file rests on: the factory constant here is
+// the same one aa derives against. If they drift, wallets get recorded under a
+// factory that did not create them.
+func TestWalletFactoryMatchesDerivationFactory(t *testing.T) {
+	if MAv2WalletFactory() != aa.MAv2FactoryAddress() {
+		t.Errorf("taskengine factory %s != aa factory %s",
+			MAv2WalletFactory().Hex(), aa.MAv2FactoryAddress().Hex())
+	}
+}

--- a/core/taskengine/wallet_ma_v2_test.go
+++ b/core/taskengine/wallet_ma_v2_test.go
@@ -68,13 +68,12 @@ func TestGetOrCreateMAv2WalletGuards(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		db    interface{}
 		owner common.Address
 		salt  *big.Int
 	}{
-		{"nil salt", db, owner, nil},
-		{"negative salt", db, owner, big.NewInt(-1)},
-		{"zero owner", db, common.Address{}, big.NewInt(0)},
+		{"nil salt", owner, nil},
+		{"negative salt", owner, big.NewInt(-1)},
+		{"zero owner", common.Address{}, big.NewInt(0)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -171,5 +170,38 @@ func TestWalletFactoryMatchesDerivationFactory(t *testing.T) {
 	if MAv2WalletFactory() != aa.MAv2FactoryAddress() {
 		t.Errorf("taskengine factory %s != aa factory %s",
 			MAv2WalletFactory().Hex(), aa.MAv2FactoryAddress().Hex())
+	}
+}
+
+// Idempotency is only as strong as the lookup it rests on. If a storage read
+// error were treated as "not registered", the fall-through would re-derive and
+// re-store with IsHidden:false — silently un-hiding a wallet the user hid. A
+// closed database is the cheapest way to make every read fail.
+func TestRegistrationDoesNotFallThroughOnStorageError(t *testing.T) {
+	db := testutil.TestMustDB()
+	owner := mav2Owner()
+	addr := common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
+	factory := MAv2WalletFactory()
+	salt := big.NewInt(0)
+
+	if err := StoreWallet(db, mav2TestChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &addr, Factory: &factory, Salt: salt, IsHidden: true,
+	}); err != nil {
+		t.Fatalf("StoreWallet: %v", err)
+	}
+	db.Close() // every subsequent read now errors rather than reporting absence
+
+	// nil RPC: if this wrongly falls through to derive-and-store it will panic
+	// or error on the RPC, either way not returning a fresh IsHidden:false
+	// record. What must NOT happen is a silent success that clobbers the flag.
+	got, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, owner, salt)
+	if err == nil {
+		if got != nil && !got.IsHidden {
+			t.Fatal("returned a re-registered record with IsHidden reset; the storage error was masked")
+		}
+		t.Fatal("expected an error when storage reads fail, got success")
+	}
+	if !strings.Contains(err.Error(), "looking up") && !strings.Contains(err.Error(), "reading registered") {
+		t.Errorf("error should name the failed lookup, got: %v", err)
 	}
 }


### PR DESCRIPTION
Sixth increment. Derives an MA v2 account and persists its record — the piece that makes a wallet visible to Gas Manager sponsorship.

## Why registration matters

The sponsorship webhook resolves a UserOperation's sender back to an owner by scanning `w:<chain>:` and **refuses senders it cannot find**. With policy access control set to `None`, that refusal is the only thing stopping the policy from funding wallets created outside this gateway.

So a derived-but-unstored MA v2 wallet is invisible to sponsorship: every operation from it is denied as an unknown sender, with nothing in the message pointing at the missing record. Verified against production:

```
w:11155111:*:0x61caf92c…  in prod storage : 0 matches
POST /webhooks/gas-manager {sender: 0x61CaF92C…} : {"approved": false}
```

## The schema already supported this

No migration, no separate keyspace. `Factory` is already part of both the stored record and the `wsalt:` index key, so a v0.6 SimpleAccount at salt 0 and an MA v2 account at salt 0 **for the same owner** occupy different index slots. They coexist, and `ListWallets` keeps working on both.

There is a test asserting those two keys differ. If they ever collided, registering an MA v2 wallet would silently repoint an existing user's canonical v0.6 wallet — a data-loss bug that would look like a wrong address rather than a corrupted index.

## Idempotency

Idempotent by address, not by "did we just derive it". The address is a pure function of `(factory, owner, salt)`, so a repeat call returns the existing record rather than duplicating it or resetting user-set flags like `IsHidden` — covered by a test that sets `IsHidden` and asserts it survives.

It checks the `wsalt:` index before deriving, which also avoids an RPC round trip on the common path.

## Still additive

Nothing calls this yet. Pointing wallet creation at MA v2 is the clean cutover from `Smart_Wallet_MA_v2_Spend_Policy.md` §4 — it changes the addresses users get, and existing tasks reference v0.6 runners. That wants to be a deliberate switch, not a side effect of this PR.

This is the **last additive increment**. Everything after it changes behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
