### PR TITLE
feat: cut every chain over to Modular Account v2 and EntryPoint v0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ tmp/rehearsal-gateway-backup/
 
 # Local Claude Code agent state (session locks, project-local skills, etc.)
 .claude/
+
+# spike harness build outputs
+/deferred_action
+/permission_hooks

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -280,7 +280,9 @@ func (agg *Aggregator) init() {
 	}
 
 	// Setup account abstraction config
-	aa.SetFactoryAddress(agg.config.SmartWallet.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(agg.config.SmartWallet); err != nil {
+		panic(fmt.Sprintf("smart_wallet: cannot resolve account factory: %v", err))
+	}
 	aa.SetEntrypointAddress(agg.config.SmartWallet.EntrypointAddress)
 }
 

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
@@ -383,8 +382,7 @@ func (r *RpcServer) ExecuteWithdraw(ctx context.Context, user *model.User, paylo
 	if userOp != nil {
 		// Get UserOp hash — sign against the chain we actually targeted
 		// so the hash matches what the bundler/paymaster validated.
-		userOpHash := userOp.GetUserOpHash(swCfg.EntrypointAddress, big.NewInt(swCfg.ChainID))
-		resp.UserOpHash = userOpHash.Hex()
+		resp.UserOpHash = userOp.UserOpHash.Hex()
 	}
 
 	if receipt != nil {
@@ -438,7 +436,7 @@ func (r *RpcServer) sendUserOpWithGlobalWs(
 	smartWalletAddress *common.Address,
 	paymasterReq *preset.VerifyingPaymasterRequest,
 	requestedChainID int64,
-) (*userop.UserOperation, *types.Receipt, error) {
+) (*preset.SentUserOp, *types.Receipt, error) {
 	// Gateway mode: route to worker
 	if r.chainRegistry != nil {
 		return r.sendUserOpViaWorker(owner, callData, smartWalletAddress, paymasterReq, requestedChainID)
@@ -447,7 +445,7 @@ func (r *RpcServer) sendUserOpWithGlobalWs(
 	// Use global WebSocket client if available, otherwise fall back to creating new connection
 	// Note: salt=nil here because rpc_server callers (e.g. WithdrawFunds) operate on already-deployed wallets
 	if r.smartWalletWsRpc != nil {
-		return preset.SendUserOpWithWsClient(
+		return preset.SendUserOpAutoWithWsClient(
 			r.config.SmartWallet,
 			owner,
 			callData,
@@ -461,7 +459,7 @@ func (r *RpcServer) sendUserOpWithGlobalWs(
 	} else {
 		// Fallback to original method (creates new WebSocket connection)
 		r.config.Logger.Warn("Global WebSocket client not available, using fallback method")
-		return preset.SendUserOp(
+		return preset.SendUserOpAuto(
 			r.config.SmartWallet,
 			owner,
 			callData,
@@ -482,7 +480,7 @@ func (r *RpcServer) sendUserOpViaWorker(
 	smartWalletAddress *common.Address,
 	paymasterReq *preset.VerifyingPaymasterRequest,
 	chainID int64,
-) (*userop.UserOperation, *types.Receipt, error) {
+) (*preset.SentUserOp, *types.Receipt, error) {
 	worker, err := r.chainRegistry.GetWorker(chainID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("no worker for chain %d: %w", chainID, err)
@@ -517,7 +515,14 @@ func (r *RpcServer) sendUserOpViaWorker(
 		}
 	}
 
-	return nil, receipt, nil
+	// The worker already reports the hash; discarding the operation here left
+	// resp.UserOpHash empty in gateway mode. Only the hash crosses the RPC
+	// boundary, so the rest of SentUserOp stays zero.
+	sent := &preset.SentUserOp{UserOpHash: common.HexToHash(resp.UserOpHash)}
+	if smartWalletAddress != nil {
+		sent.Sender = *smartWalletAddress
+	}
+	return sent, receipt, nil
 }
 
 // (Aggregator-service gRPC handlers — CreateTask, ListTasks, GetTask,

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -88,15 +88,17 @@ smart_wallet:
   # time. 'self_hosted' remains for a locally-run Voltaire; the shared Voltaire
   # bundlers this example used to assume were retired 2026-07.
   bundler_provider:       alchemy
-  # account_provider selects the smart-account implementation. Unlike
-  # bundler_provider, this defaults to the OLD value (simple_account) and is
-  # opt-in per chain — switching it changes the DERIVED ADDRESS for every
-  # (owner, salt), so flipping it on a chain with existing users moves their
-  # wallets and orphans any task whose runner references the old address.
-  # Roll it out one chain at a time, and re-onboard wallets on that chain.
-  #   simple_account      v0.6 SimpleAccount via smart_wallet.factory_address
-  #   modular_account_v2  Alchemy MA v2 via the canonical AccountFactory
-  account_provider:       simple_account
+  # account_provider selects the smart-account implementation. It now defaults
+  # to modular_account_v2 on every chain; this line names the value rather than
+  # opting in to it.
+  #
+  # Be aware of what it controls: the setting decides the DERIVED ADDRESS for
+  # every (owner, salt). Changing it moves every wallet on the chain, and a
+  # wallet created under the other provider stops executing — dispatch follows
+  # the chain's setting, not the individual wallet.
+  #   modular_account_v2  Alchemy MA v2 via the canonical AccountFactory (v0.7)
+  #   simple_account      legacy v0.6 SimpleAccount via smart_wallet.factory_address
+  account_provider:       modular_account_v2
   alchemy_api_key:        ${ALCHEMY_API_KEY}
   controller_private_key: <testnet-controller-private-key-hex>
   paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92

--- a/core/chainio/aa/aa.go
+++ b/core/chainio/aa/aa.go
@@ -36,13 +36,30 @@ var (
 	factoryAddressMu sync.RWMutex
 )
 
-// SetFactoryAddress sets the factory proxy address from config
-// This should be called during initialization with the value from config.SmartWallet.FactoryAddress
-// which already handles default value and YAML override
+// SetFactoryAddress sets the factory proxy address used by the global-factory
+// helpers (GetSenderAddress, GetNonce...).
+//
+// Prefer SetFactoryAddressForConfig. Passing config.SmartWallet.FactoryAddress
+// straight in is now wrong on any chain running Modular Account v2: that field
+// is the SimpleAccount factory, and since GetSenderAddress infers the account
+// implementation from this value, an MA v2 chain would silently derive v0.6
+// addresses everywhere the global factory is used.
 func SetFactoryAddress(address common.Address) {
 	factoryAddressMu.Lock()
 	defer factoryAddressMu.Unlock()
 	factoryAddress = address
+}
+
+// SetFactoryAddressForConfig sets the global factory to the one this chain's
+// configured account provider actually creates accounts at, which is the only
+// value the global-factory helpers can derive correctly against.
+func SetFactoryAddressForConfig(swCfg *config.SmartWalletConfig) error {
+	effective, err := EffectiveFactory(swCfg)
+	if err != nil {
+		return err
+	}
+	SetFactoryAddress(effective)
+	return nil
 }
 
 // getFactoryAddress returns the current factory address, with fallback to default from config
@@ -126,11 +143,17 @@ func computeSmartWalletAddress(factoryAddr common.Address, ownerAddress common.A
 	return common.BytesToAddress(hash[12:]), nil
 }
 
-// GetSenderAddress is a wrapper that uses the factory address from config
-// It calls GetSenderAddressForFactory with the factory address set via SetFactoryAddress()
-// which reads from config (with default value and YAML override support)
+// GetSenderAddress is a wrapper that uses the factory address from config,
+// set via SetFactoryAddress().
+//
+// It routes through DeriveSenderAddressAuto rather than calling
+// GetSenderAddressForFactory directly, so the account implementation follows
+// the configured factory. Callers of SetFactoryAddress must therefore pass the
+// EFFECTIVE factory (see EffectiveFactory) — passing the raw
+// smart_wallet.factory_address on an MA v2 chain would derive the wrong
+// address here, and every global-factory caller would inherit the mistake.
 func GetSenderAddress(conn *ethclient.Client, ownerAddress common.Address, salt *big.Int) (*common.Address, error) {
-	return GetSenderAddressForFactory(conn, ownerAddress, getFactoryAddress(), salt)
+	return DeriveSenderAddressAuto(conn, ownerAddress, getFactoryAddress(), salt)
 }
 
 // GetSenderAddressForFactory computes the smart wallet address using the factory proxy address

--- a/core/chainio/aa/aa.go
+++ b/core/chainio/aa/aa.go
@@ -62,16 +62,42 @@ func SetFactoryAddressForConfig(swCfg *config.SmartWalletConfig) error {
 	return nil
 }
 
-// getFactoryAddress returns the current factory address, with fallback to default from config
+// getFactoryAddress returns the current factory address, falling back to the
+// factory of the DEFAULT account provider when nothing has been set.
+//
+// The fallback must track config's default account_provider, which is
+// modular_account_v2. It used to be config.DefaultFactoryProxyAddressHex — the
+// v0.6 SimpleAccountFactory — and that became wrong the moment GetSenderAddress
+// started inferring the account implementation from this value: any caller
+// reaching the global before SetFactoryAddressForConfig ran would derive a v0.6
+// address on an MA v2 chain, silently and with no error to notice.
+//
+// That is not a hypothetical ordering problem. model.LoadDefaultSmartWallet and
+// the preset builders all go through GetSenderAddress, and the whole Go test
+// suite hits this path because most tests never construct an Engine.
 func getFactoryAddress() common.Address {
 	factoryAddressMu.RLock()
 	defer factoryAddressMu.RUnlock()
 	if factoryAddress != (common.Address{}) {
 		return factoryAddress
 	}
-	// Fallback to default if not set (shouldn't happen in normal operation)
-	// This uses the default from config package, which can be overridden in YAML
-	return common.HexToAddress(config.DefaultFactoryProxyAddressHex)
+	return defaultProviderFactory()
+}
+
+// defaultProviderFactory is the factory belonging to config's default
+// account_provider. Resolved through the same routing every other caller uses,
+// so it cannot drift from it.
+func defaultProviderFactory() common.Address {
+	var swCfg config.SmartWalletConfig // zero value == unset provider == the default
+	factory, err := FactoryAddressForProvider(
+		AccountProvider(swCfg.AccountProviderName()),
+		common.HexToAddress(config.DefaultFactoryProxyAddressHex),
+	)
+	if err != nil {
+		// Unreachable: the default provider is by definition a known one.
+		return common.HexToAddress(config.DefaultFactoryProxyAddressHex)
+	}
+	return factory
 }
 
 func SetEntrypointAddress(address common.Address) {

--- a/core/chainio/aa/derive.go
+++ b/core/chainio/aa/derive.go
@@ -116,6 +116,44 @@ func DeriveInitCodeAuto(owner, factory common.Address, salt *big.Int) (common.Ad
 	}
 }
 
+// PackExecuteBatchAuto builds atomic-batch calldata for the account
+// implementation this factory belongs to.
+//
+// Unlike execute(), batching did NOT carry over. MA v2 has a single
+// executeBatch((address,uint256,bytes)[]) that always takes per-call values;
+// the v0.6 account has two entry points, executeBatch(address[],bytes[]) and
+// executeBatchWithValues(...), with different selectors. Sending v0.6 batch
+// calldata to an MA v2 account reverts in validation as AA23, which names
+// neither the batch nor the account type.
+//
+// Callers pass values regardless; the v0.6 branch drops them when every value
+// is zero, because executeBatchWithValues (0xc3ff72fc) is not simulatable by
+// the bundler while plain executeBatch is.
+func PackExecuteBatchAuto(factory common.Address, targets []common.Address, values []*big.Int, datas [][]byte) ([]byte, error) {
+	if len(targets) != len(datas) || len(targets) != len(values) {
+		return nil, fmt.Errorf("batch arity mismatch: %d targets, %d values, %d calldatas",
+			len(targets), len(values), len(datas))
+	}
+	if ProviderForFactory(factory) == ProviderModularAccountV2 {
+		calls := make([]Call, len(targets))
+		for i := range targets {
+			calls[i] = Call{Target: targets[i], Value: values[i], Data: datas[i]}
+		}
+		return PackExecuteBatchMAv2(calls)
+	}
+	anyValue := false
+	for _, v := range values {
+		if v != nil && v.Sign() != 0 {
+			anyValue = true
+			break
+		}
+	}
+	if anyValue {
+		return PackExecuteBatchWithValues(targets, values, datas)
+	}
+	return PackExecuteBatch(targets, datas)
+}
+
 // EffectiveFactory returns the factory this chain creates accounts at NOW,
 // which is the MA v2 constant on an MA v2 chain and the configured
 // smart_wallet.factory_address otherwise.

--- a/core/chainio/aa/derive.go
+++ b/core/chainio/aa/derive.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -13,8 +14,14 @@ import (
 // derived from. The string values match core/config's account_provider so a
 // caller can pass either the raw yaml value or config's normalised
 // AccountProviderName() straight through — both are trimmed and lowercased
-// here. The type is redeclared rather than imported to keep chainio free of a
-// config dependency.
+// here.
+//
+// The type is redeclared rather than imported from config. That was originally
+// justified as keeping chainio free of a config dependency, which is not true:
+// aa.go already imports config. The redeclaration survives because it keeps
+// this file's derivation logic expressible in its own terms, but it does mean
+// two independent sets of string constants — see the cross-package drift guard
+// in core/taskengine, which is what actually holds them together.
 type AccountProvider string
 
 const (
@@ -32,9 +39,9 @@ const (
 // nothing will ever deploy to. Routing both through one function keeps that
 // pairing in a single place.
 //
-// An empty provider is SimpleAccount, matching config's default. That default
-// is deliberate: MA v2 derives different addresses for the same (owner, salt),
-// so silently defaulting to it would move every existing user's wallet.
+// An empty provider is Modular Account v2, matching config's default. Note
+// that this means MA v2 is what an unconfigured caller gets, and MA v2 derives
+// different addresses for the same (owner, salt) than SimpleAccount does.
 func DeriveSenderAddress(conn *ethclient.Client, owner common.Address, salt *big.Int, provider AccountProvider) (*common.Address, error) {
 	switch normaliseProvider(provider) {
 	case ProviderSimpleAccount:
@@ -45,6 +52,97 @@ func DeriveSenderAddress(conn *ethclient.Client, owner common.Address, salt *big
 		return nil, fmt.Errorf("unknown account provider %q; expected %q or %q",
 			provider, ProviderSimpleAccount, ProviderModularAccountV2)
 	}
+}
+
+// DeriveSenderAddressForFactory is DeriveSenderAddress against an explicit
+// factory rather than the package-global one. Most callers want this: the
+// factory is per-chain config, and deriving against the gateway's default
+// factory on a multi-chain task yields an address nothing will deploy to.
+//
+// The factory is honoured for BOTH providers, including MA v2 — whose factory
+// is the same constant on every chain today, but whose caller may be replaying
+// a wallet record written under a different one. Passing the recorded factory
+// back in is what lets an existing wallet re-derive to itself.
+func DeriveSenderAddressForFactory(conn *ethclient.Client, owner, factory common.Address, salt *big.Int, provider AccountProvider) (*common.Address, error) {
+	switch normaliseProvider(provider) {
+	case ProviderSimpleAccount:
+		return GetSenderAddressForFactory(conn, owner, factory, salt)
+	case ProviderModularAccountV2:
+		return GetSenderAddressMAv2ForFactory(conn, owner, factory, salt)
+	default:
+		return nil, fmt.Errorf("unknown account provider %q; expected %q or %q",
+			provider, ProviderSimpleAccount, ProviderModularAccountV2)
+	}
+}
+
+// DeriveSenderAddressAuto derives against a factory, inferring the provider
+// from that factory. Use it when re-deriving an address that already exists —
+// wallet-ownership checks, salt scans, anything replaying a stored record —
+// where the question is "what does THIS factory produce", not "what does this
+// chain create now".
+//
+// Because the factory carries the provider, this needs no extra parameter,
+// which is what keeps the ChainStateReader gRPC interface unchanged across the
+// v0.7 cutover: the worker is already given the factory.
+func DeriveSenderAddressAuto(conn *ethclient.Client, owner, factory common.Address, salt *big.Int) (*common.Address, error) {
+	return DeriveSenderAddressForFactory(conn, owner, factory, salt, ProviderForFactory(factory))
+}
+
+// DeriveInitCodeAuto returns the (factory, factoryData) pair that deploys the
+// account for (owner, salt), inferring the account implementation from the
+// factory — the init-code counterpart to DeriveSenderAddressAuto.
+//
+// The two providers build deployment calldata with different factory methods,
+// so this must route in lockstep with derivation. Building SimpleAccount
+// init code for an address derived as MA v2 produces a UserOperation whose
+// initCode deploys to a different address than its sender field, which the
+// EntryPoint rejects as AA14.
+func DeriveInitCodeAuto(owner, factory common.Address, salt *big.Int) (common.Address, []byte, error) {
+	switch ProviderForFactory(factory) {
+	case ProviderModularAccountV2:
+		return GetInitCodeMAv2ForFactory(owner, factory, salt)
+	default:
+		hexCode, err := GetInitCodeForFactory(owner.Hex(), factory, salt)
+		if err != nil {
+			return common.Address{}, nil, err
+		}
+		raw := common.FromHex(hexCode)
+		// initCode is factory(20 bytes) ++ calldata. Anything shorter means the
+		// builder returned something that is not init code at all.
+		if len(raw) <= common.AddressLength {
+			return common.Address{}, nil, fmt.Errorf("init code is %d bytes, too short to contain a factory and calldata", len(raw))
+		}
+		return factory, raw[common.AddressLength:], nil
+	}
+}
+
+// EffectiveFactory returns the factory this chain creates accounts at NOW,
+// which is the MA v2 constant on an MA v2 chain and the configured
+// smart_wallet.factory_address otherwise.
+//
+// Reach for this anywhere the old code passed swCfg.FactoryAddress into a
+// derivation. Passing the raw configured address after the v0.7 cutover
+// derives a SimpleAccount address on a chain that creates MA v2 accounts —
+// silently, since both calls succeed and return a well-formed address that
+// simply holds nothing.
+func EffectiveFactory(swCfg *config.SmartWalletConfig) (common.Address, error) {
+	if swCfg == nil {
+		return common.Address{}, fmt.Errorf("nil smart wallet config")
+	}
+	return FactoryAddressForProvider(AccountProvider(swCfg.AccountProviderName()), swCfg.FactoryAddress)
+}
+
+// ProviderForFactory reports which provider created an account at this
+// factory. This is the per-WALLET counterpart to config's per-chain setting,
+// and the two are not interchangeable: after the v0.7 cutover a chain's config
+// says modular_account_v2 while wallets created before it still carry the
+// SimpleAccount factory on their stored record. Execution has to follow the
+// wallet, not the chain, or it sends a v0.7 operation to a v0.6 account.
+func ProviderForFactory(factory common.Address) AccountProvider {
+	if factory == MAv2FactoryAddress() {
+		return ProviderModularAccountV2
+	}
+	return ProviderSimpleAccount
 }
 
 // FactoryAddressForProvider returns the factory an account of this provider is
@@ -77,7 +175,7 @@ func FactoryAddressForProvider(provider AccountProvider, simpleAccountFactory co
 func normaliseProvider(p AccountProvider) AccountProvider {
 	n := AccountProvider(strings.ToLower(strings.TrimSpace(string(p))))
 	if n == "" {
-		return ProviderSimpleAccount
+		return ProviderModularAccountV2
 	}
 	return n
 }

--- a/core/chainio/aa/derive_routing_test.go
+++ b/core/chainio/aa/derive_routing_test.go
@@ -174,3 +174,34 @@ func TestDeriveSenderAddressForFactoryRejectsUnknownProvider(t *testing.T) {
 		t.Error("expected an error for an unrecognised provider")
 	}
 }
+
+// The package-global factory is what GetSenderAddress derives against, and
+// GetSenderAddress infers the account implementation from it. So an unset
+// global must resolve to the DEFAULT provider's factory, not to the v0.6
+// SimpleAccountFactory.
+//
+// This regressed once already: the fallback stayed on
+// config.DefaultFactoryProxyAddressHex after the default provider flipped, so
+// every caller that reached the global before SetFactoryAddressForConfig ran
+// derived a v0.6 address on an MA v2 chain — silently, since both branches
+// return a well-formed address.
+func TestUnsetGlobalFactoryFollowsTheDefaultProvider(t *testing.T) {
+	SetFactoryAddress(common.Address{}) // simulate "never configured"
+
+	got := getFactoryAddress()
+	want, err := FactoryAddressForProvider("", common.HexToAddress(config.DefaultFactoryProxyAddressHex))
+	if err != nil {
+		t.Fatalf("FactoryAddressForProvider: %v", err)
+	}
+	if got != want {
+		t.Errorf("unset global factory = %s, want %s (the default provider's factory)",
+			got.Hex(), want.Hex())
+	}
+	if got == common.HexToAddress(config.DefaultFactoryProxyAddressHex) {
+		t.Error("unset global fell back to the v0.6 SimpleAccountFactory")
+	}
+	if ProviderForFactory(got) != ProviderModularAccountV2 {
+		t.Errorf("unset global resolves to provider %q, want %q",
+			ProviderForFactory(got), ProviderModularAccountV2)
+	}
+}

--- a/core/chainio/aa/derive_routing_test.go
+++ b/core/chainio/aa/derive_routing_test.go
@@ -1,0 +1,176 @@
+package aa
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// A SimpleAccount factory is any address that is not the MA v2 constant.
+var simpleAccountFactory = common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
+
+// The whole cutover rests on this: the factory address carries the provider,
+// which is what lets ChainStateReader (and its gRPC surface) stay unchanged
+// while derivation switches implementation.
+func TestProviderForFactory(t *testing.T) {
+	if got := ProviderForFactory(MAv2FactoryAddress()); got != ProviderModularAccountV2 {
+		t.Errorf("MA v2 factory resolved to %q, want %q", got, ProviderModularAccountV2)
+	}
+	if got := ProviderForFactory(simpleAccountFactory); got != ProviderSimpleAccount {
+		t.Errorf("SimpleAccount factory resolved to %q, want %q", got, ProviderSimpleAccount)
+	}
+	// The zero address is not the MA v2 factory, so it must not be treated as
+	// one. Deriving MA v2 against a zero factory would silently produce an
+	// address for an account nothing can deploy.
+	if got := ProviderForFactory(common.Address{}); got != ProviderSimpleAccount {
+		t.Errorf("zero factory resolved to %q, want %q", got, ProviderSimpleAccount)
+	}
+}
+
+func TestEffectiveFactory(t *testing.T) {
+	t.Run("MA v2 chain ignores the configured SimpleAccount factory", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{
+			FactoryAddress:  simpleAccountFactory,
+			AccountProvider: config.AccountProviderModularAccountV2,
+		}
+		got, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("EffectiveFactory: %v", err)
+		}
+		if got != MAv2FactoryAddress() {
+			t.Errorf("factory = %s, want %s", got.Hex(), MAv2FactoryAddress().Hex())
+		}
+	})
+
+	t.Run("unset provider is MA v2, matching the post-cutover default", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{FactoryAddress: simpleAccountFactory}
+		got, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("EffectiveFactory: %v", err)
+		}
+		if got != MAv2FactoryAddress() {
+			t.Errorf("factory = %s, want the MA v2 factory %s", got.Hex(), MAv2FactoryAddress().Hex())
+		}
+	})
+
+	t.Run("pinned simple_account keeps the configured factory", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{
+			FactoryAddress:  simpleAccountFactory,
+			AccountProvider: config.AccountProviderSimpleAccount,
+		}
+		got, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("EffectiveFactory: %v", err)
+		}
+		if got != simpleAccountFactory {
+			t.Errorf("factory = %s, want %s", got.Hex(), simpleAccountFactory.Hex())
+		}
+	})
+
+	t.Run("nil config is an error, not a zero address", func(t *testing.T) {
+		if _, err := EffectiveFactory(nil); err == nil {
+			t.Error("expected an error for a nil config")
+		}
+	})
+
+	t.Run("simple_account with no configured factory is an error", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{AccountProvider: config.AccountProviderSimpleAccount}
+		if _, err := EffectiveFactory(swCfg); err == nil {
+			t.Error("expected an error when simple_account has no factory configured")
+		}
+	})
+}
+
+// The round trip that keeps the two halves of the cutover honest: whatever
+// EffectiveFactory hands out must resolve back to the provider the config
+// asked for. If it doesn't, addresses get derived under one implementation and
+// recorded under another.
+func TestEffectiveFactoryRoundTripsToItsProvider(t *testing.T) {
+	for _, provider := range []string{
+		config.AccountProviderSimpleAccount,
+		config.AccountProviderModularAccountV2,
+		"", // the default
+	} {
+		swCfg := &config.SmartWalletConfig{
+			FactoryAddress:  simpleAccountFactory,
+			AccountProvider: provider,
+		}
+		factory, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("provider %q: %v", provider, err)
+		}
+		got := string(ProviderForFactory(factory))
+		if want := swCfg.AccountProviderName(); got != want {
+			t.Errorf("provider %q: factory %s resolves back to %q, want %q",
+				provider, factory.Hex(), got, want)
+		}
+	}
+}
+
+// Init code must route in lockstep with address derivation. If they disagree,
+// the UserOperation's initCode deploys to an address other than its sender and
+// the EntryPoint rejects it as AA14 — a failure that points nowhere near here.
+func TestDeriveInitCodeAutoRoutesOnFactory(t *testing.T) {
+	owner := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	salt := big.NewInt(0)
+
+	maFactory, maData, err := DeriveInitCodeAuto(owner, MAv2FactoryAddress(), salt)
+	if err != nil {
+		t.Fatalf("MA v2 init code: %v", err)
+	}
+	if maFactory != MAv2FactoryAddress() {
+		t.Errorf("MA v2 factory = %s, want %s", maFactory.Hex(), MAv2FactoryAddress().Hex())
+	}
+	if len(maData) == 0 {
+		t.Error("MA v2 factory data is empty")
+	}
+
+	simpleFactoryOut, simpleData, err := DeriveInitCodeAuto(owner, simpleAccountFactory, salt)
+	if err != nil {
+		t.Fatalf("SimpleAccount init code: %v", err)
+	}
+	if simpleFactoryOut != simpleAccountFactory {
+		t.Errorf("SimpleAccount factory = %s, want %s", simpleFactoryOut.Hex(), simpleAccountFactory.Hex())
+	}
+	if len(simpleData) == 0 {
+		t.Error("SimpleAccount factory data is empty")
+	}
+
+	// Different factory methods mean different selectors. Identical calldata
+	// would mean one branch is building the other's deployment.
+	if string(maData) == string(simpleData) {
+		t.Error("both providers produced identical factory data; the routing is not switching")
+	}
+}
+
+func TestDeriveInitCodeAutoStripsTheFactoryPrefix(t *testing.T) {
+	owner := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	_, data, err := DeriveInitCodeAuto(owner, simpleAccountFactory, big.NewInt(0))
+	if err != nil {
+		t.Fatalf("DeriveInitCodeAuto: %v", err)
+	}
+	// factoryData is the constructor call alone; leaving the 20-byte factory
+	// prefix on it would make the v0.7 wire form double-encode the factory.
+	if len(data) >= common.AddressLength &&
+		common.BytesToAddress(data[:common.AddressLength]) == simpleAccountFactory {
+		t.Error("factory data still begins with the factory address")
+	}
+	// A createAccount(address,uint256) call is a 4-byte selector plus two
+	// 32-byte words.
+	if len(data) != 4+32+32 {
+		t.Errorf("factory data is %d bytes, want %d", len(data), 4+32+32)
+	}
+}
+
+// DeriveSenderAddressForFactory and DeriveSenderAddressAuto both need a live
+// client to reach the factory, so the reachable assertion here is that an
+// unknown provider is refused before any dial happens.
+func TestDeriveSenderAddressForFactoryRejectsUnknownProvider(t *testing.T) {
+	owner := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	_, err := DeriveSenderAddressForFactory(nil, owner, simpleAccountFactory, big.NewInt(0), "not_a_provider")
+	if err == nil {
+		t.Error("expected an error for an unrecognised provider")
+	}
+}

--- a/core/chainio/aa/derive_test.go
+++ b/core/chainio/aa/derive_test.go
@@ -7,15 +7,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// The default is the single most consequential line in this file. MA v2
-// derives DIFFERENT addresses for the same (owner, salt), so a default of
-// modular_account_v2 would move every existing user's wallet the moment a
-// gateway rolled out — orphaning funds and every task whose runner references
-// the old address. If someone "tidies" this to the newer value, this fails.
-func TestDefaultProviderIsSimpleAccount(t *testing.T) {
-	if got := normaliseProvider(""); got != ProviderSimpleAccount {
-		t.Fatalf("empty provider = %q, want %q — defaulting to MA v2 would move every existing wallet",
-			got, ProviderSimpleAccount)
+// The default is the single most consequential line in this file, and it must
+// track core/config's — see the cross-package guard in core/taskengine. The
+// EntryPoint v0.7 cutover moved it to modular_account_v2 on every chain. MA v2
+// derives DIFFERENT addresses for the same (owner, salt), so reverting this
+// silently moves every wallet back.
+func TestDefaultProviderIsModularAccountV2(t *testing.T) {
+	if got := normaliseProvider(""); got != ProviderModularAccountV2 {
+		t.Fatalf("empty provider = %q, want %q", got, ProviderModularAccountV2)
 	}
 }
 
@@ -32,10 +31,10 @@ func TestFactoryAddressForProvider(t *testing.T) {
 		}
 	})
 
-	t.Run("empty provider behaves as simple account", func(t *testing.T) {
+	t.Run("empty provider behaves as MA v2 and ignores the configured factory", func(t *testing.T) {
 		got, err := FactoryAddressForProvider("", simple)
-		if err != nil || got != simple {
-			t.Errorf("got (%s, %v), want (%s, nil)", got.Hex(), err, simple.Hex())
+		if err != nil || got != MAv2FactoryAddress() {
+			t.Errorf("got (%s, %v), want (%s, nil)", got.Hex(), err, MAv2FactoryAddress().Hex())
 		}
 	})
 
@@ -98,13 +97,13 @@ func TestDeriveSenderAddressRejectsUnknownProvider(t *testing.T) {
 // as an "unknown provider", which reads as a code bug rather than whitespace.
 func TestProviderNormalisationMatchesConfig(t *testing.T) {
 	for _, in := range []AccountProvider{
-		"modular_account_v2", "MODULAR_ACCOUNT_V2", " modular_account_v2 ", "Modular_Account_V2",
+		"", "   ", "modular_account_v2", "MODULAR_ACCOUNT_V2", " modular_account_v2 ", "Modular_Account_V2",
 	} {
 		if got := normaliseProvider(in); got != ProviderModularAccountV2 {
 			t.Errorf("normaliseProvider(%q) = %q, want %q", in, got, ProviderModularAccountV2)
 		}
 	}
-	for _, in := range []AccountProvider{"", "   ", "simple_account", "SIMPLE_ACCOUNT", " Simple_Account "} {
+	for _, in := range []AccountProvider{"simple_account", "SIMPLE_ACCOUNT", " Simple_Account "} {
 		if got := normaliseProvider(in); got != ProviderSimpleAccount {
 			t.Errorf("normaliseProvider(%q) = %q, want %q", in, got, ProviderSimpleAccount)
 		}

--- a/core/chainio/aa/ma_v2_hooks.go
+++ b/core/chainio/aa/ma_v2_hooks.go
@@ -1,0 +1,227 @@
+package aa
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Permission hooks for Modular Account v2 session grants.
+//
+// A SessionGrant's Hooks entries are `bytes25 HookConfig ++ initData`, sliced
+// at exactly those offsets by ModuleManagerInternals. The HookConfig layout
+// mirrors ValidationConfig — module (20) ++ entityId (4) ++ flags (1) — but
+// the flag byte means something different (ERC-6900 HookConfigLib):
+//
+//	bit 0 (1): hook type — 1 validation hook, 0 execution hook
+//	bit 1 (2): execution hook has a post-hook
+//	bit 2 (4): execution hook has a pre-hook
+//
+// Alchemy's stock permission modules divide the §6.3 grant screen between
+// them: AllowlistModule enforces WHERE (targets/selectors, at validation) and
+// HOW MUCH of an ERC-20 (spend limit, at execution); TimeRangeModule enforces
+// HOW LONG (via ERC-4337 validation data, checked by the EntryPoint).
+//
+// The execution-hook half of the allowlist has a structural consequence: an
+// account whose validation carries ANY execution hook refuses operations
+// whose callData is not executeUserOp-wrapped (RequireUserOperationContext),
+// because without user-op context the account cannot tell at execution which
+// hooks should run. WrapExecuteUserOp does the wrapping, and every operation
+// under such a grant needs it — including the one carrying the deferred
+// install, since the hooks are live from the moment the install applies.
+const (
+	HookFlagValidation  byte = 1
+	HookFlagExecHasPost byte = 2
+	HookFlagExecHasPre  byte = 4
+)
+
+// Stock module addresses, deployed at the same address on every chain the MA
+// v2 factory is (modular-account deployments/v2/Deployments.md; code presence
+// verified on Sepolia). AllowlistModule is the v2.0.1 redeploy, matching the
+// v2.0.1 source its encoding here was written against.
+const (
+	AllowlistModuleAddressHex = "0x00000000003e826473a313e600b5b9b791f5a59a"
+	TimeRangeModuleAddressHex = "0x00000000000082B8e2012be914dFA4f62A0573eA"
+)
+
+// AllowlistModuleAddress returns the v2.0.1 AllowlistModule address.
+func AllowlistModuleAddress() common.Address { return common.HexToAddress(AllowlistModuleAddressHex) }
+
+// TimeRangeModuleAddress returns the TimeRangeModule address.
+func TimeRangeModuleAddress() common.Address { return common.HexToAddress(TimeRangeModuleAddressHex) }
+
+// selectorExecuteUserOp is IAccountExecute.executeUserOp(PackedUserOperation,
+// bytes32) — the v0.7 EntryPoint special-cases callData beginning with it and
+// hands the account the full operation as execution context.
+var selectorExecuteUserOp = [4]byte{0x8d, 0xd7, 0x71, 0x2f}
+
+// PackHookConfig builds the bytes25 HookConfig:
+// module (20) ++ entityId (4, big-endian) ++ flags (1).
+func PackHookConfig(module common.Address, entityID uint32, flags byte) [25]byte {
+	// Identical layout to ValidationConfig; only the flag semantics differ.
+	return PackValidationConfig(module, entityID, flags)
+}
+
+// AllowlistInput mirrors AllowlistModule.AllowlistInput. One entry per
+// target; target zero means "any address" for the listed selectors.
+type AllowlistInput struct {
+	Target common.Address
+	// HasSelectorAllowlist scopes the target to Selectors; false allows any
+	// selector on the target.
+	HasSelectorAllowlist bool
+	// HasERC20SpendLimit marks Target as a token whose transfer/approve
+	// amounts are capped by ERC20SpendLimit. Enforced by the module's
+	// EXECUTION hook — installing a grant with a limit requires the exec-hook
+	// entry (AllowlistExecHook) alongside the validation-hook entry, and
+	// executeUserOp wrapping on every operation.
+	HasERC20SpendLimit bool
+	ERC20SpendLimit    *big.Int
+	Selectors          [][4]byte
+}
+
+var (
+	hooksArgsOnce     sync.Once
+	allowlistDataArgs abi.Arguments
+	timeRangeDataArgs abi.Arguments
+	hooksArgsErr      error
+)
+
+func ensureHookABIs() error {
+	hooksArgsOnce.Do(func() {
+		allowlistInputType, err := abi.NewType("tuple[]", "", []abi.ArgumentMarshaling{
+			{Name: "target", Type: "address"},
+			{Name: "hasSelectorAllowlist", Type: "bool"},
+			{Name: "hasERC20SpendLimit", Type: "bool"},
+			{Name: "erc20SpendLimit", Type: "uint256"},
+			{Name: "selectors", Type: "bytes4[]"},
+		})
+		if err != nil {
+			hooksArgsErr = err
+			return
+		}
+		uint32Type, err := abi.NewType("uint32", "", nil)
+		if err != nil {
+			hooksArgsErr = err
+			return
+		}
+		uint48Type, err := abi.NewType("uint48", "", nil)
+		if err != nil {
+			hooksArgsErr = err
+			return
+		}
+		allowlistDataArgs = abi.Arguments{{Type: uint32Type}, {Type: allowlistInputType}}
+		timeRangeDataArgs = abi.Arguments{{Type: uint32Type}, {Type: uint48Type}, {Type: uint48Type}}
+	})
+	return hooksArgsErr
+}
+
+// abiAllowlistInput is the shape go-ethereum's ABI encoder expects for the
+// tuple: field names must match the marshaling above with exported Go names.
+type abiAllowlistInput struct {
+	Target               common.Address `abi:"target"`
+	HasSelectorAllowlist bool           `abi:"hasSelectorAllowlist"`
+	HasERC20SpendLimit   bool           `abi:"hasERC20SpendLimit"`
+	Erc20SpendLimit      *big.Int       `abi:"erc20SpendLimit"`
+	Selectors            [][4]byte      `abi:"selectors"`
+}
+
+// PackAllowlistInstallData encodes AllowlistModule.onInstall's payload:
+// abi.encode(uint32 entityId, AllowlistInput[] inputs).
+func PackAllowlistInstallData(entityID uint32, inputs []AllowlistInput) ([]byte, error) {
+	if err := ensureHookABIs(); err != nil {
+		return nil, err
+	}
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("an empty allowlist install allows nothing and masks a bug")
+	}
+	encoded := make([]abiAllowlistInput, len(inputs))
+	for i, in := range inputs {
+		limit := in.ERC20SpendLimit
+		if limit == nil {
+			limit = big.NewInt(0)
+		}
+		if in.HasERC20SpendLimit && limit.Sign() == 0 {
+			return nil, fmt.Errorf("input %d: a zero ERC20 spend limit with the flag set caps the token at nothing", i)
+		}
+		selectors := in.Selectors
+		if selectors == nil {
+			selectors = [][4]byte{}
+		}
+		encoded[i] = abiAllowlistInput{
+			Target:               in.Target,
+			HasSelectorAllowlist: in.HasSelectorAllowlist,
+			HasERC20SpendLimit:   in.HasERC20SpendLimit,
+			Erc20SpendLimit:      limit,
+			Selectors:            selectors,
+		}
+	}
+	return allowlistDataArgs.Pack(entityID, encoded)
+}
+
+// PackTimeRangeInstallData encodes TimeRangeModule.onInstall's payload:
+// abi.encode(uint32 entityId, uint48 validUntil, uint48 validAfter).
+// validUntil zero means "no expiry" to the module — reject it here instead:
+// every grant this system issues has an explicit expiry (master doc §6.5).
+func PackTimeRangeInstallData(entityID uint32, validUntil, validAfter uint64) ([]byte, error) {
+	if err := ensureHookABIs(); err != nil {
+		return nil, err
+	}
+	const maxUint48 = uint64(1)<<48 - 1
+	if validUntil == 0 {
+		return nil, fmt.Errorf("validUntil 0 would mean no expiry; grants must expire")
+	}
+	if validUntil > maxUint48 || validAfter > maxUint48 {
+		return nil, fmt.Errorf("time range overflows uint48")
+	}
+	if validUntil <= validAfter {
+		return nil, fmt.Errorf("validUntil %d <= validAfter %d", validUntil, validAfter)
+	}
+	return timeRangeDataArgs.Pack(entityID, new(big.Int).SetUint64(validUntil), new(big.Int).SetUint64(validAfter))
+}
+
+// AllowlistValidationHook builds the hook entry enforcing the allowlist at
+// validation, carrying the module's install data (which also seeds any ERC-20
+// limits — state is shared with the exec hook, so it installs once, here).
+func AllowlistValidationHook(entityID uint32, inputs []AllowlistInput) ([]byte, error) {
+	data, err := PackAllowlistInstallData(entityID, inputs)
+	if err != nil {
+		return nil, err
+	}
+	config := PackHookConfig(AllowlistModuleAddress(), entityID, HookFlagValidation)
+	return append(config[:], data...), nil
+}
+
+// AllowlistExecHook builds the pre-execution hook entry that enforces ERC-20
+// spend limits. No install data — the validation-hook entry installed the
+// module state; a second onInstall with the same inputs would just repeat it.
+// (The module's post-hook path reverts NotImplemented, so pre only.)
+func AllowlistExecHook(entityID uint32) []byte {
+	config := PackHookConfig(AllowlistModuleAddress(), entityID, HookFlagExecHasPre)
+	return config[:]
+}
+
+// TimeRangeValidationHook builds the hook entry that bounds the grant in
+// time. Enforcement is by the EntryPoint: the hook returns
+// validUntil/validAfter in its validation data.
+func TimeRangeValidationHook(entityID uint32, validUntil, validAfter uint64) ([]byte, error) {
+	data, err := PackTimeRangeInstallData(entityID, validUntil, validAfter)
+	if err != nil {
+		return nil, err
+	}
+	config := PackHookConfig(TimeRangeModuleAddress(), entityID, HookFlagValidation)
+	return append(config[:], data...), nil
+}
+
+// WrapExecuteUserOp prefixes execution calldata with the executeUserOp
+// selector, opting the operation into user-op context. Required for every
+// operation under a grant that carries execution hooks; harmless overhead
+// (a calldata re-read) otherwise.
+func WrapExecuteUserOp(execCallData []byte) ([]byte, error) {
+	if len(execCallData) < 4 {
+		return nil, fmt.Errorf("execution calldata is %d bytes, shorter than a selector", len(execCallData))
+	}
+	return append(selectorExecuteUserOp[:], execCallData...), nil
+}

--- a/core/chainio/aa/ma_v2_hooks_test.go
+++ b/core/chainio/aa/ma_v2_hooks_test.go
@@ -1,0 +1,137 @@
+package aa
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Golden vector produced by
+//
+//	cast abi-encode "f(uint32,(address,bool,bool,uint256,bytes4[])[])" 1 \
+//	  "[(0x1111…1111,true,true,100000000000000000000,[0xa9059cbb])]"
+//
+// so the Go tuple marshaling is checked against an independent encoder, not
+// against itself.
+const allowlistGolden = "0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000000000000000000040" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000000000000000000020" +
+	"0000000000000000000000001111111111111111111111111111111111111111" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000056bc75e2d63100000" +
+	"00000000000000000000000000000000000000000000000000000000000000a0" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"a9059cbb00000000000000000000000000000000000000000000000000000000"
+
+func TestPackAllowlistInstallDataGolden(t *testing.T) {
+	limit, _ := new(big.Int).SetString("100000000000000000000", 10) // 100e18
+	got, err := PackAllowlistInstallData(1, []AllowlistInput{{
+		Target:               common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		HasSelectorAllowlist: true,
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      limit,
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != allowlistGolden {
+		t.Fatalf("allowlist install data does not match the cast golden vector:\ngot  %x", got)
+	}
+}
+
+func TestPackAllowlistInstallDataRejectsFootguns(t *testing.T) {
+	if _, err := PackAllowlistInstallData(1, nil); err == nil {
+		t.Error("expected an empty allowlist to be rejected")
+	}
+	if _, err := PackAllowlistInstallData(1, []AllowlistInput{{
+		Target:             common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		HasERC20SpendLimit: true, // flag set, limit zero
+	}}); err == nil {
+		t.Error("expected a zero limit with the flag set to be rejected")
+	}
+}
+
+func TestPackTimeRangeInstallDataGolden(t *testing.T) {
+	// cast abi-encode "f(uint32,uint48,uint48)" 7 1790000000 12345
+	want := "0000000000000000000000000000000000000000000000000000000000000007" +
+		"000000000000000000000000000000000000000000000000000000006ab13b80" +
+		"0000000000000000000000000000000000000000000000000000000000003039"
+	got, err := PackTimeRangeInstallData(7, 1790000000, 12345)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != want {
+		t.Fatalf("time range install data = %x, want %s", got, want)
+	}
+
+	if _, err := PackTimeRangeInstallData(1, 0, 0); err == nil {
+		t.Error("expected validUntil 0 (no expiry) to be rejected")
+	}
+	if _, err := PackTimeRangeInstallData(1, 100, 100); err == nil {
+		t.Error("expected an empty window to be rejected")
+	}
+}
+
+func TestHookEntryLayout(t *testing.T) {
+	entry, err := TimeRangeValidationHook(3, 1790000000, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// [:25] HookConfig, [25:] initData — the offsets ModuleManagerInternals
+	// slices at.
+	if !bytes.Equal(entry[:20], TimeRangeModuleAddress().Bytes()) {
+		t.Fatalf("module segment = %x", entry[:20])
+	}
+	if entity := uint32(entry[20])<<24 | uint32(entry[21])<<16 | uint32(entry[22])<<8 | uint32(entry[23]); entity != 3 {
+		t.Fatalf("entity segment = %d, want 3", entity)
+	}
+	if entry[24] != HookFlagValidation {
+		t.Fatalf("flags = %x, want validation (%x)", entry[24], HookFlagValidation)
+	}
+	initData, err := PackTimeRangeInstallData(3, 1790000000, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(entry[25:], initData) {
+		t.Fatal("initData segment does not round-trip")
+	}
+}
+
+func TestAllowlistExecHookIsConfigOnly(t *testing.T) {
+	entry := AllowlistExecHook(2)
+	// The exec hook shares module state with the validation hook, which
+	// installed it — a second onInstall would re-run updateAllowlist. Config
+	// only, pre-hook only (the module's post-hook reverts NotImplemented).
+	if len(entry) != 25 {
+		t.Fatalf("exec hook entry is %d bytes, want 25 (config only)", len(entry))
+	}
+	if entry[24] != HookFlagExecHasPre {
+		t.Fatalf("flags = %x, want exec-pre (%x)", entry[24], HookFlagExecHasPre)
+	}
+}
+
+func TestWrapExecuteUserOp(t *testing.T) {
+	inner, err := PackExecute(common.HexToAddress("0x2222222222222222222222222222222222222222"), big.NewInt(0), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapped, err := WrapExecuteUserOp(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(wrapped[:4]) != "8dd7712f" {
+		t.Fatalf("wrapper selector = %x, want 8dd7712f", wrapped[:4])
+	}
+	if !bytes.Equal(wrapped[4:], inner) {
+		t.Fatal("inner calldata does not survive wrapping")
+	}
+	if _, err := WrapExecuteUserOp([]byte{0x01}); err == nil {
+		t.Error("expected sub-selector calldata to be rejected")
+	}
+}

--- a/core/chainio/aa/ma_v2_install.go
+++ b/core/chainio/aa/ma_v2_install.go
@@ -142,11 +142,17 @@ type SessionGrant struct {
 	// Signer is the session key that will sign operations for this grant.
 	Signer common.Address
 
-	// Selectors scopes the grant to specific function selectors. Empty means
-	// global — any selector the account exposes. Note these are alternatives,
-	// not additive: an enumerated set clears the global flag, because a
-	// validation that is global does not consult the selector list at all.
+	// Selectors scopes the grant to specific function selectors. Mutually
+	// exclusive with Global — a global validation never consults the selector
+	// list, so setting both would produce a grant that is wider than it reads.
 	Selectors [][4]byte
+
+	// Global lets the entity validate ANY selector the account exposes,
+	// including the account's own native functions. It must be set
+	// explicitly: it used to be inferred from an empty Selectors, which made
+	// the most dangerous grant the one you got by omission. See
+	// AllowSelfAdministration.
+	Global bool
 
 	// Hooks are the encoded permission hooks (allowlist, spend cap, time
 	// range) installed alongside the validation, each as
@@ -160,6 +166,34 @@ type SessionGrant struct {
 	// signers: the controller executes, it does not speak as the user. Set it
 	// only for a grant that genuinely represents the owner.
 	AllowSignatureValidation bool
+
+	// AllowSelfAdministration acknowledges that a Global grant carrying no
+	// execution hook can administer its own authority.
+	//
+	// A global validation may call the account's native functions, which is
+	// how one-click self-revoke works (uninstallValidation, proven on Sepolia)
+	// — but the same authority reaches installValidation, so such a grant can
+	// escalate itself: add signature validation, widen its own hooks, or
+	// install a second signer. An execution hook that rejects non-execute
+	// selectors closes this (the allowlist hook does, also proven), which is
+	// why a policied grant cannot touch its own authority.
+	//
+	// Production grants must therefore either be selector-scoped or carry an
+	// execution hook. This flag exists so a spike or a deliberately
+	// self-administering grant can still be built, loudly.
+	AllowSelfAdministration bool
+}
+
+// HasExecutionHook reports whether any hook runs at execution rather than
+// validation. Hook entries are hookConfig(25) ++ initData, and a clear
+// HookFlagValidation bit in the config's flag byte means execution.
+func (g SessionGrant) HasExecutionHook() bool {
+	for _, h := range g.Hooks {
+		if len(h) >= 25 && h[24]&HookFlagValidation == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // Validate reports why a grant cannot be installed, if it cannot.
@@ -170,13 +204,26 @@ func (g SessionGrant) Validate() error {
 	if g.Signer == (common.Address{}) {
 		return fmt.Errorf("session signer is the zero address")
 	}
+	// Scope must be stated. Neither means a grant that validates nothing;
+	// both means a grant whose selector list is silently ignored.
+	if g.Global && len(g.Selectors) > 0 {
+		return fmt.Errorf("grant is Global and also lists %d selectors; a global validation ignores the list, so this is wider than it reads", len(g.Selectors))
+	}
+	if !g.Global && len(g.Selectors) == 0 {
+		return fmt.Errorf("grant has no scope: set Global or list Selectors")
+	}
+	if g.Global && !g.HasExecutionHook() && !g.AllowSelfAdministration {
+		return fmt.Errorf(
+			"refusing a global grant with no execution hook: it can call the account's own installValidation/uninstallValidation and escalate itself. " +
+				"Scope it with Selectors, add an execution hook (e.g. aa.AllowlistExecHook), or set AllowSelfAdministration to accept this deliberately")
+	}
 	return nil
 }
 
 // Flags renders the grant's ValidationConfig flag byte.
 func (g SessionGrant) Flags() byte {
 	flags := ValidationFlagUserOp
-	if len(g.Selectors) == 0 {
+	if g.Global {
 		flags |= ValidationFlagGlobal
 	}
 	if g.AllowSignatureValidation {

--- a/core/chainio/aa/ma_v2_install.go
+++ b/core/chainio/aa/ma_v2_install.go
@@ -1,0 +1,140 @@
+package aa
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Controller validation install for Modular Account v2.
+//
+// A stock SemiModularAccountBytecode trusts exactly one signer — the owner
+// passed at creation. The controller's authority over a wallet is therefore
+// an explicit, per-account grant: an installValidation self-call naming the
+// controller as an additional validation entity. This file encodes that call.
+//
+// The encoding was established on-chain (Sepolia, avs-infra
+// MA_v2_Authority_Model_And_Spike_Results.md §3.1) rather than from
+// documentation: ValidationConfig is bytes25 = module address (20) ++
+// entityId (uint32, 4) ++ flags (1), and the flag bits follow aa-sdk's
+// serializeValidationConfig, which is NOT the intuitive order.
+
+// SingleSignerValidationModuleAddressHex is Alchemy's audited
+// SingleSignerValidationModule, deployed at the same address on every chain
+// the MA v2 factory is (verified byte-identical across our chains).
+const SingleSignerValidationModuleAddressHex = "0x00000000000099DE0BF6fA90dEB851E2A2df7d83"
+
+// SingleSignerValidationModuleAddress returns the module address.
+func SingleSignerValidationModuleAddress() common.Address {
+	return common.HexToAddress(SingleSignerValidationModuleAddressHex)
+}
+
+// ControllerEntityID is where the controller is installed. Entity 0 is the
+// account's fallback signer (the owner) and cannot be reused.
+const ControllerEntityID uint32 = 1
+
+// ValidationConfig flag bits (aa-sdk serializeValidationConfig order).
+const (
+	// ValidationFlagUserOp lets the entity validate UserOperations.
+	ValidationFlagUserOp byte = 1
+	// ValidationFlagSignature lets the entity answer isValidSignature as the
+	// account. The controller install deliberately EXCLUDES this: the
+	// controller executes, it does not speak as the user.
+	ValidationFlagSignature byte = 2
+	// ValidationFlagGlobal applies the validation to any selector rather than
+	// an enumerated set.
+	ValidationFlagGlobal byte = 4
+)
+
+// PackValidationConfig builds the bytes25 ValidationConfig:
+// module (20) ++ entityId (4, big-endian) ++ flags (1).
+func PackValidationConfig(module common.Address, entityID uint32, flags byte) [25]byte {
+	var out [25]byte
+	copy(out[:20], module.Bytes())
+	out[20] = byte(entityID >> 24)
+	out[21] = byte(entityID >> 16)
+	out[22] = byte(entityID >> 8)
+	out[23] = byte(entityID)
+	out[24] = flags
+	return out
+}
+
+var (
+	installArgsOnce      sync.Once
+	installDataArgs      abi.Arguments
+	installValidationABI abi.ABI
+	installArgsErr       error
+)
+
+func ensureInstallABIs() error {
+	installArgsOnce.Do(func() {
+		uint32Type, err := abi.NewType("uint32", "", nil)
+		if err != nil {
+			installArgsErr = err
+			return
+		}
+		addressType, err := abi.NewType("address", "", nil)
+		if err != nil {
+			installArgsErr = err
+			return
+		}
+		installDataArgs = abi.Arguments{{Type: uint32Type}, {Type: addressType}}
+
+		installValidationABI, installArgsErr = abi.JSON(strings.NewReader(`[
+		  {"type":"function","name":"installValidation","stateMutability":"nonpayable",
+		   "inputs":[{"name":"validationConfig","type":"bytes25"},
+		             {"name":"selectors","type":"bytes4[]"},
+		             {"name":"installData","type":"bytes"},
+		             {"name":"hooks","type":"bytes[]"}]}
+		]`))
+	})
+	return installArgsErr
+}
+
+// PackSingleSignerInstallData encodes the module's onInstall payload:
+// abi.encode(uint32 entityId, address signer).
+func PackSingleSignerInstallData(entityID uint32, signer common.Address) ([]byte, error) {
+	if err := ensureInstallABIs(); err != nil {
+		return nil, err
+	}
+	return installDataArgs.Pack(entityID, signer)
+}
+
+// PackInstallValidation encodes the installValidation self-call
+// (selector 0x1bbf564c, asserted in tests against deployed bytecode).
+func PackInstallValidation(config [25]byte, selectors [][4]byte, installData []byte, hooks [][]byte) ([]byte, error) {
+	if err := ensureInstallABIs(); err != nil {
+		return nil, err
+	}
+	if selectors == nil {
+		selectors = [][4]byte{}
+	}
+	if hooks == nil {
+		hooks = [][]byte{}
+	}
+	return installValidationABI.Pack("installValidation", config, selectors, installData, hooks)
+}
+
+// PackControllerInstall is the exact grant this system asks an owner to
+// authorize: SingleSignerValidationModule at entity 1 naming the controller,
+// global + userOp validation and deliberately NOT signature validation, no
+// selector scoping, no hooks (permission hooks ride here later — master doc
+// §5 step 2).
+func PackControllerInstall(controller common.Address) ([]byte, error) {
+	if controller == (common.Address{}) {
+		return nil, fmt.Errorf("controller address is zero")
+	}
+	installData, err := PackSingleSignerInstallData(ControllerEntityID, controller)
+	if err != nil {
+		return nil, fmt.Errorf("packing SingleSignerValidationModule install data: %w", err)
+	}
+	config := PackValidationConfig(
+		SingleSignerValidationModuleAddress(),
+		ControllerEntityID,
+		ValidationFlagGlobal|ValidationFlagUserOp,
+	)
+	return PackInstallValidation(config, nil, installData, nil)
+}

--- a/core/chainio/aa/ma_v2_install.go
+++ b/core/chainio/aa/ma_v2_install.go
@@ -32,9 +32,19 @@ func SingleSignerValidationModuleAddress() common.Address {
 	return common.HexToAddress(SingleSignerValidationModuleAddressHex)
 }
 
-// ControllerEntityID is where the controller is installed. Entity 0 is the
-// account's fallback signer (the owner) and cannot be reused.
-const ControllerEntityID uint32 = 1
+// MinSessionEntityID is the lowest entity a session signer may occupy. Entity
+// 0 is the account's fallback signer (the owner) and can never be reused.
+//
+// Entities are allocated PER GRANT, not per gateway — one SessionPolicy, one
+// entity, one signer (avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §6.7). That
+// is not only a product choice. The deferred-action digest commits to the full
+// nonce of the operation that will carry it, and the nonce key is derived from
+// the entity id, so a fresh entity means a fresh key whose sequence is
+// predictably zero — which is the entire reason the owner can sign the grant
+// before the operation exists. Reusing one entity across grants makes the
+// second grant's nonce unpredictable at signing time and the property
+// collapses.
+const MinSessionEntityID uint32 = 1
 
 // ValidationConfig flag bits (aa-sdk serializeValidationConfig order).
 const (
@@ -118,23 +128,77 @@ func PackInstallValidation(config [25]byte, selectors [][4]byte, installData []b
 	return installValidationABI.Pack("installValidation", config, selectors, installData, hooks)
 }
 
-// PackControllerInstall is the exact grant this system asks an owner to
-// authorize: SingleSignerValidationModule at entity 1 naming the controller,
-// global + userOp validation and deliberately NOT signature validation, no
-// selector scoping, no hooks (permission hooks ride here later — master doc
-// §5 step 2).
-func PackControllerInstall(controller common.Address) ([]byte, error) {
-	if controller == (common.Address{}) {
-		return nil, fmt.Errorf("controller address is zero")
+// SessionGrant is one grant of authority on one account: which entity, which
+// signer occupies it, and what that signer is allowed to do.
+//
+// This is the thing an owner authorizes, so every field is committed to by the
+// deferred-action digest. The gateway cannot widen a grant after signing —
+// changing any field here changes the digest and invalidates the signature.
+type SessionGrant struct {
+	// EntityID must be unique per account and >= MinSessionEntityID. It is
+	// allocated by the gateway when a SessionPolicy is created.
+	EntityID uint32
+
+	// Signer is the session key that will sign operations for this grant.
+	Signer common.Address
+
+	// Selectors scopes the grant to specific function selectors. Empty means
+	// global — any selector the account exposes. Note these are alternatives,
+	// not additive: an enumerated set clears the global flag, because a
+	// validation that is global does not consult the selector list at all.
+	Selectors [][4]byte
+
+	// Hooks are the encoded permission hooks (allowlist, spend cap, time
+	// range) installed alongside the validation, each as
+	// hookConfig ++ initData. They ride the SAME installValidation call, so
+	// they are covered by the owner's signature rather than needing one of
+	// their own.
+	Hooks [][]byte
+
+	// AllowSignatureValidation lets this entity answer isValidSignature AS the
+	// account. Default false, and it should stay false for gateway-held
+	// signers: the controller executes, it does not speak as the user. Set it
+	// only for a grant that genuinely represents the owner.
+	AllowSignatureValidation bool
+}
+
+// Validate reports why a grant cannot be installed, if it cannot.
+func (g SessionGrant) Validate() error {
+	if g.EntityID < MinSessionEntityID {
+		return fmt.Errorf("entity id %d is reserved (entity 0 is the owner's fallback signer)", g.EntityID)
 	}
-	installData, err := PackSingleSignerInstallData(ControllerEntityID, controller)
+	if g.Signer == (common.Address{}) {
+		return fmt.Errorf("session signer is the zero address")
+	}
+	return nil
+}
+
+// Flags renders the grant's ValidationConfig flag byte.
+func (g SessionGrant) Flags() byte {
+	flags := ValidationFlagUserOp
+	if len(g.Selectors) == 0 {
+		flags |= ValidationFlagGlobal
+	}
+	if g.AllowSignatureValidation {
+		flags |= ValidationFlagSignature
+	}
+	return flags
+}
+
+// PackSessionSignerInstall encodes the installValidation self-call that grants
+// this session signer its authority — the exact calldata an owner authorizes.
+func PackSessionSignerInstall(grant SessionGrant) ([]byte, error) {
+	if err := grant.Validate(); err != nil {
+		return nil, err
+	}
+	installData, err := PackSingleSignerInstallData(grant.EntityID, grant.Signer)
 	if err != nil {
 		return nil, fmt.Errorf("packing SingleSignerValidationModule install data: %w", err)
 	}
 	config := PackValidationConfig(
 		SingleSignerValidationModuleAddress(),
-		ControllerEntityID,
-		ValidationFlagGlobal|ValidationFlagUserOp,
+		grant.EntityID,
+		grant.Flags(),
 	)
-	return PackInstallValidation(config, nil, installData, nil)
+	return PackInstallValidation(config, grant.Selectors, installData, grant.Hooks)
 }

--- a/core/chainio/aa/ma_v2_install_test.go
+++ b/core/chainio/aa/ma_v2_install_test.go
@@ -38,9 +38,9 @@ func TestPackSingleSignerInstallData(t *testing.T) {
 	}
 }
 
-func TestPackControllerInstallSelectorAndShape(t *testing.T) {
+func TestPackSessionSignerInstallSelectorAndShape(t *testing.T) {
 	controller := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
-	call, err := PackControllerInstall(controller)
+	call, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID, Signer: controller})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestPackControllerInstallSelectorAndShape(t *testing.T) {
 	}
 
 	// The config word leads the arguments: bytes25 is right-padded to 32.
-	config := PackValidationConfig(SingleSignerValidationModuleAddress(), ControllerEntityID,
+	config := PackValidationConfig(SingleSignerValidationModuleAddress(), MinSessionEntityID,
 		ValidationFlagGlobal|ValidationFlagUserOp)
 	if !bytes.Equal(call[4:4+25], config[:]) {
 		t.Fatalf("leading config = %x, want %x", call[4:4+25], config)
@@ -66,8 +66,104 @@ func TestPackControllerInstallSelectorAndShape(t *testing.T) {
 	}
 }
 
-func TestPackControllerInstallRejectsZeroAddress(t *testing.T) {
-	if _, err := PackControllerInstall(common.Address{}); err == nil {
+func TestPackSessionSignerInstallRejectsZeroAddress(t *testing.T) {
+	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID}); err == nil {
 		t.Fatal("expected an error for the zero controller address")
+	}
+}
+
+// Entities are allocated per grant, so the entity id has to reach both the
+// ValidationConfig and the module's install data. If they ever disagree the
+// account installs one entity and the module binds the signer to another —
+// the grant looks applied and every operation under it fails validation.
+func TestSessionGrantEntityReachesBothEncodings(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	const entity = uint32(7)
+
+	call, err := PackSessionSignerInstall(SessionGrant{EntityID: entity, Signer: signer})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	// ValidationConfig sits in the first argument word, right-padded: module
+	// (20) ++ entityId (4) ++ flags (1).
+	cfg := call[4:29]
+	got := uint32(cfg[20])<<24 | uint32(cfg[21])<<16 | uint32(cfg[22])<<8 | uint32(cfg[23])
+	if got != entity {
+		t.Errorf("ValidationConfig entity = %d, want %d", got, entity)
+	}
+	installData, err := PackSingleSignerInstallData(entity, signer)
+	if err != nil {
+		t.Fatalf("PackSingleSignerInstallData: %v", err)
+	}
+	if !bytes.Contains(call, installData) {
+		t.Error("the install call does not carry install data for the same entity")
+	}
+}
+
+func TestSessionGrantFlags(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	t.Run("no selectors means global", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer}
+		if g.Flags()&ValidationFlagGlobal == 0 {
+			t.Error("expected the global flag")
+		}
+		if g.Flags()&ValidationFlagUserOp == 0 {
+			t.Error("expected the userOp flag")
+		}
+	})
+
+	// A global validation never consults the selector list, so setting both
+	// would silently widen a grant the owner believed was scoped.
+	t.Run("selectors clear global", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Selectors: [][4]byte{{0x09, 0x5e, 0xa7, 0xb3}}}
+		if g.Flags()&ValidationFlagGlobal != 0 {
+			t.Error("an enumerated selector set must not also be global")
+		}
+	})
+
+	// The gateway holds this key. Letting it answer isValidSignature would let
+	// it sign arbitrary messages AS the user, which is not what execution
+	// authority means.
+	t.Run("signature validation is off unless asked for", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer}
+		if g.Flags()&ValidationFlagSignature != 0 {
+			t.Error("signature validation must default off")
+		}
+		g.AllowSignatureValidation = true
+		if g.Flags()&ValidationFlagSignature == 0 {
+			t.Error("signature validation must be settable")
+		}
+	})
+}
+
+func TestSessionGrantRejectsTheOwnerEntity(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	// Entity 0 is the fallback signer. Installing over it would replace the
+	// owner's own validation with a gateway-held key.
+	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: 0, Signer: signer}); err == nil {
+		t.Error("expected entity 0 to be rejected")
+	}
+}
+
+// Hooks ride the same call, which is what puts them under the owner's single
+// signature instead of needing one of their own.
+func TestSessionGrantCarriesHooks(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	hook := append(bytes.Repeat([]byte{0xab}, 26), 0x01, 0x02)
+
+	withHook, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Hooks: [][]byte{hook}})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	if !bytes.Contains(withHook, hook) {
+		t.Error("hook payload is not present in the install call")
+	}
+	without, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	if len(withHook) <= len(without) {
+		t.Error("hooks did not lengthen the encoded call")
 	}
 }

--- a/core/chainio/aa/ma_v2_install_test.go
+++ b/core/chainio/aa/ma_v2_install_test.go
@@ -1,0 +1,73 @@
+package aa
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestPackValidationConfigLayout(t *testing.T) {
+	module := common.HexToAddress(SingleSignerValidationModuleAddressHex)
+	got := PackValidationConfig(module, 1, ValidationFlagGlobal|ValidationFlagUserOp)
+
+	// module (20) ++ entityId (4, BE) ++ flags (1) — the §3.1 layout that was
+	// verified against deployed bytecode.
+	want := "00000000000099de0bf6fa90deb851e2a2df7d83" + "00000001" + "05"
+	if hex.EncodeToString(got[:]) != want {
+		t.Fatalf("ValidationConfig = %x, want %s", got, want)
+	}
+}
+
+func TestPackSingleSignerInstallData(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	got, err := PackSingleSignerInstallData(1, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// abi.encode(uint32(1), address) = two 32-byte words.
+	if len(got) != 64 {
+		t.Fatalf("install data is %d bytes, want 64", len(got))
+	}
+	if got[31] != 1 {
+		t.Fatalf("entity id word = %x, want …01", got[:32])
+	}
+	if !bytes.Equal(got[44:64], signer.Bytes()) {
+		t.Fatalf("signer word = %x, want …%x", got[32:64], signer.Bytes())
+	}
+}
+
+func TestPackControllerInstallSelectorAndShape(t *testing.T) {
+	controller := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	call, err := PackControllerInstall(controller)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// installValidation(bytes25,bytes4[],bytes,bytes[]) — the selector §0.1 of
+	// the master doc verified against deployed bytecode.
+	if sel := hex.EncodeToString(call[:4]); sel != "1bbf564c" {
+		t.Fatalf("selector = %s, want 1bbf564c", sel)
+	}
+
+	// The config word leads the arguments: bytes25 is right-padded to 32.
+	config := PackValidationConfig(SingleSignerValidationModuleAddress(), ControllerEntityID,
+		ValidationFlagGlobal|ValidationFlagUserOp)
+	if !bytes.Equal(call[4:4+25], config[:]) {
+		t.Fatalf("leading config = %x, want %x", call[4:4+25], config)
+	}
+
+	// The controller must be granted userOp + global but NEVER signature
+	// validation — the scoping §2.4 of the findings doc presents as the
+	// security improvement.
+	if config[24]&ValidationFlagSignature != 0 {
+		t.Fatal("controller install must not carry isSignatureValidation")
+	}
+}
+
+func TestPackControllerInstallRejectsZeroAddress(t *testing.T) {
+	if _, err := PackControllerInstall(common.Address{}); err == nil {
+		t.Fatal("expected an error for the zero controller address")
+	}
+}

--- a/core/chainio/aa/ma_v2_install_test.go
+++ b/core/chainio/aa/ma_v2_install_test.go
@@ -3,6 +3,7 @@ package aa
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -40,7 +41,7 @@ func TestPackSingleSignerInstallData(t *testing.T) {
 
 func TestPackSessionSignerInstallSelectorAndShape(t *testing.T) {
 	controller := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
-	call, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID, Signer: controller})
+	call, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID, Signer: controller, Global: true, AllowSelfAdministration: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +68,7 @@ func TestPackSessionSignerInstallSelectorAndShape(t *testing.T) {
 }
 
 func TestPackSessionSignerInstallRejectsZeroAddress(t *testing.T) {
-	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID}); err == nil {
+	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID, Global: true, AllowSelfAdministration: true}); err == nil {
 		t.Fatal("expected an error for the zero controller address")
 	}
 }
@@ -80,7 +81,7 @@ func TestSessionGrantEntityReachesBothEncodings(t *testing.T) {
 	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
 	const entity = uint32(7)
 
-	call, err := PackSessionSignerInstall(SessionGrant{EntityID: entity, Signer: signer})
+	call, err := PackSessionSignerInstall(SessionGrant{EntityID: entity, Signer: signer, Global: true, AllowSelfAdministration: true})
 	if err != nil {
 		t.Fatalf("PackSessionSignerInstall: %v", err)
 	}
@@ -103,8 +104,8 @@ func TestSessionGrantEntityReachesBothEncodings(t *testing.T) {
 func TestSessionGrantFlags(t *testing.T) {
 	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
 
-	t.Run("no selectors means global", func(t *testing.T) {
-		g := SessionGrant{EntityID: 1, Signer: signer}
+	t.Run("Global sets the global flag", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true}
 		if g.Flags()&ValidationFlagGlobal == 0 {
 			t.Error("expected the global flag")
 		}
@@ -113,9 +114,7 @@ func TestSessionGrantFlags(t *testing.T) {
 		}
 	})
 
-	// A global validation never consults the selector list, so setting both
-	// would silently widen a grant the owner believed was scoped.
-	t.Run("selectors clear global", func(t *testing.T) {
+	t.Run("selector-scoped grants are not global", func(t *testing.T) {
 		g := SessionGrant{EntityID: 1, Signer: signer, Selectors: [][4]byte{{0x09, 0x5e, 0xa7, 0xb3}}}
 		if g.Flags()&ValidationFlagGlobal != 0 {
 			t.Error("an enumerated selector set must not also be global")
@@ -126,7 +125,7 @@ func TestSessionGrantFlags(t *testing.T) {
 	// it sign arbitrary messages AS the user, which is not what execution
 	// authority means.
 	t.Run("signature validation is off unless asked for", func(t *testing.T) {
-		g := SessionGrant{EntityID: 1, Signer: signer}
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true}
 		if g.Flags()&ValidationFlagSignature != 0 {
 			t.Error("signature validation must default off")
 		}
@@ -141,7 +140,7 @@ func TestSessionGrantRejectsTheOwnerEntity(t *testing.T) {
 	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
 	// Entity 0 is the fallback signer. Installing over it would replace the
 	// owner's own validation with a gateway-held key.
-	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: 0, Signer: signer}); err == nil {
+	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: 0, Signer: signer, Global: true, AllowSelfAdministration: true}); err == nil {
 		t.Error("expected entity 0 to be rejected")
 	}
 }
@@ -152,18 +151,106 @@ func TestSessionGrantCarriesHooks(t *testing.T) {
 	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
 	hook := append(bytes.Repeat([]byte{0xab}, 26), 0x01, 0x02)
 
-	withHook, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Hooks: [][]byte{hook}})
+	withHook, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Global: true, Hooks: [][]byte{hook}, AllowSelfAdministration: true})
 	if err != nil {
 		t.Fatalf("PackSessionSignerInstall: %v", err)
 	}
 	if !bytes.Contains(withHook, hook) {
 		t.Error("hook payload is not present in the install call")
 	}
-	without, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer})
+	without, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Global: true, AllowSelfAdministration: true})
 	if err != nil {
 		t.Fatalf("PackSessionSignerInstall: %v", err)
 	}
 	if len(withHook) <= len(without) {
 		t.Error("hooks did not lengthen the encoded call")
 	}
+}
+
+// A global validation may call the account's own native functions. That is
+// how one-click self-revoke works (uninstallValidation, proven on Sepolia),
+// but the same authority reaches installValidation — so a bare global grant
+// can escalate itself: add signature validation, widen its hooks, install a
+// second signer.
+//
+// This previously WAS the default. Flags() inferred global from an empty
+// Selectors, so the plainest possible grant — entity and signer, nothing else
+// — produced the one shape that must never reach production. The rule lived in
+// a doc sentence while the code made violating it the path of least
+// resistance. It is now a build-time refusal.
+func TestBareGlobalGrantIsRefused(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	// The exact literal that used to be the easy, and wrong, thing to write.
+	_, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Global: true})
+	if err == nil {
+		t.Fatal("a global grant with no execution hook must be refused")
+	}
+	if !strings.Contains(err.Error(), "escalate itself") {
+		t.Errorf("the error should say why, got: %v", err)
+	}
+
+	t.Run("an execution hook makes it safe", func(t *testing.T) {
+		// The allowlist exec hook rejects non-execute selectors, which is what
+		// stopped the policied grant from revoking itself in the spike.
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true,
+			Hooks: [][]byte{AllowlistExecHook(1)}}
+		if !g.HasExecutionHook() {
+			t.Fatal("AllowlistExecHook was not recognised as an execution hook")
+		}
+		if _, err := PackSessionSignerInstall(g); err != nil {
+			t.Errorf("a hook-carrying global grant must be allowed: %v", err)
+		}
+	})
+
+	t.Run("a validation-only hook does not make it safe", func(t *testing.T) {
+		// TimeRange runs at validation, so it never sees the selector being
+		// executed and cannot block a self-administering call.
+		timeHook, err := TimeRangeValidationHook(1, 1785541743, 0)
+		if err != nil {
+			t.Fatalf("TimeRangeValidationHook: %v", err)
+		}
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true, Hooks: [][]byte{timeHook}}
+		if g.HasExecutionHook() {
+			t.Fatal("a validation hook must not count as an execution hook")
+		}
+		if _, err := PackSessionSignerInstall(g); err == nil {
+			t.Error("validation-only hooks must not satisfy the guard")
+		}
+	})
+
+	t.Run("selector scoping makes it safe", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer,
+			Selectors: [][4]byte{{0xb6, 0x1d, 0x27, 0xf6}}} // execute
+		if _, err := PackSessionSignerInstall(g); err != nil {
+			t.Errorf("a selector-scoped grant must be allowed: %v", err)
+		}
+	})
+
+	t.Run("the escape hatch is explicit", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true, AllowSelfAdministration: true}
+		if _, err := PackSessionSignerInstall(g); err != nil {
+			t.Errorf("an acknowledged self-administering grant must build: %v", err)
+		}
+	})
+}
+
+// Scope must be stated rather than inferred, in both directions.
+func TestGrantScopeMustBeUnambiguous(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	t.Run("no scope at all", func(t *testing.T) {
+		if _, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer}); err == nil {
+			t.Error("a grant with neither Global nor Selectors must be refused")
+		}
+	})
+
+	t.Run("both is wider than it reads", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true,
+			Selectors:               [][4]byte{{0xb6, 0x1d, 0x27, 0xf6}},
+			AllowSelfAdministration: true}
+		if _, err := PackSessionSignerInstall(g); err == nil {
+			t.Error("Global plus Selectors must be refused; the list is silently ignored on chain")
+		}
+	})
 }

--- a/core/chainio/aa/ma_v2_uninstall.go
+++ b/core/chainio/aa/ma_v2_uninstall.go
@@ -1,0 +1,120 @@
+package aa
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Revocation for Modular Account v2 session grants.
+//
+// uninstallValidation(bytes24 moduleEntity, bytes uninstallData,
+// bytes[] hookUninstallData), selector 0xb6b1ccfe. Like installValidation it
+// is annotated "may be validated by a global validation" in the account
+// source — which is why a BARE global session grant can revoke (or reinstall)
+// itself, and why a policied grant cannot: the allowlist's execution hook
+// reverts SpendingRequestNotAllowed for any selector that is not
+// execute/executeBatch. Both behaviors carry receipts in the results doc
+// §3.5. The owner always can, either as a UserOperation or as a plain
+// transaction straight to the account (fallback direct-call validation).
+//
+// hookUninstallData ordering is the account's, not the install's:
+// **validation hooks in STORED order (reverse of install — the hook set is a
+// prepend-on-add linked list), then execution hooks (same reversal)**, one
+// entry per installed hook or ArrayLengthMismatch. An entry routed to the
+// wrong module does NOT fail the uninstall: onUninstall reverts are caught,
+// flagged only in the ValidationUninstalled event, and the module state is
+// silently stranded. Verify cleanup by reading module state back, not by the
+// transaction succeeding.
+//
+// The uninstall payloads must be reconstructable at revoke time, which is
+// one more reason master §7.4a stores the grant's install_call rather than
+// re-deriving it: the AllowlistModule's uninstall data is the SAME
+// (entityId, inputs) tuple it was installed with — decode it from the stored
+// call, do not rebuild it from current code.
+
+// PackModuleEntity builds the bytes24 ModuleEntity:
+// module (20) ++ entityId (4, big-endian).
+func PackModuleEntity(module common.Address, entityID uint32) [24]byte {
+	var out [24]byte
+	copy(out[:20], module.Bytes())
+	out[20] = byte(entityID >> 24)
+	out[21] = byte(entityID >> 16)
+	out[22] = byte(entityID >> 8)
+	out[23] = byte(entityID)
+	return out
+}
+
+var (
+	uninstallOnce   sync.Once
+	uninstallABI    abi.ABI
+	uninstallABIErr error
+)
+
+func ensureUninstallABI() error {
+	uninstallOnce.Do(func() {
+		uninstallABI, uninstallABIErr = abi.JSON(strings.NewReader(`[
+		  {"type":"function","name":"uninstallValidation","stateMutability":"nonpayable",
+		   "inputs":[{"name":"validationFunction","type":"bytes24"},
+		             {"name":"uninstallData","type":"bytes"},
+		             {"name":"hookUninstallData","type":"bytes[]"}]}
+		]`))
+	})
+	return uninstallABIErr
+}
+
+// PackUninstallValidation encodes the uninstallValidation self-call.
+// hookUninstallData must have exactly one entry per installed hook, in the
+// account's stored order (see the package comment), or be empty to skip all
+// hook cleanup. An empty entry skips that one hook's onUninstall.
+func PackUninstallValidation(module common.Address, entityID uint32, uninstallData []byte, hookUninstallData [][]byte) ([]byte, error) {
+	if err := ensureUninstallABI(); err != nil {
+		return nil, err
+	}
+	if hookUninstallData == nil {
+		hookUninstallData = [][]byte{}
+	}
+	for i, entry := range hookUninstallData {
+		if entry == nil {
+			hookUninstallData[i] = []byte{}
+		}
+	}
+	return uninstallABI.Pack("uninstallValidation", PackModuleEntity(module, entityID), uninstallData, hookUninstallData)
+}
+
+// PackSingleSignerUninstallData encodes SingleSignerValidationModule's
+// onUninstall payload: abi.encode(uint32 entityId). The module zeroes the
+// signer for that entity.
+func PackSingleSignerUninstallData(entityID uint32) ([]byte, error) {
+	if err := ensureHookABIs(); err != nil {
+		return nil, err
+	}
+	// Single uint32 argument — reuse the time-range args' first element.
+	uint32Only := abi.Arguments{timeRangeDataArgs[0]}
+	return uint32Only.Pack(entityID)
+}
+
+// PackTimeRangeUninstallData encodes TimeRangeModule's onUninstall payload:
+// abi.encode(uint32 entityId) — note NOT the install tuple; the module only
+// needs the entity to delete its range.
+func PackTimeRangeUninstallData(entityID uint32) ([]byte, error) {
+	return PackSingleSignerUninstallData(entityID)
+}
+
+// PackSessionSignerUninstall encodes the revocation of a session grant
+// installed by PackSessionSignerInstall: the SingleSignerValidationModule
+// entity plus per-hook cleanup payloads supplied by the caller in the
+// account's stored hook order.
+func PackSessionSignerUninstall(entityID uint32, hookUninstallData [][]byte) ([]byte, error) {
+	if entityID < MinSessionEntityID {
+		return nil, fmt.Errorf("entity id %d is reserved (entity 0 is the owner's fallback signer)", entityID)
+	}
+	uninstallData, err := PackSingleSignerUninstallData(entityID)
+	if err != nil {
+		return nil, err
+	}
+	return PackUninstallValidation(SingleSignerValidationModuleAddress(), entityID, uninstallData, hookUninstallData)
+}

--- a/core/chainio/aa/ma_v2_uninstall_test.go
+++ b/core/chainio/aa/ma_v2_uninstall_test.go
@@ -1,0 +1,91 @@
+package aa
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestPackModuleEntity(t *testing.T) {
+	got := PackModuleEntity(SingleSignerValidationModuleAddress(), 1)
+	want := "00000000000099de0bf6fa90deb851e2a2df7d83" + "00000001"
+	if hex.EncodeToString(got[:]) != want {
+		t.Fatalf("ModuleEntity = %x, want %s", got, want)
+	}
+}
+
+func TestPackSessionSignerUninstallShape(t *testing.T) {
+	timeRangeData, err := PackTimeRangeUninstallData(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := PackSessionSignerUninstall(1, [][]byte{timeRangeData, nil, {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// uninstallValidation(bytes24,bytes,bytes[]) — cast sig 0xb6b1ccfe.
+	if sel := hex.EncodeToString(call[:4]); sel != "b6b1ccfe" {
+		t.Fatalf("selector = %s, want b6b1ccfe", sel)
+	}
+
+	// The ModuleEntity leads the arguments, right-padded to a word.
+	entity := PackModuleEntity(SingleSignerValidationModuleAddress(), 1)
+	if !bytes.Equal(call[4:4+24], entity[:]) {
+		t.Fatalf("leading module entity = %x, want %x", call[4:4+24], entity)
+	}
+
+	// The uninstall data is abi.encode(uint32 1) — a single word ending in 01.
+	uninstallData, err := PackSingleSignerUninstallData(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(uninstallData) != 32 || uninstallData[31] != 1 {
+		t.Fatalf("uninstall data = %x, want a single word of 1", uninstallData)
+	}
+	if !bytes.Contains(call, uninstallData) {
+		t.Fatal("the uninstall call does not carry the module's entity payload")
+	}
+}
+
+func TestPackSessionSignerUninstallRejectsOwnerEntity(t *testing.T) {
+	// Uninstalling entity 0 is not revocation, it is disabling the owner.
+	if _, err := PackSessionSignerUninstall(0, nil); err == nil {
+		t.Fatal("expected entity 0 to be rejected")
+	}
+}
+
+func TestUninstallAndTimeRangePayloadsMatch(t *testing.T) {
+	// Both modules take a bare abi.encode(uint32) on uninstall. If these ever
+	// diverge the shared implementation must split.
+	a, err := PackSingleSignerUninstallData(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := PackTimeRangeUninstallData(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Fatal("SSVM and TimeRange uninstall payloads diverged")
+	}
+}
+
+func TestPackUninstallValidationEmptyHookEntries(t *testing.T) {
+	// Empty entries (skip that hook's onUninstall) must encode as zero-length
+	// bytes, not nil-panic or drop from the array — the account requires one
+	// entry per installed hook.
+	data, err := PackSingleSignerUninstallData(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := PackUninstallValidation(common.HexToAddress("0x1111111111111111111111111111111111111111"), 2, data, [][]byte{nil, nil, nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(call) == 0 {
+		t.Fatal("empty call")
+	}
+}

--- a/core/config/bundler_provider_test.go
+++ b/core/config/bundler_provider_test.go
@@ -85,3 +85,29 @@ func TestBundlerConfigured(t *testing.T) {
 		t.Fatal("self_hosted without url should report not configured")
 	}
 }
+
+// The four chains the expansion targets must resolve to an Alchemy subdomain.
+// A missing entry is a hard error at send time (ActiveBundlerURL refuses to
+// guess), so it would surface as a chain that boots fine and then cannot
+// execute anything.
+func TestExpansionChainsHaveAlchemySubdomains(t *testing.T) {
+	for _, tc := range []struct {
+		chainID int64
+		want    string
+	}{
+		{56, "https://bnb-mainnet.g.alchemy.com/v2/K"},
+		{42161, "https://arb-mainnet.g.alchemy.com/v2/K"},
+		{999, "https://hyperliquid-mainnet.g.alchemy.com/v2/K"},
+		{4663, "https://robinhood-mainnet.g.alchemy.com/v2/K"},
+	} {
+		c := SmartWalletConfig{ChainID: tc.chainID, BundlerProvider: "alchemy", AlchemyAPIKey: "K"}
+		got, err := c.ActiveBundlerURL()
+		if err != nil {
+			t.Errorf("chain %d: %v", tc.chainID, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("chain %d: got %s, want %s", tc.chainID, got, tc.want)
+		}
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -240,6 +240,12 @@ type SmartWalletConfig struct {
 	// derives and deploys: Alchemy Modular Account v2 (the default), or the
 	// legacy v0.6 SimpleAccount fork. See AccountProviderName.
 	AccountProvider string
+
+	// GasManagerPolicyID is copied down from the top-level config so the v0.7
+	// send path — which is handed only a SmartWalletConfig — can request
+	// sponsorship without reaching back up. Empty means unsponsored: the
+	// operation is priced by estimation and the account pays its own gas.
+	GasManagerPolicyID string
 }
 
 // Bundler provider identifiers for SmartWalletConfig.BundlerProvider.
@@ -707,6 +713,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			PaymasterAddress:     common.HexToAddress(configRaw.SmartWallet.PaymasterAddress),
 			WhitelistAddresses:   convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
 			MaxWalletsPerOwner:   configRaw.SmartWallet.MaxWalletsPerOwner,
+			GasManagerPolicyID:   firstNonEmpty(configRaw.GasManagerPolicyID, os.Getenv("ALCHEMY_GAS_POLICY_ID")),
 			// PaymasterOwnerAddress will be populated below by calling owner() on the paymaster contract
 		},
 
@@ -822,6 +829,10 @@ func NewConfig(configFilePath string) (*Config, error) {
 				return nil, fmt.Errorf("parsing chain config for %s (chain_id=%d): %w",
 					chainRaw.Name, chainRaw.ChainID, err)
 			}
+			// Sponsorship is configured once for the gateway, not per chain, but
+			// the v0.7 send path is only ever handed a SmartWalletConfig. Push
+			// the policy down so every chain can reach it.
+			chainCfg.SmartWallet.GasManagerPolicyID = config.GasManagerPolicyID
 			config.Chains = append(config.Chains, chainCfg)
 		}
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -237,9 +237,8 @@ type SmartWalletConfig struct {
 	MaxWalletsPerOwner int
 
 	// AccountProvider selects which smart-account implementation this chain
-	// derives and deploys: the v0.6 SimpleAccount fork, or Alchemy Modular
-	// Account v2. See AccountProviderName for why this defaults to the OLD
-	// value, unlike BundlerProvider.
+	// derives and deploys: Alchemy Modular Account v2 (the default), or the
+	// legacy v0.6 SimpleAccount fork. See AccountProviderName.
 	AccountProvider string
 }
 
@@ -256,22 +255,21 @@ const (
 )
 
 // AccountProviderName returns the effective smart-account implementation,
-// defaulting to simple_account when unset.
+// defaulting to modular_account_v2 when unset.
 //
-// This defaults to the OLD value, which is the opposite of BundlerProvider —
-// and the difference is deliberate. Switching bundlers is invisible to users:
-// the same account sends the same operations through a different relay.
-// Switching account providers changes the DERIVED ADDRESS for every
-// (owner, salt), so defaulting to modular_account_v2 would silently move every
-// user's wallet the moment a gateway rolled out, orphaning their funds and
-// every task whose runner references the old address.
+// This default was flipped as part of the EntryPoint v0.7 cutover. Be aware of
+// what it means: the provider changes the DERIVED ADDRESS for every
+// (owner, salt), so a chain that omits account_provider resolves its users to
+// different wallets than it did under simple_account. That is the intended
+// migration, taken deliberately across all chains at once after an audit found
+// no meaningful balances in the v0.6 wallets.
 //
-// The switch is therefore opt-in per chain, so a rollout is a config change
-// that can be made one chain at a time and reverted, rather than a deploy.
+// simple_account remains selectable so a chain can be pinned to the legacy
+// derivation, but it is now the exception rather than the fallback.
 func (c *SmartWalletConfig) AccountProviderName() string {
 	p := strings.ToLower(strings.TrimSpace(c.AccountProvider))
 	if p == "" {
-		return AccountProviderSimpleAccount
+		return AccountProviderModularAccountV2
 	}
 	return p
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -48,7 +48,19 @@ const DefaultFactoryProxyAddressHex = "0xB99BC2E399e06CddCF5E725c0ea341E8f032283
 // DefaultEntrypointAddressHex is the default ERC-4337 EntryPoint address used
 // across supported chains. If the aggregator config omits the
 // smart_wallet.entrypoint_address field, this value will be used.
+//
+// This is the v0.6 EntryPoint, and smart_wallet.entrypoint_address configures
+// only the v0.6 path. Modular Account v2 operations run against
+// EntryPointV07AddressHex regardless of what the YAML says — read
+// SmartWalletConfig.EntryPointAddress() rather than the field, or you will
+// address the wrong contract on an MA v2 chain.
 const DefaultEntrypointAddressHex = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+
+// EntryPointV07AddressHex is the canonical ERC-4337 v0.7 EntryPoint, the same
+// address on every chain that has one. It is deliberately NOT configurable:
+// unlike the v0.6 deployment there is nothing per-chain to point at, and a
+// YAML override could only ever be wrong.
+const EntryPointV07AddressHex = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
 
 // NOTE: there is no DefaultPaymasterAddressHex. The paymaster contract
 // is deployed per network (mainnet and testnet have different addresses),
@@ -285,6 +297,22 @@ func (c *SmartWalletConfig) UsesModularAccountV2() bool {
 	return c.AccountProviderName() == AccountProviderModularAccountV2
 }
 
+// EntryPointAddress returns the EntryPoint this chain's operations actually
+// run against: the canonical v0.7 contract on an MA v2 chain, otherwise the
+// configured (v0.6) address.
+//
+// Prefer this over reading EntrypointAddress directly. That field is the v0.6
+// EntryPoint, and using it on an MA v2 chain addresses a contract the
+// operation never touches — which does not fail loudly. It produces userOp
+// hashes that match nothing on chain, and receipt polling that waits out its
+// full timeout looking for an event emitted somewhere else.
+func (c *SmartWalletConfig) EntryPointAddress() common.Address {
+	if c.UsesModularAccountV2() {
+		return common.HexToAddress(EntryPointV07AddressHex)
+	}
+	return c.EntrypointAddress
+}
+
 // ValidateAccountProvider rejects an unrecognised value rather than silently
 // falling back. A typo would otherwise derive v0.6 addresses on a chain the
 // operator believed was on MA v2 — and the mistake is only visible as users
@@ -309,6 +337,14 @@ var alchemyNetworkSubdomain = map[int64]string{
 	8453:     "base-mainnet",
 	84532:    "base-sepolia",
 	56:       "bnb-mainnet",
+	// Chain IDs read from each chain's own eth_chainId rather than from
+	// documentation, and each verified to carry the canonical EntryPoint v0.7
+	// (16,035 bytes) and Modular Account v2 factory (6,661 bytes) at the
+	// standard addresses — byte-identical to Sepolia, where operations have
+	// actually landed.
+	42161: "arb-mainnet",
+	999:   "hyperliquid-mainnet",
+	4663:  "robinhood-mainnet",
 }
 
 // ProviderName returns the effective bundler provider, defaulting to alchemy

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -6,21 +6,21 @@ import "testing"
 // defaults have to agree: config decides what the gateway believes, aa decides
 // what gets derived. If they ever diverge, wallets get recorded under one
 // provider and derived under the other.
-func TestAccountProviderDefaultsToSimpleAccount(t *testing.T) {
+func TestAccountProviderDefaultsToModularAccountV2(t *testing.T) {
 	var c SmartWalletConfig
-	if got := c.AccountProviderName(); got != AccountProviderSimpleAccount {
-		t.Fatalf("default = %q, want %q — defaulting to MA v2 would move every existing wallet",
-			got, AccountProviderSimpleAccount)
+	if got := c.AccountProviderName(); got != AccountProviderModularAccountV2 {
+		t.Fatalf("default = %q, want %q — the v0.7 cutover made MA v2 the default on every chain",
+			got, AccountProviderModularAccountV2)
 	}
-	if c.UsesModularAccountV2() {
-		t.Error("UsesModularAccountV2 is true by default")
+	if !c.UsesModularAccountV2() {
+		t.Error("UsesModularAccountV2 is false by default")
 	}
 }
 
 func TestAccountProviderNormalisation(t *testing.T) {
 	for in, want := range map[string]string{
-		"":                      AccountProviderSimpleAccount,
-		"  ":                    AccountProviderSimpleAccount,
+		"":                      AccountProviderModularAccountV2,
+		"  ":                    AccountProviderModularAccountV2,
 		"simple_account":        AccountProviderSimpleAccount,
 		"MODULAR_ACCOUNT_V2":    AccountProviderModularAccountV2,
 		" modular_account_v2  ": AccountProviderModularAccountV2,
@@ -51,18 +51,23 @@ func TestValidateAccountProvider(t *testing.T) {
 }
 
 // Before this was wired, ValidateAccountProvider existed but was never called
-// during config load: a typo like "mav2" was accepted, AccountProviderName()
-// returned it verbatim, and UsesModularAccountV2() went false — so a chain the
-// operator believed was on MA v2 silently handed users v0.6 addresses. The
-// function existing is not the same as it running.
-func TestTypoWouldSilentlyReadAsSimpleAccount(t *testing.T) {
+// during config load. A typo like "mav2" was accepted and returned verbatim by
+// AccountProviderName(), so UsesModularAccountV2() went false on a chain the
+// operator believed was on MA v2. The function existing is not the same as it
+// running.
+//
+// Since the default flipped, a typo no longer degrades to v0.6 addresses — it
+// reaches aa.DeriveSenderAddress as an unknown provider and errors there. That
+// is a louder failure but a much later one, at the first wallet derivation
+// rather than at boot, which is why validation at load still matters.
+func TestTypoIsRejectedAtLoad(t *testing.T) {
 	c := SmartWalletConfig{AccountProvider: "mav2"}
 
 	if c.UsesModularAccountV2() {
 		t.Fatal("precondition changed")
 	}
-	// This is the trap: it looks harmless. Only validation catches it.
+	// This is the trap: it looks harmless. Only validation catches it early.
 	if err := c.ValidateAccountProvider(); err == nil {
-		t.Fatal("a typo must be rejected; otherwise it degrades silently to simple_account")
+		t.Fatal("a typo must be rejected at config load, not at first derivation")
 	}
 }

--- a/core/config/entrypoint_test.go
+++ b/core/config/entrypoint_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// EntrypointAddress (the YAML field) is the v0.6 EntryPoint. Using it on an
+// MA v2 chain does not fail loudly — it produces userOp hashes that match
+// nothing on chain, and receipt polling that waits out its full timeout
+// watching a contract the operation never touched.
+func TestEntryPointAddressFollowsAccountProvider(t *testing.T) {
+	configured := common.HexToAddress(DefaultEntrypointAddressHex)
+	v07 := common.HexToAddress(EntryPointV07AddressHex)
+
+	if configured == v07 {
+		t.Fatal("the v0.6 and v0.7 EntryPoints must be different addresses")
+	}
+
+	t.Run("MA v2 uses the canonical v0.7 EntryPoint", func(t *testing.T) {
+		c := SmartWalletConfig{
+			EntrypointAddress: configured,
+			AccountProvider:   AccountProviderModularAccountV2,
+		}
+		if got := c.EntryPointAddress(); got != v07 {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), v07.Hex())
+		}
+	})
+
+	t.Run("unset provider is MA v2, so also v0.7", func(t *testing.T) {
+		c := SmartWalletConfig{EntrypointAddress: configured}
+		if got := c.EntryPointAddress(); got != v07 {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), v07.Hex())
+		}
+	})
+
+	t.Run("simple_account keeps the configured address", func(t *testing.T) {
+		c := SmartWalletConfig{
+			EntrypointAddress: configured,
+			AccountProvider:   AccountProviderSimpleAccount,
+		}
+		if got := c.EntryPointAddress(); got != configured {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), configured.Hex())
+		}
+	})
+
+	// A YAML override must still reach the v0.6 path — it is the only
+	// EntryPoint that is per-deployment.
+	t.Run("simple_account honours a YAML override", func(t *testing.T) {
+		custom := common.HexToAddress("0x00000000000000000000000000000000000000ee")
+		c := SmartWalletConfig{
+			EntrypointAddress: custom,
+			AccountProvider:   AccountProviderSimpleAccount,
+		}
+		if got := c.EntryPointAddress(); got != custom {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), custom.Hex())
+		}
+	})
+}

--- a/core/taskengine/aave_integration_sepolia_test.go
+++ b/core/taskengine/aave_integration_sepolia_test.go
@@ -62,7 +62,7 @@ func TestAAVEHealthFactorContractRead(t *testing.T) {
 		t.Skip("OWNER_EOA or TEST_PRIVATE_KEY not set, skipping AAVE integration test")
 	}
 	smartWalletConfig := config.SmartWallet
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	setGlobalFactory(t, smartWalletConfig)
 	client, err := ethclient.Dial(smartWalletConfig.EthRpcUrl)
 	require.NoError(t, err, "Failed to connect to RPC")
 	defer client.Close()

--- a/core/taskengine/account_provider_consistency_test.go
+++ b/core/taskengine/account_provider_consistency_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // `aa` deliberately redeclares AccountProvider as its own string type instead
@@ -38,7 +39,7 @@ func TestAccountProviderConstantsMatchAcrossPackages(t *testing.T) {
 }
 
 // Both packages must also agree on what an unset value means. If config
-// defaulted to simple_account while aa defaulted to modular_account_v2 (or
+// defaulted to modular_account_v2 while aa defaulted to simple_account (or
 // vice versa), a chain with no account_provider set would be recorded as one
 // and derived as the other.
 func TestAccountProviderDefaultsAgreeAcrossPackages(t *testing.T) {
@@ -46,21 +47,29 @@ func TestAccountProviderDefaultsAgreeAcrossPackages(t *testing.T) {
 	configDefault := swCfg.AccountProviderName()
 
 	// aa's default is observable through the factory it selects for an empty
-	// provider: SimpleAccount uses the supplied factory, MA v2 ignores it.
-	simpleFactory := MAv2WalletFactory() // any non-zero address works as a probe
-	got, err := aa.FactoryAddressForProvider("", simpleFactory)
+	// provider: SimpleAccount echoes back the supplied factory, MA v2 ignores
+	// it and returns its own constant. The probe must therefore be an address
+	// that is NOT the MA v2 factory, or the two branches are indistinguishable.
+	probeFactory := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	if probeFactory == MAv2WalletFactory() {
+		t.Fatal("probe address collides with the MA v2 factory; pick another")
+	}
+	got, err := aa.FactoryAddressForProvider("", probeFactory)
 	if err != nil {
 		t.Fatalf("aa.FactoryAddressForProvider(\"\"): %v", err)
 	}
 
-	aaDefaultIsSimple := got == simpleFactory
+	aaDefaultIsSimple := got == probeFactory
 	configDefaultIsSimple := configDefault == config.AccountProviderSimpleAccount
 
 	if aaDefaultIsSimple != configDefaultIsSimple {
 		t.Fatalf("default mismatch: config says %q, aa resolves an empty provider differently",
 			configDefault)
 	}
-	if !configDefaultIsSimple {
-		t.Fatal("default is no longer simple_account; enabling MA v2 by default moves every existing wallet")
+	// The EntryPoint v0.7 cutover made MA v2 the default on every chain. If
+	// this flips back, an unconfigured chain silently returns to v0.6
+	// derivation and every wallet address moves again.
+	if configDefault != config.AccountProviderModularAccountV2 {
+		t.Fatalf("default is %q, want %q", configDefault, config.AccountProviderModularAccountV2)
 	}
 }

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -66,7 +66,9 @@ type ChainStateReader interface {
 
 	// GetSmartWalletAddress derives the CREATE2 smart-wallet address for
 	// (owner, salt) under the given factory on this chain. Mirrors
-	// aa.GetSenderAddressForFactory.
+	// aa.DeriveSenderAddressAuto — the factory determines which account
+	// implementation (and therefore which derivation ABI) is used, so callers
+	// must pass the factory they actually mean. See aa.EffectiveFactory.
 	GetSmartWalletAddress(ctx context.Context, owner, factory common.Address, salt *big.Int) (common.Address, error)
 
 	// CallContract executes a read-only contract call (eth_call) at the
@@ -219,7 +221,7 @@ func (d *directChainStateReader) GetSmartWalletAddress(_ context.Context, owner,
 	if salt == nil {
 		salt = big.NewInt(0)
 	}
-	addr, err := aa.GetSenderAddressForFactory(d.client, owner, factory, salt)
+	addr, err := aa.DeriveSenderAddressAuto(d.client, owner, factory, salt)
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -283,7 +285,7 @@ func (d *directChainStateReader) FindMatchingWalletSalt(ctx context.Context, own
 		if err := ctx.Err(); err != nil {
 			return false, 0, err
 		}
-		addr, err := aa.GetSenderAddressForFactory(d.client, owner, factory, big.NewInt(salt))
+		addr, err := aa.DeriveSenderAddressAuto(d.client, owner, factory, big.NewInt(salt))
 		if err != nil {
 			lastErr = err
 			errCount++

--- a/core/taskengine/effective_factory_testhelper_test.go
+++ b/core/taskengine/effective_factory_testhelper_test.go
@@ -1,0 +1,23 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+// effectiveFactoryHex is the factory a chain actually creates wallets under.
+//
+// Tests used to assert against smart_wallet.factory_address directly. Since
+// the EntryPoint v0.7 cutover that is only the SimpleAccount factory, while an
+// MA v2 chain records wallets under the MA v2 constant — so asserting the
+// configured value tests a wallet the engine no longer creates.
+func effectiveFactoryHex(t *testing.T, swCfg *config.SmartWalletConfig) string {
+	t.Helper()
+	factory, err := aa.EffectiveFactory(swCfg)
+	if err != nil {
+		t.Fatalf("resolving effective factory: %v", err)
+	}
+	return factory.Hex()
+}

--- a/core/taskengine/effective_factory_testhelper_test.go
+++ b/core/taskengine/effective_factory_testhelper_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // effectiveFactoryHex is the factory a chain actually creates wallets under.
@@ -20,4 +21,29 @@ func effectiveFactoryHex(t *testing.T, swCfg *config.SmartWalletConfig) string {
 		t.Fatalf("resolving effective factory: %v", err)
 	}
 	return factory.Hex()
+}
+
+// setGlobalFactory points aa's package-global factory at the one this chain
+// actually creates accounts under.
+//
+// Tests used to call setGlobalFactory(t, cfg.SmartWallet)
+// directly. That field is the v0.6 SimpleAccountFactory, and since
+// aa.GetSenderAddress infers the account implementation from the global, those
+// tests forced themselves onto v0.6 derivation while the engine they were
+// exercising derived MA v2 — so the runner never matched any derived address.
+func setGlobalFactory(t *testing.T, swCfg *config.SmartWalletConfig) {
+	t.Helper()
+	if err := aa.SetFactoryAddressForConfig(swCfg); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
+}
+
+// effectiveFactoryAddr is effectiveFactoryHex as an address.
+func effectiveFactoryAddr(t *testing.T, swCfg *config.SmartWalletConfig) common.Address {
+	t.Helper()
+	factory, err := aa.EffectiveFactory(swCfg)
+	if err != nil {
+		t.Fatalf("resolving effective factory: %v", err)
+	}
+	return factory
 }

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -389,7 +389,9 @@ func New(db storage.Storage, config *config.Config, queue *apqueue.Queue, logger
 	SetMacroSecrets(config.MacroSecrets)
 
 	SetRpc(config.SmartWallet.EthRpcUrl)
-	aa.SetFactoryAddress(config.SmartWallet.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(config.SmartWallet); err != nil {
+		panic(fmt.Sprintf("smart_wallet: cannot resolve account factory: %v", err))
+	}
 	//SetWsRpc(config.SmartWallet.EthWsUrl)
 
 	// Use global TokenEnrichmentService or initialize if not set
@@ -1096,13 +1098,18 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 	walletsToReturnProto := []*avsproto.SmartWallet{}
 	processedAddresses := make(map[string]bool)
 
-	defaultSystemFactory := n.smartWalletConfig.FactoryAddress
+	// The chain's CURRENT factory, not the raw configured one: on an MA v2
+	// chain those differ, and deriving against the configured SimpleAccount
+	// factory would hand the user their pre-cutover address.
+	defaultSystemFactory, factoryErr := aa.EffectiveFactory(n.smartWalletConfig)
 	var defaultDerivedAddress *common.Address
 	var deriveErr error
 
 	// Only try to derive default address if rpcConn is available
-	if rpcConn != nil {
-		defaultDerivedAddress, deriveErr = aa.GetSenderAddressForFactory(rpcConn, owner, defaultSystemFactory, defaultSalt)
+	if factoryErr != nil {
+		deriveErr = factoryErr
+	} else if rpcConn != nil {
+		defaultDerivedAddress, deriveErr = aa.DeriveSenderAddressAuto(rpcConn, owner, defaultSystemFactory, defaultSalt)
 	} else {
 		// In test environment or when RPC is unavailable, skip default derivation
 		n.logger.Debug("Skipping default wallet derivation due to nil rpcConn (test environment)", "owner", owner.Hex())
@@ -1342,7 +1349,13 @@ func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, pay
 		}
 	}
 
-	factoryAddr := swCfg.FactoryAddress
+	factoryAddr, factoryErr := aa.EffectiveFactory(swCfg)
+	if factoryErr != nil {
+		return nil, status.Errorf(codes.Internal, "GetWallet: resolve factory: %v", factoryErr)
+	}
+	// An explicit factory still wins — that is how a caller reaches a wallet
+	// created under the pre-cutover factory, whose provider is then inferred
+	// from the address itself rather than from this chain's config.
 	if payload.GetFactoryAddress() != "" {
 		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
@@ -1413,7 +1426,7 @@ func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, pay
 				"GetWallet: cannot reach chain %d RPC: %v", chainID, dialErr)
 		}
 		defer chainRPC.Close()
-		derivedSenderAddress, err = aa.GetSenderAddressForFactory(chainRPC, user.Address, factoryAddr, saltBig)
+		derivedSenderAddress, err = aa.DeriveSenderAddressAuto(chainRPC, user.Address, factoryAddr, saltBig)
 		if err != nil {
 			n.logger.Error("GetWallet: factory.getAddress() failed",
 				"chain_id", chainID, "owner", user.Address.Hex(), "factory", factoryAddr.Hex(),
@@ -1527,7 +1540,10 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid salt format: %s", payload.GetSalt())
 	}
 
-	factoryAddr := n.smartWalletConfig.FactoryAddress // Default factory
+	factoryAddr, factoryErr := aa.EffectiveFactory(n.smartWalletConfig) // Default factory
+	if factoryErr != nil {
+		return nil, status.Errorf(codes.Internal, "SetWallet: resolve factory: %v", factoryErr)
+	}
 	if payload.GetFactoryAddress() != "" {
 		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
@@ -1536,7 +1552,7 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, err
 	}
 
-	derivedWalletAddress, err := aa.GetSenderAddressForFactory(rpcConn, owner, factoryAddr, saltBig)
+	derivedWalletAddress, err := aa.DeriveSenderAddressAuto(rpcConn, owner, factoryAddr, saltBig)
 	if err != nil {
 		n.logger.Error("Failed to derive wallet address for SetWallet", "owner", owner.Hex(), "salt", payload.GetSalt(), "factory", payload.GetFactoryAddress(), "error", err)
 		return nil, status.Errorf(codes.Internal, "Failed to derive wallet address: %v", err)

--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -43,7 +43,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	t.Logf("   Chain: Sepolia (ID: %d)", cfg.SmartWallet.ChainID)
 
 	// Set factory for AA library
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("   Computing salt:0 smart wallet address...")
 
 	// Connect to Sepolia

--- a/core/taskengine/execute_uniswap_approval_test.go
+++ b/core/taskengine/execute_uniswap_approval_test.go
@@ -34,7 +34,7 @@ func TestExecuteTask_UniswapApprovalAndSwap_DifferentApprovalAmounts_Sepolia(t *
 
 	// Derive smart wallet address from OWNER_EOA + salt:2
 	// Using salt=2 for address 0x5a8A8a79DdF433756D4D97DCCE33334D9E218856 which has proper balance
-	aa.SetFactoryAddress(config.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, config.SmartWallet)
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 	require.NoError(t, err, "Failed to connect to RPC")
 	defer client.Close()

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -1212,7 +1212,11 @@ func (x *WorkflowExecutor) validateWalletOwnership(ctx context.Context, chainID 
 	if swCfg != nil {
 		if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
 			// Gateway mode: derive salt:0 via the chain worker (no gateway dial).
-			if addr, derr := reader.GetSmartWalletAddress(ctx, user.Address, swCfg.FactoryAddress, big.NewInt(0)); derr == nil {
+			defaultFactory, factoryErr := aa.EffectiveFactory(swCfg)
+			if factoryErr != nil {
+				x.logger.Warn("Failed to resolve factory for validation",
+					"chain_id", chainID, "error", factoryErr)
+			} else if addr, derr := reader.GetSmartWalletAddress(ctx, user.Address, defaultFactory, big.NewInt(0)); derr == nil {
 				user.SmartAccountAddress = &addr
 			} else {
 				x.logger.Warn("Failed to load default smart wallet for validation",
@@ -1261,7 +1265,14 @@ func (x *WorkflowExecutor) validateWalletOwnership(ctx context.Context, chainID 
 // passing it in (rather than reading x.smartWalletConfig) is what makes
 // this work in gateway mode where the executor is shared across chains.
 func (x *WorkflowExecutor) validateDerivedWallet(ctx context.Context, chainID int64, swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
-	factoryAddr := swCfg.FactoryAddress
+	// Scans this chain's CURRENT factory only. After the v0.7 cutover that is
+	// the MA v2 factory, so a pre-cutover v0.6 wallet no longer validates by
+	// derivation — it validates through its stored record in step 2 of
+	// validateWalletOwnership, which is where existing wallets are recognised.
+	factoryAddr, factoryErr := aa.EffectiveFactory(swCfg)
+	if factoryErr != nil {
+		return false, factoryErr
+	}
 
 	// Try salt values from 0 to max_wallets_per_owner to see if any produce the target wallet address
 	// This uses the configured limit from aggregator.yaml
@@ -1296,7 +1307,7 @@ func (x *WorkflowExecutor) validateDerivedWallet(ctx context.Context, chainID in
 	defer rpcClient.Close()
 
 	for salt := int64(0); salt < maxWallets; salt++ {
-		derivedAddr, derr := aa.GetSenderAddressForFactory(rpcClient, owner, factoryAddr, big.NewInt(salt))
+		derivedAddr, derr := aa.DeriveSenderAddressAuto(rpcClient, owner, factoryAddr, big.NewInt(salt))
 		if derr != nil {
 			x.logger.Debug("Failed to derive wallet address",
 				"owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt, "error", derr)

--- a/core/taskengine/fee_estimator.go
+++ b/core/taskengine/fee_estimator.go
@@ -352,22 +352,22 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 		gasPrice = big.NewInt(int64(DefaultGasPrice))
 	}
 
-	// Build createAccount calldata using the factory ABI.
-	factoryAddress := fe.smartWalletConfig.FactoryAddress
-	initCodeHex, err := aa.GetInitCodeForFactory(walletAddress.Hex(), factoryAddress, big.NewInt(0))
+	// Build account-creation calldata against the factory this chain actually
+	// deploys with — the method differs between SimpleAccount and MA v2, so
+	// estimating against the configured SimpleAccount factory on an MA v2
+	// chain would price a deployment that never happens.
+	factoryAddress, err := aa.EffectiveFactory(fe.smartWalletConfig)
 	if err != nil {
-		fe.logger.Warn("Failed to build createAccount calldata, using fallback gas estimate",
+		fe.logger.Warn("Failed to resolve account factory, using fallback gas estimate",
 			"error", err, "fallback_gas", fallbackCreationGas)
 		return big.NewInt(fallbackCreationGas), gasPrice, nil
 	}
-
-	// initCode = factoryAddress (20 bytes) + calldata, so strip the factory address prefix
-	initCodeBytes := common.FromHex(initCodeHex)
-	if len(initCodeBytes) <= 20 {
-		fe.logger.Warn("InitCode too short, using fallback gas estimate", "fallback_gas", fallbackCreationGas)
+	factoryAddress, calldata, err := aa.DeriveInitCodeAuto(walletAddress, factoryAddress, big.NewInt(0))
+	if err != nil {
+		fe.logger.Warn("Failed to build account-creation calldata, using fallback gas estimate",
+			"error", err, "fallback_gas", fallbackCreationGas)
 		return big.NewInt(fallbackCreationGas), gasPrice, nil
 	}
-	calldata := initCodeBytes[20:]
 
 	// Estimate gas via eth_estimateGas against the factory contract
 	estimatedGas, err := fe.chain.EstimateGas(ctx, ethereum.CallMsg{

--- a/core/taskengine/list_wallets_storage_test.go
+++ b/core/taskengine/list_wallets_storage_test.go
@@ -34,7 +34,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	// Find the default wallet in the response
 	var defaultWallet *avsproto.SmartWallet
 	for _, w := range listResp.Items {
-		if w.Salt == "0" && w.Factory == config.SmartWallet.FactoryAddress.Hex() {
+		if w.Salt == "0" && w.Factory == effectiveFactoryHex(t, config.SmartWallet) {
 			defaultWallet = w
 			break
 		}
@@ -52,7 +52,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, defaultWallet.Address, storedWallet.Address.Hex(), "Stored wallet address should match")
 	assert.Equal(t, "0", storedWallet.Salt.String(), "Stored wallet salt should be 0")
-	assert.Equal(t, config.SmartWallet.FactoryAddress.Hex(), storedWallet.Factory.Hex(), "Stored wallet factory should match")
+	assert.Equal(t, effectiveFactoryHex(t, config.SmartWallet), storedWallet.Factory.Hex(), "Stored wallet factory should match")
 	assert.False(t, storedWallet.IsHidden, "Default wallet should not be hidden")
 }
 
@@ -194,7 +194,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	// Verify all wallets belong to the same owner
 	for address, wallet := range storedAddresses {
 		assert.Equal(t, user.Address, *wallet.Owner, "Wallet %s should belong to test user", address)
-		assert.Equal(t, config.SmartWallet.FactoryAddress.Hex(), wallet.Factory.Hex(), "Wallet %s should use default factory", address)
+		assert.Equal(t, effectiveFactoryHex(t, config.SmartWallet), wallet.Factory.Hex(), "Wallet %s should use default factory", address)
 	}
 }
 
@@ -327,7 +327,7 @@ func TestListWalletsDatabaseStateVerification(t *testing.T) {
 	for addr, wallet := range wallets1 {
 		salt0Address = addr
 		assert.Equal(t, "0", wallet.Salt.String(), "First wallet should have salt 0")
-		assert.Equal(t, config.SmartWallet.FactoryAddress.Hex(), wallet.Factory.Hex(), "Wallet should use default factory")
+		assert.Equal(t, effectiveFactoryHex(t, config.SmartWallet), wallet.Factory.Hex(), "Wallet should use default factory")
 		assert.Equal(t, user.Address, *wallet.Owner, "Wallet should belong to test user")
 		assert.False(t, wallet.IsHidden, "Wallet should not be hidden")
 		break

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2685,7 +2685,10 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 					// runs the scan server-side. Fall back to a direct dial +
 					// local loop when no reader is registered.
 					const runnerSaltScan = int64(5)
-					factoryAddr := n.smartWalletConfig.FactoryAddress
+					factoryAddr, factoryErr := aa.EffectiveFactory(n.smartWalletConfig)
+					if factoryErr != nil {
+						return nil, fmt.Errorf("failed to resolve factory for runner validation: %w", factoryErr)
+					}
 					runnerAddr := common.HexToAddress(runnerStr)
 					if reader := GetChainStateReaderForChain(uint64(n.smartWalletConfig.ChainID)); reader != nil {
 						found, salt, derr := reader.FindMatchingWalletSalt(ctx, vm.TaskOwner, factoryAddr, runnerAddr, runnerSaltScan)
@@ -2702,7 +2705,7 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 							return nil, fmt.Errorf("failed to connect to RPC for address derivation: %w", err)
 						}
 						for salt := int64(0); salt < runnerSaltScan; salt++ {
-							derivedAddr, derr := aa.GetSenderAddress(client, vm.TaskOwner, big.NewInt(salt))
+							derivedAddr, derr := aa.DeriveSenderAddressAuto(client, vm.TaskOwner, factoryAddr, big.NewInt(salt))
 							if derr != nil {
 								if n.logger != nil {
 									n.logger.Debug("Failed to derive address for salt", "salt", salt, "error", derr)

--- a/core/taskengine/run_node_immediately_missing_dependencies_test.go
+++ b/core/taskengine/run_node_immediately_missing_dependencies_test.go
@@ -34,7 +34,7 @@ func TestRunNodeImmediately_ContractWrite_MissingNodeDependency(t *testing.T) {
 	}
 
 	ownerEOA := *ownerAddr
-	factory := config.SmartWallet.FactoryAddress
+	factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 	// Connect to RPC client for GetSenderAddress
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)

--- a/core/taskengine/run_node_immediately_rpc_test.go
+++ b/core/taskengine/run_node_immediately_rpc_test.go
@@ -29,7 +29,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		// Create test user (simulating authenticated user from JWT)
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -271,7 +271,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		// Create test user (simulating authenticated user from JWT)
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -441,7 +441,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		// reliably and the balance override is never masked by a real balance.
 		ownerEOA := common.HexToAddress("0xe8a78b476AE1403b7fD39b662545AE608Aced7c7")
 
-		aa.SetFactoryAddress(config.SmartWallet.FactoryAddress)
+		setGlobalFactory(t, config.SmartWallet)
 		client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 		require.NoError(t, err, "Failed to connect to RPC")
 		defer client.Close()

--- a/core/taskengine/run_node_immediately_settings_test.go
+++ b/core/taskengine/run_node_immediately_settings_test.go
@@ -23,7 +23,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		// Create test user (simulating authenticated user from JWT)
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()

--- a/core/taskengine/run_node_immediately_tuple_test.go
+++ b/core/taskengine/run_node_immediately_tuple_test.go
@@ -33,7 +33,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 	}
 
 	ownerEOA := *ownerAddr
-	factory := config.SmartWallet.FactoryAddress
+	factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 	// Connect to RPC client for GetSenderAddress
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)

--- a/core/taskengine/run_node_with_inputs_simulation_mode_test.go
+++ b/core/taskengine/run_node_with_inputs_simulation_mode_test.go
@@ -57,7 +57,7 @@ func TestRunNodeWithInputsRespectsIsSimulatedFlag(t *testing.T) {
 			engine := New(db, config, nil, testutil.GetLogger())
 
 			smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-			aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+			setGlobalFactory(t, smartWalletConfig)
 
 			// Create test user (simulating authenticated user from JWT)
 			ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -246,7 +246,7 @@ func TestRunNodeWithInputsDefaultsToSimulation(t *testing.T) {
 	engine := New(db, config, nil, testutil.GetLogger())
 
 	smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	setGlobalFactory(t, smartWalletConfig)
 
 	// Create test user
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()

--- a/core/taskengine/simulate_sequential_contract_writes_test.go
+++ b/core/taskengine/simulate_sequential_contract_writes_test.go
@@ -43,7 +43,7 @@ func TestSimulateTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	t.Logf("   Chain: Sepolia (ID: %d)", cfg.SmartWallet.ChainID)
 
 	// Set factory for AA library
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("   Computing salt:0 smart wallet address...")
 
 	// Connect to Sepolia

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -51,7 +51,7 @@ func TestSimulateTask_StopLossWorkflow_Sepolia(t *testing.T) {
 	cfg, err := config.NewConfig(testutil.GetConfigPath(testutil.DefaultConfigPath))
 	require.NoError(t, err, "load aggregator config")
 
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 
 	client, err := ethclient.Dial(cfg.SmartWallet.EthRpcUrl)
 	require.NoError(t, err, "connect to Sepolia RPC")

--- a/core/taskengine/userops_batch_swap_test.go
+++ b/core/taskengine/userops_batch_swap_test.go
@@ -68,7 +68,7 @@ func TestUserOpAtomicBatch_Sepolia(t *testing.T) {
 	require.NoError(t, err, "Failed to connect to RPC")
 	t.Cleanup(func() { client.Close() })
 
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 
 	smartWalletAddress, err := aa.GetSenderAddress(client, ownerAddress, big.NewInt(0))
 	require.NoError(t, err, "Failed to derive smart wallet address")

--- a/core/taskengine/userops_withdraw_all_test.go
+++ b/core/taskengine/userops_withdraw_all_test.go
@@ -85,7 +85,7 @@ func TestWithdrawAllETH_Sepolia(t *testing.T) {
 	t.Cleanup(func() { client.Close() })
 
 	// Set factory address for smart wallet derivation
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("🔧 Set factory address: %s", cfg.SmartWallet.FactoryAddress.Hex())
 
 	// Always derive smart wallet address from owner + salt:0 using GetSenderAddress

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -60,7 +60,7 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 	t.Cleanup(func() { client.Close() })
 
 	// Set factory address for smart wallet derivation
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 
 	// Always derive smart wallet address from owner + salt:0
 	// This ensures consistency and tests the auto-creation flow
@@ -489,7 +489,7 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 	t.Cleanup(func() { client.Close() })
 
 	// Set factory address for smart wallet derivation
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("🔧 Set factory address: %s", cfg.SmartWallet.FactoryAddress.Hex())
 
 	// Always derive smart wallet address from owner + salt:0

--- a/core/taskengine/utils_calldata_test.go
+++ b/core/taskengine/utils_calldata_test.go
@@ -559,7 +559,7 @@ func TestContractWrite_InvalidNumericValue_ResponseStructure(t *testing.T) {
 
 	// Get smart wallet address for settings
 	smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	setGlobalFactory(t, smartWalletConfig)
 
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 	require.NoError(t, err, "Failed to connect to RPC")

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1671,7 +1671,7 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 		v.logger.Info("🔍 VM DEBUG - Smart wallet config details",
 			"bundler_url", swConfig.BundlerURL,
 			"factory_address", swConfig.FactoryAddress,
-			"entrypoint_address", swConfig.EntrypointAddress,
+			"entrypoint_address", swConfig.EntryPointAddress(),
 			"eth_rpc_url", swConfig.EthRpcUrl)
 	} else {
 		v.logger.Warn("⚠️ VM DEBUG - Smart wallet config is NIL in VM!")

--- a/core/taskengine/vm_contract_write_waiting.go
+++ b/core/taskengine/vm_contract_write_waiting.go
@@ -121,7 +121,9 @@ func (v *VM) waitForUserOpConfirmation(userOpHash string) (*waitForUserOpConfirm
 		return nil, fmt.Errorf("failed to create bundler client: %w", err)
 	}
 
-	entrypoint := v.smartWalletConfig.EntrypointAddress
+	// The EntryPoint the operation actually ran against, not the configured
+	// v0.6 address — polling the wrong one just waits out the full timeout.
+	entrypoint := v.smartWalletConfig.EntryPointAddress()
 
 	v.logger.Info("⏳ Waiting for UserOp confirmation",
 		"userOpHash", userOpHash,

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -399,7 +399,7 @@ func (r *ContractWriteProcessor) executeMethodCall(
 		r.vm.logger.Info("🔍 CONTRACT WRITE DEBUG - Smart Wallet Config Details",
 			"bundler_url", r.smartWalletConfig.BundlerURL,
 			"factory_address", r.smartWalletConfig.FactoryAddress,
-			"entrypoint_address", r.smartWalletConfig.EntrypointAddress)
+			"entrypoint_address", r.smartWalletConfig.EntryPointAddress())
 	} else {
 		r.vm.logger.Warn("⚠️ CONTRACT WRITE DEBUG - Smart wallet config is NIL!")
 	}
@@ -2025,8 +2025,8 @@ func (r *ContractWriteProcessor) Execute(stepID string, node *avsproto.ContractW
 					}
 				}()
 				if r.smartWalletConfig != nil {
-					if (r.smartWalletConfig.EntrypointAddress != common.Address{}) {
-						log.WriteString(fmt.Sprintf("  EntryPoint: %s\n", r.smartWalletConfig.EntrypointAddress.Hex()))
+					if (r.smartWalletConfig.EntryPointAddress() != common.Address{}) {
+						log.WriteString(fmt.Sprintf("  EntryPoint: %s\n", r.smartWalletConfig.EntryPointAddress().Hex()))
 					}
 					if r.smartWalletConfig.BundlerURL != "" {
 						log.WriteString(fmt.Sprintf("  Bundler: %s\n", r.smartWalletConfig.BundlerURL))
@@ -2042,7 +2042,7 @@ func (r *ContractWriteProcessor) Execute(stepID string, node *avsproto.ContractW
 			// If this is a bundler/AA error, add additional debugging information
 			if strings.Contains(result.Error, "Bundler failed") || strings.Contains(result.Error, "AA21") {
 				log.WriteString("BUNDLER FAILURE DETAILS:\n")
-				log.WriteString(fmt.Sprintf("  Entry Point: %s\n", r.smartWalletConfig.EntrypointAddress.Hex()))
+				log.WriteString(fmt.Sprintf("  Entry Point: %s\n", r.smartWalletConfig.EntryPointAddress().Hex()))
 				log.WriteString(fmt.Sprintf("  Factory: %s\n", r.smartWalletConfig.FactoryAddress.Hex()))
 
 				if strings.Contains(result.Error, "AA21") {

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -1169,15 +1169,19 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 	// Pack the atomic batch. Prefer executeBatch (no per-call values) when every value is zero — its
 	// selector is bundler-estimatable, unlike executeBatchWithValues (0xc3ff72fc) which the bundler
 	// can't simulate. Only fall back to executeBatchWithValues when a call actually carries value.
-	packKind := "executeBatch"
-	var smartWalletCallData []byte
-	var packErr error
-	if anyValue {
-		packKind = "executeBatchWithValues"
-		smartWalletCallData, packErr = aa.PackExecuteBatchWithValues(targets, values, datas)
-	} else {
-		smartWalletCallData, packErr = aa.PackExecuteBatch(targets, datas)
+	// Routed on the chain's account implementation. Batching is the one call
+	// shape that did NOT carry over to MA v2 — see aa.PackExecuteBatchAuto —
+	// so packing v0.6 batch calldata here reverts in validation as AA23,
+	// naming neither the batch nor the account type.
+	batchFactory, factoryErr := aa.EffectiveFactory(r.smartWalletConfig)
+	if factoryErr != nil {
+		return failAll(fmt.Sprintf("failed to resolve account factory for batch: %v", factoryErr), nil)
 	}
+	packKind := "executeBatch"
+	if anyValue && aa.ProviderForFactory(batchFactory) != aa.ProviderModularAccountV2 {
+		packKind = "executeBatchWithValues"
+	}
+	smartWalletCallData, packErr := aa.PackExecuteBatchAuto(batchFactory, targets, values, datas)
 	if packErr != nil {
 		return failAll(fmt.Sprintf("failed to pack atomic batch calldata: %v", packErr), nil)
 	}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -23,7 +23,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/byte4"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/bundler"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -38,7 +37,7 @@ type SendUserOpFunc func(
 	saltOverride *big.Int,
 	executionFeeWei *big.Int,
 	lgr logger.Logger,
-) (*userop.UserOperation, *types.Receipt, error)
+) (*preset.SentUserOp, *types.Receipt, error)
 
 type ContractWriteProcessor struct {
 	*CommonProcessor
@@ -56,7 +55,7 @@ func NewContractWriteProcessor(vm *VM, client ChainStateReader, smartWalletConfi
 		client:            client,
 		smartWalletConfig: smartWalletConfig,
 		owner:             owner,
-		sendUserOpFunc:    preset.SendUserOp, // Default to the real implementation
+		sendUserOpFunc:    preset.SendUserOpAuto, // Default to the real implementation
 		CommonProcessor: &CommonProcessor{
 			vm: vm,
 		},
@@ -680,7 +679,7 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 	logLabel string,
 	logTarget string,
 	executionLogBuilder *strings.Builder,
-) (*userop.UserOperation, *types.Receipt, string) {
+) (*preset.SentUserOp, *types.Receipt, string) {
 	// Set up factory address for AA operations
 	if err := aa.SetFactoryAddressForConfig(r.smartWalletConfig); err != nil {
 		return nil, nil, fmt.Sprintf("cannot resolve account factory: %v", err)
@@ -1209,7 +1208,7 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 }
 
 // createRealTransactionResult creates a result from a real UserOp transaction
-func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contractAddress, callData string, parsedABI *abi.ABI, userOp *userop.UserOperation, receipt *types.Receipt) *avsproto.ContractWriteNode_MethodResult {
+func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contractAddress, callData string, parsedABI *abi.ABI, userOp *preset.SentUserOp, receipt *types.Receipt) *avsproto.ContractWriteNode_MethodResult {
 	r.vm.logger.Info("🔍 DEPLOYED WORKFLOW: Creating real transaction result",
 		"method_name", methodName,
 		"contract_address", contractAddress,
@@ -1282,7 +1281,7 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 	} else if userOp != nil {
 		// UserOp submitted but receipt not available yet
 		receiptMap = map[string]interface{}{
-			"userOpHash":      userOp.GetUserOpHash(r.smartWalletConfig.EntrypointAddress, big.NewInt(r.smartWalletConfig.ChainID)).Hex(),
+			"userOpHash":      userOp.UserOpHash.Hex(),
 			"sender":          userOp.Sender.Hex(),
 			"nonce":           fmt.Sprintf("0x%x", userOp.Nonce.Uint64()),
 			"status":          "pending",
@@ -1383,7 +1382,7 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 	if receiptMap != nil {
 		receiptMap["executionStatus"] = executionStatus
 		if _, hasHash := receiptMap["userOpHash"]; !hasHash && userOp != nil && r.smartWalletConfig != nil {
-			receiptMap["userOpHash"] = userOp.GetUserOpHash(r.smartWalletConfig.EntrypointAddress, big.NewInt(r.smartWalletConfig.ChainID)).Hex()
+			receiptMap["userOpHash"] = userOp.UserOpHash.Hex()
 		}
 		if v, err := structpb.NewValue(receiptMap); err == nil {
 			receiptValue = v

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -682,7 +682,9 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 	executionLogBuilder *strings.Builder,
 ) (*userop.UserOperation, *types.Receipt, string) {
 	// Set up factory address for AA operations
-	aa.SetFactoryAddress(r.smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(r.smartWalletConfig); err != nil {
+		return nil, nil, fmt.Sprintf("cannot resolve account factory: %v", err)
+	}
 	aa.SetEntrypointAddress(r.smartWalletConfig.EntrypointAddress)
 
 	// Optional runner validation: if task.SmartWalletAddress is set, ensure it matches
@@ -693,10 +695,17 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 		// Derive sender at salt:0 via the per-chain reader (worker-routed in
 		// gateway mode) instead of a direct dial. Best-effort sanity check;
 		// the authoritative wallet-list validation runs in the run_node path.
-		sender, derr := r.client.GetSmartWalletAddress(ctx, r.owner, r.smartWalletConfig.FactoryAddress, big.NewInt(0))
-		if derr == nil && (sender != common.Address{}) {
-			if !strings.EqualFold(sender.Hex(), runnerStr) {
-				r.vm.logger.Warn("runner does not match derived salt:0; proceeding (wallet list validation applies in run_node)", "expected", sender.Hex(), "runner", runnerStr)
+		// A factory-resolution failure only costs us the sanity check; the
+		// authoritative validation still runs in run_node. Skipping beats
+		// failing the write on a diagnostic.
+		if defaultFactory, factoryErr := aa.EffectiveFactory(r.smartWalletConfig); factoryErr != nil {
+			r.vm.logger.Warn("skipping runner sanity check: cannot resolve factory", "error", factoryErr)
+		} else {
+			sender, derr := r.client.GetSmartWalletAddress(ctx, r.owner, defaultFactory, big.NewInt(0))
+			if derr == nil && (sender != common.Address{}) {
+				if !strings.EqualFold(sender.Hex(), runnerStr) {
+					r.vm.logger.Warn("runner does not match derived salt:0; proceeding (wallet list validation applies in run_node)", "expected", sender.Hex(), "runner", runnerStr)
+				}
 			}
 		}
 	}

--- a/core/taskengine/vm_runner_contract_write_batch_test.go
+++ b/core/taskengine/vm_runner_contract_write_batch_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/ethereum/go-ethereum/common"
@@ -76,7 +75,7 @@ func TestAtomicBatchOnDemand(t *testing.T) {
 	}
 
 	countingSender := func(callCount *int, captured *[]byte, status uint64) SendUserOpFunc {
-		return func(_ *config.SmartWalletConfig, _ common.Address, callData []byte, _ *preset.VerifyingPaymasterRequest, _ *common.Address, _ *big.Int, _ *big.Int, _ logger.Logger) (*userop.UserOperation, *types.Receipt, error) {
+		return func(_ *config.SmartWalletConfig, _ common.Address, callData []byte, _ *preset.VerifyingPaymasterRequest, _ *common.Address, _ *big.Int, _ *big.Int, _ logger.Logger) (*preset.SentUserOp, *types.Receipt, error) {
 			*callCount++
 			if captured != nil {
 				*captured = callData

--- a/core/taskengine/vm_runner_contract_write_data_priority_test.go
+++ b/core/taskengine/vm_runner_contract_write_data_priority_test.go
@@ -33,14 +33,14 @@ func TestContractWriteDataPriority(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()
 		if !ok {
 			t.Skip("Owner EOA address not set, skipping test")
 		}
 		ownerEOA := *ownerAddr
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 		client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 		require.NoError(t, err, "Failed to connect to RPC")

--- a/core/taskengine/vm_runner_contract_write_ondemand_test.go
+++ b/core/taskengine/vm_runner_contract_write_ondemand_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/ethereum/go-ethereum/common"
@@ -18,19 +17,14 @@ import (
 
 // wellFormedUserOp returns a UserOperation with every big.Int/byte field populated
 // so GetUserOpHash / PackForSignature don't panic in unit tests.
-func wellFormedUserOp(sender common.Address) *userop.UserOperation {
-	return &userop.UserOperation{
+func wellFormedUserOp(sender common.Address) *preset.SentUserOp {
+	return &preset.SentUserOp{
 		Sender:               sender,
 		Nonce:                big.NewInt(0),
-		InitCode:             []byte{},
-		CallData:             []byte{},
 		CallGasLimit:         big.NewInt(0),
 		VerificationGasLimit: big.NewInt(0),
 		PreVerificationGas:   big.NewInt(0),
 		MaxFeePerGas:         big.NewInt(0),
-		MaxPriorityFeePerGas: big.NewInt(0),
-		PaymasterAndData:     []byte{},
-		Signature:            []byte{},
 	}
 }
 
@@ -144,7 +138,7 @@ func TestContractWriteRealPathForwardsNativeValue(t *testing.T) {
 			_ *big.Int,
 			_ *big.Int,
 			_ logger.Logger,
-		) (*userop.UserOperation, *types.Receipt, error) {
+		) (*preset.SentUserOp, *types.Receipt, error) {
 			capturedCallData = callData
 			return wellFormedUserOp(runner), minedReceipt(1), nil
 		}

--- a/core/taskengine/vm_runner_contract_write_simulation_test.go
+++ b/core/taskengine/vm_runner_contract_write_simulation_test.go
@@ -94,7 +94,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		}
 		ownerEOA := *ownerAddr
 		// Factory address is automatically set by engine.New() from config.SmartWallet.FactoryAddress
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 		// Derive actual salt:0 smart wallet address (no mock needed)
 		// Connect to RPC to derive address
@@ -161,7 +161,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 			t.Skip("Owner EOA address not set, skipping simulation test")
 		}
 		ownerEOA := *ownerAddr
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 		// Derive actual salt:0 smart wallet address (need ethclient)
 		client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
@@ -298,7 +298,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		}
 		ethc, err := ethclient.Dial(rpcURL)
 		require.NoError(t, err, "Failed to connect RPC for derivation")
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 		derivedRunner, derr := aa.GetSenderAddress(ethc, ownerEOA, big.NewInt(0))
 		require.NoError(t, derr, "Failed to derive runner")
 

--- a/core/taskengine/vm_runner_contract_write_transaction_limit_test.go
+++ b/core/taskengine/vm_runner_contract_write_transaction_limit_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -23,9 +22,9 @@ func mockSendUserOp(
 	saltOverride *big.Int,
 	executionFeeWei *big.Int,
 	lgr logger.Logger,
-) (*userop.UserOperation, *types.Receipt, error) {
+) (*preset.SentUserOp, *types.Receipt, error) {
 	capturedPaymasterRequest = paymasterReq
-	return &userop.UserOperation{}, &types.Receipt{}, nil
+	return &preset.SentUserOp{}, &types.Receipt{}, nil
 }
 
 /*

--- a/core/taskengine/vm_runner_eth_transfer.go
+++ b/core/taskengine/vm_runner_eth_transfer.go
@@ -351,7 +351,7 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 	p.vm.mu.Unlock()
 
 	// Send UserOp transaction with overrides
-	userOp, receipt, err := preset.SendUserOp(
+	userOp, receipt, err := preset.SendUserOpAuto(
 		p.smartWalletConfig,
 		*p.taskOwner,
 		smartWalletCallData,
@@ -383,7 +383,7 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 		txHash = receipt.TxHash.Hex()
 	} else if userOp != nil {
 		// Fallback: use a deterministic hash based on UserOp
-		txHash = fmt.Sprintf("0x%064x", userOp.GetUserOpHash(aa.EntrypointAddress, big.NewInt(p.smartWalletConfig.ChainID)))
+		txHash = userOp.UserOpHash.Hex()
 	} else {
 		txHash = fmt.Sprintf("0x%064d", time.Now().UnixNano())
 	}
@@ -405,7 +405,7 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 	// and include the userOpHash so waitForOnChainConfirmationIfNeeded can poll for it.
 	if receipt == nil && userOp != nil {
 		resultObj["receiptStatus"] = "pending"
-		resultObj["userOpHash"] = fmt.Sprintf("0x%064x", userOp.GetUserOpHash(aa.EntrypointAddress, big.NewInt(p.smartWalletConfig.ChainID)))
+		resultObj["userOpHash"] = userOp.UserOpHash.Hex()
 	}
 
 	// Extract gas information from receipt if available

--- a/core/taskengine/vm_runner_eth_transfer.go
+++ b/core/taskengine/vm_runner_eth_transfer.go
@@ -300,7 +300,9 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 	// Use the aa and preset packages that should already be imported
 
 	// Set up factory address for AA operations
-	aa.SetFactoryAddress(p.smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(p.smartWalletConfig); err != nil {
+		return nil, fmt.Errorf("cannot resolve account factory: %w", err)
+	}
 	aa.SetEntrypointAddress(p.smartWalletConfig.EntrypointAddress)
 
 	// For ETH transfers, we need to create a call to the smart wallet's execute function

--- a/core/taskengine/wallet_ma_v2.go
+++ b/core/taskengine/wallet_ma_v2.go
@@ -1,20 +1,12 @@
 package taskengine
 
 import (
-	"errors"
-	"fmt"
-	"math/big"
-
-	"github.com/dgraph-io/badger/v4"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
-	"github.com/AvaProtocol/EigenLayer-AVS/model"
-	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
 
-// Modular Account v2 wallet creation.
+// Modular Account v2 wallet registration.
 //
 // MA v2 wallets reuse the existing record and index schema unchanged, because
 // `Factory` is already part of both the stored record and the `wsalt:` index
@@ -31,102 +23,17 @@ import (
 // An MA v2 wallet that is derived but never stored is therefore invisible to
 // sponsorship: every operation from it is denied, with a message about an
 // unknown sender rather than anything pointing at the missing record.
+//
+// There is deliberately no MA v2-specific creation function. There was one,
+// and the v0.7 cutover made it redundant: Engine.GetWallet now derives through
+// aa.EffectiveFactory and stores whatever factory that returns, so on an MA v2
+// chain the ordinary path already registers MA v2 wallets under the MA v2
+// factory. A parallel creation path would have been a second way to do the
+// same thing, differing only in forcing MA v2 on chains pinned to
+// simple_account — where forcing it is wrong. Use aa.ProviderForFactory to ask
+// what a stored record is.
 
 // MAv2WalletFactory returns the factory address MA v2 wallets are recorded
 // under. Distinct from config.DefaultFactoryProxyAddressHex, which is the
 // v0.6 SimpleAccountFactory.
 func MAv2WalletFactory() common.Address { return aa.MAv2FactoryAddress() }
-
-// IsMAv2Wallet reports whether a stored record was created by the MA v2
-// factory, as opposed to the v0.6 SimpleAccountFactory.
-//
-// Records predating the factory field (Factory == nil) are v0.6 by
-// definition — MA v2 records have always carried it.
-func IsMAv2Wallet(wallet *model.SmartWallet) bool {
-	if wallet == nil || wallet.Factory == nil {
-		return false
-	}
-	return *wallet.Factory == MAv2WalletFactory()
-}
-
-// GetOrCreateMAv2Wallet derives the MA v2 account for (owner, salt) on the
-// given chain and persists its record, returning the existing one if it has
-// already been registered.
-//
-// Idempotent by address rather than by "did we just derive it": the address is
-// a pure function of (factory, owner, salt), so a second call for the same
-// tuple must return the same record instead of writing a duplicate or
-// resetting user-set flags like IsHidden.
-//
-// The address comes from the factory on-chain (see aa.GetSenderAddressMAv2)
-// rather than a local CREATE2 computation, so a derivation that drifts from
-// the contract fails loudly here instead of registering an address that will
-// never hold anything.
-func GetOrCreateMAv2Wallet(db storage.Storage, rpcConn *ethclient.Client, chainID int64, owner common.Address, salt *big.Int) (*model.SmartWallet, error) {
-	if db == nil {
-		return nil, fmt.Errorf("nil storage")
-	}
-	if salt == nil {
-		return nil, fmt.Errorf("salt is nil")
-	}
-	if salt.Sign() < 0 {
-		return nil, fmt.Errorf("salt must be non-negative, got %s", salt)
-	}
-	if owner == (common.Address{}) {
-		return nil, fmt.Errorf("owner is the zero address")
-	}
-
-	factory := MAv2WalletFactory()
-
-	// Prefer the (chain, owner, factory, salt) index over deriving again — it
-	// answers "has this been registered?" without an RPC round trip, and it is
-	// the same index StoreWallet maintains.
-	//
-	// Only a genuine "not recorded yet" may fall through to derive-and-store.
-	// Treating any read error as absence would re-register on a transient
-	// storage fault, and re-registration writes IsHidden:false — silently
-	// un-hiding a wallet the user had hidden. Idempotency here is only as good
-	// as the lookup it rests on.
-	existingAddr, err := LookupCanonicalWalletAddress(db, chainID, owner, factory, salt)
-	switch {
-	case err == nil:
-		wallet, getErr := GetWallet(db, chainID, owner, existingAddr.Hex())
-		if getErr == nil {
-			return wallet, nil
-		}
-		if !errors.Is(getErr, badger.ErrKeyNotFound) {
-			return nil, fmt.Errorf("reading registered MA v2 wallet %s for owner %s on chain %d: %w",
-				existingAddr.Hex(), owner.Hex(), chainID, getErr)
-		}
-		// Index points at a record that is gone. Rewrite it rather than
-		// returning a dangling reference.
-	case errors.Is(err, badger.ErrKeyNotFound):
-		// Not registered yet — the expected path for a new wallet.
-	default:
-		return nil, fmt.Errorf("looking up MA v2 wallet index for owner %s salt %s on chain %d: %w",
-			owner.Hex(), salt, chainID, err)
-	}
-
-	derived, err := aa.GetSenderAddressMAv2ForFactory(rpcConn, owner, factory, salt)
-	if err != nil {
-		return nil, fmt.Errorf("deriving MA v2 wallet for owner %s salt %s on chain %d: %w",
-			owner.Hex(), salt, chainID, err)
-	}
-	if derived == nil || *derived == (common.Address{}) {
-		return nil, fmt.Errorf("factory %s returned the zero address for owner %s salt %s",
-			factory.Hex(), owner.Hex(), salt)
-	}
-
-	wallet := &model.SmartWallet{
-		Owner:    &owner,
-		Address:  derived,
-		Factory:  &factory,
-		Salt:     salt,
-		IsHidden: false,
-	}
-	if err := StoreWallet(db, chainID, owner, wallet); err != nil {
-		return nil, fmt.Errorf("storing MA v2 wallet %s for owner %s on chain %d: %w",
-			derived.Hex(), owner.Hex(), chainID, err)
-	}
-	return wallet, nil
-}

--- a/core/taskengine/wallet_ma_v2_test.go
+++ b/core/taskengine/wallet_ma_v2_test.go
@@ -19,30 +19,6 @@ func mav2Owner() common.Address {
 	return common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
 }
 
-func TestIsMAv2Wallet(t *testing.T) {
-	mav2 := MAv2WalletFactory()
-	v06 := common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
-	owner, addr := mav2Owner(), common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
-
-	tests := []struct {
-		name   string
-		wallet *model.SmartWallet
-		want   bool
-	}{
-		{"MA v2 factory", &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &mav2}, true},
-		{"v0.6 factory", &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &v06}, false},
-		{"no factory recorded is v0.6 by definition", &model.SmartWallet{Owner: &owner, Address: &addr}, false},
-		{"nil wallet", nil, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsMAv2Wallet(tt.wallet); got != tt.want {
-				t.Errorf("IsMAv2Wallet = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // The factory address is what keeps MA v2 and v0.6 records from colliding in
 // the wsalt: index. If both used the same factory, registering an MA v2 wallet
 // at salt 0 would overwrite the v0.6 index entry for the same owner and salt,
@@ -59,37 +35,6 @@ func TestMAv2AndV06IndexKeysDoNotCollide(t *testing.T) {
 	if !strings.Contains(strings.ToLower(string(mav2Key)), strings.ToLower(MAv2WalletFactory().Hex()[2:])) {
 		t.Errorf("index key %q does not carry the factory address", mav2Key)
 	}
-}
-
-func TestGetOrCreateMAv2WalletGuards(t *testing.T) {
-	db := testutil.TestMustDB()
-	defer db.Close()
-	owner := mav2Owner()
-
-	tests := []struct {
-		name  string
-		owner common.Address
-		salt  *big.Int
-	}{
-		{"nil salt", owner, nil},
-		{"negative salt", owner, big.NewInt(-1)},
-		{"zero owner", common.Address{}, big.NewInt(0)},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// rpcConn is nil: every case here must fail on validation before
-			// any RPC is attempted, so a nil client can never be dereferenced.
-			if _, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, tt.owner, tt.salt); err == nil {
-				t.Error("expected an error")
-			}
-		})
-	}
-
-	t.Run("nil storage", func(t *testing.T) {
-		if _, err := GetOrCreateMAv2Wallet(nil, nil, mav2TestChain, owner, big.NewInt(0)); err == nil {
-			t.Error("expected an error for nil storage")
-		}
-	})
 }
 
 // The whole point of registration: the sponsorship webhook resolves a sender
@@ -133,36 +78,6 @@ func TestMAv2RecordIsDiscoverableBySenderScan(t *testing.T) {
 	}
 }
 
-// A second call for the same tuple must return the existing record rather than
-// writing a duplicate or resetting user-set flags.
-func TestMAv2RegistrationIsIdempotent(t *testing.T) {
-	db := testutil.TestMustDB()
-	defer db.Close()
-
-	owner := mav2Owner()
-	addr := common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
-	factory := MAv2WalletFactory()
-	salt := big.NewInt(0)
-
-	first := &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &factory, Salt: salt, IsHidden: true}
-	if err := StoreWallet(db, mav2TestChain, owner, first); err != nil {
-		t.Fatalf("StoreWallet: %v", err)
-	}
-
-	// nil RPC: if the lookup path works, no derivation is attempted, so this
-	// returning successfully is itself the assertion that the index was used.
-	got, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, owner, salt)
-	if err != nil {
-		t.Fatalf("GetOrCreateMAv2Wallet on an already-registered wallet: %v", err)
-	}
-	if got.Address == nil || *got.Address != addr {
-		t.Errorf("address = %v, want %s", got.Address, addr.Hex())
-	}
-	if !got.IsHidden {
-		t.Error("IsHidden was reset; re-registration must not clobber user-set flags")
-	}
-}
-
 // Guards the assumption the whole file rests on: the factory constant here is
 // the same one aa derives against. If they drift, wallets get recorded under a
 // factory that did not create them.
@@ -170,38 +85,5 @@ func TestWalletFactoryMatchesDerivationFactory(t *testing.T) {
 	if MAv2WalletFactory() != aa.MAv2FactoryAddress() {
 		t.Errorf("taskengine factory %s != aa factory %s",
 			MAv2WalletFactory().Hex(), aa.MAv2FactoryAddress().Hex())
-	}
-}
-
-// Idempotency is only as strong as the lookup it rests on. If a storage read
-// error were treated as "not registered", the fall-through would re-derive and
-// re-store with IsHidden:false — silently un-hiding a wallet the user hid. A
-// closed database is the cheapest way to make every read fail.
-func TestRegistrationDoesNotFallThroughOnStorageError(t *testing.T) {
-	db := testutil.TestMustDB()
-	owner := mav2Owner()
-	addr := common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
-	factory := MAv2WalletFactory()
-	salt := big.NewInt(0)
-
-	if err := StoreWallet(db, mav2TestChain, owner, &model.SmartWallet{
-		Owner: &owner, Address: &addr, Factory: &factory, Salt: salt, IsHidden: true,
-	}); err != nil {
-		t.Fatalf("StoreWallet: %v", err)
-	}
-	db.Close() // every subsequent read now errors rather than reporting absence
-
-	// nil RPC: if this wrongly falls through to derive-and-store it will panic
-	// or error on the RPC, either way not returning a fresh IsHidden:false
-	// record. What must NOT happen is a silent success that clobbers the flag.
-	got, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, owner, salt)
-	if err == nil {
-		if got != nil && !got.IsHidden {
-			t.Fatal("returned a re-registered record with IsHidden reset; the storage error was masked")
-		}
-		t.Fatal("expected an error when storage reads fail, got success")
-	}
-	if !strings.Contains(err.Error(), "looking up") && !strings.Contains(err.Error(), "reading registered") {
-		t.Errorf("error should name the failed lookup, got: %v", err)
 	}
 }

--- a/core/taskengine/wallet_salt_index_test.go
+++ b/core/taskengine/wallet_salt_index_test.go
@@ -244,7 +244,7 @@ func TestListWallets_HardFiltersStaleRows(t *testing.T) {
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
-	factory := cfg.SmartWallet.FactoryAddress
+	factory := effectiveFactoryAddr(t, cfg.SmartWallet)
 
 	// Two wallets for different salts, then mark one stale and verify
 	// it disappears from the list response entirely.

--- a/core/taskengine/wallet_test.go
+++ b/core/taskengine/wallet_test.go
@@ -15,7 +15,7 @@ func TestSetWalletHiddenStatus(t *testing.T) {
 	config := testutil.GetAggregatorConfig()
 	n := New(db, config, nil, testutil.GetLogger())
 	u := testutil.TestUser1()
-	defaultFactory := n.smartWalletConfig.FactoryAddress.Hex()
+	defaultFactory := effectiveFactoryHex(t, n.smartWalletConfig)
 
 	saltValue := "12345"
 	// Ensure wallet exists
@@ -215,7 +215,7 @@ func TestHideDefaultWallet(t *testing.T) {
 	config := testutil.GetAggregatorConfig()
 	n := New(db, config, nil, testutil.GetLogger())
 	u := testutil.TestUser1()
-	defaultFactory := n.smartWalletConfig.FactoryAddress.Hex()
+	defaultFactory := effectiveFactoryHex(t, n.smartWalletConfig)
 	defaultSalt := "0"
 
 	// Ensure default wallet exists and get its address

--- a/core/testutil/utils.go
+++ b/core/testutil/utils.go
@@ -865,13 +865,18 @@ func CheckBundlerAvailability(bundlerURL string) error {
 // This is useful for integration tests that need wallets to be deployed before testing UserOp execution.
 // It uses GetSenderAddress to compute the wallet address, which is what the system actually uses.
 func EnsureWalletDeployed(client *ethclient.Client, factoryAddress common.Address, ownerAddress common.Address, salt *big.Int, controllerPrivateKey string) error {
-	// Set factory address so GetSenderAddress uses the correct factory
-	aa.SetFactoryAddress(factoryAddress)
-
-	// Get expected wallet address using GetSenderAddress (this is what the system uses)
-	expectedWalletPtr, err := aa.GetSenderAddress(client, ownerAddress, salt)
+	// Derive against the passed factory explicitly rather than parking it in
+	// the package global first. That global is process-wide: setting it here
+	// changed which factory unrelated tests derived against for the rest of
+	// the run, depending only on execution order.
+	//
+	// The provider is pinned to SimpleAccount because that is what this helper
+	// can actually deploy — it goes through NewSimpleFactory below. It is not
+	// a stand-in for the chain's configured provider.
+	expectedWalletPtr, err := aa.DeriveSenderAddressForFactory(
+		client, ownerAddress, factoryAddress, salt, aa.ProviderSimpleAccount)
 	if err != nil {
-		return fmt.Errorf("failed to get address from GetSenderAddress: %w", err)
+		return fmt.Errorf("failed to derive SimpleAccount address: %w", err)
 	}
 	expectedWallet := *expectedWalletPtr
 
@@ -963,7 +968,10 @@ func GetTestSmartWalletAddress(t *testing.T, client *ethclient.Client, factoryAd
 	err := EnsureWalletDeployed(client, factoryAddress, owner, salt, controllerPrivateKey)
 	require.NoError(t, err, "Failed to ensure wallet is deployed for salt %s", salt.String())
 
-	walletAddress, err := aa.GetSenderAddress(client, owner, salt)
+	// Same factory and provider EnsureWalletDeployed just deployed with, rather
+	// than whatever the package global happens to hold.
+	walletAddress, err := aa.DeriveSenderAddressForFactory(
+		client, owner, factoryAddress, salt, aa.ProviderSimpleAccount)
 	require.NoError(t, err, "Failed to get wallet address for salt %s", salt.String())
 
 	return *walletAddress

--- a/pkg/erc4337/preset/builder_execution_success_test.go
+++ b/pkg/erc4337/preset/builder_execution_success_test.go
@@ -27,7 +27,9 @@ func TestUserOpWithdrawalSkipsReimbursementWhenBalanceInsufficient(t *testing.T)
 	require.NoError(t, err, "Failed to connect to RPC")
 	defer client.Close()
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()
 	if !ok {
@@ -167,7 +169,9 @@ func TestUserOpExecutionFailureExcessiveTransfer(t *testing.T) {
 		t.Skipf("Skipping TestUserOpExecutionFailureExcessiveTransfer: chain ID %d is not Sepolia (11155111)", chainID.Uint64())
 	}
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	// Get owner EOA from environment variable (OWNER_EOA or TEST_PRIVATE_KEY)
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -263,7 +267,9 @@ func TestUserOpExecutionSuccessWithPaymaster(t *testing.T) {
 		t.Skipf("Skipping TestUserOpExecutionSuccessWithPaymaster: chain ID %d is not Sepolia (11155111)", chainID.Uint64())
 	}
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	// Get owner EOA from environment variable (OWNER_EOA or TEST_PRIVATE_KEY)
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()

--- a/pkg/erc4337/preset/builder_test.go
+++ b/pkg/erc4337/preset/builder_test.go
@@ -39,7 +39,9 @@ func mockGetBaseTestSmartWalletConfig() *config.SmartWalletConfig {
 func TestSendUserOp(t *testing.T) {
 	smartWalletConfig := mockGetBaseTestSmartWalletConfig()
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()
 	if !ok {
@@ -89,7 +91,9 @@ func TestPaymaster(t *testing.T) {
 
 	smartWalletConfig := mockGetBaseTestSmartWalletConfig()
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	// Because we used the master key to signed, the address cannot be calculated from that key and need to set explicitly
 	owner := common.HexToAddress("0xe272b72E51a5bF8cB720fc6D6DF164a4D5E321C5")

--- a/pkg/erc4337/preset/builder_v07.go
+++ b/pkg/erc4337/preset/builder_v07.go
@@ -14,11 +14,15 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 )
 
-// EntryPointV07Address is the same on every chain Alchemy supports.
-const EntryPointV07Address = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+// EntryPointV07Address is the same on every chain Alchemy supports. It is an
+// alias for config's constant rather than a second literal: two copies of an
+// address are two things to get out of step, and a mismatch would surface as
+// signatures that verify nowhere.
+const EntryPointV07Address = config.EntryPointV07AddressHex
 
 // EntryPointV07 returns the v0.7 EntryPoint address.
 func EntryPointV07() common.Address { return common.HexToAddress(EntryPointV07Address) }

--- a/pkg/erc4337/preset/deferred_v07.go
+++ b/pkg/erc4337/preset/deferred_v07.go
@@ -1,0 +1,69 @@
+package preset
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// Deferred-action variants of the v0.7 signing helpers. The operation's nonce
+// must carry ValidationOptionDeferredAction and the entity id of the
+// validation the deferred call installs — the CONTROLLER's entity, not the
+// owner's. The owner's part (encodedData + ownerSig) was produced at grant
+// time; only the controller signs here.
+
+// DeferredEstimationSignature builds the signature to estimate a deferred
+// operation with. The deferred segments must be REAL: unlike ordinary
+// signature validation, which fails gracefully so estimation can proceed, a
+// bad deferred-action signature REVERTS (DeferredActionSignatureInvalid) —
+// the owner's actual grant has to ride along even for estimation. Only the
+// controller's part is a dummy.
+func DeferredEstimationSignature(encodedData []byte, ownerSig []byte) ([]byte, error) {
+	return userop.WrapSignatureMAv2Deferred(encodedData, ownerSig, dummySignatureV07())
+}
+
+// SignUserOpV07Deferred signs the operation with the controller key and
+// installs the full deferred-action signature: the owner's grant segments
+// followed by the controller's framed signature. Sign last — the controller
+// signature covers every gas and paymaster field. The owner's signature does
+// not, which is the property that lets it be collected before pricing exists.
+func SignUserOpV07Deferred(
+	op *userop.UserOperationV07,
+	entryPoint common.Address,
+	chainID *big.Int,
+	controllerKey *ecdsa.PrivateKey,
+	encodedData []byte,
+	ownerSig []byte,
+) error {
+	if op == nil {
+		return fmt.Errorf("nil user operation")
+	}
+	if controllerKey == nil {
+		return fmt.Errorf("nil controller key")
+	}
+	hash, err := op.GetUserOpHash(entryPoint, chainID)
+	if err != nil {
+		return fmt.Errorf("computing userOpHash: %w", err)
+	}
+	sig, err := crypto.Sign(accounts.TextHash(hash.Bytes()), controllerKey)
+	if err != nil {
+		return fmt.Errorf("signing userOpHash %s: %w", hash.Hex(), err)
+	}
+	sig[64] += 27
+	framed, err := userop.WrapSignatureMAv2(sig)
+	if err != nil {
+		return err
+	}
+	full, err := userop.WrapSignatureMAv2Deferred(encodedData, ownerSig, framed)
+	if err != nil {
+		return err
+	}
+	op.Signature = full
+	return nil
+}

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -1,0 +1,233 @@
+package preset
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// SendUserOpMAv2 is the v0.7 counterpart to SendUserOp: it takes the same
+// inputs, builds a Modular Account v2 operation, and returns once the
+// operation is mined. (SendUserOpV07 is the raw one-shot send this sits on
+// top of; this is the orchestrator that builds, prices, and signs first.)
+//
+// callData is the account's execute() calldata, the SAME bytes the v0.6 path
+// builds. execute(address,uint256,bytes) kept selector 0xb61d27f6 in MA v2, so
+// aa.PackExecute output is byte-identical to aa.PackExecuteMAv2 and callers
+// need no repacking. That is NOT true of batching:
+// executeBatchWithValues has no MA v2 successor, so a batched operation must
+// be packed with aa.PackExecuteBatchMAv2 before it gets here.
+//
+// Sponsorship is all-or-nothing on purpose. When a Gas Manager policy is
+// configured, an operation the policy declines fails rather than falling back
+// to self-funded — silently paying out of the account's own balance is how a
+// declined sponsorship turns into a drained wallet.
+func SendUserOpMAv2(
+	smartWalletConfig *config.SmartWalletConfig,
+	owner common.Address,
+	callData []byte,
+	senderOverride *common.Address,
+	saltOverride *big.Int,
+	lgr logger.Logger,
+) (*userop.UserOperationV07, *types.Receipt, error) {
+	l := logger.EnsureLogger(lgr)
+	if smartWalletConfig == nil {
+		return nil, nil, fmt.Errorf("nil smart wallet config")
+	}
+	if smartWalletConfig.ControllerPrivateKey == nil {
+		return nil, nil, fmt.Errorf("no controller private key configured")
+	}
+
+	bundlerURL, err := smartWalletConfig.ActiveBundlerURL()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving bundler url: %w", err)
+	}
+
+	ctx := context.Background()
+	chainRPC, err := ethclient.Dial(smartWalletConfig.EthRpcUrl)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dialing chain rpc: %w", err)
+	}
+	defer chainRPC.Close()
+
+	bundlerRPC, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dialing bundler: %w", err)
+	}
+	defer bundlerRPC.Close()
+
+	entryPoint := EntryPointV07()
+	chainID := big.NewInt(smartWalletConfig.ChainID)
+
+	salt := saltOverride
+	if salt == nil {
+		salt = big.NewInt(0)
+	}
+
+	factory, err := aa.EffectiveFactory(smartWalletConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving account factory: %w", err)
+	}
+
+	sender, err := resolveSenderV07(chainRPC, owner, factory, salt, senderOverride)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	op := &userop.UserOperationV07{
+		Sender:               sender,
+		CallData:             callData,
+		CallGasLimit:         big.NewInt(initialCallGasLimit),
+		PreVerificationGas:   big.NewInt(initialPreVerificationGas),
+		MaxFeePerGas:         big.NewInt(0),
+		MaxPriorityFeePerGas: big.NewInt(0),
+	}
+
+	// An account with no code yet must carry its own deployment. Reading the
+	// code is the authoritative check — a wallet record can exist for an
+	// address that was never deployed, and vice versa.
+	deployed, err := isDeployed(ctx, chainRPC, sender)
+	if err != nil {
+		return nil, nil, fmt.Errorf("checking whether %s is deployed: %w", sender.Hex(), err)
+	}
+	if !deployed {
+		deployFactory, factoryData, initErr := aa.DeriveInitCodeAuto(owner, factory, salt)
+		if initErr != nil {
+			return nil, nil, fmt.Errorf("building init code: %w", initErr)
+		}
+		op.Factory = &deployFactory
+		op.FactoryData = factoryData
+	}
+	op.VerificationGasLimit = seedVerificationGas(op)
+
+	// MA v2 selects its validation function from the NONCE, not the signature.
+	// A zero nonce reverts with ValidationFunctionMissing rather than as a
+	// nonce error, which is the single most misleading failure on this path.
+	nonce, err := NextNonceV07(ctx, bundlerRPC, entryPoint, sender,
+		userop.FallbackSignerEntityID, userop.ValidationOptionGlobal)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading nonce: %w", err)
+	}
+	op.Nonce = nonce
+
+	if err := priceOperationV07(ctx, chainRPC, bundlerRPC, op, entryPoint, smartWalletConfig, l); err != nil {
+		return nil, nil, err
+	}
+
+	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID,
+		smartWalletConfig.ControllerPrivateKey)
+	if err != nil {
+		return op, nil, fmt.Errorf("sending user operation: %w", err)
+	}
+	l.Info("v0.7 user operation sent",
+		"sender", sender.Hex(), "userop_hash", opHash.Hex(),
+		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil)
+
+	// Reuses the v0.6 confirmation watcher: UserOperationEvent is unchanged
+	// between EntryPoint versions, so only the EntryPoint address differs.
+	var wsClient *ethclient.Client
+	if smartWalletConfig.EthWsUrl != "" {
+		if ws, wsErr := ethclient.Dial(smartWalletConfig.EthWsUrl); wsErr == nil {
+			wsClient = ws
+			defer ws.Close()
+		} else {
+			l.Warn("websocket dial failed, polling for the receipt instead", "error", wsErr)
+		}
+	}
+	receipt, err := waitForUserOpConfirmation(chainRPC, wsClient, entryPoint, opHash.Hex(), l)
+	if err != nil {
+		return op, nil, err
+	}
+	return op, receipt, nil
+}
+
+// resolveSenderV07 picks the account the operation runs as. An explicit
+// override is trusted (the caller has already resolved which of the owner's
+// wallets to use); otherwise the address is derived from the factory.
+func resolveSenderV07(
+	chainRPC *ethclient.Client,
+	owner, factory common.Address,
+	salt *big.Int,
+	senderOverride *common.Address,
+) (common.Address, error) {
+	if senderOverride != nil && *senderOverride != (common.Address{}) {
+		return *senderOverride, nil
+	}
+	derived, err := aa.DeriveSenderAddressAuto(chainRPC, owner, factory, salt)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("deriving sender for owner %s salt %s: %w",
+			owner.Hex(), salt.String(), err)
+	}
+	if derived == nil || *derived == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("derived a zero sender for owner %s salt %s",
+			owner.Hex(), salt.String())
+	}
+	return *derived, nil
+}
+
+// priceOperationV07 fills the gas and paymaster fields, either from a Gas
+// Manager policy (which prices the operation as part of sponsoring it) or from
+// the bundler's own estimate.
+func priceOperationV07(
+	ctx context.Context,
+	chainRPC *ethclient.Client,
+	bundlerRPC *rpc.Client,
+	op *userop.UserOperationV07,
+	entryPoint common.Address,
+	smartWalletConfig *config.SmartWalletConfig,
+	l logger.Logger,
+) error {
+	if policyID := smartWalletConfig.GasManagerPolicyID; policyID != "" {
+		if err := RequestSponsorshipV07(ctx, bundlerRPC, op, entryPoint,
+			SponsorshipRequestV07{PolicyID: policyID}); err != nil {
+			// Deliberately fatal. See SendUserOpV07's contract: falling through
+			// to an unsponsored send would spend the account's own balance on
+			// an operation the policy just refused to fund.
+			return fmt.Errorf("gas manager declined to sponsor: %w", err)
+		}
+		l.Debug("operation sponsored", "paymaster", op.Paymaster.Hex())
+		return nil
+	}
+
+	// Unsponsored: the account pays, so the fee fields have to be real. A
+	// zero maxFeePerGas is accepted by estimation and then silently never
+	// mined, which reads as a hung operation rather than a pricing bug.
+	tip, err := chainRPC.SuggestGasTipCap(ctx)
+	if err != nil {
+		return fmt.Errorf("suggesting gas tip: %w", err)
+	}
+	head, err := chainRPC.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("reading latest header: %w", err)
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+
+	estimate, err := EstimateUserOpGasV07(ctx, bundlerRPC, op, entryPoint)
+	if err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	op.CallGasLimit = estimate.CallGasLimit
+	op.VerificationGasLimit = estimate.VerificationGasLimit
+	op.PreVerificationGas = estimate.PreVerificationGas
+	return nil
+}
+
+// isDeployed reports whether an account already has code.
+func isDeployed(ctx context.Context, client *ethclient.Client, addr common.Address) (bool, error) {
+	code, err := client.CodeAt(ctx, addr, nil)
+	if err != nil {
+		return false, err
+	}
+	return len(code) > 0, nil
+}

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -124,6 +124,14 @@ func SendUserOpMAv2(
 		return nil, nil, err
 	}
 
+	// Sign last: the signature covers every gas and paymaster field, so it has
+	// to come after pricing. SendUserOpV07WithRetry only RE-signs, and only
+	// when it tightens the verification gas limit — it will not sign an
+	// unsigned operation, it rejects one.
+	if err := SignUserOpV07(op, entryPoint, chainID, smartWalletConfig.ControllerPrivateKey); err != nil {
+		return op, nil, fmt.Errorf("signing user operation: %w", err)
+	}
+
 	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID,
 		smartWalletConfig.ControllerPrivateKey)
 	if err != nil {
@@ -210,6 +218,23 @@ func priceOperationV07(
 	if err != nil {
 		return fmt.Errorf("reading latest header: %w", err)
 	}
+
+	// The bundler enforces its own priority-fee floor, independent of what the
+	// chain suggests, and rejects anything under it in precheck:
+	//
+	//	maxPriorityFeePerGas is 1500000 but must be at least 100000000
+	//
+	// On a quiet testnet the chain's suggestion is well below that floor, so
+	// the chain value alone is not enough. Ask the bundler and take whichever
+	// is higher — it is the party that decides whether to accept the operation.
+	if bundlerTip, tipErr := bundlerMaxPriorityFee(ctx, bundlerRPC); tipErr != nil {
+		l.Debug("bundler did not report a priority fee, using the chain's", "error", tipErr)
+	} else if bundlerTip.Cmp(tip) > 0 {
+		l.Debug("raising priority fee to the bundler's floor",
+			"chain_tip", tip.String(), "bundler_tip", bundlerTip.String())
+		tip = bundlerTip
+	}
+
 	op.MaxPriorityFeePerGas = tip
 	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
 
@@ -230,4 +255,20 @@ func isDeployed(ctx context.Context, client *ethclient.Client, addr common.Addre
 		return false, err
 	}
 	return len(code) > 0, nil
+}
+
+// bundlerMaxPriorityFee asks the bundler what priority fee it currently wants.
+//
+// Rundler exposes this as rundler_maxPriorityFeePerGas. It is not part of
+// ERC-4337, so a bundler that does not implement it returns a method error —
+// which is why the caller treats failure as "no opinion" rather than fatal.
+func bundlerMaxPriorityFee(ctx context.Context, client *rpc.Client) (*big.Int, error) {
+	if client == nil {
+		return nil, fmt.Errorf("nil bundler client")
+	}
+	var out string
+	if err := client.CallContext(ctx, &out, "rundler_maxPriorityFeePerGas"); err != nil {
+		return nil, err
+	}
+	return parseHexBig(out, "rundler_maxPriorityFeePerGas")
 }

--- a/pkg/erc4337/preset/sent_userop.go
+++ b/pkg/erc4337/preset/sent_userop.go
@@ -1,0 +1,173 @@
+package preset
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// SentUserOp is what an execution path reports about an operation it sent,
+// independent of EntryPoint version.
+//
+// Callers only ever read this handful of fields off the operation — sender,
+// nonce, the gas limits, and the hash — so carrying the version-specific
+// struct out to them bought nothing and forced every consumer to know which
+// UserOperation shape it had.
+//
+// UserOpHash is computed here rather than left for the caller. That is not
+// just convenience: the hash binds to an EntryPoint address, and consumers
+// were computing it against smart_wallet.entrypoint_address, which is the
+// v0.6 EntryPoint. Doing that to a v0.7 operation yields a plausible-looking
+// hash that matches nothing on chain — it would have been reported in
+// execution logs and receipts as if it were real.
+type SentUserOp struct {
+	Sender     common.Address
+	Nonce      *big.Int
+	EntryPoint common.Address
+	UserOpHash common.Hash
+
+	CallGasLimit         *big.Int
+	VerificationGasLimit *big.Int
+	PreVerificationGas   *big.Int
+	MaxFeePerGas         *big.Int
+
+	// Sponsored reports whether a paymaster covered this operation, whichever
+	// mechanism did it — the v0.6 verifying paymaster or a v0.7 Gas Manager
+	// policy.
+	Sponsored bool
+}
+
+// SendUserOpAuto sends an operation using whichever account implementation the
+// chain is configured for, and reports the result in version-neutral terms.
+//
+// Dispatch is per CHAIN, not per wallet. That is a deliberate consequence of
+// cutting every chain over at once: a wallet created before the cutover is a
+// v0.6 SimpleAccount, and on a chain now configured for MA v2 it will no
+// longer execute. Those wallets were audited to hold no meaningful balances
+// before this was chosen. If that assumption ever stops holding, this is the
+// function that has to learn to look at the wallet's factory instead.
+//
+// paymasterReq and executionFeeWei apply only to the v0.6 path. MA v2
+// sponsorship comes from the Gas Manager policy on the chain's config, so
+// those arguments are ignored there rather than quietly changing meaning.
+func SendUserOpAuto(
+	smartWalletConfig *config.SmartWalletConfig,
+	owner common.Address,
+	callData []byte,
+	paymasterReq *VerifyingPaymasterRequest,
+	senderOverride *common.Address,
+	saltOverride *big.Int,
+	executionFeeWei *big.Int,
+	lgr logger.Logger,
+) (*SentUserOp, *types.Receipt, error) {
+	if smartWalletConfig == nil {
+		return nil, nil, fmt.Errorf("nil smart wallet config")
+	}
+
+	if smartWalletConfig.UsesModularAccountV2() {
+		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, lgr)
+		sent, convErr := sentFromV07(op, big.NewInt(smartWalletConfig.ChainID))
+		if err != nil {
+			// Report the send failure, not the conversion: the send is why
+			// this failed, and `sent` is best-effort context for the caller.
+			return sent, receipt, err
+		}
+		if convErr != nil {
+			return nil, receipt, convErr
+		}
+		return sent, receipt, nil
+	}
+
+	op, receipt, err := SendUserOp(smartWalletConfig, owner, callData, paymasterReq,
+		senderOverride, saltOverride, executionFeeWei, lgr)
+	sent := sentFromV06(op, smartWalletConfig.EntrypointAddress, big.NewInt(smartWalletConfig.ChainID))
+	if err != nil {
+		return sent, receipt, err
+	}
+	return sent, receipt, nil
+}
+
+// SendUserOpAutoWithWsClient is SendUserOpAuto reusing a caller-owned
+// WebSocket client for receipt monitoring.
+//
+// The MA v2 path ignores wsClient and opens its own from the chain config.
+// Sharing the aggregator's long-lived socket saved a dial on the v0.6 path;
+// threading it through the v0.7 builder is not worth a second signature for
+// what is only a receipt watcher.
+func SendUserOpAutoWithWsClient(
+	smartWalletConfig *config.SmartWalletConfig,
+	owner common.Address,
+	callData []byte,
+	paymasterReq *VerifyingPaymasterRequest,
+	senderOverride *common.Address,
+	saltOverride *big.Int,
+	wsClient *ethclient.Client,
+	executionFeeWei *big.Int,
+	lgr logger.Logger,
+) (*SentUserOp, *types.Receipt, error) {
+	if smartWalletConfig == nil {
+		return nil, nil, fmt.Errorf("nil smart wallet config")
+	}
+	if smartWalletConfig.UsesModularAccountV2() {
+		return SendUserOpAuto(smartWalletConfig, owner, callData, paymasterReq,
+			senderOverride, saltOverride, executionFeeWei, lgr)
+	}
+	op, receipt, err := SendUserOpWithWsClient(smartWalletConfig, owner, callData, paymasterReq,
+		senderOverride, saltOverride, wsClient, executionFeeWei, lgr)
+	sent := sentFromV06(op, smartWalletConfig.EntrypointAddress, big.NewInt(smartWalletConfig.ChainID))
+	if err != nil {
+		return sent, receipt, err
+	}
+	return sent, receipt, nil
+}
+
+// sentFromV07 converts a v0.7 operation. It returns (nil, nil) for a nil
+// operation so a failed send that never built one is not an error here.
+func sentFromV07(op *userop.UserOperationV07, chainID *big.Int) (*SentUserOp, error) {
+	if op == nil {
+		return nil, nil
+	}
+	entryPoint := EntryPointV07()
+	sent := &SentUserOp{
+		Sender:               op.Sender,
+		Nonce:                op.Nonce,
+		EntryPoint:           entryPoint,
+		CallGasLimit:         op.CallGasLimit,
+		VerificationGasLimit: op.VerificationGasLimit,
+		PreVerificationGas:   op.PreVerificationGas,
+		MaxFeePerGas:         op.MaxFeePerGas,
+		Sponsored:            op.Paymaster != nil,
+	}
+	// An operation that never got priced cannot be hashed — every gas field
+	// participates. Leaving the hash zero is honest; inventing one is not.
+	hash, err := op.GetUserOpHash(entryPoint, chainID)
+	if err != nil {
+		return sent, nil
+	}
+	sent.UserOpHash = hash
+	return sent, nil
+}
+
+func sentFromV06(op *userop.UserOperation, entryPoint common.Address, chainID *big.Int) *SentUserOp {
+	if op == nil {
+		return nil
+	}
+	return &SentUserOp{
+		Sender:               op.Sender,
+		Nonce:                op.Nonce,
+		EntryPoint:           entryPoint,
+		UserOpHash:           op.GetUserOpHash(entryPoint, chainID),
+		CallGasLimit:         op.CallGasLimit,
+		VerificationGasLimit: op.VerificationGasLimit,
+		PreVerificationGas:   op.PreVerificationGas,
+		MaxFeePerGas:         op.MaxFeePerGas,
+		Sponsored:            len(op.PaymasterAndData) > 0,
+	}
+}

--- a/pkg/erc4337/userop/deferred_action.go
+++ b/pkg/erc4337/userop/deferred_action.go
@@ -1,0 +1,174 @@
+package userop
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Deferred actions — the mechanism that lets the owner authorize the
+// controller install as an off-chain EIP-712 signature, executed later during
+// validation of the first controller-signed operation. The owner never signs
+// a UserOperation; the grant is collected at the Studio grant screen and the
+// install rides the first real op (avs-infra
+// MA_v2_Authority_Model_And_Spike_Results.md §5.1).
+//
+// Everything here mirrors ModularAccountBase.sol v2.0.1 (the deployed
+// implementation), not aa-sdk. Three facts worth stating because each was
+// established by reading that source and cost nothing to get wrong silently:
+//
+//  1. The typed data commits to the FULL 256-bit nonce of the operation that
+//     will carry the action — locator bits and sequence included. The digest
+//     can therefore be produced at grant time only because a fresh account's
+//     first sequence under a fresh key is predictably zero, and because the
+//     gas fields are NOT part of it.
+//  2. The digest is signed RAW. During validateUserOp the fallback signer's
+//     1271 path skips the usual replay-safe rewrap ("the hash is already
+//     replay-safe" — SemiModularAccountBase._exec1271Validation), so the
+//     bytes a wallet returns from eth_signTypedData_v4 are exactly what the
+//     account verifies. No EIP-191 prefix anywhere.
+//  3. The account's EIP-712 domain is minimal:
+//     EIP712Domain(uint256 chainId,address verifyingContract) — no name, no
+//     version. The verifyingContract is the counterfactual account address.
+var (
+	// keccak256("DeferredAction(uint256 nonce,uint48 deadline,bytes call)")
+	deferredActionTypeHash = crypto.Keccak256Hash(
+		[]byte("DeferredAction(uint256 nonce,uint48 deadline,bytes call)"))
+	// keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
+	deferredDomainTypeHash = crypto.Keccak256Hash(
+		[]byte("EIP712Domain(uint256 chainId,address verifyingContract)"))
+)
+
+// maxDeadline is the uint48 ceiling; the contract truncates anything wider,
+// which would make the signed digest and the encoded data disagree.
+const maxDeadline = uint64(1)<<48 - 1
+
+// PackValidationLocator builds the bytes21 ValidationLocator the account
+// reads out of a deferred action's encoded data: uint168 big-endian,
+// entityId<<8 | options. For the owner's fallback validation this is entity 0
+// with only the global bit — which the lookup masks back to the fallback key.
+func PackValidationLocator(entityID uint32, options uint8) ([21]byte, error) {
+	var out [21]byte
+	if options&ValidationOptionDirectCall != 0 {
+		return out, fmt.Errorf("direct-call locators carry a 20-byte address, not an entity id")
+	}
+	out[16] = byte(entityID >> 24)
+	out[17] = byte(entityID >> 16)
+	out[18] = byte(entityID >> 8)
+	out[19] = byte(entityID)
+	out[20] = options
+	return out, nil
+}
+
+// FallbackSignerLocator is the locator naming the account's own fallback
+// signer (the owner) as the validation for the deferred action's signature.
+// The global bit must be set: installValidation is checked against the
+// deferred validation's applicability, and the fallback signer is a global
+// validation.
+func FallbackSignerLocator() [21]byte {
+	loc, _ := PackValidationLocator(FallbackSignerEntityID, ValidationOptionGlobal)
+	return loc
+}
+
+// EncodeDeferredActionData assembles the encodedData segment of a deferred
+// signature: locator (21) ++ deadline (uint48 big-endian, 6) ++ the self-call
+// the account will execute during validation. A zero deadline means no
+// deadline.
+func EncodeDeferredActionData(locator [21]byte, deadline uint64, call []byte) ([]byte, error) {
+	if deadline > maxDeadline {
+		return nil, fmt.Errorf("deadline %d overflows uint48", deadline)
+	}
+	if len(call) < 4 {
+		return nil, fmt.Errorf("deferred call is %d bytes, shorter than a selector", len(call))
+	}
+	out := make([]byte, 0, 21+6+len(call))
+	out = append(out, locator[:]...)
+	var d [8]byte
+	binary.BigEndian.PutUint64(d[:], deadline)
+	out = append(out, d[2:8]...)
+	return append(out, call...), nil
+}
+
+// DeferredActionDigest computes the EIP-712 digest the OWNER signs:
+//
+//	keccak256(0x1901 ++ domainSeparator ++ structHash)
+//	domainSeparator = keccak256(abi.encode(domainTypeHash, chainId, account))
+//	structHash      = keccak256(abi.encode(typeHash, nonce, deadline, keccak256(call)))
+//
+// nonce is the full nonce of the operation that will carry the action —
+// build it with EncodeNonceMAv2 using the SAME entity id and options
+// (including ValidationOptionDeferredAction) the operation will use, or the
+// signature verifies against a digest the account never computes.
+func DeferredActionDigest(chainID *big.Int, account common.Address, nonce *big.Int, deadline uint64, call []byte) (common.Hash, error) {
+	if chainID == nil || chainID.Sign() <= 0 {
+		return common.Hash{}, fmt.Errorf("chain id is nil or non-positive")
+	}
+	if nonce == nil || nonce.Sign() < 0 || nonce.BitLen() > 256 {
+		return common.Hash{}, fmt.Errorf("nonce is nil, negative, or overflows uint256")
+	}
+	if deadline > maxDeadline {
+		return common.Hash{}, fmt.Errorf("deadline %d overflows uint48", deadline)
+	}
+
+	var word [32]byte
+	domain := make([]byte, 0, 96)
+	domain = append(domain, deferredDomainTypeHash.Bytes()...)
+	chainID.FillBytes(word[:])
+	domain = append(domain, word[:]...)
+	domain = append(domain, common.LeftPadBytes(account.Bytes(), 32)...)
+	domainSeparator := crypto.Keccak256(domain)
+
+	structData := make([]byte, 0, 128)
+	structData = append(structData, deferredActionTypeHash.Bytes()...)
+	nonce.FillBytes(word[:])
+	structData = append(structData, word[:]...)
+	new(big.Int).SetUint64(deadline).FillBytes(word[:])
+	structData = append(structData, word[:]...)
+	structData = append(structData, crypto.Keccak256(call)...)
+	structHash := crypto.Keccak256(structData)
+
+	return crypto.Keccak256Hash([]byte{0x19, 0x01}, domainSeparator, structHash), nil
+}
+
+// WrapSignatureMAv2Deferred assembles the full UserOperation signature for an
+// operation whose nonce carries ValidationOptionDeferredAction. Layout, per
+// ModularAccountBase._validateUserOp:
+//
+//	[0:4]   uint32 len(encodedData)
+//	[4:..]  encodedData             (EncodeDeferredActionData output)
+//	[..]    uint32 len(deferredSig)
+//	[..]    deferredSig = 0x00 (SignatureType.EOA) ++ owner's 65-byte ECDSA
+//	        over DeferredActionDigest — raw, no segment marker
+//	[..]    framedUserOpSig         (WrapSignatureMAv2 output: 0xFF 0x00 ++
+//	        the controller's signature over the EIP-191 hash of userOpHash)
+func WrapSignatureMAv2Deferred(encodedData []byte, ownerSig []byte, framedUserOpSig []byte) ([]byte, error) {
+	if len(encodedData) < 21+6+4 {
+		return nil, fmt.Errorf("encoded deferred data is %d bytes, shorter than locator+deadline+selector", len(encodedData))
+	}
+	if len(ownerSig) != 65 {
+		return nil, fmt.Errorf("expected a 65-byte owner signature, got %d bytes", len(ownerSig))
+	}
+	if v := ownerSig[64]; v != 27 && v != 28 {
+		return nil, fmt.Errorf("owner signature v is %d, want 27 or 28 — go-ethereum's crypto.Sign returns 0/1 and needs +27", v)
+	}
+	if len(framedUserOpSig) < 2 || framedUserOpSig[0] != SigSegmentValidationData {
+		return nil, fmt.Errorf("user-op signature is not framed (missing 0xFF segment marker); wrap it first")
+	}
+
+	deferredSig := make([]byte, 0, 1+len(ownerSig))
+	deferredSig = append(deferredSig, byte(0x00)) // SignatureType.EOA
+	deferredSig = append(deferredSig, ownerSig...)
+
+	out := make([]byte, 0, 4+len(encodedData)+4+len(deferredSig)+len(framedUserOpSig))
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(encodedData)))
+	out = append(out, l[:]...)
+	out = append(out, encodedData...)
+	binary.BigEndian.PutUint32(l[:], uint32(len(deferredSig)))
+	out = append(out, l[:]...)
+	out = append(out, deferredSig...)
+	return append(out, framedUserOpSig...), nil
+}

--- a/pkg/erc4337/userop/deferred_action_test.go
+++ b/pkg/erc4337/userop/deferred_action_test.go
@@ -1,0 +1,165 @@
+package userop
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+)
+
+func TestPackValidationLocator(t *testing.T) {
+	loc, err := PackValidationLocator(1, ValidationOptionGlobal|ValidationOptionDeferredAction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// uint168 big-endian: entityId<<8 | options in the low 5 bytes.
+	want := "000000000000000000000000000000000000000103"
+	if hex.EncodeToString(loc[:]) != want {
+		t.Fatalf("locator = %x, want %s", loc, want)
+	}
+
+	if _, err := PackValidationLocator(1, ValidationOptionDirectCall); err == nil {
+		t.Fatal("expected the direct-call option to be rejected")
+	}
+}
+
+func TestFallbackSignerLocator(t *testing.T) {
+	loc := FallbackSignerLocator()
+	// Entity 0 with only the global bit. The account masks the global bit off
+	// when deriving the lookup key, landing on FALLBACK_VALIDATION_LOOKUP_KEY
+	// (zero) — but without the bit the applicability check would consult the
+	// fallback's (empty) selector set and revert.
+	want := "000000000000000000000000000000000000000001"
+	if hex.EncodeToString(loc[:]) != want {
+		t.Fatalf("fallback locator = %x, want %s", loc, want)
+	}
+}
+
+func TestEncodeDeferredActionDataLayout(t *testing.T) {
+	loc := FallbackSignerLocator()
+	call := common.FromHex("0x1bbf564cdeadbeef")
+	data, err := EncodeDeferredActionData(loc, 1234567, call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// [:21] locator, [21:27] uint48 deadline, [27:] call — the fixed offsets
+	// ModularAccountBase._handleDeferredAction slices at.
+	if !bytes.Equal(data[:21], loc[:]) {
+		t.Fatalf("locator segment = %x", data[:21])
+	}
+	deadline := binary.BigEndian.Uint64(append(make([]byte, 2), data[21:27]...))
+	if deadline != 1234567 {
+		t.Fatalf("deadline segment = %d, want 1234567", deadline)
+	}
+	if !bytes.Equal(data[27:], call) {
+		t.Fatalf("call segment = %x", data[27:])
+	}
+
+	if _, err := EncodeDeferredActionData(loc, uint64(1)<<48, call); err == nil {
+		t.Fatal("expected a uint48 deadline overflow to be rejected")
+	}
+	if _, err := EncodeDeferredActionData(loc, 0, []byte{0x1b}); err == nil {
+		t.Fatal("expected a sub-selector call to be rejected")
+	}
+}
+
+// TestDeferredActionDigestMatchesTypedData proves the manual digest assembly
+// equals what a wallet computes from the equivalent eth_signTypedData_v4
+// payload. This is the property §5.1 of the findings doc depends on: the
+// grant screen hands the wallet structured typed data, and the bytes the
+// wallet returns must verify against the digest the account computes.
+func TestDeferredActionDigestMatchesTypedData(t *testing.T) {
+	chainID := big.NewInt(11155111)
+	account := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	nonce, err := EncodeNonceMAv2(1, ValidationOptionGlobal|ValidationOptionDeferredAction, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := uint64(1790000000)
+	call := common.FromHex("0x1bbf564c00112233445566778899aabbccddeeff")
+
+	manual, err := DeferredActionDigest(chainID, account, nonce, deadline, call)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typed := apitypes.TypedData{
+		Types: apitypes.Types{
+			"EIP712Domain": []apitypes.Type{
+				{Name: "chainId", Type: "uint256"},
+				{Name: "verifyingContract", Type: "address"},
+			},
+			"DeferredAction": []apitypes.Type{
+				{Name: "nonce", Type: "uint256"},
+				{Name: "deadline", Type: "uint48"},
+				{Name: "call", Type: "bytes"},
+			},
+		},
+		PrimaryType: "DeferredAction",
+		Domain: apitypes.TypedDataDomain{
+			ChainId:           (*math.HexOrDecimal256)(chainID),
+			VerifyingContract: account.Hex(),
+		},
+		Message: apitypes.TypedDataMessage{
+			"nonce":    (*math.HexOrDecimal256)(nonce),
+			"deadline": (*math.HexOrDecimal256)(new(big.Int).SetUint64(deadline)),
+			"call":     hexutil.Bytes(call),
+		},
+	}
+	walletDigest, _, err := apitypes.TypedDataAndHash(typed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(manual.Bytes(), walletDigest) {
+		t.Fatalf("manual digest %s != typed-data digest %s", manual.Hex(), hexutil.Encode(walletDigest))
+	}
+}
+
+func TestWrapSignatureMAv2Deferred(t *testing.T) {
+	loc := FallbackSignerLocator()
+	call := common.FromHex("0x1bbf564cdeadbeef")
+	encoded, err := EncodeDeferredActionData(loc, 0, call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerSig := bytes.Repeat([]byte{0x11}, 65)
+	ownerSig[64] = 27
+	inner := bytes.Repeat([]byte{0x22}, 65)
+	framedInner, err := WrapSignatureMAv2(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	full, err := WrapSignatureMAv2Deferred(encoded, ownerSig, framedInner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-slice exactly as ModularAccountBase._validateUserOp does.
+	encLen := int(binary.BigEndian.Uint32(full[:4]))
+	if !bytes.Equal(full[4:4+encLen], encoded) {
+		t.Fatal("encodedData segment does not round-trip")
+	}
+	sigLen := int(binary.BigEndian.Uint32(full[4+encLen : 8+encLen]))
+	deferredSig := full[8+encLen : 8+encLen+sigLen]
+	if deferredSig[0] != 0x00 || !bytes.Equal(deferredSig[1:], ownerSig) {
+		t.Fatal("deferred signature segment is not SignatureType.EOA ++ ownerSig")
+	}
+	if !bytes.Equal(full[8+encLen+sigLen:], framedInner) {
+		t.Fatal("trailing user-op signature segment does not round-trip")
+	}
+
+	badV := bytes.Repeat([]byte{0x11}, 65) // v = 0x11: crypto.Sign output not normalised
+	if _, err := WrapSignatureMAv2Deferred(encoded, badV, framedInner); err == nil {
+		t.Fatal("expected an un-normalised v to be rejected")
+	}
+	if _, err := WrapSignatureMAv2Deferred(encoded, ownerSig, inner); err == nil {
+		t.Fatal("expected an unframed user-op signature to be rejected")
+	}
+}

--- a/scripts/spike/deferred_action/main.go
+++ b/scripts/spike/deferred_action/main.go
@@ -1,0 +1,426 @@
+// Deferred-action spike — proves the §5.1 onboarding flow end to end on a
+// live chain (avs-infra MA_v2_Authority_Model_And_Spike_Results.md):
+//
+//  1. The OWNER signs one EIP-712 deferred-action payload, off-chain, at
+//     "grant time" — before any gas price or operation exists.
+//  2. The CONTROLLER signs the first real UserOperation, which deploys the
+//     account (initCode), applies the controller install during validation
+//     (the deferred action), and executes — one operation, no owner UserOp
+//     signature, ever.
+//  3. A second, plain controller-signed operation proves the install
+//     persists.
+//
+// Environment:
+//
+//	SPIKE_OWNER_KEY       hex private key of the owner EOA (signs the grant,
+//	                      prefunds the account)
+//	SPIKE_CONTROLLER_KEY  hex private key of the controller
+//	SPIKE_BUNDLER_URL     v0.7-capable bundler (Alchemy Rundler)
+//	SPIKE_RPC_URL         chain RPC (default: Sepolia publicnode)
+//	SPIKE_SALT            account salt (default 2 — salts 0/1 were consumed
+//	                      by the §3 spike)
+//	SPIKE_DEADLINE_HOURS  grant deadline horizon (default 24)
+//
+// Run: go run ./scripts/spike/deferred_action
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+const defaultRPC = "https://ethereum-sepolia-rpc.publicnode.com"
+
+// prefundWei covers both operations at Sepolia fee levels with headroom;
+// the unspent remainder stays in the account.
+var prefundWei = big.NewInt(2_000_000_000_000_000) // 0.002 ETH
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "spike failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, common.Address{}, fmt.Errorf("%s is not set", name)
+	}
+	key, err := crypto.HexToECDSA(trim0x(raw))
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func trim0x(s string) string {
+	if len(s) >= 2 && s[:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}
+
+func run() error {
+	ctx := context.Background()
+
+	ownerKey, ownerAddr, err := requireKey("SPIKE_OWNER_KEY")
+	if err != nil {
+		return err
+	}
+	controllerKey, controllerAddr, err := requireKey("SPIKE_CONTROLLER_KEY")
+	if err != nil {
+		return err
+	}
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	if bundlerURL == "" {
+		return fmt.Errorf("SPIKE_BUNDLER_URL is not set")
+	}
+
+	salt := big.NewInt(2)
+	if s := os.Getenv("SPIKE_SALT"); s != "" {
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			return fmt.Errorf("SPIKE_SALT %q is not a decimal integer", s)
+		}
+		salt = v
+	}
+	deadlineHours, err := strconv.Atoi(env("SPIKE_DEADLINE_HOURS", "24"))
+	if err != nil {
+		return fmt.Errorf("SPIKE_DEADLINE_HOURS: %w", err)
+	}
+
+	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return fmt.Errorf("dialing chain rpc: %w", err)
+	}
+	defer chain.Close()
+	chainRPC := chain.Client()
+
+	bundler, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return fmt.Errorf("dialing bundler: %w", err)
+	}
+	defer bundler.Close()
+
+	chainID, err := chain.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("reading chain id: %w", err)
+	}
+	entryPoint := preset.EntryPointV07()
+
+	fmt.Printf("chain %s, entrypoint %s\n", chainID, entryPoint)
+	fmt.Printf("owner      %s\ncontroller %s\nsalt       %s\n", ownerAddr, controllerAddr, salt)
+
+	// ── The account ────────────────────────────────────────────────────────
+	accountPtr, err := aa.GetSenderAddressMAv2(chain, ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	account := *accountPtr
+	code, err := chain.CodeAt(ctx, account, nil)
+	if err != nil {
+		return err
+	}
+	alreadyDeployed := len(code) > 0
+	if alreadyDeployed {
+		fmt.Printf("account    %s already deployed — skipping grant + op A, proving persistence only\n\n", account)
+	} else {
+		fmt.Printf("account    %s (counterfactual, salt %s)\n\n", account, salt)
+	}
+
+	// ── Grant time: the owner's one off-chain signature ───────────────────
+	// Everything the owner commits to is knowable before any operation or
+	// gas price exists: the install call, the deadline, and the full nonce —
+	// a fresh account's first sequence under the deferred key is zero.
+	if alreadyDeployed {
+		if err := ensurePrefund(ctx, chain, chainID, ownerKey, ownerAddr, account); err != nil {
+			return err
+		}
+		return proveInstallPersists(ctx, chain, chainRPC, bundler, entryPoint, chainID,
+			account, ownerAddr, controllerKey)
+	}
+	installCall, err := aa.PackControllerInstall(controllerAddr)
+	if err != nil {
+		return err
+	}
+	opts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+	nonce, err := userop.EncodeNonceMAv2(aa.ControllerEntityID, opts, 0)
+	if err != nil {
+		return err
+	}
+	// Cross-check the assumption rather than trusting it: the on-chain
+	// sequence for this key must still be zero.
+	liveNonce, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, aa.ControllerEntityID, opts)
+	if err != nil {
+		return err
+	}
+	if liveNonce.Cmp(nonce) != 0 {
+		return fmt.Errorf("live nonce %s != grant-time nonce %s — key already used", liveNonce, nonce)
+	}
+
+	deadline := uint64(time.Now().Add(time.Duration(deadlineHours) * time.Hour).Unix())
+	digest, err := userop.DeferredActionDigest(chainID, account, nonce, deadline, installCall)
+	if err != nil {
+		return err
+	}
+	ownerSig, err := crypto.Sign(digest.Bytes(), ownerKey) // raw digest — no EIP-191 wrap
+	if err != nil {
+		return err
+	}
+	ownerSig[64] += 27
+	encodedData, err := userop.EncodeDeferredActionData(userop.FallbackSignerLocator(), deadline, installCall)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("grant signed (owner, off-chain, gasless)\n  712 digest %s\n  deadline   %s\n  nonce      0x%x\n\n",
+		digest, time.Unix(int64(deadline), 0).UTC().Format(time.RFC3339), nonce)
+
+	// ── Prefund the counterfactual account (it pays its own gas) ─────────
+	if err := ensurePrefund(ctx, chain, chainID, ownerKey, ownerAddr, account); err != nil {
+		return err
+	}
+
+	// ── First use: controller builds, signs, sends — deploy + install + execute ──
+	callData, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	factory, factoryData, err := aa.GetInitCodeMAv2(ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	opA := &userop.UserOperationV07{
+		Sender:      account,
+		Nonce:       nonce,
+		Factory:     &factory,
+		FactoryData: factoryData,
+		CallData:    callData,
+		// Deploy (~160k) + deferred install (~45k) + 1271 check must fit under
+		// the seed, and Rundler echoes seeds rather than computing them.
+		VerificationGasLimit: big.NewInt(300_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opA, entryPoint, encodedData, ownerSig); err != nil {
+		return err
+	}
+	if err := preset.SignUserOpV07Deferred(opA, entryPoint, chainID, controllerKey, encodedData, ownerSig); err != nil {
+		return err
+	}
+	hashA, err := preset.SendUserOpV07(ctx, bundler, opA, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op A (deploy + deferred install + execute): %w", err)
+	}
+	fmt.Printf("op A sent: deploy + deferred install + execute, controller-signed\n  userOpHash %s\n", hashA)
+	receiptA, err := waitReceipt(ctx, bundler, hashA)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s costWei=%s tx=%s\n\n",
+		receiptA.Success, receiptA.ActualGasUsed, receiptA.ActualGasCost, receiptA.TxHash)
+	if !receiptA.Success {
+		return fmt.Errorf("op A mined but reverted")
+	}
+
+	// ── Persistence: a plain controller-signed op, no deferred action ─────
+	return proveInstallPersists(ctx, chain, chainRPC, bundler, entryPoint, chainID,
+		account, ownerAddr, controllerKey)
+}
+
+// proveInstallPersists sends an ordinary controller-signed operation with no
+// deferred action attached. It can only succeed if the entity-1 validation
+// the deferred action installed is durable account state.
+func proveInstallPersists(ctx context.Context, chain *ethclient.Client, chainRPC *rpc.Client,
+	bundler *rpc.Client, entryPoint common.Address, chainID *big.Int,
+	account, ownerAddr common.Address, controllerKey *ecdsa.PrivateKey) error {
+
+	callData, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	nonceB, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, aa.ControllerEntityID,
+		userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	opB := &userop.UserOperationV07{
+		Sender:   account,
+		Nonce:    nonceB,
+		CallData: callData,
+		// The deployed-account default seed (60k) is too tight here: module
+		// validation at entity 1 plus the first write to a fresh nonce-key
+		// slot (~22k cold SSTORE) lands actual verification just above it,
+		// which AA26s at send. Measured on this spike; see the results doc.
+		VerificationGasLimit: big.NewInt(100_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opB, entryPoint, nil, nil); err != nil {
+		return err
+	}
+	if err := preset.SignUserOpV07(opB, entryPoint, chainID, controllerKey); err != nil {
+		return err
+	}
+	hashB, err := preset.SendUserOpV07(ctx, bundler, opB, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op B (plain controller op): %w", err)
+	}
+	fmt.Printf("op B sent: ordinary op, controller-signed, no deferred action\n  userOpHash %s\n", hashB)
+	receiptB, err := waitReceipt(ctx, bundler, hashB)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s costWei=%s tx=%s\n\n",
+		receiptB.Success, receiptB.ActualGasUsed, receiptB.ActualGasCost, receiptB.TxHash)
+	if !receiptB.Success {
+		return fmt.Errorf("op B mined but reverted")
+	}
+
+	fmt.Println("PROVEN: owner signed once, off-chain, before gas existed; the controller")
+	fmt.Println("deployed, installed itself, and executed in one operation, and kept")
+	fmt.Println("authority afterwards. The owner never signed a UserOperation.")
+	return nil
+}
+
+// priceOp fills fee fields from chain + bundler and sizes gas via estimation.
+// For the deferred op, estimation must carry the REAL owner grant — a fake
+// deferred signature reverts instead of failing gracefully.
+func priceOp(ctx context.Context, chain *ethclient.Client, bundler *rpc.Client,
+	op *userop.UserOperationV07, entryPoint common.Address, encodedData, ownerSig []byte) error {
+
+	tip, err := chain.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	var bundlerTipHex string
+	if err := bundler.CallContext(ctx, &bundlerTipHex, "rundler_maxPriorityFeePerGas"); err == nil {
+		if bundlerTip, ok := new(big.Int).SetString(trim0x(bundlerTipHex), 16); ok && bundlerTip.Cmp(tip) > 0 {
+			tip = bundlerTip
+		}
+	}
+	head, err := chain.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+
+	if encodedData != nil {
+		sig, err := preset.DeferredEstimationSignature(encodedData, ownerSig)
+		if err != nil {
+			return err
+		}
+		op.Signature = sig
+		defer func() { op.Signature = nil }()
+	}
+	if _, err := preset.EstimateUserOpGasV07(ctx, bundler, op, entryPoint); err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	return nil
+}
+
+func ensurePrefund(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, account common.Address) error {
+
+	balance, err := chain.BalanceAt(ctx, account, nil)
+	if err != nil {
+		return err
+	}
+	if balance.Cmp(prefundWei) >= 0 {
+		fmt.Printf("account already holds %s wei, skipping prefund\n\n", balance)
+		return nil
+	}
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+	// A deployed MA v2 account's receive() costs more than a bare transfer's
+	// 21k; a hardcoded 21k limit makes the top-up revert out-of-gas. Ask.
+	gasLimit, err := chain.EstimateGas(ctx, ethereum.CallMsg{
+		From: ownerAddr, To: &account, Value: prefundWei,
+	})
+	if err != nil {
+		return fmt.Errorf("estimating prefund transfer gas: %w", err)
+	}
+	tx := types.NewTransaction(nonce, account, prefundWei, gasLimit+10_000, gasPrice, nil)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return fmt.Errorf("prefunding %s: %w", account, err)
+	}
+	fmt.Printf("prefunding %s wei from owner, tx %s ", prefundWei, signed.Hash())
+	for range 60 {
+		receipt, err := chain.TransactionReceipt(ctx, signed.Hash())
+		if err == nil && receipt.Status == types.ReceiptStatusSuccessful {
+			fmt.Printf("— mined\n\n")
+			return nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return fmt.Errorf("prefund tx %s not mined after 3 minutes", signed.Hash())
+}
+
+type userOpReceipt struct {
+	Success       bool
+	ActualGasUsed *big.Int
+	ActualGasCost *big.Int
+	TxHash        string
+}
+
+func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (*userOpReceipt, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var raw json.RawMessage
+		if err := bundler.CallContext(ctx, &raw, "eth_getUserOperationReceipt", opHash.Hex()); err == nil &&
+			len(raw) > 0 && string(raw) != "null" {
+			var parsed struct {
+				Success       bool   `json:"success"`
+				ActualGasUsed string `json:"actualGasUsed"`
+				ActualGasCost string `json:"actualGasCost"`
+				Receipt       struct {
+					TransactionHash string `json:"transactionHash"`
+				} `json:"receipt"`
+			}
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return nil, fmt.Errorf("decoding userop receipt: %w", err)
+			}
+			gasUsed, _ := new(big.Int).SetString(trim0x(parsed.ActualGasUsed), 16)
+			gasCost, _ := new(big.Int).SetString(trim0x(parsed.ActualGasCost), 16)
+			return &userOpReceipt{
+				Success:       parsed.Success,
+				ActualGasUsed: gasUsed,
+				ActualGasCost: gasCost,
+				TxHash:        parsed.Receipt.TransactionHash,
+			}, nil
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return nil, fmt.Errorf("no receipt for %s after 3 minutes", opHash)
+}

--- a/scripts/spike/deferred_action/main.go
+++ b/scripts/spike/deferred_action/main.go
@@ -52,6 +52,10 @@ const defaultRPC = "https://ethereum-sepolia-rpc.publicnode.com"
 // the unspent remainder stays in the account.
 var prefundWei = big.NewInt(2_000_000_000_000_000) // 0.002 ETH
 
+// spikeEntityID is the entity this harness grants. Real grants allocate one
+// per SessionPolicy; the spike only ever creates one.
+const spikeEntityID = aa.MinSessionEntityID
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "spike failed: %v\n", err)
@@ -164,18 +168,21 @@ func run() error {
 		return proveInstallPersists(ctx, chain, chainRPC, bundler, entryPoint, chainID,
 			account, ownerAddr, controllerKey)
 	}
-	installCall, err := aa.PackControllerInstall(controllerAddr)
+	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: spikeEntityID,
+		Signer:   controllerAddr,
+	})
 	if err != nil {
 		return err
 	}
 	opts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
-	nonce, err := userop.EncodeNonceMAv2(aa.ControllerEntityID, opts, 0)
+	nonce, err := userop.EncodeNonceMAv2(spikeEntityID, opts, 0)
 	if err != nil {
 		return err
 	}
 	// Cross-check the assumption rather than trusting it: the on-chain
 	// sequence for this key must still be zero.
-	liveNonce, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, aa.ControllerEntityID, opts)
+	liveNonce, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, spikeEntityID, opts)
 	if err != nil {
 		return err
 	}
@@ -261,7 +268,7 @@ func proveInstallPersists(ctx context.Context, chain *ethclient.Client, chainRPC
 	if err != nil {
 		return err
 	}
-	nonceB, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, aa.ControllerEntityID,
+	nonceB, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, spikeEntityID,
 		userop.ValidationOptionGlobal)
 	if err != nil {
 		return err

--- a/scripts/spike/deferred_action/main.go
+++ b/scripts/spike/deferred_action/main.go
@@ -171,6 +171,12 @@ func run() error {
 	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
 		EntityID: spikeEntityID,
 		Signer:   controllerAddr,
+		Global:   true,
+		// This harness proves the deferred-action mechanism in isolation, so
+		// it grants bare global authority on purpose. A grant of this shape
+		// can administer itself (see SessionGrant.AllowSelfAdministration);
+		// production grants are selector-scoped or carry an execution hook.
+		AllowSelfAdministration: true,
 	})
 	if err != nil {
 		return err

--- a/scripts/spike/permission_hooks/main.go
+++ b/scripts/spike/permission_hooks/main.go
@@ -218,7 +218,12 @@ func run() error {
 	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
 		EntityID: entity,
 		Signer:   controllerAddr,
-		Hooks:    [][]byte{allowHook, aa.AllowlistExecHook(entity), timeHook},
+		Global:   true,
+		// Global is safe here BECAUSE of the allowlist execution hook: it
+		// rejects any non-execute selector, so this grant cannot reach the
+		// account's own installValidation/uninstallValidation. Probe D proved
+		// exactly that.
+		Hooks: [][]byte{allowHook, aa.AllowlistExecHook(entity), timeHook},
 	})
 	if err != nil {
 		return err

--- a/scripts/spike/permission_hooks/main.go
+++ b/scripts/spike/permission_hooks/main.go
@@ -1,0 +1,618 @@
+// Permission-hooks spike — master doc §5 step 2, the last unproven claim:
+// that the policy hooks a SessionGrant carries actually ENFORCE, not merely
+// install. One owner signature grants a session signer bounded by all three
+// §6.3 dimensions, then four operations probe the bounds:
+//
+//	C  in-policy ERC-20 transfer            → mines, cap 100 → 60
+//	D  call to a non-allowlisted target     → refused at validation
+//	E  transfer over the remaining cap      → mines success=false, cap rolls back
+//	F  in-policy again, after expiry        → refused as expired
+//
+// Where each bound enforces is part of the finding: the allowlist enforces at
+// VALIDATION (nothing mines), the ERC-20 cap at EXECUTION (the op mines and
+// reverts, gas is spent), the expiry at the ENTRYPOINT via validation data.
+//
+// The grant carries an execution hook (the cap), which obligates EVERY
+// operation under it to be executeUserOp-wrapped — including the one carrying
+// the deferred install. That wrapping is exercised here for the first time.
+//
+// Environment: as scripts/spike/deferred_action, plus
+//
+//	SPIKE_SALT           default 3
+//	SPIKE_TOKEN          existing SpikeToken address; deployed fresh if unset
+//	SPIKE_VALID_MINUTES  time-range window (default 8) — the harness waits it
+//	                     out to prove expiry, so total runtime exceeds it
+//
+// Run: go run ./scripts/spike/permission_hooks
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+const defaultRPC = "https://ethereum-sepolia-rpc.publicnode.com"
+
+var (
+	prefundWei = big.NewInt(3_000_000_000_000_000) // 0.003 ETH
+	oneToken   = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+	capTokens      = tokens(100) // the grant's ERC-20 spend limit
+	inPolicyAmount = tokens(40)  // op C — leaves 60 under the cap
+	overCapAmount  = tokens(100) // op E — exceeds the remaining 60
+	expiryAmount   = tokens(10)  // op F — in policy except for time
+)
+
+func tokens(n int64) *big.Int { return new(big.Int).Mul(big.NewInt(n), oneToken) }
+
+// spikeTokenCreationHex is the compiled SpikeToken (solc 0.8.26 via forge), a
+// minimal ERC-20 that mints 1,000,000e18 to its deployer and exposes exactly
+// transfer(address,uint256) — the selector the allowlist scopes to. Source in
+// the doc; re-compile with `forge build` on the snippet there to reproduce.
+const spikeTokenCreationHex = "0x60a060405234801561000f575f80fd5b5069d3c21bcecceda10000006080818152505069d3c21bcecceda10000005f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20819055503373ffffffffffffffffffffffffffffffffffffffff165f73ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef69d3c21bcecceda10000006040516100d4919061012c565b60405180910390a3610145565b5f819050919050565b5f819050919050565b5f819050919050565b5f61011661011161010c846100e1565b6100f3565b6100ea565b9050919050565b610126816100fc565b82525050565b5f60208201905061013f5f83018461011d565b92915050565b60805161062261015d5f395f61017701526106225ff3fe608060405234801561000f575f80fd5b5060043610610060575f3560e01c806306fdde031461006457806318160ddd14610082578063313ce567146100a057806370a08231146100be57806395d89b41146100ee578063a9059cbb1461010c575b5f80fd5b61006c61013c565b60405161007991906103db565b60405180910390f35b61008a610175565b6040516100979190610413565b60405180910390f35b6100a8610199565b6040516100b59190610447565b60405180910390f35b6100d860048036038101906100d391906104be565b61019e565b6040516100e59190610413565b60405180910390f35b6100f66101b2565b60405161010391906103db565b60405180910390f35b61012660048036038101906101219190610513565b6101eb565b604051610133919061056b565b60405180910390f35b6040518060400160405280601081526020017f4d417632205370696b6520546f6b656e0000000000000000000000000000000081525081565b7f000000000000000000000000000000000000000000000000000000000000000081565b601281565b5f602052805f5260405f205f915090505481565b6040518060400160405280600581526020017f5350494b4500000000000000000000000000000000000000000000000000000081525081565b5f805f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205490508281101561026f576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610266906105ce565b60405180910390fd5b8281035f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f2081905550825f808673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825401925050819055508373ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef856040516103589190610413565b60405180910390a3600191505092915050565b5f81519050919050565b5f82825260208201905092915050565b8281835e5f83830152505050565b5f601f19601f8301169050919050565b5f6103ad8261036b565b6103b78185610375565b93506103c7818560208601610385565b6103d081610393565b840191505092915050565b5f6020820190508181035f8301526103f381846103a3565b905092915050565b5f819050919050565b61040d816103fb565b82525050565b5f6020820190506104265f830184610404565b92915050565b5f60ff82169050919050565b6104418161042c565b82525050565b5f60208201905061045a5f830184610438565b92915050565b5f80fd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f61048d82610464565b9050919050565b61049d81610483565b81146104a7575f80fd5b50565b5f813590506104b881610494565b92915050565b5f602082840312156104d3576104d2610460565b5b5f6104e0848285016104aa565b91505092915050565b6104f2816103fb565b81146104fc575f80fd5b50565b5f8135905061050d816104e9565b92915050565b5f806040838503121561052957610528610460565b5b5f610536858286016104aa565b9250506020610547858286016104ff565b9150509250929050565b5f8115159050919050565b61056581610551565b82525050565b5f60208201905061057e5f83018461055c565b92915050565b7f5370696b65546f6b656e3a2062616c616e6365000000000000000000000000005f82015250565b5f6105b8601383610375565b91506105c382610584565b602082019050919050565b5f6020820190508181035f8301526105e5816105ac565b905091905056fea2646970667358221220def2f328ce26f0b8b67e18e56a58766dc05a67ea41c0396f3686c267aace530264736f6c634300081a0033"
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "spike failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, common.Address{}, fmt.Errorf("%s is not set", name)
+	}
+	key, err := crypto.HexToECDSA(trim0x(raw))
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func trim0x(s string) string {
+	if len(s) >= 2 && s[:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}
+
+func packTransfer(to common.Address, amount *big.Int) []byte {
+	out := make([]byte, 0, 4+64)
+	out = append(out, 0xa9, 0x05, 0x9c, 0xbb)
+	out = append(out, common.LeftPadBytes(to.Bytes(), 32)...)
+	return append(out, common.LeftPadBytes(amount.Bytes(), 32)...)
+}
+
+func run() error {
+	ctx := context.Background()
+
+	ownerKey, ownerAddr, err := requireKey("SPIKE_OWNER_KEY")
+	if err != nil {
+		return err
+	}
+	controllerKey, controllerAddr, err := requireKey("SPIKE_CONTROLLER_KEY")
+	if err != nil {
+		return err
+	}
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	if bundlerURL == "" {
+		return fmt.Errorf("SPIKE_BUNDLER_URL is not set")
+	}
+	salt := big.NewInt(3)
+	if s := os.Getenv("SPIKE_SALT"); s != "" {
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			return fmt.Errorf("SPIKE_SALT %q is not a decimal integer", s)
+		}
+		salt = v
+	}
+	validMinutes, err := strconv.Atoi(env("SPIKE_VALID_MINUTES", "8"))
+	if err != nil {
+		return fmt.Errorf("SPIKE_VALID_MINUTES: %w", err)
+	}
+
+	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return err
+	}
+	defer chain.Close()
+	chainRPC := chain.Client()
+	bundler, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return err
+	}
+	defer bundler.Close()
+	chainID, err := chain.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+	entryPoint := preset.EntryPointV07()
+
+	fmt.Printf("chain %s, owner %s, controller %s, salt %s\n", chainID, ownerAddr, controllerAddr, salt)
+
+	// ── Test token ─────────────────────────────────────────────────────────
+	var token common.Address
+	if t := os.Getenv("SPIKE_TOKEN"); t != "" {
+		token = common.HexToAddress(t)
+	} else {
+		token, err = deployToken(ctx, chain, chainID, ownerKey, ownerAddr)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("token      %s\n", token)
+
+	// ── The account ────────────────────────────────────────────────────────
+	accountPtr, err := aa.GetSenderAddressMAv2(chain, ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	account := *accountPtr
+	if code, cErr := chain.CodeAt(ctx, account, nil); cErr != nil {
+		return cErr
+	} else if len(code) > 0 {
+		return fmt.Errorf("account %s already has code — bump SPIKE_SALT for a fresh grant", account)
+	}
+	fmt.Printf("account    %s (counterfactual)\n\n", account)
+
+	// Seed it: SPIKE for the transfers, ETH for gas. Both idempotent so a
+	// failed run can be retried without doubling the account's stake.
+	if held, hErr := readTokenBalance(ctx, chain, token, account); hErr != nil {
+		return hErr
+	} else if held.Cmp(tokens(1000)) < 0 {
+		if err := transferToken(ctx, chain, chainID, ownerKey, ownerAddr, token, account, tokens(1000)); err != nil {
+			return err
+		}
+	}
+	if bal, bErr := chain.BalanceAt(ctx, account, nil); bErr != nil {
+		return bErr
+	} else if bal.Cmp(prefundWei) < 0 {
+		if err := sendETH(ctx, chain, chainID, ownerKey, ownerAddr, account, prefundWei); err != nil {
+			return err
+		}
+	}
+
+	// ── The grant: signer + all three §6.3 bounds, one owner signature ─────
+	entity := aa.MinSessionEntityID
+	validUntil := uint64(time.Now().Add(time.Duration(validMinutes) * time.Minute).Unix())
+	allowHook, err := aa.AllowlistValidationHook(entity, []aa.AllowlistInput{{
+		Target:               token,
+		HasSelectorAllowlist: true,
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      capTokens,
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}}, // transfer
+	}})
+	if err != nil {
+		return err
+	}
+	timeHook, err := aa.TimeRangeValidationHook(entity, validUntil, 0)
+	if err != nil {
+		return err
+	}
+	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: entity,
+		Signer:   controllerAddr,
+		Hooks:    [][]byte{allowHook, aa.AllowlistExecHook(entity), timeHook},
+	})
+	if err != nil {
+		return err
+	}
+
+	opts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+	carrierNonce, err := userop.EncodeNonceMAv2(entity, opts, 0)
+	if err != nil {
+		return err
+	}
+	deadline := uint64(time.Now().Add(time.Hour).Unix())
+	digest, err := userop.DeferredActionDigest(chainID, account, carrierNonce, deadline, installCall)
+	if err != nil {
+		return err
+	}
+	ownerSig, err := crypto.Sign(digest.Bytes(), ownerKey)
+	if err != nil {
+		return err
+	}
+	ownerSig[64] += 27
+	encodedData, err := userop.EncodeDeferredActionData(userop.FallbackSignerLocator(), deadline, installCall)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("grant signed: allowlist(token, transfer) + cap 100 SPIKE + expires %s\n  712 digest %s\n\n",
+		time.Unix(int64(validUntil), 0).UTC().Format(time.RFC3339), digest)
+
+	// ── Op C: in-policy transfer, carries the deferred install ────────────
+	execC, err := aa.PackExecute(token, big.NewInt(0), packTransfer(controllerAddr, inPolicyAmount))
+	if err != nil {
+		return err
+	}
+	callC, err := aa.WrapExecuteUserOp(execC)
+	if err != nil {
+		return err
+	}
+	factory, factoryData, err := aa.GetInitCodeMAv2(ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	opC := &userop.UserOperationV07{
+		Sender:      account,
+		Nonce:       carrierNonce,
+		Factory:     &factory,
+		FactoryData: factoryData,
+		CallData:    callC,
+		// Deploy + install (validation + 3 hooks + allowlist state) + hook
+		// validation runtime. Rundler echoes seeds; the floor is 0.4. The
+		// hook-carrying install is far heavier than the bare one (§3.2's
+		// 300k seed AA26'd here): every allowlist entry is cold SSTOREs.
+		VerificationGasLimit: big.NewInt(700_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opC, entryPoint, encodedData, ownerSig); err != nil {
+		return fmt.Errorf("pricing op C: %w", err)
+	}
+	if err := preset.SignUserOpV07Deferred(opC, entryPoint, chainID, controllerKey, encodedData, ownerSig); err != nil {
+		return err
+	}
+	hashC, err := preset.SendUserOpV07(ctx, bundler, opC, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op C: %w", err)
+	}
+	fmt.Printf("op C sent: deploy + deferred install(signer+3 hooks) + transfer 40 SPIKE\n  userOpHash %s\n", hashC)
+	rC, err := waitReceipt(ctx, bundler, hashC)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s tx=%s\n", rC.Success, rC.ActualGasUsed, rC.TxHash)
+	if !rC.Success {
+		return fmt.Errorf("op C reverted — the in-policy operation must succeed")
+	}
+	limitAfterC, err := readSpendLimit(ctx, chain, entity, token, account)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  on-chain cap after C: %s SPIKE (want 60)\n\n", inTokens(limitAfterC))
+	if limitAfterC.Cmp(tokens(60)) != 0 {
+		return fmt.Errorf("cap after C is %s, want 60e18", limitAfterC)
+	}
+
+	// ── Op D: off-allowlist target — must die at validation ───────────────
+	execD, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	callD, err := aa.WrapExecuteUserOp(execD)
+	if err != nil {
+		return err
+	}
+	nonceD, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	opD := &userop.UserOperationV07{
+		Sender: account, Nonce: nonceD, CallData: callD,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	errD := priceOp(ctx, chain, bundler, opD, entryPoint, nil, nil)
+	if errD == nil {
+		return fmt.Errorf("op D (non-allowlisted target) was NOT refused — the allowlist does not enforce")
+	}
+	fmt.Printf("op D refused at validation, as required (target not on allowlist)\n  %s\n\n", firstLine(errD.Error()))
+
+	// ── Op E: over the remaining cap — mines, reverts at execution ────────
+	execE, err := aa.PackExecute(token, big.NewInt(0), packTransfer(controllerAddr, overCapAmount))
+	if err != nil {
+		return err
+	}
+	callE, err := aa.WrapExecuteUserOp(execE)
+	if err != nil {
+		return err
+	}
+	opE := &userop.UserOperationV07{
+		Sender: account, Nonce: nonceD, CallData: callE,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opE, entryPoint, nil, nil); err != nil {
+		// The cap enforces at execution: some estimators refuse the reverting
+		// call outright. Fall back to op C's numbers — validation is cheaper
+		// here than there, so they are safe over-estimates for sending.
+		fmt.Printf("op E estimation refused (%s) — sending with op C's gas numbers\n", firstLine(err.Error()))
+		opE.CallGasLimit = opC.CallGasLimit
+		opE.PreVerificationGas = opC.PreVerificationGas
+		opE.MaxFeePerGas = opC.MaxFeePerGas
+		opE.MaxPriorityFeePerGas = opC.MaxPriorityFeePerGas
+	}
+	if err := preset.SignUserOpV07(opE, entryPoint, chainID, controllerKey); err != nil {
+		return err
+	}
+	hashE, err := preset.SendUserOpV07(ctx, bundler, opE, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op E: %w", err)
+	}
+	fmt.Printf("op E sent: transfer 100 SPIKE against a remaining cap of 60\n  userOpHash %s\n", hashE)
+	rE, err := waitReceipt(ctx, bundler, hashE)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s tx=%s\n", rE.Success, rE.ActualGasUsed, rE.TxHash)
+	if rE.Success {
+		return fmt.Errorf("op E SUCCEEDED over the cap — the spend limit does not enforce")
+	}
+	limitAfterE, err := readSpendLimit(ctx, chain, entity, token, account)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  on-chain cap after E: %s SPIKE (rollback intact, want 60)\n\n", inTokens(limitAfterE))
+	if limitAfterE.Cmp(tokens(60)) != 0 {
+		return fmt.Errorf("cap after E is %s, want 60e18 — the failed execution leaked accounting", limitAfterE)
+	}
+
+	// ── Op F: in policy except for time ───────────────────────────────────
+	wait := time.Until(time.Unix(int64(validUntil), 0).Add(30 * time.Second))
+	if wait > 0 {
+		fmt.Printf("waiting %s for the grant to expire…\n", wait.Round(time.Second))
+		time.Sleep(wait)
+	}
+	execF, err := aa.PackExecute(token, big.NewInt(0), packTransfer(controllerAddr, expiryAmount))
+	if err != nil {
+		return err
+	}
+	callF, err := aa.WrapExecuteUserOp(execF)
+	if err != nil {
+		return err
+	}
+	nonceF, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	opF := &userop.UserOperationV07{
+		Sender: account, Nonce: nonceF, CallData: callF,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	errF := priceOp(ctx, chain, bundler, opF, entryPoint, nil, nil)
+	if errF == nil {
+		if err := preset.SignUserOpV07(opF, entryPoint, chainID, controllerKey); err != nil {
+			return err
+		}
+		_, errF = preset.SendUserOpV07(ctx, bundler, opF, entryPoint)
+		if errF == nil {
+			return fmt.Errorf("op F was accepted AFTER expiry — the time range does not enforce")
+		}
+	}
+	fmt.Printf("op F refused after expiry, as required\n  %s\n\n", firstLine(errF.Error()))
+
+	fmt.Println("PROVEN: one owner signature installed signer + allowlist + cap + expiry;")
+	fmt.Println("in-policy ran, off-list died at validation, over-cap reverted at execution")
+	fmt.Println("with clean rollback, and the whole grant went dark on schedule.")
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func priceOp(ctx context.Context, chain *ethclient.Client, bundler *rpc.Client,
+	op *userop.UserOperationV07, entryPoint common.Address, encodedData, ownerSig []byte) error {
+
+	tip, err := chain.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	var bundlerTipHex string
+	if err := bundler.CallContext(ctx, &bundlerTipHex, "rundler_maxPriorityFeePerGas"); err == nil {
+		if bundlerTip, ok := new(big.Int).SetString(trim0x(bundlerTipHex), 16); ok && bundlerTip.Cmp(tip) > 0 {
+			tip = bundlerTip
+		}
+	}
+	head, err := chain.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+
+	if encodedData != nil {
+		sig, err := preset.DeferredEstimationSignature(encodedData, ownerSig)
+		if err != nil {
+			return err
+		}
+		op.Signature = sig
+		defer func() { op.Signature = nil }()
+	}
+	if _, err := preset.EstimateUserOpGasV07(ctx, bundler, op, entryPoint); err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	return nil
+}
+
+func deployToken(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr common.Address) (common.Address, error) {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return common.Address{}, err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return common.Address{}, err
+	}
+	data := common.FromHex(spikeTokenCreationHex)
+	tx := types.NewContractCreation(nonce, big.NewInt(0), 600_000, gasPrice, data)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return common.Address{}, fmt.Errorf("deploying SpikeToken: %w", err)
+	}
+	receipt, err := waitMined(ctx, chain, signed.Hash())
+	if err != nil {
+		return common.Address{}, err
+	}
+	fmt.Printf("SpikeToken deployed at %s (tx %s)\n", receipt.ContractAddress, signed.Hash())
+	return receipt.ContractAddress, nil
+}
+
+func transferToken(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, token, to common.Address, amount *big.Int) error {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+	tx := types.NewTransaction(nonce, token, big.NewInt(0), 80_000, gasPrice, packTransfer(to, amount))
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return fmt.Errorf("seeding SPIKE: %w", err)
+	}
+	if _, err := waitMined(ctx, chain, signed.Hash()); err != nil {
+		return err
+	}
+	fmt.Printf("seeded %s SPIKE to the account\n", inTokens(amount))
+	return nil
+}
+
+func sendETH(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, to common.Address, amount *big.Int) error {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+	gasLimit, err := chain.EstimateGas(ctx, ethereum.CallMsg{From: ownerAddr, To: &to, Value: amount})
+	if err != nil {
+		return err
+	}
+	tx := types.NewTransaction(nonce, to, amount, gasLimit+10_000, gasPrice, nil)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return fmt.Errorf("prefunding: %w", err)
+	}
+	if _, err := waitMined(ctx, chain, signed.Hash()); err != nil {
+		return err
+	}
+	fmt.Printf("prefunded %s wei\n\n", amount)
+	return nil
+}
+
+func waitMined(ctx context.Context, chain *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
+	for range 60 {
+		receipt, err := chain.TransactionReceipt(ctx, hash)
+		if err == nil {
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return nil, fmt.Errorf("tx %s mined but failed", hash)
+			}
+			return receipt, nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return nil, fmt.Errorf("tx %s not mined after 3 minutes", hash)
+}
+
+// readTokenBalance reads SpikeToken.balanceOf(holder).
+func readTokenBalance(ctx context.Context, chain *ethclient.Client, token, holder common.Address) (*big.Int, error) {
+	selector := crypto.Keccak256([]byte("balanceOf(address)"))[:4]
+	data := append(selector, common.LeftPadBytes(holder.Bytes(), 32)...)
+	out, err := chain.CallContract(ctx, ethereum.CallMsg{To: &token, Data: data}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading balanceOf: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+// readSpendLimit reads AllowlistModule.erc20SpendLimits(entity, token, account)
+// — the live on-chain cap accounting.
+func readSpendLimit(ctx context.Context, chain *ethclient.Client, entity uint32, token, account common.Address) (*big.Int, error) {
+	selector := crypto.Keccak256([]byte("erc20SpendLimits(uint32,address,address)"))[:4]
+	data := make([]byte, 0, 4+96)
+	data = append(data, selector...)
+	data = append(data, common.LeftPadBytes(big.NewInt(int64(entity)).Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(token.Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(account.Bytes(), 32)...)
+	module := aa.AllowlistModuleAddress()
+	out, err := chain.CallContract(ctx, ethereum.CallMsg{To: &module, Data: data}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading erc20SpendLimits: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+func inTokens(wei *big.Int) string {
+	return new(big.Int).Div(wei, oneToken).String()
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+type userOpReceipt struct {
+	Success       bool
+	ActualGasUsed *big.Int
+	TxHash        string
+}
+
+func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (*userOpReceipt, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var raw json.RawMessage
+		if err := bundler.CallContext(ctx, &raw, "eth_getUserOperationReceipt", opHash.Hex()); err == nil &&
+			len(raw) > 0 && string(raw) != "null" {
+			var parsed struct {
+				Success       bool   `json:"success"`
+				ActualGasUsed string `json:"actualGasUsed"`
+				Receipt       struct {
+					TransactionHash string `json:"transactionHash"`
+				} `json:"receipt"`
+			}
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return nil, err
+			}
+			gasUsed, _ := new(big.Int).SetString(trim0x(parsed.ActualGasUsed), 16)
+			return &userOpReceipt{
+				Success:       parsed.Success,
+				ActualGasUsed: gasUsed,
+				TxHash:        parsed.Receipt.TransactionHash,
+			}, nil
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return nil, fmt.Errorf("no receipt for %s after 3 minutes", opHash)
+}

--- a/scripts/spike/revoke/main.go
+++ b/scripts/spike/revoke/main.go
@@ -1,0 +1,451 @@
+// Revoke spike — the last unproven line of master §5: uninstallValidation,
+// which §6.4's revoke screen depends on. Four probes across the two accounts
+// the earlier spikes left behind, answering WHO can revoke, not just whether
+// the call works:
+//
+//	R1  bare grant (salt 2): the CONTROLLER uninstalls itself — one
+//	    controller-signed op, no owner involvement. This is §6.4's
+//	    "backend uninstalls" one-click revoke. It works because
+//	    uninstallValidation "may be validated by a global validation"
+//	    (account source) — which cuts both ways: a bare global grant could
+//	    equally call installValidation. Bare grants are self-modifiable
+//	    BY DESIGN; the receipt here is the evidence.
+//	R2  bare grant, after R1: a controller op is refused — authority is gone.
+//	R4  policied grant (salt 3): the controller CANNOT self-revoke — the
+//	    allowlist's execution hook reverts any selector that is not
+//	    execute/executeBatch. Policied grants are not self-modifiable.
+//	R3  policied grant: the OWNER revokes with a PLAIN transaction straight
+//	    to the account (fallback direct-call validation) — no UserOp, no
+//	    bundler. This is the backstop against a gateway that refuses to
+//	    revoke. Hook cleanup data rides along in the account's STORED hook
+//	    order (validation hooks in reverse install order, then exec hooks);
+//	    module state is then read back to prove the cleanup landed, because
+//	    a misrouted entry does not fail the transaction — it strands state
+//	    silently.
+//
+// Environment: as the earlier spikes; SPIKE_BARE_SALT (default 2),
+// SPIKE_POLICIED_SALT (default 3), SPIKE_TOKEN (default the §3.4 SpikeToken).
+// The policied grant's uninstall payload must reproduce the §3.4 install
+// inputs exactly — in production this comes from the stored install_call
+// (master §7.4a), never re-derived.
+//
+// Run: go run ./scripts/spike/revoke
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+const (
+	defaultRPC   = "https://ethereum-sepolia-rpc.publicnode.com"
+	defaultToken = "0xaA4D01B75fdEB5fbbD98276EC7755eF71801c2E7"
+)
+
+var oneToken = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "spike failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, common.Address{}, fmt.Errorf("%s is not set", name)
+	}
+	key, err := crypto.HexToECDSA(trim0x(raw))
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func trim0x(s string) string {
+	if len(s) >= 2 && s[:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}
+
+func run() error {
+	ctx := context.Background()
+
+	ownerKey, ownerAddr, err := requireKey("SPIKE_OWNER_KEY")
+	if err != nil {
+		return err
+	}
+	controllerKey, controllerAddr, err := requireKey("SPIKE_CONTROLLER_KEY")
+	if err != nil {
+		return err
+	}
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	if bundlerURL == "" {
+		return fmt.Errorf("SPIKE_BUNDLER_URL is not set")
+	}
+	bareSalt, ok := new(big.Int).SetString(env("SPIKE_BARE_SALT", "2"), 10)
+	if !ok {
+		return fmt.Errorf("SPIKE_BARE_SALT is not a decimal integer")
+	}
+	policiedSalt, ok := new(big.Int).SetString(env("SPIKE_POLICIED_SALT", "3"), 10)
+	if !ok {
+		return fmt.Errorf("SPIKE_POLICIED_SALT is not a decimal integer")
+	}
+	token := common.HexToAddress(env("SPIKE_TOKEN", defaultToken))
+
+	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return err
+	}
+	defer chain.Close()
+	chainRPC := chain.Client()
+	bundler, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return err
+	}
+	defer bundler.Close()
+	chainID, err := chain.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+	entryPoint := preset.EntryPointV07()
+	entity := aa.MinSessionEntityID
+
+	bare, err := aa.GetSenderAddressMAv2(chain, ownerAddr, bareSalt)
+	if err != nil {
+		return err
+	}
+	policied, err := aa.GetSenderAddressMAv2(chain, ownerAddr, policiedSalt)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("chain %s\nowner      %s\ncontroller %s\nbare       %s (salt %s)\npolicied   %s (salt %s)\n\n",
+		chainID, ownerAddr, controllerAddr, bare.Hex(), bareSalt, policied.Hex(), policiedSalt)
+
+	// Preconditions: both grants must still be live.
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *bare); sErr != nil {
+		return sErr
+	} else if signer != controllerAddr {
+		return fmt.Errorf("bare account's entity-%d signer is %s, want the controller — §3.2 state gone?", entity, signer)
+	}
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *policied); sErr != nil {
+		return sErr
+	} else if signer != controllerAddr {
+		return fmt.Errorf("policied account's entity-%d signer is %s, want the controller — §3.4 state gone?", entity, signer)
+	}
+
+	// ── R1: controller revokes itself on the bare grant ───────────────────
+	uninstallBare, err := aa.PackSessionSignerUninstall(entity, nil) // no hooks installed, no cleanup entries
+	if err != nil {
+		return err
+	}
+	nonce1, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *bare, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op1 := &userop.UserOperationV07{
+		Sender: *bare, Nonce: nonce1, CallData: uninstallBare,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	if err := priceOp(ctx, chain, bundler, op1, entryPoint); err != nil {
+		return fmt.Errorf("pricing R1: %w", err)
+	}
+	if err := preset.SignUserOpV07(op1, entryPoint, chainID, controllerKey); err != nil {
+		return err
+	}
+	// The retry variant handles Rundler's efficiency floor: an uninstall's
+	// verification is light (~50k) and a comfortable seed lands under the
+	// 0.4 actual/limit ratio, so the send must tighten and re-sign.
+	hash1, err := preset.SendUserOpV07WithRetry(ctx, bundler, op1, entryPoint, chainID, controllerKey)
+	if err != nil {
+		return fmt.Errorf("sending R1: %w", err)
+	}
+	fmt.Printf("R1 sent: controller-signed uninstallValidation on the bare grant\n  userOpHash %s\n", hash1)
+	r1, err := waitReceipt(ctx, bundler, hash1)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s tx=%s\n", r1.Success, r1.ActualGasUsed, r1.TxHash)
+	if !r1.Success {
+		return fmt.Errorf("R1 reverted — controller self-revoke on a bare grant should succeed")
+	}
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *bare); sErr != nil {
+		return sErr
+	} else if signer != (common.Address{}) {
+		return fmt.Errorf("SSVM still names %s after R1", signer)
+	}
+	fmt.Printf("  module signer cleared: signers(%d, bare) = 0x0\n\n", entity)
+
+	// ── R2: the controller's authority is gone ────────────────────────────
+	probe, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	nonce2, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *bare, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op2 := &userop.UserOperationV07{Sender: *bare, Nonce: nonce2, CallData: probe,
+		VerificationGasLimit: big.NewInt(150_000)}
+	if err := priceOp(ctx, chain, bundler, op2, entryPoint); err == nil {
+		return fmt.Errorf("R2: a controller op was accepted AFTER revocation")
+	} else {
+		fmt.Printf("R2: controller op refused after revoke, as required\n  %s\n\n", firstLine(err.Error()))
+	}
+
+	// ── R4: the policied grant cannot self-revoke ─────────────────────────
+	// Three hook entries exist; content is irrelevant because the allowlist
+	// exec hook rejects the selector before the uninstall would run.
+	uninstallPolicied, err := aa.PackSessionSignerUninstall(entity, [][]byte{nil, nil, nil})
+	if err != nil {
+		return err
+	}
+	wrapped, err := aa.WrapExecuteUserOp(uninstallPolicied)
+	if err != nil {
+		return err
+	}
+	nonce4, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *policied, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op4 := &userop.UserOperationV07{Sender: *policied, Nonce: nonce4, CallData: wrapped,
+		VerificationGasLimit: big.NewInt(200_000)}
+	if err := priceOp(ctx, chain, bundler, op4, entryPoint); err == nil {
+		return fmt.Errorf("R4: the policied controller's self-revoke was NOT blocked")
+	} else {
+		fmt.Printf("R4: policied controller self-revoke blocked by the execution hook, as required\n  %s\n\n", firstLine(err.Error()))
+	}
+
+	// ── R3: the owner revokes the policied grant with a plain transaction ──
+	// Hook cleanup in STORED order: validation hooks reversed from install
+	// ([allowlist, timerange] installed → [timerange, allowlist] stored),
+	// then the exec hook (empty: same module as the allowlist entry, state
+	// already deleted there).
+	timeRangeCleanup, err := aa.PackTimeRangeUninstallData(entity)
+	if err != nil {
+		return err
+	}
+	allowlistCleanup, err := aa.PackAllowlistInstallData(entity, []aa.AllowlistInput{{
+		Target:               token,
+		HasSelectorAllowlist: true,
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      new(big.Int).Mul(big.NewInt(100), oneToken),
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}},
+	}})
+	if err != nil {
+		return err
+	}
+	uninstallR3, err := aa.PackSessionSignerUninstall(entity, [][]byte{timeRangeCleanup, allowlistCleanup, nil})
+	if err != nil {
+		return err
+	}
+	txHash, gasUsed, err := sendOwnerTx(ctx, chain, chainID, ownerKey, ownerAddr, *policied, uninstallR3)
+	if err != nil {
+		return fmt.Errorf("R3: %w", err)
+	}
+	fmt.Printf("R3: owner revoked the policied grant with a PLAIN transaction (no UserOp, no bundler)\n  tx %s gasUsed=%d\n", txHash, gasUsed)
+
+	// Cleanup verification — reads, not vibes.
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *policied); sErr != nil {
+		return sErr
+	} else if signer != (common.Address{}) {
+		return fmt.Errorf("SSVM still names %s after R3", signer)
+	}
+	limit, err := readSpendLimit(ctx, chain, entity, token, *policied)
+	if err != nil {
+		return err
+	}
+	until, after, err := readTimeRange(ctx, chain, entity, *policied)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  module state cleared: signer=0x0, erc20SpendLimit=%s, timeRange=(%d,%d)\n\n", limit, until, after)
+	if limit.Sign() != 0 || until != 0 || after != 0 {
+		return fmt.Errorf("hook module state survived the uninstall — cleanup order wrong or onUninstall failed")
+	}
+
+	// ── Post-R3: the policied controller is dead too ──────────────────────
+	probeWrapped, err := aa.WrapExecuteUserOp(probe)
+	if err != nil {
+		return err
+	}
+	nonce5, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *policied, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op5 := &userop.UserOperationV07{Sender: *policied, Nonce: nonce5, CallData: probeWrapped,
+		VerificationGasLimit: big.NewInt(150_000)}
+	if err := priceOp(ctx, chain, bundler, op5, entryPoint); err == nil {
+		return fmt.Errorf("post-R3: a controller op was accepted AFTER the owner's revoke")
+	} else {
+		fmt.Printf("post-R3: controller op refused, as required\n  %s\n\n", firstLine(err.Error()))
+	}
+
+	fmt.Println("PROVEN: a bare grant one-click revokes itself (and is therefore")
+	fmt.Println("self-modifiable — by design); a policied grant cannot touch its own")
+	fmt.Println("authority; the owner revokes either kind with a plain transaction and")
+	fmt.Println("the hook state provably clears. Revocation has receipts.")
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func priceOp(ctx context.Context, chain *ethclient.Client, bundler *rpc.Client,
+	op *userop.UserOperationV07, entryPoint common.Address) error {
+
+	tip, err := chain.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	var bundlerTipHex string
+	if err := bundler.CallContext(ctx, &bundlerTipHex, "rundler_maxPriorityFeePerGas"); err == nil {
+		if bundlerTip, ok := new(big.Int).SetString(trim0x(bundlerTipHex), 16); ok && bundlerTip.Cmp(tip) > 0 {
+			tip = bundlerTip
+		}
+	}
+	head, err := chain.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+	if _, err := preset.EstimateUserOpGasV07(ctx, bundler, op, entryPoint); err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	return nil
+}
+
+func sendOwnerTx(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, to common.Address, data []byte) (common.Hash, uint64, error) {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return common.Hash{}, 0, err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return common.Hash{}, 0, err
+	}
+	gasLimit, err := chain.EstimateGas(ctx, ethereum.CallMsg{From: ownerAddr, To: &to, Data: data})
+	if err != nil {
+		return common.Hash{}, 0, fmt.Errorf("estimating the owner's revoke tx: %w", err)
+	}
+	tx := types.NewTransaction(nonce, to, big.NewInt(0), gasLimit+20_000, gasPrice, data)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return common.Hash{}, 0, err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return common.Hash{}, 0, err
+	}
+	for range 60 {
+		receipt, rErr := chain.TransactionReceipt(ctx, signed.Hash())
+		if rErr == nil {
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return signed.Hash(), receipt.GasUsed, fmt.Errorf("owner revoke tx mined but failed")
+			}
+			return signed.Hash(), receipt.GasUsed, nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return signed.Hash(), 0, fmt.Errorf("owner revoke tx not mined after 3 minutes")
+}
+
+func callWords(ctx context.Context, chain *ethclient.Client, to common.Address, sig string, args ...[]byte) ([]byte, error) {
+	data := crypto.Keccak256([]byte(sig))[:4]
+	for _, a := range args {
+		data = append(data, common.LeftPadBytes(a, 32)...)
+	}
+	return chain.CallContract(ctx, ethereum.CallMsg{To: &to, Data: data}, nil)
+}
+
+func readSessionSigner(ctx context.Context, chain *ethclient.Client, entity uint32, account common.Address) (common.Address, error) {
+	out, err := callWords(ctx, chain, aa.SingleSignerValidationModuleAddress(),
+		"signers(uint32,address)", big.NewInt(int64(entity)).Bytes(), account.Bytes())
+	if err != nil || len(out) < 32 {
+		return common.Address{}, fmt.Errorf("reading SSVM signer: %w", err)
+	}
+	return common.BytesToAddress(out[12:32]), nil
+}
+
+func readSpendLimit(ctx context.Context, chain *ethclient.Client, entity uint32, token, account common.Address) (*big.Int, error) {
+	out, err := callWords(ctx, chain, aa.AllowlistModuleAddress(),
+		"erc20SpendLimits(uint32,address,address)", big.NewInt(int64(entity)).Bytes(), token.Bytes(), account.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("reading erc20SpendLimits: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+func readTimeRange(ctx context.Context, chain *ethclient.Client, entity uint32, account common.Address) (uint64, uint64, error) {
+	out, err := callWords(ctx, chain, aa.TimeRangeModuleAddress(),
+		"timeRanges(uint32,address)", big.NewInt(int64(entity)).Bytes(), account.Bytes())
+	if err != nil || len(out) < 64 {
+		return 0, 0, fmt.Errorf("reading timeRanges: %w", err)
+	}
+	return new(big.Int).SetBytes(out[:32]).Uint64(), new(big.Int).SetBytes(out[32:64]).Uint64(), nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+type userOpReceipt struct {
+	Success       bool
+	ActualGasUsed *big.Int
+	TxHash        string
+}
+
+func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (*userOpReceipt, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var raw json.RawMessage
+		if err := bundler.CallContext(ctx, &raw, "eth_getUserOperationReceipt", opHash.Hex()); err == nil &&
+			len(raw) > 0 && string(raw) != "null" {
+			var parsed struct {
+				Success       bool   `json:"success"`
+				ActualGasUsed string `json:"actualGasUsed"`
+				Receipt       struct {
+					TransactionHash string `json:"transactionHash"`
+				} `json:"receipt"`
+			}
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return nil, err
+			}
+			gasUsed, _ := new(big.Int).SetString(trim0x(parsed.ActualGasUsed), 16)
+			return &userOpReceipt{Success: parsed.Success, ActualGasUsed: gasUsed,
+				TxHash: parsed.Receipt.TransactionHash}, nil
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return nil, fmt.Errorf("no receipt for %s after 3 minutes", opHash)
+}

--- a/worker/server.go
+++ b/worker/server.go
@@ -182,7 +182,10 @@ func (s *Server) GetSmartWalletAddress(ctx context.Context, req *avsproto.Worker
 	// worker's configured factory. The gateway passes its per-chain /
 	// per-request factory so worker-derived addresses match the gateway's
 	// direct-RPC derivation exactly.
-	factory := s.worker.smartWalletCfg.FactoryAddress
+	factory, factoryErr := aa.EffectiveFactory(s.worker.smartWalletCfg)
+	if factoryErr != nil {
+		return nil, factoryErr
+	}
 	if req.FactoryAddress != "" {
 		if !common.IsHexAddress(req.FactoryAddress) {
 			return nil, fmt.Errorf("invalid factory address %q", req.FactoryAddress)
@@ -190,7 +193,7 @@ func (s *Server) GetSmartWalletAddress(ctx context.Context, req *avsproto.Worker
 		factory = common.HexToAddress(req.FactoryAddress)
 	}
 
-	addr, err := aa.GetSenderAddressForFactory(
+	addr, err := aa.DeriveSenderAddressAuto(
 		s.worker.rpcClient,
 		ownerAddr,
 		factory,
@@ -460,7 +463,10 @@ func (s *Server) FindMatchingWalletSalt(ctx context.Context, req *avsproto.Worke
 		return nil, fmt.Errorf("max_salts %d exceeds cap %d", req.MaxSalts, maxWalletSaltScan)
 	}
 
-	factory := s.worker.smartWalletCfg.FactoryAddress
+	factory, factoryErr := aa.EffectiveFactory(s.worker.smartWalletCfg)
+	if factoryErr != nil {
+		return nil, factoryErr
+	}
 	if req.FactoryAddress != "" {
 		if !common.IsHexAddress(req.FactoryAddress) {
 			return nil, fmt.Errorf("invalid factory address %q", req.FactoryAddress)
@@ -475,7 +481,7 @@ func (s *Server) FindMatchingWalletSalt(ctx context.Context, req *avsproto.Worke
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		addr, err := aa.GetSenderAddressForFactory(s.worker.rpcClient, owner, factory, big.NewInt(salt))
+		addr, err := aa.DeriveSenderAddressAuto(s.worker.rpcClient, owner, factory, big.NewInt(salt))
 		if err != nil {
 			// A single failed derivation shouldn't abort the whole scan.
 			continue

--- a/worker/server.go
+++ b/worker/server.go
@@ -93,7 +93,7 @@ func (s *Server) ExecuteUserOp(ctx context.Context, req *avsproto.ExecuteUserOpR
 		)
 	}
 
-	userOp, receipt, err := preset.SendUserOp(
+	userOp, receipt, err := preset.SendUserOpAuto(
 		s.worker.smartWalletCfg,
 		ownerAddr,
 		req.CallData,
@@ -115,11 +115,7 @@ func (s *Server) ExecuteUserOp(ctx context.Context, req *avsproto.ExecuteUserOpR
 	}
 
 	if userOp != nil {
-		opHash := userOp.GetUserOpHash(
-			s.worker.smartWalletCfg.EntrypointAddress,
-			big.NewInt(s.worker.config.ChainID),
-		)
-		resp.UserOpHash = opHash.Hex()
+		resp.UserOpHash = userOp.UserOpHash.Hex()
 	}
 
 	if receipt != nil {


### PR DESCRIPTION
Completes the EntryPoint v0.7 / Modular Account v2 migration. The foundation landed over six earlier PRs and had **zero callers** — `account_provider` existed but nothing read it, so setting it changed nothing. This wires it up and flips the default, on every chain at once.

## The address change is the point

MA v2 derives a different address for the same `(owner, salt)`, so every owner's default wallet moves. That was chosen deliberately after auditing the v0.6 wallets and finding no meaningful balances. Existing tasks keep validating through their stored wallet records rather than by re-derivation, so this lands as an address change, not a fund loss.

**Dispatch is per chain, not per wallet.** A wallet created before the cutover is a v0.6 SimpleAccount and will no longer execute. `SendUserOpAuto` is the single place that would have to learn to read the wallet's factory if that assumption stops holding.

## What made it tractable

**The factory address carries the provider.** The MA v2 factory is a known constant, so `ProviderForFactory` recovers the implementation from any factory address. The ChainStateReader gRPC interface needed no new field — the worker protocol is untouched.

**`execute()` calldata is byte-identical.** MA v2 kept selector `0xb61d27f6`, so `PackExecute` and `PackExecuteMAv2` emit the same bytes and no caller needed repacking. Verified by comparing the encoders directly rather than reading the ABI. Batching is the exception — `executeBatchWithValues` has no successor.

## Four bugs found while wiring, none about EntryPoint versions

1. **UserOp hashes computed against the wrong EntryPoint.** Callers passed `smart_wallet.entrypoint_address` — the v0.6 address. Against a v0.7 operation that yields a well-formed hash matching nothing on chain, and it was reported in execution logs, receipts, and the withdrawal RPC response as real. Now computed inside the send path.
2. **Receipt polling watched the v0.6 EntryPoint.** `vm_contract_write_waiting` would have waited out its full five-minute timeout looking for an event emitted somewhere else. Nothing in `"timeout waiting for UserOp confirmation"` points at the EntryPoint.
3. **The gateway worker route discarded the operation** and returned nil, so `resp.UserOpHash` was silently empty for every worker-executed withdrawal. The worker had reported the hash all along.
4. **`testutil.EnsureWalletDeployed` mutated the process-global factory** as a side effect, changing which factory unrelated tests derived against for the rest of the run — depending only on execution order.

## Chain expansion

Arbitrum One (42161), Hyperliquid (999), Robinhood (4663) added to the Alchemy subdomain map. Chain IDs read from each chain's `eth_chainId`, and each verified to carry EntryPoint v0.7 (16,035 bytes) and the MA v2 factory (6,661 bytes) at the canonical addresses — byte-identical to Sepolia. **Sepolia was run first as a control**, because a check that can't tell "absent" from "the RPC rejected me" proves nothing; an earlier run without one reported "not deployed" when it had actually just failed to authenticate.

## Deleted rather than wired

`GetOrCreateMAv2Wallet` and `IsMAv2Wallet` had no callers outside their own tests. Once `GetWallet` derived through `EffectiveFactory`, the generic path already registered MA v2 wallets under the MA v2 factory — wiring the specialised one would have added a second path differing only in forcing MA v2 on chains pinned to `simple_account`, where that is wrong.

## Testing

`go vet ./...` clean. All packages green except four `_Sepolia` live-chain tests, which now target MA v2 addresses that were never deployed or funded:

```
runner 0x8Ee38eB3… does not match any derived address (salt:0 through salt:4)
```

That is a funding task, not a code fix. `TestBalanceNode_MissingAPIKey` also fails, but it fails on `staging` too.

## Bundler support: verified on all five chains

`eth_supportedEntryPoints` against Alchemy's bundler, using the production key:

| chain | v0.7 EntryPoint |
|---|---|
| eth-sepolia | supported |
| arb-mainnet | supported |
| bnb-mainnet | supported |
| hyperliquid-mainnet | supported |
| robinhood-mainnet | supported |

Together with the on-chain checks above, both halves are now confirmed for every target chain: the contracts exist, and Alchemy will relay v0.7 operations against them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
