### PR TITLE
chore(version): default semver to dev, drop the manual bump

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,16 +1,28 @@
 package version
 
 var (
-	// Default values stamped into the binary when -ldflags doesn't
-	// override them. Both Makefile targets (`make build`, `make build-prod`)
-	// and the Dockerfile now derive these from `git describe` / `git rev-parse`
-	// at compile time, so these defaults only fire when the build path
-	// bypasses both (e.g. a one-off `go build ./...` without ldflags).
+	// Defaults for builds that bypass -ldflags. Every real build path stamps
+	// these instead:
 	//
-	// Keep `semver` here roughly in sync with the latest release tag as a
-	// safety net — if a build slips through without ldflags, /health will
-	// still report something plausible rather than ancient history.
-	semver   = "4.7.1"
+	//	make build / build-prod   SEMVER from `git describe --tags`
+	//	Dockerfile               ARG SEMVER, falling back to the git tag
+	//	publish-prod-docker.yml  SEMVER from the published release tag
+	//
+	// so these values only surface on a bare `go build ./...`, a `go run`, or
+	// a test binary.
+	//
+	// semver is deliberately "dev" rather than the latest release number. A
+	// stale release number here is worse than no number: an unstamped binary
+	// reporting "4.7.1" on /health and in Sentry's release tag is
+	// indistinguishable from a real 4.7.1, so a locally-built binary running
+	// somewhere it shouldn't looks like a legitimate deploy. "dev" says
+	// exactly what it is.
+	//
+	// This also removes a manual chore. Keeping the literal in step with the
+	// tag meant a `chore: bump version.go` commit on main after every release,
+	// which then had to be synced back to staging — upkeep for a value nothing
+	// reads in production.
+	semver   = "dev"
 	revision = "unknown"
 )
 


### PR DESCRIPTION
`version.go`'s `semver` was kept in step with the latest release tag by hand — a `chore: bump version.go` commit on main after every release, which then had to be synced back to staging. That upkeep protects a value production never reads.

## Every real build path already stamps it

| path | source |
|---|---|
| `make build` / `build-prod` | `git describe --tags` → ldflags |
| `Dockerfile` | `ARG SEMVER`, falling back to the git tag → ldflags |
| `publish-prod-docker.yml` | published release tag: `SEMVER="${TAG#v}"` → ldflags |

The literal only surfaces on a bare `go build ./...`, a `go run`, or a test binary. Verified both directions:

```
unstamped (go run)   -> dev
make build           -> 4.8.0   (from the tag)
```

Production confirms it independently: the deployed gateway's `/telemetry` reports `Aggregator 4.7.1`, matching the `ap-avs:v4.7.1` image it runs — stamped from the release tag, not from this file.

## Why "dev" rather than automating the bump

A stale release number is worse than no number. An unstamped binary reporting `4.7.1` on `/health` and in Sentry's `release` tag is **indistinguishable from a real 4.7.1** — so a locally-built binary running somewhere it shouldn't looks like a legitimate deploy. `dev` says exactly what it is.

Automating the bump was the alternative, but it automates a ritual whose output nothing consumes, and it perpetuates the sync dance: each release puts main one commit ahead, and staging needs re-syncing.

Note the bump was **already missed for v4.8.0** — the tag exists, main still said `4.7.1`. That is the failure mode this removes rather than schedules a robot to perform.

## Note on the original proposal

Bumping version.go *before* merging staging→main can't work: at PR time the next version isn't known, because `go-semantic-release` computes it from the PR title at merge. There is nothing to write until after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
