### PR TITLE
feat(config): per-chain account_provider switch

### DIFF
--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -88,6 +88,15 @@ smart_wallet:
   # time. 'self_hosted' remains for a locally-run Voltaire; the shared Voltaire
   # bundlers this example used to assume were retired 2026-07.
   bundler_provider:       alchemy
+  # account_provider selects the smart-account implementation. Unlike
+  # bundler_provider, this defaults to the OLD value (simple_account) and is
+  # opt-in per chain — switching it changes the DERIVED ADDRESS for every
+  # (owner, salt), so flipping it on a chain with existing users moves their
+  # wallets and orphans any task whose runner references the old address.
+  # Roll it out one chain at a time, and re-onboard wallets on that chain.
+  #   simple_account      v0.6 SimpleAccount via smart_wallet.factory_address
+  #   modular_account_v2  Alchemy MA v2 via the canonical AccountFactory
+  account_provider:       simple_account
   alchemy_api_key:        ${ALCHEMY_API_KEY}
   controller_private_key: <testnet-controller-private-key-hex>
   paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92

--- a/core/chainio/aa/derive.go
+++ b/core/chainio/aa/derive.go
@@ -3,6 +3,7 @@ package aa
 import (
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -10,8 +11,10 @@ import (
 
 // AccountProvider selects which smart-account implementation an address is
 // derived from. The string values match core/config's account_provider so a
-// caller can pass the config value straight through; the type is redeclared
-// here rather than imported to keep chainio free of a config dependency.
+// caller can pass either the raw yaml value or config's normalised
+// AccountProviderName() straight through — both are trimmed and lowercased
+// here. The type is redeclared rather than imported to keep chainio free of a
+// config dependency.
 type AccountProvider string
 
 const (
@@ -65,9 +68,16 @@ func FactoryAddressForProvider(provider AccountProvider, simpleAccountFactory co
 	}
 }
 
+// normaliseProvider trims and lowercases so this package accepts exactly what
+// config accepts. Config's AccountProviderName() already does both, but
+// callers reasonably pass the raw yaml value through — and if this were
+// stricter, a config the gateway loaded happily ("  Modular_Account_V2 ")
+// would fail here as an unknown provider, which reads as a code bug rather
+// than a whitespace one.
 func normaliseProvider(p AccountProvider) AccountProvider {
-	if p == "" {
+	n := AccountProvider(strings.ToLower(strings.TrimSpace(string(p))))
+	if n == "" {
 		return ProviderSimpleAccount
 	}
-	return p
+	return n
 }

--- a/core/chainio/aa/derive.go
+++ b/core/chainio/aa/derive.go
@@ -1,0 +1,73 @@
+package aa
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// AccountProvider selects which smart-account implementation an address is
+// derived from. The string values match core/config's account_provider so a
+// caller can pass the config value straight through; the type is redeclared
+// here rather than imported to keep chainio free of a config dependency.
+type AccountProvider string
+
+const (
+	ProviderSimpleAccount    AccountProvider = "simple_account"
+	ProviderModularAccountV2 AccountProvider = "modular_account_v2"
+)
+
+// DeriveSenderAddress returns the counterfactual account address for
+// (owner, salt) under the given provider.
+//
+// The two providers do not merely use different factory addresses — they use
+// different derivation ABIs (`getAddress(owner,salt)` vs
+// `getAddressSemiModular(owner,salt)`). Swapping only the factory address
+// would call the wrong method and either revert or, worse, return an address
+// nothing will ever deploy to. Routing both through one function keeps that
+// pairing in a single place.
+//
+// An empty provider is SimpleAccount, matching config's default. That default
+// is deliberate: MA v2 derives different addresses for the same (owner, salt),
+// so silently defaulting to it would move every existing user's wallet.
+func DeriveSenderAddress(conn *ethclient.Client, owner common.Address, salt *big.Int, provider AccountProvider) (*common.Address, error) {
+	switch normaliseProvider(provider) {
+	case ProviderSimpleAccount:
+		return GetSenderAddress(conn, owner, salt)
+	case ProviderModularAccountV2:
+		return GetSenderAddressMAv2(conn, owner, salt)
+	default:
+		return nil, fmt.Errorf("unknown account provider %q; expected %q or %q",
+			provider, ProviderSimpleAccount, ProviderModularAccountV2)
+	}
+}
+
+// FactoryAddressForProvider returns the factory an account of this provider is
+// created by — the value recorded on the wallet record, and what keeps the
+// `wsalt:` index from conflating a v0.6 and an MA v2 wallet at the same salt.
+//
+// SimpleAccount has no single answer: its factory is per-deployment and comes
+// from config (smart_wallet.factory_address), so callers must supply it. Only
+// the MA v2 factory is a constant, being the same address on every chain.
+func FactoryAddressForProvider(provider AccountProvider, simpleAccountFactory common.Address) (common.Address, error) {
+	switch normaliseProvider(provider) {
+	case ProviderSimpleAccount:
+		if simpleAccountFactory == (common.Address{}) {
+			return common.Address{}, fmt.Errorf("simple_account requires a configured factory address")
+		}
+		return simpleAccountFactory, nil
+	case ProviderModularAccountV2:
+		return MAv2FactoryAddress(), nil
+	default:
+		return common.Address{}, fmt.Errorf("unknown account provider %q", provider)
+	}
+}
+
+func normaliseProvider(p AccountProvider) AccountProvider {
+	if p == "" {
+		return ProviderSimpleAccount
+	}
+	return p
+}

--- a/core/chainio/aa/derive_test.go
+++ b/core/chainio/aa/derive_test.go
@@ -91,3 +91,34 @@ func TestDeriveSenderAddressRejectsUnknownProvider(t *testing.T) {
 		t.Error("expected an error for an unrecognised provider")
 	}
 }
+
+// This package must accept exactly what config accepts. Config normalises
+// (trim + lowercase) before storing, but callers reasonably pass the raw yaml
+// value through — and a config the gateway loaded happily must not fail here
+// as an "unknown provider", which reads as a code bug rather than whitespace.
+func TestProviderNormalisationMatchesConfig(t *testing.T) {
+	for _, in := range []AccountProvider{
+		"modular_account_v2", "MODULAR_ACCOUNT_V2", " modular_account_v2 ", "Modular_Account_V2",
+	} {
+		if got := normaliseProvider(in); got != ProviderModularAccountV2 {
+			t.Errorf("normaliseProvider(%q) = %q, want %q", in, got, ProviderModularAccountV2)
+		}
+	}
+	for _, in := range []AccountProvider{"", "   ", "simple_account", "SIMPLE_ACCOUNT", " Simple_Account "} {
+		if got := normaliseProvider(in); got != ProviderSimpleAccount {
+			t.Errorf("normaliseProvider(%q) = %q, want %q", in, got, ProviderSimpleAccount)
+		}
+	}
+}
+
+// A whitespace/case variant must reach the right factory, not error.
+func TestFactoryAddressAcceptsUnnormalisedProvider(t *testing.T) {
+	simple := common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
+	got, err := FactoryAddressForProvider(" Modular_Account_V2 ", simple)
+	if err != nil {
+		t.Fatalf("unexpected error for a value config would accept: %v", err)
+	}
+	if got != MAv2FactoryAddress() {
+		t.Errorf("factory = %s, want %s", got.Hex(), MAv2FactoryAddress().Hex())
+	}
+}

--- a/core/chainio/aa/derive_test.go
+++ b/core/chainio/aa/derive_test.go
@@ -1,0 +1,93 @@
+package aa
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// The default is the single most consequential line in this file. MA v2
+// derives DIFFERENT addresses for the same (owner, salt), so a default of
+// modular_account_v2 would move every existing user's wallet the moment a
+// gateway rolled out — orphaning funds and every task whose runner references
+// the old address. If someone "tidies" this to the newer value, this fails.
+func TestDefaultProviderIsSimpleAccount(t *testing.T) {
+	if got := normaliseProvider(""); got != ProviderSimpleAccount {
+		t.Fatalf("empty provider = %q, want %q — defaulting to MA v2 would move every existing wallet",
+			got, ProviderSimpleAccount)
+	}
+}
+
+func TestFactoryAddressForProvider(t *testing.T) {
+	simple := common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
+
+	t.Run("simple account uses the configured factory", func(t *testing.T) {
+		got, err := FactoryAddressForProvider(ProviderSimpleAccount, simple)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != simple {
+			t.Errorf("factory = %s, want %s", got.Hex(), simple.Hex())
+		}
+	})
+
+	t.Run("empty provider behaves as simple account", func(t *testing.T) {
+		got, err := FactoryAddressForProvider("", simple)
+		if err != nil || got != simple {
+			t.Errorf("got (%s, %v), want (%s, nil)", got.Hex(), err, simple.Hex())
+		}
+	})
+
+	t.Run("MA v2 uses the canonical factory and ignores the configured one", func(t *testing.T) {
+		got, err := FactoryAddressForProvider(ProviderModularAccountV2, simple)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != MAv2FactoryAddress() {
+			t.Errorf("factory = %s, want %s", got.Hex(), MAv2FactoryAddress().Hex())
+		}
+		if got == simple {
+			t.Error("MA v2 returned the SimpleAccount factory")
+		}
+	})
+
+	t.Run("simple account with no configured factory is an error", func(t *testing.T) {
+		// Falling back to a zero address would record wallets under a factory
+		// that created nothing, and derive addresses that hold nothing.
+		if _, err := FactoryAddressForProvider(ProviderSimpleAccount, common.Address{}); err == nil {
+			t.Error("expected an error when no factory is configured")
+		}
+	})
+
+	t.Run("unknown provider is an error, not a fallback", func(t *testing.T) {
+		if _, err := FactoryAddressForProvider("modular_account", simple); err == nil {
+			t.Error("expected an error for an unrecognised provider")
+		}
+	})
+}
+
+// The providers must resolve to different factories — that difference is what
+// keeps their wsalt: index entries apart, so an MA v2 wallet cannot overwrite a
+// user's canonical v0.6 wallet at the same salt.
+func TestProvidersResolveToDifferentFactories(t *testing.T) {
+	simple := common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
+	a, err := FactoryAddressForProvider(ProviderSimpleAccount, simple)
+	if err != nil {
+		t.Fatalf("simple: %v", err)
+	}
+	b, err := FactoryAddressForProvider(ProviderModularAccountV2, simple)
+	if err != nil {
+		t.Fatalf("mav2: %v", err)
+	}
+	if a == b {
+		t.Fatal("both providers resolve to the same factory; index entries would collide")
+	}
+}
+
+func TestDeriveSenderAddressRejectsUnknownProvider(t *testing.T) {
+	owner := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	if _, err := DeriveSenderAddress(nil, owner, big.NewInt(0), "not_a_provider"); err == nil {
+		t.Error("expected an error for an unrecognised provider")
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -235,6 +235,12 @@ type SmartWalletConfig struct {
 	// Maximum number of smart wallets allowed per EOA owner
 	// Unlimited is NOT supported. If zero or negative, the default limit is applied.
 	MaxWalletsPerOwner int
+
+	// AccountProvider selects which smart-account implementation this chain
+	// derives and deploys: the v0.6 SimpleAccount fork, or Alchemy Modular
+	// Account v2. See AccountProviderName for why this defaults to the OLD
+	// value, unlike BundlerProvider.
+	AccountProvider string
 }
 
 // Bundler provider identifiers for SmartWalletConfig.BundlerProvider.
@@ -242,6 +248,52 @@ const (
 	BundlerProviderAlchemy    = "alchemy"
 	BundlerProviderSelfHosted = "self_hosted"
 )
+
+// Account provider identifiers for SmartWalletConfig.AccountProvider.
+const (
+	AccountProviderSimpleAccount    = "simple_account"
+	AccountProviderModularAccountV2 = "modular_account_v2"
+)
+
+// AccountProviderName returns the effective smart-account implementation,
+// defaulting to simple_account when unset.
+//
+// This defaults to the OLD value, which is the opposite of BundlerProvider —
+// and the difference is deliberate. Switching bundlers is invisible to users:
+// the same account sends the same operations through a different relay.
+// Switching account providers changes the DERIVED ADDRESS for every
+// (owner, salt), so defaulting to modular_account_v2 would silently move every
+// user's wallet the moment a gateway rolled out, orphaning their funds and
+// every task whose runner references the old address.
+//
+// The switch is therefore opt-in per chain, so a rollout is a config change
+// that can be made one chain at a time and reverted, rather than a deploy.
+func (c *SmartWalletConfig) AccountProviderName() string {
+	p := strings.ToLower(strings.TrimSpace(c.AccountProvider))
+	if p == "" {
+		return AccountProviderSimpleAccount
+	}
+	return p
+}
+
+// UsesModularAccountV2 reports whether this chain derives MA v2 accounts.
+func (c *SmartWalletConfig) UsesModularAccountV2() bool {
+	return c.AccountProviderName() == AccountProviderModularAccountV2
+}
+
+// ValidateAccountProvider rejects an unrecognised value rather than silently
+// falling back. A typo would otherwise derive v0.6 addresses on a chain the
+// operator believed was on MA v2 — and the mistake is only visible as users
+// receiving unexpected addresses.
+func (c *SmartWalletConfig) ValidateAccountProvider() error {
+	switch c.AccountProviderName() {
+	case AccountProviderSimpleAccount, AccountProviderModularAccountV2:
+		return nil
+	default:
+		return fmt.Errorf("unknown account_provider %q (chain_id=%d); expected %q or %q",
+			c.AccountProvider, c.ChainID, AccountProviderSimpleAccount, AccountProviderModularAccountV2)
+	}
+}
 
 // alchemyNetworkSubdomain maps a chain ID to its Alchemy JSON-RPC/bundler
 // network subdomain (https://<subdomain>.g.alchemy.com/v2/<key>). Extend this
@@ -312,6 +364,7 @@ type SmartWalletConfigRaw struct {
 	EthWsUrl             string   `yaml:"eth_ws_url"`
 	BundlerURL           string   `yaml:"bundler_url"`
 	BundlerProvider      string   `yaml:"bundler_provider"`
+	AccountProvider      string   `yaml:"account_provider"`
 	AlchemyAPIKey        string   `yaml:"alchemy_api_key"`
 	FactoryAddress       string   `yaml:"factory_address"`
 	EntrypointAddress    string   `yaml:"entrypoint_address"`
@@ -647,6 +700,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			EthWsUrl:             configRaw.SmartWallet.EthWsUrl,
 			BundlerURL:           configRaw.SmartWallet.BundlerURL,
 			BundlerProvider:      configRaw.SmartWallet.BundlerProvider,
+			AccountProvider:      configRaw.SmartWallet.AccountProvider,
 			AlchemyAPIKey:        configRaw.SmartWallet.AlchemyAPIKey,
 			FactoryAddress:       common.HexToAddress(firstNonEmpty(configRaw.SmartWallet.FactoryAddress, DefaultFactoryProxyAddressHex)),
 			EntrypointAddress:    common.HexToAddress(firstNonEmpty(configRaw.SmartWallet.EntrypointAddress, DefaultEntrypointAddressHex)),
@@ -1045,6 +1099,7 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 			EthWsUrl:             wsURL,
 			BundlerURL:           sw.BundlerURL,
 			BundlerProvider:      sw.BundlerProvider,
+			AccountProvider:      sw.AccountProvider,
 			AlchemyAPIKey:        sw.AlchemyAPIKey,
 			FactoryAddress:       common.HexToAddress(firstNonEmpty(sw.FactoryAddress, DefaultFactoryProxyAddressHex)),
 			EntrypointAddress:    common.HexToAddress(firstNonEmpty(sw.EntrypointAddress, DefaultEntrypointAddressHex)),

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -766,6 +766,13 @@ func NewConfig(configFilePath string) (*Config, error) {
 	// "no contract code at given address" (Sentry EIGENLAYER-AVS-1N/1M, user-reported
 	// failure 2026-05-30 01:55 UTC on Sepolia). Fail-fast surfaces the same problem
 	// at startup where it's diagnosable, not hours later on a real workflow.
+	// Same fail-at-boot rule for the top-level smart_wallet as for each chain.
+	if config.SmartWallet != nil {
+		if err := config.SmartWallet.ValidateAccountProvider(); err != nil {
+			return nil, fmt.Errorf("top-level smart_wallet: %w", err)
+		}
+	}
+
 	if config.SmartWallet != nil && config.SmartWallet.PaymasterAddress != (common.Address{}) {
 		paymasterOwner, err := fetchPaymasterOwner(smartWalletRpcClient, config.SmartWallet.PaymasterAddress)
 		if err != nil {
@@ -1110,6 +1117,14 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 			WhitelistAddresses:   convertToAddressSlice(sw.WhitelistAddresses),
 			MaxWalletsPerOwner:   maxWallets,
 		},
+	}
+
+	// Reject an unrecognised account_provider at boot rather than at the first
+	// derivation. A typo silently reads as simple_account, so a chain the
+	// operator believed was on MA v2 would quietly hand users v0.6 addresses —
+	// visible only much later, and not obviously as a config error.
+	if err := chainCfg.SmartWallet.ValidateAccountProvider(); err != nil {
+		return nil, fmt.Errorf("chain %s (chain_id=%d): %w", raw.Name, raw.ChainID, err)
 	}
 
 	// Probe paymaster on this chain's RPC. Catches mismatched

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -1,0 +1,51 @@
+package config
+
+import "testing"
+
+// Mirrors the aa-package default test at the config layer, because the two
+// defaults have to agree: config decides what the gateway believes, aa decides
+// what gets derived. If they ever diverge, wallets get recorded under one
+// provider and derived under the other.
+func TestAccountProviderDefaultsToSimpleAccount(t *testing.T) {
+	var c SmartWalletConfig
+	if got := c.AccountProviderName(); got != AccountProviderSimpleAccount {
+		t.Fatalf("default = %q, want %q — defaulting to MA v2 would move every existing wallet",
+			got, AccountProviderSimpleAccount)
+	}
+	if c.UsesModularAccountV2() {
+		t.Error("UsesModularAccountV2 is true by default")
+	}
+}
+
+func TestAccountProviderNormalisation(t *testing.T) {
+	for in, want := range map[string]string{
+		"":                      AccountProviderSimpleAccount,
+		"  ":                    AccountProviderSimpleAccount,
+		"simple_account":        AccountProviderSimpleAccount,
+		"MODULAR_ACCOUNT_V2":    AccountProviderModularAccountV2,
+		" modular_account_v2  ": AccountProviderModularAccountV2,
+	} {
+		c := SmartWalletConfig{AccountProvider: in}
+		if got := c.AccountProviderName(); got != want {
+			t.Errorf("AccountProviderName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// A typo must fail loudly. Silently falling back would derive v0.6 addresses
+// on a chain the operator believed was on MA v2, visible only as users getting
+// unexpected addresses.
+func TestValidateAccountProvider(t *testing.T) {
+	for _, ok := range []string{"", "simple_account", "modular_account_v2", "Modular_Account_V2"} {
+		c := SmartWalletConfig{AccountProvider: ok}
+		if err := c.ValidateAccountProvider(); err != nil {
+			t.Errorf("ValidateAccountProvider(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"modular_account", "mav2", "simple", "v0.7"} {
+		c := SmartWalletConfig{AccountProvider: bad}
+		if err := c.ValidateAccountProvider(); err == nil {
+			t.Errorf("ValidateAccountProvider(%q) = nil, want an error", bad)
+		}
+	}
+}

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -49,3 +49,20 @@ func TestValidateAccountProvider(t *testing.T) {
 		}
 	}
 }
+
+// Before this was wired, ValidateAccountProvider existed but was never called
+// during config load: a typo like "mav2" was accepted, AccountProviderName()
+// returned it verbatim, and UsesModularAccountV2() went false — so a chain the
+// operator believed was on MA v2 silently handed users v0.6 addresses. The
+// function existing is not the same as it running.
+func TestTypoWouldSilentlyReadAsSimpleAccount(t *testing.T) {
+	c := SmartWalletConfig{AccountProvider: "mav2"}
+
+	if c.UsesModularAccountV2() {
+		t.Fatal("precondition changed")
+	}
+	// This is the trap: it looks harmless. Only validation catches it.
+	if err := c.ValidateAccountProvider(); err == nil {
+		t.Fatal("a typo must be rejected; otherwise it degrades silently to simple_account")
+	}
+}


### PR DESCRIPTION
Seventh increment, and the one that makes MA v2 reachable. Follows the pattern `bundler_provider` already proved in this codebase: a per-chain switch, so rollout is a config change that can be made one chain at a time and reverted, rather than a deploy-and-pray.

## One deliberate difference from bundler_provider

`bundler_provider` defaults to the **new** value. This defaults to the **old** one.

Switching bundlers is invisible to users — the same account sends the same operations through a different relay. Switching account providers changes the **derived address** for every `(owner, salt)`. Defaulting to `modular_account_v2` would silently move every user's wallet the moment a gateway rolled out, orphaning their funds and every task whose runner references the old address.

There is a test at each layer asserting the default, so "tidying" it to the newer value fails loudly rather than shipping.

## Why the switch isn't just a factory address

`aa.DeriveSenderAddress` routes on the provider because the two use **different derivation ABIs**:

| provider | factory | method |
|---|---|---|
| `simple_account` | `smart_wallet.factory_address` (per-deployment) | `getAddress(owner, salt)` |
| `modular_account_v2` | canonical `AccountFactory` (same on every chain) | `getAddressSemiModular(owner, salt)` |

Swapping only the factory address would call the wrong method and either revert or — worse — return an address nothing will ever deploy to. Keeping that pairing in one function is the point of the helper.

A test asserts the two providers resolve to **different** factories, since that difference is what keeps their `wsalt:` index entries apart so an MA v2 wallet can't overwrite a user's canonical v0.6 wallet at the same salt.

## Fails loudly, doesn't fall back

- An unrecognised `account_provider` is an error. A typo would otherwise derive v0.6 addresses on a chain the operator believed was on MA v2 — visible only as users receiving unexpected addresses.
- `simple_account` with no configured factory is an error rather than a zero-address fallback, which would record wallets under a factory that created nothing.

## Behaviour unchanged

With the field unset: `AccountProviderName()` → `simple_account`, `UsesModularAccountV2()` → `false`. Verified by running it, not just by reading it.

## Rolling it out

Set `account_provider: modular_account_v2` on one chain — Sepolia first — and re-onboard wallets on that chain. Existing v0.6 wallets keep working; they simply stop being the default for new derivations. Reverting is the same edit backwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
