### PR TITLE
feat: session-grant execution, /policies REST surface, v0.7 nonce manager

### DIFF
--- a/.github/actions/setup-test-config/action.yml
+++ b/.github/actions/setup-test-config/action.yml
@@ -22,6 +22,13 @@ inputs:
   owner-eoa:
     description: 'Owner EOA address for test smart wallet derivation (controller signs UserOps)'
     required: true
+  test-private-key:
+    description: |
+      Private key for the owner EOA. Under MA v2 the gateway holds no
+      authority until the owner signs a session grant, and only the owner's
+      key can sign one — so live tests need the key, not just owner-eoa.
+      Optional: jobs that do not run live tests (e.g. lint) can omit it.
+    required: false
   moralis-api-key:
     description: 'Moralis Web3 Data API key for token balance integration tests'
     required: false
@@ -45,3 +52,14 @@ runs:
         MORALIS_API_KEY: "${{ inputs.moralis-api-key }}"
       shell: bash
       run: ./.github/scripts/generate-test-config.sh
+
+    # The live-test fixtures read TEST_PRIVATE_KEY from the ENVIRONMENT
+    # (os.Getenv), not from config/test.yaml — so export it to the job so
+    # every later step sees it. Referenced via $env, not interpolated into
+    # the script body, so the secret never appears verbatim in the command.
+    - name: Export the owner key to the job environment
+      if: ${{ inputs.test-private-key != '' }}
+      shell: bash
+      env:
+        TEST_PRIVATE_KEY: "${{ inputs.test-private-key }}"
+      run: echo "TEST_PRIVATE_KEY=${TEST_PRIVATE_KEY}" >> "$GITHUB_ENV"

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -157,16 +157,17 @@ jobs:
           controller-private-key: ${{ secrets.CONTROLLER_PRIVATE_KEY }}
           tenderly-access-key: ${{ secrets.TENDERLY_ACCESS_KEY }}
           owner-eoa: ${{ vars.OWNER_EOA }}
+          # The owner's key, not just its address: MA v2 wallets grant the
+          # gateway nothing by default, so live tests authorize a session
+          # grant the way production owners do, and only the owner's key can
+          # sign one (core/taskengine/session_grant_testhelper_test.go). The
+          # action exports it to the job environment for the test step.
+          test-private-key: ${{ secrets.TEST_PRIVATE_KEY }}
           moralis-api-key: ${{ secrets.MORALIS_API_KEY }}
 
       - name: Run Go test
         env:
           OWNER_EOA: ${{ vars.OWNER_EOA }}
-          # The owner's key, not just its address: MA v2 wallets grant the
-          # gateway nothing by default, so live tests must authorize a session
-          # grant the way production owners do — and only the owner's key can
-          # sign one (core/taskengine/session_grant_testhelper_test.go).
-          TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
         run: |
           cd ./${{ matrix.test }}
           go test . -v -short

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -162,6 +162,11 @@ jobs:
       - name: Run Go test
         env:
           OWNER_EOA: ${{ vars.OWNER_EOA }}
+          # The owner's key, not just its address: MA v2 wallets grant the
+          # gateway nothing by default, so live tests must authorize a session
+          # grant the way production owners do — and only the owner's key can
+          # sign one (core/taskengine/session_grant_testhelper_test.go).
+          TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
         run: |
           cd ./${{ matrix.test }}
           go test . -v -short

--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -74,6 +74,21 @@ type ServerInterface interface {
 	// Update wallet properties
 	// (PATCH /wallets/{address})
 	UpdateWallet(ctx echo.Context, address EthereumAddress) error
+	// List the wallet's session policies
+	// (GET /wallets/{address}/policies)
+	ListWalletPolicies(ctx echo.Context, address EthereumAddress, params ListWalletPoliciesParams) error
+	// Revoke a session policy
+	// (DELETE /wallets/{address}/policies/{policyId})
+	RevokeWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params RevokeWalletPolicyParams) error
+	// Get one session policy
+	// (GET /wallets/{address}/policies/{policyId})
+	GetWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params GetWalletPolicyParams) error
+	// Allocate a grant and return the EIP-712 payload the owner signs
+	// (POST /wallets/{address}/policies:prepare)
+	PrepareWalletPolicy(ctx echo.Context, address EthereumAddress) error
+	// Submit the owner's signature and persist the grant
+	// (POST /wallets/{address}/policies:submit)
+	SubmitWalletPolicy(ctx echo.Context, address EthereumAddress) error
 	// Get the smart wallet's current nonce
 	// (GET /wallets/{address}:getNonce)
 	GetWalletNonce(ctx echo.Context, address EthereumAddress, params GetWalletNonceParams) error
@@ -534,6 +549,139 @@ func (w *ServerInterfaceWrapper) UpdateWallet(ctx echo.Context) error {
 	return err
 }
 
+// ListWalletPolicies converts echo context to params.
+func (w *ServerInterfaceWrapper) ListWalletPolicies(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListWalletPoliciesParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ListWalletPolicies(ctx, address, params)
+	return err
+}
+
+// RevokeWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) RevokeWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	// ------------- Path parameter "policyId" -------------
+	var policyId Ulid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyId", ctx.Param("policyId"), &policyId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter policyId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params RevokeWalletPolicyParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.RevokeWalletPolicy(ctx, address, policyId, params)
+	return err
+}
+
+// GetWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) GetWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	// ------------- Path parameter "policyId" -------------
+	var policyId Ulid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyId", ctx.Param("policyId"), &policyId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter policyId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetWalletPolicyParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetWalletPolicy(ctx, address, policyId, params)
+	return err
+}
+
+// PrepareWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) PrepareWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.PrepareWalletPolicy(ctx, address)
+	return err
+}
+
+// SubmitWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) SubmitWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.SubmitWalletPolicy(ctx, address)
+	return err
+}
+
 // GetWalletNonce converts echo context to params.
 func (w *ServerInterfaceWrapper) GetWalletNonce(ctx echo.Context) error {
 	var err error
@@ -865,6 +1013,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/wallets", wrapper.ListWallets)
 	router.POST(baseURL+"/wallets", wrapper.CreateWallet)
 	router.PATCH(baseURL+"/wallets/:address", wrapper.UpdateWallet)
+	router.GET(baseURL+"/wallets/:address/policies", wrapper.ListWalletPolicies)
+	router.DELETE(baseURL+"/wallets/:address/policies/:policyId", wrapper.RevokeWalletPolicy)
+	router.GET(baseURL+"/wallets/:address/policies/:policyId", wrapper.GetWalletPolicy)
+	router.POST(baseURL+"/wallets/:address/policies:prepare", wrapper.PrepareWalletPolicy)
+	router.POST(baseURL+"/wallets/:address/policies:submit", wrapper.SubmitWalletPolicy)
 	router.GET(baseURL+"/wallets/:address:getNonce", wrapper.GetWalletNonce)
 	router.POST(baseURL+"/wallets/:address:withdraw", wrapper.WithdrawWallet)
 	router.GET(baseURL+"/workflows", wrapper.ListWorkflows)
@@ -1611,6 +1764,294 @@ func (response UpdateWallet404ApplicationProblemPlusJSONResponse) VisitUpdateWal
 	return json.NewEncoder(w).Encode(response)
 }
 
+type ListWalletPoliciesRequestObject struct {
+	Address EthereumAddress `json:"address"`
+	Params  ListWalletPoliciesParams
+}
+
+type ListWalletPoliciesResponseObject interface {
+	VisitListWalletPoliciesResponse(w http.ResponseWriter) error
+}
+
+type ListWalletPolicies200JSONResponse SessionPolicyList
+
+func (response ListWalletPolicies200JSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListWalletPolicies401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response ListWalletPolicies401ApplicationProblemPlusJSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListWalletPolicies403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response ListWalletPolicies403ApplicationProblemPlusJSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListWalletPolicies404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response ListWalletPolicies404ApplicationProblemPlusJSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicyRequestObject struct {
+	Address  EthereumAddress `json:"address"`
+	PolicyId Ulid            `json:"policyId"`
+	Params   RevokeWalletPolicyParams
+}
+
+type RevokeWalletPolicyResponseObject interface {
+	VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type RevokeWalletPolicy200JSONResponse RevokePolicyResponse
+
+func (response RevokeWalletPolicy200JSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response RevokeWalletPolicy401ApplicationProblemPlusJSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response RevokeWalletPolicy403ApplicationProblemPlusJSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response RevokeWalletPolicy404ApplicationProblemPlusJSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicyRequestObject struct {
+	Address  EthereumAddress `json:"address"`
+	PolicyId Ulid            `json:"policyId"`
+	Params   GetWalletPolicyParams
+}
+
+type GetWalletPolicyResponseObject interface {
+	VisitGetWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type GetWalletPolicy200JSONResponse SessionPolicy
+
+func (response GetWalletPolicy200JSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response GetWalletPolicy401ApplicationProblemPlusJSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response GetWalletPolicy403ApplicationProblemPlusJSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response GetWalletPolicy404ApplicationProblemPlusJSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicyRequestObject struct {
+	Address EthereumAddress `json:"address"`
+	Body    *PrepareWalletPolicyJSONRequestBody
+}
+
+type PrepareWalletPolicyResponseObject interface {
+	VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type PrepareWalletPolicy200JSONResponse PreparedPolicy
+
+func (response PrepareWalletPolicy200JSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy400ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy401ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy403ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy404ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicyRequestObject struct {
+	Address EthereumAddress `json:"address"`
+	Body    *SubmitWalletPolicyJSONRequestBody
+}
+
+type SubmitWalletPolicyResponseObject interface {
+	VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type SubmitWalletPolicy201JSONResponse SessionPolicy
+
+func (response SubmitWalletPolicy201JSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy400ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy401ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy403ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy404ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy409ApplicationProblemPlusJSONResponse Problem
+
+func (response SubmitWalletPolicy409ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetWalletNonceRequestObject struct {
 	Address EthereumAddress `json:"address"`
 	Params  GetWalletNonceParams
@@ -2266,6 +2707,21 @@ type StrictServerInterface interface {
 	// Update wallet properties
 	// (PATCH /wallets/{address})
 	UpdateWallet(ctx context.Context, request UpdateWalletRequestObject) (UpdateWalletResponseObject, error)
+	// List the wallet's session policies
+	// (GET /wallets/{address}/policies)
+	ListWalletPolicies(ctx context.Context, request ListWalletPoliciesRequestObject) (ListWalletPoliciesResponseObject, error)
+	// Revoke a session policy
+	// (DELETE /wallets/{address}/policies/{policyId})
+	RevokeWalletPolicy(ctx context.Context, request RevokeWalletPolicyRequestObject) (RevokeWalletPolicyResponseObject, error)
+	// Get one session policy
+	// (GET /wallets/{address}/policies/{policyId})
+	GetWalletPolicy(ctx context.Context, request GetWalletPolicyRequestObject) (GetWalletPolicyResponseObject, error)
+	// Allocate a grant and return the EIP-712 payload the owner signs
+	// (POST /wallets/{address}/policies:prepare)
+	PrepareWalletPolicy(ctx context.Context, request PrepareWalletPolicyRequestObject) (PrepareWalletPolicyResponseObject, error)
+	// Submit the owner's signature and persist the grant
+	// (POST /wallets/{address}/policies:submit)
+	SubmitWalletPolicy(ctx context.Context, request SubmitWalletPolicyRequestObject) (SubmitWalletPolicyResponseObject, error)
 	// Get the smart wallet's current nonce
 	// (GET /wallets/{address}:getNonce)
 	GetWalletNonce(ctx context.Context, request GetWalletNonceRequestObject) (GetWalletNonceResponseObject, error)
@@ -2822,6 +3278,148 @@ func (sh *strictHandler) UpdateWallet(ctx echo.Context, address EthereumAddress)
 		return err
 	} else if validResponse, ok := response.(UpdateWalletResponseObject); ok {
 		return validResponse.VisitUpdateWalletResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// ListWalletPolicies operation middleware
+func (sh *strictHandler) ListWalletPolicies(ctx echo.Context, address EthereumAddress, params ListWalletPoliciesParams) error {
+	var request ListWalletPoliciesRequestObject
+
+	request.Address = address
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.ListWalletPolicies(ctx.Request().Context(), request.(ListWalletPoliciesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListWalletPolicies")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(ListWalletPoliciesResponseObject); ok {
+		return validResponse.VisitListWalletPoliciesResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// RevokeWalletPolicy operation middleware
+func (sh *strictHandler) RevokeWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params RevokeWalletPolicyParams) error {
+	var request RevokeWalletPolicyRequestObject
+
+	request.Address = address
+	request.PolicyId = policyId
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.RevokeWalletPolicy(ctx.Request().Context(), request.(RevokeWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RevokeWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(RevokeWalletPolicyResponseObject); ok {
+		return validResponse.VisitRevokeWalletPolicyResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// GetWalletPolicy operation middleware
+func (sh *strictHandler) GetWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params GetWalletPolicyParams) error {
+	var request GetWalletPolicyRequestObject
+
+	request.Address = address
+	request.PolicyId = policyId
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetWalletPolicy(ctx.Request().Context(), request.(GetWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetWalletPolicyResponseObject); ok {
+		return validResponse.VisitGetWalletPolicyResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// PrepareWalletPolicy operation middleware
+func (sh *strictHandler) PrepareWalletPolicy(ctx echo.Context, address EthereumAddress) error {
+	var request PrepareWalletPolicyRequestObject
+
+	request.Address = address
+
+	var body PrepareWalletPolicyJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PrepareWalletPolicy(ctx.Request().Context(), request.(PrepareWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PrepareWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(PrepareWalletPolicyResponseObject); ok {
+		return validResponse.VisitPrepareWalletPolicyResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// SubmitWalletPolicy operation middleware
+func (sh *strictHandler) SubmitWalletPolicy(ctx echo.Context, address EthereumAddress) error {
+	var request SubmitWalletPolicyRequestObject
+
+	request.Address = address
+
+	var body SubmitWalletPolicyJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.SubmitWalletPolicy(ctx.Request().Context(), request.(SubmitWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "SubmitWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(SubmitWalletPolicyResponseObject); ok {
+		return validResponse.VisitSubmitWalletPolicyResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -200,11 +200,24 @@ const (
 	PUT     RestAPINodeConfigMethod = "PUT"
 )
 
+// Defines values for RevokePolicyResponseStatus.
+const (
+	Deleted RevokePolicyResponseStatus = "deleted"
+	Revoked RevokePolicyResponseStatus = "revoked"
+)
+
 // Defines values for SecretScope.
 const (
 	SecretScopeOrg      SecretScope = "org"
 	SecretScopeUser     SecretScope = "user"
 	SecretScopeWorkflow SecretScope = "workflow"
+)
+
+// Defines values for SessionPolicyStatus.
+const (
+	SessionPolicyStatusActive  SessionPolicyStatus = "active"
+	SessionPolicyStatusPending SessionPolicyStatus = "pending"
+	SessionPolicyStatusRevoked SessionPolicyStatus = "revoked"
 )
 
 // Defines values for SignalExecutionRequestDecision.
@@ -251,12 +264,21 @@ const (
 
 // Defines values for WorkflowStatus.
 const (
-	Completed WorkflowStatus = "completed"
-	Disabled  WorkflowStatus = "disabled"
-	Enabled   WorkflowStatus = "enabled"
-	Failed    WorkflowStatus = "failed"
-	Running   WorkflowStatus = "running"
+	WorkflowStatusCompleted WorkflowStatus = "completed"
+	WorkflowStatusDisabled  WorkflowStatus = "disabled"
+	WorkflowStatusEnabled   WorkflowStatus = "enabled"
+	WorkflowStatusFailed    WorkflowStatus = "failed"
+	WorkflowStatusRunning   WorkflowStatus = "running"
 )
+
+// AllowedAction One contract the agent may call, scoped to selectors.
+type AllowedAction struct {
+	// Selectors 4-byte function selectors permitted on the target.
+	Selectors []string `json:"selectors"`
+
+	// Target Lowercase or checksummed hex EOA / contract address.
+	Target EthereumAddress `json:"target"`
+}
 
 // AuthExchangeRequest defines model for AuthExchangeRequest.
 type AuthExchangeRequest struct {
@@ -587,6 +609,16 @@ type Edge struct {
 
 	// Target Node ID where this edge ends.
 	Target string `json:"target"`
+}
+
+// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+// token must appear as an `allowedActions` target.
+type Erc20SpendCap struct {
+	// Amount Total cap in the token's smallest unit (decimal string, no reset).
+	Amount string `json:"amount"`
+
+	// Token Lowercase or checksummed hex EOA / contract address.
+	Token EthereumAddress `json:"token"`
 }
 
 // EstimateFeesRequest defines model for EstimateFeesRequest.
@@ -1082,6 +1114,54 @@ type PageInfo struct {
 	StartCursor *string `json:"startCursor,omitempty"`
 }
 
+// PreparePolicyRequest defines model for PreparePolicyRequest.
+type PreparePolicyRequest struct {
+	AgentLabel     string          `json:"agentLabel"`
+	AllowedActions []AllowedAction `json:"allowedActions"`
+
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
+
+	// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+	// token must appear as an `allowedActions` target.
+	Erc20SpendCap Erc20SpendCap `json:"erc20SpendCap"`
+
+	// ExpiresInSeconds Grant lifetime, relative (skew-proof). Becomes an absolute validUntil.
+	ExpiresInSeconds int64   `json:"expiresInSeconds"`
+	Justification    *string `json:"justification,omitempty"`
+}
+
+// PreparedPolicy defines model for PreparedPolicy.
+type PreparedPolicy struct {
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
+
+	// Deadline Unix seconds; bounds signing → first use, NOT the grant lifetime.
+	Deadline int64 `json:"deadline"`
+
+	// Digest The EIP-712 hash the typed data produces, for client-side verification.
+	Digest string `json:"digest"`
+
+	// EntityId The validation entity allocated for this grant (provisional until submit).
+	EntityId int64 `json:"entityId"`
+
+	// PolicyId ULID identifier (26-char Crockford base32).
+	PolicyId Ulid `json:"policyId"`
+
+	// SessionSigner Lowercase or checksummed hex EOA / contract address.
+	SessionSigner EthereumAddress `json:"sessionSigner"`
+
+	// TypedData The exact eth_signTypedData_v4 payload for the owner's wallet.
+	TypedData map[string]interface{} `json:"typedData"`
+
+	// ValidUntil Absolute grant expiry, unix milliseconds. Echo verbatim to submit.
+	ValidUntil int64 `json:"validUntil"`
+}
+
 // Problem RFC 7807 problem+json. Returned as `application/problem+json` on any
 // 4xx/5xx response. `type` and `title` describe the error class; `detail`
 // is human-readable; `instance` is a per-request identifier suitable for
@@ -1166,6 +1246,19 @@ type RestAPINodeConfig_Options struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
+// RevokePolicyResponse defines model for RevokePolicyResponse.
+type RevokePolicyResponse struct {
+	// OnChainCleanupRequired True when the grant's validation is still installed on the
+	// account and needs the owner's uninstallValidation to clear.
+	OnChainCleanupRequired bool `json:"onChainCleanupRequired"`
+
+	// Status deleted = was pending, nothing was ever installed. revoked = retained for audit.
+	Status RevokePolicyResponseStatus `json:"status"`
+}
+
+// RevokePolicyResponseStatus deleted = was pending, nothing was ever installed. revoked = retained for audit.
+type RevokePolicyResponseStatus string
+
 // RunNodeRequest defines model for RunNodeRequest.
 type RunNodeRequest struct {
 	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
@@ -1244,6 +1337,51 @@ type SecretList struct {
 	PageInfo PageInfo `json:"pageInfo"`
 }
 
+// SessionPolicy defines model for SessionPolicy.
+type SessionPolicy struct {
+	AgentLabel     string           `json:"agentLabel"`
+	AllowedActions *[]AllowedAction `json:"allowedActions,omitempty"`
+
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
+
+	// CreatedAt Unix milliseconds.
+	CreatedAt int64 `json:"createdAt"`
+	EntityId  int64 `json:"entityId"`
+
+	// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+	// token must appear as an `allowedActions` target.
+	Erc20SpendCap *Erc20SpendCap `json:"erc20SpendCap,omitempty"`
+
+	// Id ULID identifier (26-char Crockford base32).
+	Id            Ulid    `json:"id"`
+	Justification *string `json:"justification,omitempty"`
+
+	// Runner Lowercase or checksummed hex EOA / contract address.
+	Runner EthereumAddress `json:"runner"`
+
+	// SessionSigner Lowercase or checksummed hex EOA / contract address.
+	SessionSigner EthereumAddress `json:"sessionSigner"`
+
+	// Status pending = signed and stored, install not yet on-chain (revocable
+	// for free). active = install applied. revoked = grants nothing.
+	Status SessionPolicyStatus `json:"status"`
+
+	// ValidUntil Unix milliseconds.
+	ValidUntil int64 `json:"validUntil"`
+}
+
+// SessionPolicyStatus pending = signed and stored, install not yet on-chain (revocable
+// for free). active = install applied. revoked = grants nothing.
+type SessionPolicyStatus string
+
+// SessionPolicyList defines model for SessionPolicyList.
+type SessionPolicyList struct {
+	Items []SessionPolicy `json:"items"`
+}
+
 // SignalExecutionRequest defines model for SignalExecutionRequest.
 type SignalExecutionRequest struct {
 	// Decision The approver's decision.
@@ -1272,6 +1410,33 @@ type SimulateWorkflowRequest struct {
 	InputVariables InputVariables `json:"inputVariables"`
 	Nodes          []Node         `json:"nodes"`
 	Trigger        Trigger        `json:"trigger"`
+}
+
+// SubmitPolicyRequest defines model for SubmitPolicyRequest.
+type SubmitPolicyRequest struct {
+	AgentLabel     string          `json:"agentLabel"`
+	AllowedActions []AllowedAction `json:"allowedActions"`
+
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId  ChainId `json:"chainId"`
+	Deadline int64   `json:"deadline"`
+	EntityId int64   `json:"entityId"`
+
+	// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+	// token must appear as an `allowedActions` target.
+	Erc20SpendCap Erc20SpendCap `json:"erc20SpendCap"`
+	Justification *string       `json:"justification,omitempty"`
+
+	// PolicyId ULID identifier (26-char Crockford base32).
+	PolicyId Ulid `json:"policyId"`
+
+	// Signature The owner's 65-byte signature over the prepared digest.
+	Signature string `json:"signature"`
+
+	// ValidUntil The ABSOLUTE expiry from prepare. It is baked into the signed calldata; recomputing it would change the digest.
+	ValidUntil int64 `json:"validUntil"`
 }
 
 // Timestamp RFC 3339 timestamp.
@@ -1643,6 +1808,27 @@ type GetTokenParams struct {
 	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 
+// ListWalletPoliciesParams defines parameters for ListWalletPolicies.
+type ListWalletPoliciesParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
+// RevokeWalletPolicyParams defines parameters for RevokeWalletPolicy.
+type RevokeWalletPolicyParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
+// GetWalletPolicyParams defines parameters for GetWalletPolicy.
+type GetWalletPolicyParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
 // GetWalletNonceParams defines parameters for GetWalletNonce.
 type GetWalletNonceParams struct {
 	// ChainId The chain to operate on (a single value). Omit to use the aggregator
@@ -1706,6 +1892,12 @@ type CreateWalletJSONRequestBody = CreateWalletRequest
 
 // UpdateWalletJSONRequestBody defines body for UpdateWallet for application/json ContentType.
 type UpdateWalletJSONRequestBody = UpdateWalletRequest
+
+// PrepareWalletPolicyJSONRequestBody defines body for PrepareWalletPolicy for application/json ContentType.
+type PrepareWalletPolicyJSONRequestBody = PreparePolicyRequest
+
+// SubmitWalletPolicyJSONRequestBody defines body for SubmitWalletPolicy for application/json ContentType.
+type SubmitWalletPolicyJSONRequestBody = SubmitPolicyRequest
 
 // WithdrawWalletJSONRequestBody defines body for WithdrawWallet for application/json ContentType.
 type WithdrawWalletJSONRequestBody = WithdrawRequest

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -1,0 +1,327 @@
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// /wallets/{address}/policies — the grant screen's backend.
+//
+// Granting is prepare → sign → submit (master doc §7.5 as reshaped by
+// §7.4a): prepare allocates and returns the EIP-712 payload, the owner's
+// wallet signs it, submit verifies and persists. Prepare stores nothing;
+// submit trusts nothing — the grant is recomputed from the echoed fields and
+// the signature is the only authority.
+//
+// Every handler leads with refusePartnerAssertion: a policy is fund
+// authority, and the refusal must be explicit rather than a handler that
+// silently never consults the header.
+
+const policyCapability = "Session-policy management"
+
+// policyChainID resolves the chain: explicit value wins, then the JWT's
+// audience chain. Zero means unresolvable (single-chain deployments have an
+// aud; a request with neither is malformed).
+func policyChainID(ctx echo.Context, explicit *int64) int64 {
+	if explicit != nil && *explicit > 0 {
+		return *explicit
+	}
+	if authed := restmw.UserFromContext(ctx); authed != nil {
+		return authed.ChainID
+	}
+	return 0
+}
+
+// policyAuth is the shared preamble: partner refusal, then user auth, then
+// path-address validation.
+func (s *Server) policyAuth(ctx echo.Context, address generated.EthereumAddress) (*model.User, common.Address, error) {
+	if err := refusePartnerAssertion(ctx, policyCapability); err != nil {
+		return nil, common.Address{}, err
+	}
+	user, err := s.requireUser(ctx)
+	if err != nil {
+		return nil, common.Address{}, err
+	}
+	if !common.IsHexAddress(string(address)) {
+		return nil, common.Address{}, badRequest("POLICIES_BAD_ADDRESS", "Invalid wallet address",
+			"The {address} path parameter must be a valid 0x-prefixed hex address.")
+	}
+	return user, common.HexToAddress(string(address)), nil
+}
+
+// PrepareWalletPolicy allocates a grant and returns the payload to sign.
+func (s *Server) PrepareWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	var req generated.PreparePolicyRequest
+	if err := ctx.Bind(&req); err != nil {
+		return badRequest("POLICIES_BAD_BODY", "Invalid request body", err.Error())
+	}
+	if req.ExpiresInSeconds <= 0 {
+		return badRequest("POLICIES_BAD_EXPIRY", "Invalid expiry", "expiresInSeconds must be positive.")
+	}
+	perms, err := permissionsFromAPI(req.AllowedActions, &req.Erc20SpendCap, nowMs()+req.ExpiresInSeconds*1000)
+	if err != nil {
+		return badRequest("POLICIES_BAD_PERMISSIONS", "Invalid permissions", err.Error())
+	}
+
+	prepared, err := s.engine.PrepareSessionPolicy(user, taskengine.SessionPolicyInput{
+		Wallet:        wallet,
+		ChainID:       int64(req.ChainId),
+		AgentLabel:    req.AgentLabel,
+		Justification: deref(req.Justification),
+		Permissions:   perms,
+	})
+	if err != nil {
+		return mapPolicyError(err)
+	}
+
+	policy := prepared.Policy
+	typedData, err := typedDataJSON(policy)
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, generated.PreparedPolicy{
+		PolicyId:      generated.Ulid(policy.ID),
+		ChainId:       generated.ChainId(policy.ChainID),
+		EntityId:      int64(policy.EntityID),
+		SessionSigner: generated.EthereumAddress(policy.SessionSigner.Hex()),
+		Deadline:      int64(policy.Grant.Deadline),
+		ValidUntil:    policy.ValidUntil,
+		Digest:        prepared.Digest.Hex(),
+		TypedData:     typedData,
+	})
+}
+
+// SubmitWalletPolicy verifies the owner's signature and stores the grant.
+func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	var req generated.SubmitPolicyRequest
+	if err := ctx.Bind(&req); err != nil {
+		return badRequest("POLICIES_BAD_BODY", "Invalid request body", err.Error())
+	}
+	signature := common.FromHex(req.Signature)
+	if len(signature) != 65 {
+		return badRequest("POLICIES_BAD_SIGNATURE", "Invalid signature",
+			"signature must be 65 hex-encoded bytes (r ++ s ++ v).")
+	}
+	if req.EntityId <= 0 || req.EntityId > int64(^uint32(0)) {
+		return badRequest("POLICIES_BAD_ENTITY", "Invalid entity id", "entityId is out of range.")
+	}
+	if req.Deadline <= 0 {
+		return badRequest("POLICIES_BAD_DEADLINE", "Invalid deadline", "deadline must be positive.")
+	}
+	perms, err := permissionsFromAPI(req.AllowedActions, &req.Erc20SpendCap, req.ValidUntil)
+	if err != nil {
+		return badRequest("POLICIES_BAD_PERMISSIONS", "Invalid permissions", err.Error())
+	}
+
+	policy, err := s.engine.SubmitSessionPolicy(user, taskengine.SessionPolicyInput{
+		Wallet:        wallet,
+		ChainID:       int64(req.ChainId),
+		AgentLabel:    req.AgentLabel,
+		Justification: deref(req.Justification),
+		Permissions:   perms,
+	}, string(req.PolicyId), uint32(req.EntityId), uint64(req.Deadline), signature)
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	return ctx.JSON(http.StatusCreated, policyToAPI(policy))
+}
+
+// ListWalletPolicies lists the wallet's grants, newest first.
+func (s *Server) ListWalletPolicies(ctx echo.Context, address generated.EthereumAddress, params generated.ListWalletPoliciesParams) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	chainID := policyChainID(ctx, (*int64)(params.ChainId))
+	if chainID <= 0 {
+		return badRequest("POLICIES_BAD_CHAIN_ID", "Chain unresolvable",
+			"Provide ?chainId= or authenticate with a chain-scoped token.")
+	}
+	policies, err := s.engine.ListSessionPoliciesForWallet(user, chainID, wallet)
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	items := make([]generated.SessionPolicy, 0, len(policies))
+	for _, p := range policies {
+		items = append(items, policyToAPI(p))
+	}
+	return ctx.JSON(http.StatusOK, generated.SessionPolicyList{Items: items})
+}
+
+// GetWalletPolicy returns one grant.
+func (s *Server) GetWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.GetWalletPolicyParams) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	chainID := policyChainID(ctx, (*int64)(params.ChainId))
+	if chainID <= 0 {
+		return badRequest("POLICIES_BAD_CHAIN_ID", "Chain unresolvable",
+			"Provide ?chainId= or authenticate with a chain-scoped token.")
+	}
+	policy, err := s.engine.GetSessionPolicyByID(user, chainID, wallet, string(policyID))
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	return ctx.JSON(http.StatusOK, policyToAPI(policy))
+}
+
+// RevokeWalletPolicy revokes one grant.
+func (s *Server) RevokeWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.RevokeWalletPolicyParams) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	chainID := policyChainID(ctx, (*int64)(params.ChainId))
+	if chainID <= 0 {
+		return badRequest("POLICIES_BAD_CHAIN_ID", "Chain unresolvable",
+			"Provide ?chainId= or authenticate with a chain-scoped token.")
+	}
+	deleted, cleanupRequired, err := s.engine.RevokeSessionPolicyByID(user, chainID, wallet, string(policyID))
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	status := generated.RevokePolicyResponseStatus("revoked")
+	if deleted {
+		status = generated.RevokePolicyResponseStatus("deleted")
+	}
+	return ctx.JSON(http.StatusOK, generated.RevokePolicyResponse{
+		Status:                 status,
+		OnChainCleanupRequired: cleanupRequired,
+	})
+}
+
+// ── mapping ───────────────────────────────────────────────────────────────
+
+// permissionsFromAPI translates wire permissions into the engine's set.
+func permissionsFromAPI(actions []generated.AllowedAction, spendCap *generated.Erc20SpendCap, validUntilMs int64) (taskengine.SessionPermissions, error) {
+	perms := taskengine.SessionPermissions{ValidUntilMs: validUntilMs}
+	for _, a := range actions {
+		if !common.IsHexAddress(string(a.Target)) {
+			return perms, errors.New("allowed action target is not a valid address")
+		}
+		target := common.HexToAddress(string(a.Target))
+		perms.AllowedActions = append(perms.AllowedActions, model.AllowedAction{
+			Target:    &target,
+			Selectors: a.Selectors,
+		})
+	}
+	if spendCap != nil {
+		if !common.IsHexAddress(string(spendCap.Token)) {
+			return perms, errors.New("spend cap token is not a valid address")
+		}
+		token := common.HexToAddress(string(spendCap.Token))
+		perms.SpendCap = &model.ERC20SpendCap{Token: &token, Amount: spendCap.Amount}
+	}
+	return perms, nil
+}
+
+// policyToAPI renders a policy for responses. Grant material — calldata,
+// nonce, the owner's signature — is secret-grade and never leaves storage.
+func policyToAPI(p *model.SessionPolicy) generated.SessionPolicy {
+	out := generated.SessionPolicy{
+		Id:         generated.Ulid(p.ID),
+		ChainId:    generated.ChainId(p.ChainID),
+		Status:     generated.SessionPolicyStatus(p.Status),
+		EntityId:   int64(p.EntityID),
+		AgentLabel: p.AgentLabel,
+		ValidUntil: p.ValidUntil,
+		CreatedAt:  p.CreatedAt,
+	}
+	if p.Runner != nil {
+		out.Runner = generated.EthereumAddress(p.Runner.Hex())
+	}
+	if p.SessionSigner != nil {
+		out.SessionSigner = generated.EthereumAddress(p.SessionSigner.Hex())
+	}
+	if p.Justification != "" {
+		out.Justification = &p.Justification
+	}
+	if len(p.AllowedActions) > 0 {
+		actions := make([]generated.AllowedAction, 0, len(p.AllowedActions))
+		for _, a := range p.AllowedActions {
+			if a.Target == nil {
+				continue
+			}
+			actions = append(actions, generated.AllowedAction{
+				Target:    generated.EthereumAddress(a.Target.Hex()),
+				Selectors: a.Selectors,
+			})
+		}
+		out.AllowedActions = &actions
+	}
+	if p.ERC20SpendCap != nil && p.ERC20SpendCap.Token != nil {
+		out.Erc20SpendCap = &generated.Erc20SpendCap{
+			Token:  generated.EthereumAddress(p.ERC20SpendCap.Token.Hex()),
+			Amount: p.ERC20SpendCap.Amount,
+		}
+	}
+	return out
+}
+
+// typedDataJSON renders the eth_signTypedData_v4 payload for the prepare
+// response — built from the SAME fields the digest was computed over, so the
+// wallet signs exactly what submit will verify.
+func typedDataJSON(policy *model.SessionPolicy) (map[string]interface{}, error) {
+	typed := userop.DeferredActionTypedData(
+		bigChainID(policy.ChainID), *policy.Runner,
+		policy.Grant.CarrierNonce, policy.Grant.Deadline, policy.Grant.InstallCall)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// mapPolicyError translates engine sentinels into REST problems.
+func mapPolicyError(err error) error {
+	switch {
+	case errors.Is(err, taskengine.ErrWalletNotOwned), errors.Is(err, taskengine.ErrSessionPolicyNotFound):
+		// Existence is not confirmed to non-owners: both cases read as 404.
+		return &restmw.HTTPError{Status: http.StatusNotFound, Code: "POLICIES_NOT_FOUND",
+			Title: "Not found", Detail: "No such wallet or policy for this account."}
+	case errors.Is(err, taskengine.ErrSessionEntityTaken):
+		return &restmw.HTTPError{Status: http.StatusConflict, Code: "POLICIES_ENTITY_TAKEN",
+			Title: "Grant allocation superseded", Detail: err.Error() + " Prepare the grant again."}
+	case strings.Contains(err.Error(), "signed by"):
+		return badRequest("POLICIES_BAD_SIGNATURE", "Signature does not match", err.Error())
+	default:
+		return badRequest("POLICIES_REJECTED", "Policy request rejected", err.Error())
+	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func nowMs() int64 { return time.Now().UnixMilli() }
+
+func bigChainID(chainID int64) *big.Int { return big.NewInt(chainID) }

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -72,8 +72,10 @@ func (s *Server) PrepareWalletPolicy(ctx echo.Context, address generated.Ethereu
 	if err := ctx.Bind(&req); err != nil {
 		return badRequest("POLICIES_BAD_BODY", "Invalid request body", err.Error())
 	}
-	if req.ExpiresInSeconds <= 0 {
-		return badRequest("POLICIES_BAD_EXPIRY", "Invalid expiry", "expiresInSeconds must be positive.")
+	// Matches the published contract (openapi.yaml minimum: 60): a
+	// sub-minute grant expires before its first operation can mine.
+	if req.ExpiresInSeconds < 60 {
+		return badRequest("POLICIES_BAD_EXPIRY", "Invalid expiry", "expiresInSeconds must be at least 60.")
 	}
 	perms, err := permissionsFromAPI(req.AllowedActions, &req.Erc20SpendCap, nowMs()+req.ExpiresInSeconds*1000)
 	if err != nil {

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -1,0 +1,269 @@
+package rest
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// The /policies surface end to end at the HTTP layer: the guard, the
+// prepare → sign → submit round trip (including proof that the returned
+// typed data hashes to the returned digest — what the wallet signs is what
+// submit verifies), and the secret-grade handling of grant material.
+
+const policyTestChain = int64(11155111)
+
+type policyTestRig struct {
+	server   *Server
+	ownerKey *ecdsa.PrivateKey
+	owner    common.Address
+	wallet   common.Address
+}
+
+func newPolicyRig(t *testing.T) *policyTestRig {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	cfg := testutil.GetAggregatorConfig()
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	cfg.SmartWallet.ControllerPrivateKey = controllerKey
+	cfg.SmartWallet.ChainID = policyTestChain
+	engine := taskengine.New(db, cfg, nil, testutil.GetLogger())
+
+	logger, err := sdklogging.NewZapLogger(sdklogging.Development)
+	require.NoError(t, err)
+
+	ownerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	wallet := common.HexToAddress("0x00000000000000000000000000000000000000b2")
+	factory := common.HexToAddress("0x00000000000017c61b5bEe81050EC8eFc9c6fecd")
+	require.NoError(t, taskengine.StoreWallet(db, policyTestChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &wallet, Factory: &factory, Salt: big.NewInt(0),
+	}))
+
+	return &policyTestRig{
+		server:   &Server{engine: engine, logger: logger, config: cfg},
+		ownerKey: ownerKey,
+		owner:    owner,
+		wallet:   wallet,
+	}
+}
+
+// call builds an authed request, runs the handler, and returns the recorder.
+func (r *policyTestRig) call(t *testing.T, body any, handler func(echo.Context) error, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/wallets/x/policies", &buf)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	ctx := echo.New().NewContext(req, rec)
+	ctx.Set("auth.user", &restmw.AuthenticatedUser{Subject: r.owner.Hex(), ChainID: policyTestChain})
+
+	if err := handler(ctx); err != nil {
+		// Match production behavior enough to assert on: structured errors
+		// carry their own status.
+		var httpErr *restmw.HTTPError
+		if ok := asHTTPError(err, &httpErr); ok {
+			rec.Code = httpErr.Status
+			rec.Body.Reset()
+			raw, _ := json.Marshal(httpErr)
+			rec.Body.Write(raw)
+		} else {
+			t.Fatalf("handler returned an unstructured error: %v", err)
+		}
+	}
+	return rec
+}
+
+func asHTTPError(err error, target **restmw.HTTPError) bool {
+	for e := err; e != nil; {
+		if he, ok := e.(*restmw.HTTPError); ok {
+			*target = he
+			return true
+		}
+		u, ok := e.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		e = u.Unwrap()
+	}
+	return false
+}
+
+func prepareBody(chainID int64) generated.PreparePolicyRequest {
+	token := "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+	router := "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E"
+	return generated.PreparePolicyRequest{
+		ChainId:    generated.ChainId(chainID),
+		AgentLabel: "TradingBot",
+		AllowedActions: []generated.AllowedAction{
+			{Target: generated.EthereumAddress(router), Selectors: []string{"0x04e45aaf"}},
+			{Target: generated.EthereumAddress(token), Selectors: []string{"0x095ea7b3"}},
+		},
+		Erc20SpendCap:    generated.Erc20SpendCap{Token: generated.EthereumAddress(token), Amount: "500000000"},
+		ExpiresInSeconds: int64((30 * 24 * time.Hour).Seconds()),
+	}
+}
+
+func TestPoliciesRefusePartnerAssertionsEverywhere(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+	assertion := map[string]string{partnerAssertionHeader: "any-value"}
+
+	handlers := map[string]func(echo.Context) error{
+		"prepare": func(c echo.Context) error { return rig.server.PrepareWalletPolicy(c, address) },
+		"submit":  func(c echo.Context) error { return rig.server.SubmitWalletPolicy(c, address) },
+		"list": func(c echo.Context) error {
+			return rig.server.ListWalletPolicies(c, address, generated.ListWalletPoliciesParams{})
+		},
+		"get": func(c echo.Context) error {
+			return rig.server.GetWalletPolicy(c, address, "01JG2FE5MDVKBPHEG0PEYSDKAC", generated.GetWalletPolicyParams{})
+		},
+		"revoke": func(c echo.Context) error {
+			return rig.server.RevokeWalletPolicy(c, address, "01JG2FE5MDVKBPHEG0PEYSDKAC", generated.RevokeWalletPolicyParams{})
+		},
+	}
+	for name, h := range handlers {
+		rec := rig.call(t, nil, h, assertion)
+		require.Equal(t, http.StatusForbidden, rec.Code, "%s must refuse partner assertions", name)
+		require.Contains(t, rec.Body.String(), "PARTNER_DELEGATION_UNSUPPORTED", "%s refusal must be explicit", name)
+	}
+}
+
+func TestPoliciesPrepareSignSubmitOverHTTP(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+
+	// Prepare.
+	rec := rig.call(t, prepareBody(policyTestChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+	require.NotEmpty(t, prepared.PolicyId)
+	require.EqualValues(t, 1, prepared.EntityId)
+
+	// The returned typed data must hash to the returned digest — what the
+	// owner's wallet displays and signs is exactly what submit verifies.
+	rawTyped, err := json.Marshal(prepared.TypedData)
+	require.NoError(t, err)
+	var typed apitypes.TypedData
+	require.NoError(t, json.Unmarshal(rawTyped, &typed))
+	walletDigest, _, err := apitypes.TypedDataAndHash(typed)
+	require.NoError(t, err)
+	require.Equal(t, prepared.Digest, fmt.Sprintf("0x%x", walletDigest),
+		"typed data and digest disagree; the wallet would sign something submit rejects")
+
+	// Sign as the owner's wallet would.
+	sig, err := crypto.Sign(walletDigest, rig.ownerKey)
+	require.NoError(t, err)
+	sig[64] += 27
+
+	// Submit the echo.
+	body := prepareBody(policyTestChain)
+	submit := generated.SubmitPolicyRequest{
+		ChainId:        body.ChainId,
+		PolicyId:       prepared.PolicyId,
+		EntityId:       prepared.EntityId,
+		Deadline:       prepared.Deadline,
+		ValidUntil:     prepared.ValidUntil,
+		AgentLabel:     body.AgentLabel,
+		AllowedActions: body.AllowedActions,
+		Erc20SpendCap:  body.Erc20SpendCap,
+		Signature:      fmt.Sprintf("0x%x", sig),
+	}
+	rec = rig.call(t, submit, func(c echo.Context) error {
+		return rig.server.SubmitWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var policy generated.SessionPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &policy))
+	require.Equal(t, "pending", string(policy.Status))
+	require.Equal(t, "500000000", policy.Erc20SpendCap.Amount)
+
+	// Grant material is secret-grade: neither the submit response nor the
+	// list may carry calldata, the carrier nonce, or the owner's signature.
+	for _, marker := range []string{"install_call", "owner_signature", "carrier_nonce", "installCall", "ownerSignature"} {
+		require.NotContains(t, rec.Body.String(), marker, "grant material leaked")
+	}
+
+	rec = rig.call(t, nil, func(c echo.Context) error {
+		return rig.server.ListWalletPolicies(c, address, generated.ListWalletPoliciesParams{})
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), string(prepared.PolicyId))
+	require.NotContains(t, rec.Body.String(), "ownerSignature")
+
+	// Revoke: pending → deleted outright, no on-chain cleanup.
+	rec = rig.call(t, nil, func(c echo.Context) error {
+		return rig.server.RevokeWalletPolicy(c, address, prepared.PolicyId, generated.RevokeWalletPolicyParams{})
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var revoked generated.RevokePolicyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &revoked))
+	require.Equal(t, "deleted", string(revoked.Status))
+	require.False(t, revoked.OnChainCleanupRequired)
+}
+
+func TestPoliciesSubmitRejectsTamperedCapOverHTTP(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+
+	rec := rig.call(t, prepareBody(policyTestChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+
+	sig, err := crypto.Sign(common.HexToHash(prepared.Digest).Bytes(), rig.ownerKey)
+	require.NoError(t, err)
+	sig[64] += 27
+
+	body := prepareBody(policyTestChain)
+	body.Erc20SpendCap.Amount = "999999999999" // not what the owner signed
+	submit := generated.SubmitPolicyRequest{
+		ChainId: body.ChainId, PolicyId: prepared.PolicyId, EntityId: prepared.EntityId,
+		Deadline: prepared.Deadline, ValidUntil: prepared.ValidUntil,
+		AgentLabel: body.AgentLabel, AllowedActions: body.AllowedActions,
+		Erc20SpendCap: body.Erc20SpendCap, Signature: fmt.Sprintf("0x%x", sig),
+	}
+	rec = rig.call(t, submit, func(c echo.Context) error {
+		return rig.server.SubmitWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.True(t, strings.Contains(rec.Body.String(), "POLICIES_BAD_SIGNATURE"),
+		"a tampered echo must surface as a signature mismatch, got: %s", rec.Body.String())
+}

--- a/aggregator/rest/partner.go
+++ b/aggregator/rest/partner.go
@@ -135,6 +135,37 @@ func (s *Server) requireWalletDeriveAuth(ctx echo.Context) (*model.User, error) 
 	return user, nil
 }
 
+// refusePartnerAssertion explicitly rejects a request that presents
+// X-Partner-Assertion on an endpoint partner delegation may never reach.
+//
+// Session-policy management is FUND AUTHORITY: a policy record carries the
+// owner's signed grant of on-chain execution rights, and creating, reading,
+// or revoking one is exactly the class of operation the package comment
+// above excludes from delegation. The failure mode this guard exists for is
+// silent non-consultation — a handler that authenticates the user JWT and
+// never looks at the assertion header, leaving a partner integrating against
+// the wrong endpoint to discover the boundary from behavior instead of from
+// an error.
+//
+// The assertion is refused WITHOUT verification, valid or not: the boundary
+// is categorical, verification costs signature checks, and a
+// validity-dependent response would make this endpoint an oracle for
+// assertion validity.
+//
+// MUST be the first line of every /policies handler (avs-infra master doc
+// §7.4a; the decision predates the routes). Returns nil when no assertion is
+// present — user-JWT requests pass through untouched.
+func refusePartnerAssertion(ctx echo.Context, capability string) error {
+	if strings.TrimSpace(ctx.Request().Header.Get(partnerAssertionHeader)) == "" {
+		return nil
+	}
+	return partnerError(http.StatusForbidden, "PARTNER_DELEGATION_UNSUPPORTED",
+		"Partner delegation not supported here",
+		fmt.Sprintf("%s is fund authority and cannot be exercised through a partner assertion. "+
+			"Partner delegation covers the no-fund simulate family only; use the end-user's "+
+			"Bearer JWT (POST /api/v1/auth:exchange) for this endpoint.", capability))
+}
+
 // verifyPartnerAssertion validates the X-Partner-Assertion header against the
 // configured partner registry. It returns:
 //

--- a/aggregator/rest/partner_refusal_test.go
+++ b/aggregator/rest/partner_refusal_test.go
@@ -1,0 +1,59 @@
+package rest
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+)
+
+// The policy surface never honors partner delegation, and the refusal must be
+// explicit — a reasoned 403, not a handler that quietly ignores the header.
+
+func TestRefusePartnerAssertion_NoHeaderPassesThrough(t *testing.T) {
+	if err := refusePartnerAssertion(ctxWithAssertion(""), "Session-policy management"); err != nil {
+		t.Fatalf("a request without an assertion must pass: %v", err)
+	}
+}
+
+func TestRefusePartnerAssertion_RefusesWithoutVerifying(t *testing.T) {
+	// Garbage that could never verify — refused for WHERE it was sent, not
+	// for what it is.
+	err := refusePartnerAssertion(ctxWithAssertion("not-a-jwt"), "Session-policy management")
+	assertDelegationRefusal(t, err)
+}
+
+func TestRefusePartnerAssertion_RefusesEvenAValidAssertion(t *testing.T) {
+	// A fully valid assertion from an active, correctly-scoped partner is
+	// refused identically: the boundary is categorical, and the response must
+	// not become an oracle for assertion validity.
+	_, priv, _ := ed25519.GenerateKey(nil)
+	err := refusePartnerAssertion(
+		ctxWithAssertion(signAssertion(t, priv, validClaims())), "Session-policy management")
+	assertDelegationRefusal(t, err)
+}
+
+func assertDelegationRefusal(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	var httpErr *restmw.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected an HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.Status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", httpErr.Status)
+	}
+	if httpErr.Code != "PARTNER_DELEGATION_UNSUPPORTED" {
+		t.Fatalf("code = %s, want PARTNER_DELEGATION_UNSUPPORTED", httpErr.Code)
+	}
+	// The reason must name the boundary and the way forward.
+	if !strings.Contains(httpErr.Detail, "fund authority") ||
+		!strings.Contains(httpErr.Detail, "Bearer JWT") {
+		t.Fatalf("detail should explain the fund-authority boundary and point at the JWT path, got: %s", httpErr.Detail)
+	}
+}

--- a/aggregator/rest/server.go
+++ b/aggregator/rest/server.go
@@ -372,6 +372,15 @@ func registerColonActionShimRoutes(api *echo.Group, s *Server) {
 		return s.SignalExecution(c, generated.Ulid(c.Param("id")), params)
 	})
 
+	// Session-policy grant flow: prepare → sign → submit. Nested under the
+	// wallet, so the shim path carries the :address parameter.
+	api.POST("/wallets/:address/policies"+colonActionShim+"prepare", func(c echo.Context) error {
+		return s.PrepareWalletPolicy(c, generated.EthereumAddress(c.Param("address")))
+	})
+	api.POST("/wallets/:address/policies"+colonActionShim+"submit", func(c echo.Context) error {
+		return s.SubmitWalletPolicy(c, generated.EthereumAddress(c.Param("address")))
+	})
+
 	// Collection-level actions. Routed via the generated wrapper so the
 	// oapi-codegen runtime handles query-param binding the same way the
 	// non-shim routes would.

--- a/aggregator/task_engine.go
+++ b/aggregator/task_engine.go
@@ -227,6 +227,11 @@ func (agg *Aggregator) startTaskEngine(ctx context.Context) {
 		agg.queue,
 		agg.logger,
 	)
+	// Teach the send path where session grants live. Installed here — the one
+	// place a single production engine exists — rather than in New, which test
+	// suites call many times per process (the resolver is process-global, and
+	// engines constructed later would silently overwrite earlier ones).
+	agg.engine.InstallSessionResolver()
 
 	// Price service for fee conversion (USD → ETH and ERC20 lookups). When
 	// Moralis isn't configured, it stays nil and callers gracefully degrade

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1639,6 +1639,180 @@ components:
           type: array
           items: { $ref: '#/components/schemas/OperatorInfo' }
 
+    # -------------------------------------------------------------------
+    # Session policies
+    # -------------------------------------------------------------------
+
+    AllowedAction:
+      type: object
+      required: [target, selectors]
+      properties:
+        target:
+          $ref: '#/components/schemas/EthereumAddress'
+        selectors:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            pattern: '^0x[a-fA-F0-9]{8}$'
+          description: 4-byte function selectors permitted on the target.
+      description: One contract the agent may call, scoped to selectors.
+
+    Erc20SpendCap:
+      type: object
+      required: [token, amount]
+      properties:
+        token:
+          $ref: '#/components/schemas/EthereumAddress'
+        amount:
+          type: string
+          pattern: '^[0-9]+$'
+          description: Total cap in the token's smallest unit (decimal string, no reset).
+          example: '500000000'
+      description: |
+        Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+        token must appear as an `allowedActions` target.
+
+    PreparePolicyRequest:
+      type: object
+      required: [chainId, agentLabel, allowedActions, erc20SpendCap, expiresInSeconds]
+      properties:
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        agentLabel:
+          type: string
+          minLength: 1
+          maxLength: 120
+        justification:
+          type: string
+          maxLength: 500
+        allowedActions:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        expiresInSeconds:
+          type: integer
+          format: int64
+          minimum: 60
+          description: Grant lifetime, relative (skew-proof). Becomes an absolute validUntil.
+
+    PreparedPolicy:
+      type: object
+      required: [policyId, chainId, entityId, sessionSigner, deadline, validUntil, digest, typedData]
+      properties:
+        policyId: { $ref: '#/components/schemas/Ulid' }
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        entityId:
+          type: integer
+          format: int64
+          description: The validation entity allocated for this grant (provisional until submit).
+        sessionSigner:
+          $ref: '#/components/schemas/EthereumAddress'
+        deadline:
+          type: integer
+          format: int64
+          description: Unix seconds; bounds signing → first use, NOT the grant lifetime.
+        validUntil:
+          type: integer
+          format: int64
+          description: Absolute grant expiry, unix milliseconds. Echo verbatim to submit.
+        digest:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{64}$'
+          description: The EIP-712 hash the typed data produces, for client-side verification.
+        typedData:
+          type: object
+          additionalProperties: true
+          description: The exact eth_signTypedData_v4 payload for the owner's wallet.
+
+    SubmitPolicyRequest:
+      type: object
+      required: [chainId, policyId, entityId, deadline, validUntil, agentLabel, allowedActions, erc20SpendCap, signature]
+      properties:
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        policyId: { $ref: '#/components/schemas/Ulid' }
+        entityId:
+          type: integer
+          format: int64
+        deadline:
+          type: integer
+          format: int64
+        validUntil:
+          type: integer
+          format: int64
+          description: The ABSOLUTE expiry from prepare. It is baked into the signed calldata; recomputing it would change the digest.
+        agentLabel:
+          type: string
+          minLength: 1
+          maxLength: 120
+        justification:
+          type: string
+          maxLength: 500
+        allowedActions:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        signature:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{130}$'
+          description: The owner's 65-byte signature over the prepared digest.
+
+    SessionPolicy:
+      type: object
+      required: [id, runner, chainId, status, entityId, sessionSigner, agentLabel, validUntil, createdAt]
+      properties:
+        id: { $ref: '#/components/schemas/Ulid' }
+        runner: { $ref: '#/components/schemas/EthereumAddress' }
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        status:
+          type: string
+          enum: [pending, active, revoked]
+          description: |
+            pending = signed and stored, install not yet on-chain (revocable
+            for free). active = install applied. revoked = grants nothing.
+        entityId:
+          type: integer
+          format: int64
+        sessionSigner:
+          $ref: '#/components/schemas/EthereumAddress'
+        agentLabel: { type: string }
+        justification: { type: string }
+        allowedActions:
+          type: array
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        validUntil:
+          type: integer
+          format: int64
+          description: Unix milliseconds.
+        createdAt:
+          type: integer
+          format: int64
+          description: Unix milliseconds.
+
+    SessionPolicyList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/SessionPolicy' }
+
+    RevokePolicyResponse:
+      type: object
+      required: [status, onChainCleanupRequired]
+      properties:
+        status:
+          type: string
+          enum: [deleted, revoked]
+          description: deleted = was pending, nothing was ever installed. revoked = retained for audit.
+        onChainCleanupRequired:
+          type: boolean
+          description: |
+            True when the grant's validation is still installed on the
+            account and needs the owner's uninstallValidation to clear.
+
   responses:
     BadRequest:
       description: Request validation failed.
@@ -2343,6 +2517,153 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/NonceResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # =====================================================================
+  # Session policies — grants of execution authority on a wallet
+  # =====================================================================
+  # A policy is the record behind the grant screen: which agent may act on a
+  # wallet, bounded by allowed actions, an ERC-20 spend cap, and an expiry.
+  # Granting is prepare → sign → submit: the wallet needs the EIP-712 payload
+  # before the owner can sign it, and nothing is stored until the signature
+  # comes back. Fund authority — never reachable through a partner assertion.
+
+  /wallets/{address}/policies:prepare:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+    post:
+      tags: [Policies]
+      summary: Allocate a grant and return the EIP-712 payload the owner signs
+      description: |
+        Allocates the policy id, validation entity, and session signer, builds
+        the exact `installValidation` calldata the signature will commit to,
+        and returns the typed data for `eth_signTypedData_v4`. Stores nothing:
+        a prepare that is never submitted leaves no state behind. The echoed
+        fields must be passed back verbatim to `:submit` — the gateway
+        recomputes everything from them, so tampering only produces a
+        signature that no longer verifies.
+      operationId: prepareWalletPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PreparePolicyRequest' }
+      responses:
+        '200':
+          description: Payload to sign, plus the allocations submit must echo.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PreparedPolicy' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /wallets/{address}/policies:submit:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+    post:
+      tags: [Policies]
+      summary: Submit the owner's signature and persist the grant
+      description: |
+        Recomputes the grant from the echoed prepare fields, verifies the
+        signature recovers to the authenticated owner, re-checks the entity
+        allocation inside the write, and stores the policy as `pending`. The
+        install itself rides the first workflow operation on this wallet —
+        nothing reaches the chain here.
+      operationId: submitWalletPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SubmitPolicyRequest' }
+      responses:
+        '201':
+          description: Grant stored; the gateway may now execute within it.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicy' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: |
+            The validation entity was taken by another grant while this one
+            was being signed. Prepare again.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+
+  /wallets/{address}/policies:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+      - $ref: '#/components/parameters/ChainIdQuery'
+    get:
+      tags: [Policies]
+      summary: List the wallet's session policies
+      description: Grant material (calldata, signatures) is never echoed.
+      operationId: listWalletPolicies
+      responses:
+        '200':
+          description: Policies for this wallet, newest first.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicyList' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /wallets/{address}/policies/{policyId}:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+      - name: policyId
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/Ulid' }
+      - $ref: '#/components/parameters/ChainIdQuery'
+    get:
+      tags: [Policies]
+      summary: Get one session policy
+      operationId: getWalletPolicy
+      responses:
+        '200':
+          description: The policy.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicy' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [Policies]
+      summary: Revoke a session policy
+      description: |
+        A `pending` grant (never used on-chain) is deleted outright — nothing
+        was installed, so nothing remains. An `active` grant stops authorizing
+        immediately, but its on-chain validation still exists until the owner
+        executes `uninstallValidation`; the response says which case applied.
+      operationId: revokeWalletPolicy
+      responses:
+        '200':
+          description: Revocation outcome.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RevokePolicyResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
   # =====================================================================

--- a/core/chainio/aa/aa.go
+++ b/core/chainio/aa/aa.go
@@ -355,13 +355,14 @@ func PackExecuteBatchWithValues(targetAddresses []common.Address, values []*big.
 	return result, nil
 }
 
-// UnpackExecuteCalldata decodes SimpleAccount smart-wallet calldata — produced by PackExecute,
-// PackExecuteBatch, or PackExecuteBatchWithValues — back into per-call (target, value, data)
-// tuples. It dispatches on the 4-byte function selector via the embedded ABI, so it stays correct
-// regardless of which pack helper produced the calldata:
-//   - execute(address,uint256,bytes)                  → one entry
-//   - executeBatch(address[],bytes[])                 → N entries, all values 0
-//   - executeBatchWithValues(address[],uint256[],bytes[]) → N entries with explicit values
+// UnpackExecuteCalldata decodes smart-wallet execution calldata — produced by any of the pack
+// helpers, v0.6 or MA v2 — back into per-call (target, value, data) tuples. It dispatches on the
+// 4-byte function selector via the embedded ABIs, so it stays correct regardless of which pack
+// helper produced the calldata:
+//   - execute(address,uint256,bytes)                  → one entry (identical in both accounts)
+//   - executeBatch(address[],bytes[])                 → N entries, all values 0 (v0.6)
+//   - executeBatchWithValues(address[],uint256[],bytes[]) → N entries with explicit values (v0.6 fork)
+//   - executeBatch((address,uint256,bytes)[])         → N entries, per-tuple values (MA v2)
 //
 // It is the inverse the paymaster reimbursement wrapper needs to append its own batch entries onto
 // an already-batched call without having to know how that call was originally packed.
@@ -377,7 +378,9 @@ func UnpackExecuteCalldata(calldata []byte) (targets []common.Address, values []
 	selector := calldata[:4]
 	method, err := parsedABI.MethodById(selector)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unrecognized smart-wallet method selector 0x%x: %w", selector, err)
+		// Not a v0.6 SimpleAccount method — try the MA v2 account, whose
+		// batch selector differs (tuple-array form; see ma_v2.go).
+		return unpackExecuteCalldataMAv2(calldata, selector)
 	}
 
 	args, err := method.Inputs.Unpack(calldata[4:])
@@ -440,4 +443,34 @@ func UnpackExecuteCalldata(calldata []byte) (targets []common.Address, values []
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported smart-wallet method %q for reimbursement wrapping", method.Name)
 	}
+}
+
+// unpackExecuteCalldataMAv2 decodes the MA v2 executeBatch tuple form.
+// (MA v2's `execute` shares the v0.6 selector and never reaches here.)
+func unpackExecuteCalldataMAv2(calldata, selector []byte) (targets []common.Address, values []*big.Int, datas [][]byte, err error) {
+	parsedABI, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	method, err := parsedABI.MethodById(selector)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unrecognized smart-wallet method selector 0x%x: %w", selector, err)
+	}
+	args, err := method.Inputs.Unpack(calldata[4:])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to unpack MA v2 %s calldata: %w", method.Name, err)
+	}
+	if method.Name != "executeBatch" || len(args) != 1 {
+		return nil, nil, nil, fmt.Errorf("unsupported MA v2 smart-wallet method %q", method.Name)
+	}
+	calls := *abi.ConvertType(args[0], new([]Call)).(*[]Call)
+	targets = make([]common.Address, len(calls))
+	values = make([]*big.Int, len(calls))
+	datas = make([][]byte, len(calls))
+	for i, call := range calls {
+		targets[i] = call.Target
+		values[i] = call.Value
+		datas[i] = call.Data
+	}
+	return targets, values, datas, nil
 }

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/gow"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
@@ -392,6 +393,11 @@ func New(db storage.Storage, config *config.Config, queue *apqueue.Queue, logger
 	if err := aa.SetFactoryAddressForConfig(config.SmartWallet); err != nil {
 		panic(fmt.Sprintf("smart_wallet: cannot resolve account factory: %v", err))
 	}
+
+	// Teach the send path where session grants live. Without this every MA v2
+	// operation is signed as the account's fallback signer -- the user's EOA,
+	// whose key we do not hold -- so nothing the gateway executes validates.
+	preset.SetSessionResolver(NewSessionResolver(db, controllerSessionSigner(config)))
 	//SetWsRpc(config.SmartWallet.EthWsUrl)
 
 	// Use global TokenEnrichmentService or initialize if not set

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -20,7 +20,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/gow"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
@@ -394,10 +393,6 @@ func New(db storage.Storage, config *config.Config, queue *apqueue.Queue, logger
 		panic(fmt.Sprintf("smart_wallet: cannot resolve account factory: %v", err))
 	}
 
-	// Teach the send path where session grants live. Without this every MA v2
-	// operation is signed as the account's fallback signer -- the user's EOA,
-	// whose key we do not hold -- so nothing the gateway executes validates.
-	preset.SetSessionResolver(NewSessionResolver(db, controllerSessionSigner(config)))
 	//SetWsRpc(config.SmartWallet.EthWsUrl)
 
 	// Use global TokenEnrichmentService or initialize if not set

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -1,0 +1,227 @@
+package taskengine
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/oklog/ulid/v2"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// Engine surface for /policies — ownership-gated wrappers over the session
+// grant machinery, one per REST operation. The REST layer maps types and
+// errors; everything that decides anything lives here.
+
+// Sentinel errors the REST layer maps to specific statuses.
+var (
+	// ErrWalletNotOwned: the wallet is not the caller's → 404 (existence is
+	// not confirmed to non-owners).
+	ErrWalletNotOwned = errors.New("wallet is not owned by the caller")
+	// ErrSessionEntityTaken: another grant claimed the entity between prepare
+	// and submit → 409, prepare again.
+	ErrSessionEntityTaken = errors.New("validation entity was taken while the grant was being signed")
+	// ErrSessionPolicyNotFound → 404.
+	ErrSessionPolicyNotFound = errors.New("session policy not found")
+)
+
+// SessionPolicyInput carries one grant's declared shape between prepare and
+// submit. On submit every field is the client's echo of what prepare
+// returned; nothing in it is trusted — the grant is recomputed from it and
+// the signature decides.
+type SessionPolicyInput struct {
+	Wallet        common.Address
+	ChainID       int64
+	AgentLabel    string
+	Justification string
+	Permissions   SessionPermissions
+}
+
+func (in *SessionPolicyInput) validate() error {
+	if in.ChainID <= 0 {
+		return fmt.Errorf("chain id %d is not valid", in.ChainID)
+	}
+	if strings.TrimSpace(in.AgentLabel) == "" {
+		return fmt.Errorf("agent label is required")
+	}
+	return in.Permissions.Validate()
+}
+
+// sessionSignerAddress is the signer the gateway assigns to new grants —
+// today always the controller (see controllerSessionSigner for why that
+// interim holds the model).
+func (n *Engine) sessionSignerAddress() (common.Address, error) {
+	if n.config == nil || n.config.SmartWallet == nil || n.config.SmartWallet.ControllerPrivateKey == nil {
+		return common.Address{}, fmt.Errorf("no controller key configured; cannot assign a session signer")
+	}
+	return crypto.PubkeyToAddress(n.config.SmartWallet.ControllerPrivateKey.PublicKey), nil
+}
+
+// requireOwnedWallet gates every policy operation on wallet ownership. The
+// grant authorizes execution against the wallet, so acting on another
+// owner's wallet — even just listing — is refused as not-found.
+func (n *Engine) requireOwnedWallet(user *model.User, wallet common.Address) error {
+	if user == nil {
+		return fmt.Errorf("no authenticated user")
+	}
+	owned, err := n.userOwnsWalletOnAnyChain(user, wallet)
+	if err != nil {
+		return fmt.Errorf("checking wallet ownership: %w", err)
+	}
+	if !owned {
+		return ErrWalletNotOwned
+	}
+	return nil
+}
+
+// PrepareSessionPolicy allocates a grant and returns what the owner signs.
+// Nothing is stored; an abandoned prepare leaves no state.
+func (n *Engine) PrepareSessionPolicy(user *model.User, in SessionPolicyInput) (*PreparedSessionGrant, error) {
+	if err := in.validate(); err != nil {
+		return nil, err
+	}
+	if err := n.requireOwnedWallet(user, in.Wallet); err != nil {
+		return nil, err
+	}
+	signer, err := n.sessionSignerAddress()
+	if err != nil {
+		return nil, err
+	}
+	prepared, err := PrepareSessionGrant(n.db, in.ChainID, signer, strings.ToLower(ulid.Make().String()), SessionGrantRequest{
+		Owner:         user.Address,
+		Wallet:        in.Wallet,
+		AgentLabel:    in.AgentLabel,
+		Justification: in.Justification,
+		ValidUntil:    in.Permissions.ValidUntilMs,
+		HooksFor:      in.Permissions.HooksFor,
+	})
+	if err != nil {
+		return nil, err
+	}
+	attachDeclaredPermissions(prepared.Policy, in.Permissions)
+	return prepared, nil
+}
+
+// SubmitSessionPolicy verifies the owner's signature over a deterministic
+// re-preparation of the grant and stores it as pending.
+//
+// The client's echo is input, never truth: the install calldata, digest, and
+// carrier nonce are all recomputed here from the declared permissions and the
+// pinned (policyID, entityID, deadline). A tampered echo either fails
+// signature recovery or is a differently-shaped grant that must survive full
+// validation on its own merits — there is no path on which stored bytes
+// diverge from what the owner's wallet displayed and signed.
+func (n *Engine) SubmitSessionPolicy(
+	user *model.User,
+	in SessionPolicyInput,
+	policyID string,
+	entityID uint32,
+	deadline uint64,
+	ownerSignature []byte,
+) (*model.SessionPolicy, error) {
+	if err := in.validate(); err != nil {
+		return nil, err
+	}
+	if err := n.requireOwnedWallet(user, in.Wallet); err != nil {
+		return nil, err
+	}
+	if _, err := ulid.ParseStrict(strings.ToUpper(policyID)); err != nil {
+		return nil, fmt.Errorf("policy id %q is not a ULID", policyID)
+	}
+	if deadline <= uint64(time.Now().Unix()) {
+		return nil, fmt.Errorf("the signing window (deadline %d) has expired; prepare the grant again", deadline)
+	}
+	signer, err := n.sessionSignerAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	prepared, err := PrepareSessionGrant(n.db, in.ChainID, signer, strings.ToLower(policyID), SessionGrantRequest{
+		Owner:         user.Address,
+		Wallet:        in.Wallet,
+		AgentLabel:    in.AgentLabel,
+		Justification: in.Justification,
+		ValidUntil:    in.Permissions.ValidUntilMs,
+		HooksFor:      in.Permissions.HooksFor,
+		Deadline:      deadline,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if prepared.Policy.EntityID != entityID {
+		return nil, fmt.Errorf("%w: prepared entity %d, next free is now %d",
+			ErrSessionEntityTaken, entityID, prepared.Policy.EntityID)
+	}
+	attachDeclaredPermissions(prepared.Policy, in.Permissions)
+	return SubmitSessionGrant(n.db, prepared, ownerSignature)
+}
+
+// ListSessionPoliciesForWallet returns the wallet's policies, newest first.
+func (n *Engine) ListSessionPoliciesForWallet(user *model.User, chainID int64, wallet common.Address) ([]*model.SessionPolicy, error) {
+	if err := n.requireOwnedWallet(user, wallet); err != nil {
+		return nil, err
+	}
+	all, err := ListSessionPolicies(n.db, chainID, user.Address)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*model.SessionPolicy, 0, len(all))
+	for _, p := range all {
+		if p.Runner != nil && *p.Runner == wallet {
+			out = append(out, p)
+		}
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i] // ULID keys scan oldest-first
+	}
+	return out, nil
+}
+
+// GetSessionPolicyByID returns one policy, or ErrSessionPolicyNotFound.
+func (n *Engine) GetSessionPolicyByID(user *model.User, chainID int64, wallet common.Address, policyID string) (*model.SessionPolicy, error) {
+	policies, err := n.ListSessionPoliciesForWallet(user, chainID, wallet)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range policies {
+		if strings.EqualFold(p.ID, policyID) {
+			return p, nil
+		}
+	}
+	return nil, ErrSessionPolicyNotFound
+}
+
+// RevokeSessionPolicyByID revokes one policy. deleted reports the pending
+// case (record removed outright); cleanupRequired reports that the grant's
+// validation is still installed on the account and needs the owner's
+// uninstallValidation.
+func (n *Engine) RevokeSessionPolicyByID(user *model.User, chainID int64, wallet common.Address, policyID string) (deleted, cleanupRequired bool, err error) {
+	policy, err := n.GetSessionPolicyByID(user, chainID, wallet, policyID)
+	if err != nil {
+		return false, false, err
+	}
+	cleanupRequired, err = RevokeSessionGrant(n.db, policy)
+	if err != nil {
+		return false, false, err
+	}
+	return !cleanupRequired, cleanupRequired, nil
+}
+
+// attachDeclaredPermissions records the grant's declared shape on the policy
+// for the manage screen and revocation cleanup. Display data — the signed
+// truth is Grant.InstallCall.
+func attachDeclaredPermissions(policy *model.SessionPolicy, perms SessionPermissions) {
+	if policy == nil {
+		return
+	}
+	policy.AllowedActions = perms.AllowedActions
+	if perms.SpendCap != nil {
+		spendCap := *perms.SpendCap
+		spendCap.GrantedCap = spendCap.Amount
+		policy.ERC20SpendCap = &spendCap
+	}
+}

--- a/core/taskengine/engine_session_policy_test.go
+++ b/core/taskengine/engine_session_policy_test.go
@@ -1,0 +1,243 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// The /policies engine surface, exercised fully offline: prepare, sign,
+// submit, list, get, revoke. Nothing here touches a chain — the grant flow's
+// whole point is that only the FIRST WORKFLOW OPERATION does.
+
+const testPolicyChain = int64(11155111)
+
+var (
+	testTokenAddr  = common.HexToAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238")
+	testRouterAddr = common.HexToAddress("0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E")
+)
+
+func newPolicyTestEngine(t *testing.T) (*Engine, storage.Storage, *ecdsa.PrivateKey, common.Address, common.Address) {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	// The full test config: Engine's constructor dials the configured RPC, so
+	// a hand-built config with no URL panics. Nothing in the policy flow
+	// itself touches the chain. The fixture config carries no controller key
+	// and pins chain 1; both are overridable per its own comments — the key
+	// is only ever used here as an ADDRESS (the assigned session signer).
+	cfg := testutil.GetAggregatorConfig()
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	cfg.SmartWallet.ControllerPrivateKey = controllerKey
+	cfg.SmartWallet.ChainID = testPolicyChain
+	engine := New(db, cfg, nil, testutil.GetLogger())
+
+	ownerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	wallet := common.HexToAddress("0x00000000000000000000000000000000000000a1")
+	factory := common.HexToAddress("0x00000000000017c61b5bEe81050EC8eFc9c6fecd")
+	require.NoError(t, StoreWallet(db, testPolicyChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &wallet, Factory: &factory, Salt: big.NewInt(0),
+	}))
+	return engine, db, ownerKey, owner, wallet
+}
+
+func testPermissions() SessionPermissions {
+	token, router := testTokenAddr, testRouterAddr
+	return SessionPermissions{
+		AllowedActions: []model.AllowedAction{
+			{Target: &router, Selectors: []string{"0x04e45aaf"}}, // exactInputSingle
+			{Target: &token, Selectors: []string{"0x095ea7b3"}},  // approve
+		},
+		SpendCap:     &model.ERC20SpendCap{Token: &token, Amount: "500000000"},
+		ValidUntilMs: time.Now().Add(30 * 24 * time.Hour).UnixMilli(),
+	}
+}
+
+func signDigest(t *testing.T, key *ecdsa.PrivateKey, digest common.Hash) []byte {
+	t.Helper()
+	sig, err := crypto.Sign(digest.Bytes(), key)
+	require.NoError(t, err)
+	sig[64] += 27
+	return sig
+}
+
+func TestSessionPolicyPrepareSubmitRoundTrip(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	perms := testPermissions()
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "swaps you approve",
+		Permissions: perms,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, prepared.Policy.EntityID, "first grant takes entity 1")
+	require.True(t, prepared.Policy.Grant.RequiresExecuteUserOp, "a cap installs an execution hook")
+
+	// Nothing stored by prepare: an abandoned screen leaves no state.
+	policies, err := engine.ListSessionPoliciesForWallet(user, testPolicyChain, wallet)
+	require.NoError(t, err)
+	require.Empty(t, policies)
+
+	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "swaps you approve",
+		Permissions: perms,
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.NoError(t, err)
+	require.Equal(t, model.SessionPolicyPending, stored.Status)
+	require.Len(t, stored.Grant.OwnerSignature, 65)
+	require.Equal(t, "500000000", stored.ERC20SpendCap.GrantedCap)
+	require.Len(t, stored.AllowedActions, 2)
+
+	got, err := engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.Equal(t, stored.ID, got.ID)
+}
+
+// A tampered echo (here: a raised cap) produces different calldata, hence a
+// different digest, hence a signature that recovers to a stranger. The exact
+// property the stateless submit exists for.
+func TestSessionPolicySubmitRejectsTamperedEcho(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	perms := testPermissions()
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: perms,
+	})
+	require.NoError(t, err)
+	sig := signDigest(t, ownerKey, prepared.Digest)
+
+	tampered := testPermissions()
+	tampered.SpendCap.Amount = "500000000000" // 1000x the signed cap
+
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: tampered,
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline, sig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signed by", "the tamper must surface as a signature mismatch")
+}
+
+func TestSessionPolicySubmitRejectsWrongSigner(t *testing.T) {
+	engine, _, _, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+
+	strangerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: testPermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, strangerKey, prepared.Digest))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signed by")
+}
+
+// Two prepares race the same entity; the slower submit must 409, not
+// silently overwrite the faster grant's signer on chain.
+func TestSessionPolicySubmitDetectsEntityRace(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	preparedA, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "A", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	preparedB, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "B", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, preparedA.Policy.EntityID, preparedB.Policy.EntityID, "both prepares saw entity 1")
+
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "A", Permissions: testPermissions(),
+	}, preparedA.Policy.ID, preparedA.Policy.EntityID, preparedA.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, preparedA.Digest))
+	require.NoError(t, err)
+
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "B", Permissions: testPermissions(),
+	}, preparedB.Policy.ID, preparedB.Policy.EntityID, preparedB.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, preparedB.Digest))
+	require.ErrorIs(t, err, ErrSessionEntityTaken)
+}
+
+func TestSessionPolicyOwnershipGate(t *testing.T) {
+	engine, _, _, _, wallet := newPolicyTestEngine(t)
+	strangerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	stranger := &model.User{Address: crypto.PubkeyToAddress(strangerKey.PublicKey)}
+
+	_, err = engine.PrepareSessionPolicy(stranger, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "X", Permissions: testPermissions(),
+	})
+	require.ErrorIs(t, err, ErrWalletNotOwned)
+
+	_, err = engine.ListSessionPoliciesForWallet(stranger, testPolicyChain, wallet)
+	require.ErrorIs(t, err, ErrWalletNotOwned)
+}
+
+func TestSessionPolicyRevokePendingDeletesOutright(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.NoError(t, err)
+
+	deleted, cleanupRequired, err := engine.RevokeSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.True(t, deleted, "a pending grant was never on-chain; revoke deletes it")
+	require.False(t, cleanupRequired)
+
+	_, err = engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.True(t, errors.Is(err, ErrSessionPolicyNotFound))
+}
+
+func TestSessionPermissionsValidation(t *testing.T) {
+	token := testTokenAddr
+	base := testPermissions()
+
+	capless := base
+	capless.SpendCap = nil
+	require.Error(t, capless.Validate(), "v1 requires a cap — it installs the exec hook that stops self-administration")
+
+	uncovered := base
+	other := common.HexToAddress("0x00000000000000000000000000000000000000f9")
+	uncovered.SpendCap = &model.ERC20SpendCap{Token: &other, Amount: "1"}
+	require.Error(t, uncovered.Validate(), "the cap token must be an allowed target")
+
+	anyFunction := base
+	anyFunction.AllowedActions = []model.AllowedAction{{Target: &token, Selectors: nil}}
+	require.Error(t, anyFunction.Validate(), "any-function grants are not offered")
+
+	expired := base
+	expired.ValidUntilMs = time.Now().Add(-time.Hour).UnixMilli()
+	require.Error(t, expired.Validate())
+}

--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -108,6 +108,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 			TaskType: &avsproto.TaskNode_ContractWrite{
 				ContractWrite: &avsproto.ContractWriteNode{
 					Config: &avsproto.ContractWriteNode_Config{
+						ChainId:         cfg.SmartWallet.ChainID,
 						ContractAddress: SEPOLIA_USDC,
 						ContractAbi: func() []*structpb.Value {
 							abi, _ := structpb.NewValue(map[string]interface{}{
@@ -139,6 +140,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 			TaskType: &avsproto.TaskNode_ContractWrite{
 				ContractWrite: &avsproto.ContractWriteNode{
 					Config: &avsproto.ContractWriteNode_Config{
+						ChainId:         cfg.SmartWallet.ChainID,
 						ContractAddress: SEPOLIA_SWAPROUTER,
 						ContractAbi: func() []*structpb.Value {
 							abi, _ := structpb.NewValue(map[string]interface{}{

--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -67,6 +67,12 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 
 	// Initialize test database and engine
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddr)
+
 	t.Cleanup(func() {
 		storage.Destroy(db.(*storage.BadgerStorage))
 	})

--- a/core/taskengine/mav2_grant_integration_test.go
+++ b/core/taskengine/mav2_grant_integration_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+// +build integration
+
+package taskengine
+
+// End-to-end proof of the production MA v2 path: an owner authorizes a session
+// grant with ONE off-chain signature, and the gateway then deploys the
+// account, installs the grant during validation, and executes — all in one
+// operation it signs itself.
+//
+// This is the folded-in form of scripts/spike/deferred_action, promoted from a
+// hand-run harness so the flow is protected by the suite. It exercises the
+// public API (aa.SessionGrant, preset.SessionAuthorization,
+// preset.SendUserOpMAv2) rather than harness internals, so it fails when the
+// contract the gateway depends on changes.
+//
+// Prerequisites are REQUIRED, not skipped: a test that silently skips when a
+// key is missing reports success for a path it never ran. Run with:
+//
+//	make test/integration
+//
+// Env: SPIKE_OWNER_KEY, SPIKE_CONTROLLER_KEY, SPIKE_BUNDLER_URL,
+//      SPIKE_RPC_URL (optional), SPIKE_SALT (optional, default 9).
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// requireKey loads a private key that the test cannot run without.
+func requireKey(t *testing.T, name string) (*ecdsa.PrivateKey, common.Address) {
+	t.Helper()
+	raw := os.Getenv(name)
+	require.NotEmpty(t, raw, "%s must be set — this test executes real operations and cannot be faked", name)
+	key, err := crypto.HexToECDSA(strings.TrimPrefix(raw, "0x"))
+	require.NoError(t, err, "%s is not a valid hex private key", name)
+	return key, crypto.PubkeyToAddress(key.PublicKey)
+}
+
+func TestMAv2SessionGrantEndToEnd(t *testing.T) {
+	ownerKey, owner := requireKey(t, "SPIKE_OWNER_KEY")
+	controllerKey, controller := requireKey(t, "SPIKE_CONTROLLER_KEY")
+
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	require.NotEmpty(t, bundlerURL, "SPIKE_BUNDLER_URL must be set")
+
+	rpcURL := os.Getenv("SPIKE_RPC_URL")
+	if rpcURL == "" {
+		rpcURL = "https://ethereum-sepolia-rpc.publicnode.com"
+	}
+	salt := big.NewInt(9)
+	if s := os.Getenv("SPIKE_SALT"); s != "" {
+		n, err := strconv.ParseInt(s, 10, 64)
+		require.NoError(t, err, "SPIKE_SALT must be a decimal integer")
+		salt = big.NewInt(n)
+	}
+
+	ctx := context.Background()
+	chain, err := ethclient.Dial(rpcURL)
+	require.NoError(t, err, "cannot reach the chain RPC")
+	defer chain.Close()
+
+	chainID, err := chain.ChainID(ctx)
+	require.NoError(t, err)
+
+	swCfg := &config.SmartWalletConfig{
+		EthRpcUrl:            rpcURL,
+		BundlerURL:           bundlerURL,
+		BundlerProvider:      config.BundlerProviderSelfHosted, // BundlerURL is used verbatim
+		AccountProvider:      config.AccountProviderModularAccountV2,
+		ChainID:              chainID.Int64(),
+		ControllerPrivateKey: controllerKey,
+		FactoryAddress:       common.HexToAddress(config.DefaultFactoryProxyAddressHex),
+	}
+
+	factory, err := aa.EffectiveFactory(swCfg)
+	require.NoError(t, err)
+	require.Equal(t, aa.MAv2FactoryAddress(), factory,
+		"an MA v2 chain must resolve to the MA v2 factory")
+
+	account, err := aa.DeriveSenderAddressAuto(chain, owner, factory, salt)
+	require.NoError(t, err, "deriving the account address")
+	t.Logf("owner=%s controller=%s account=%s salt=%s",
+		owner.Hex(), controller.Hex(), account.Hex(), salt)
+
+	code, err := chain.CodeAt(ctx, *account, nil)
+	require.NoError(t, err)
+	require.Empty(t, code,
+		"account %s is already deployed — this test proves the FIRST operation, so use an unused SPIKE_SALT",
+		account.Hex())
+
+	balance, err := chain.BalanceAt(ctx, *account, nil)
+	require.NoError(t, err)
+	require.Positive(t, balance.Sign(),
+		"account %s holds no native balance; fund it before running (it pays its own gas here)",
+		account.Hex())
+
+	// ---- the owner's single, off-chain authorization -------------------------
+	//
+	// Signed before the operation exists: no gas price, no deployment, nothing
+	// on chain. That property is what lets the grant screen collect it.
+
+	const entity = aa.MinSessionEntityID
+	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: entity,
+		Signer:   controller,
+		Global:   true,
+		// No execution hook here, so this grant can administer itself. That is
+		// acceptable for a test fixture and deliberately loud; production
+		// grants carry hooks or selector scoping.
+		AllowSelfAdministration: true,
+	})
+	require.NoError(t, err, "packing the install call")
+
+	deadline := uint64(time.Now().Add(2 * time.Hour).Unix())
+
+	// The digest commits to the FULL nonce of the operation that will carry
+	// the action, which is knowable in advance only because a fresh entity is
+	// a fresh nonce key whose sequence is zero.
+	carrierNonce, err := userop.EncodeNonceMAv2(entity,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction, 0)
+	require.NoError(t, err)
+
+	digest, err := userop.DeferredActionDigest(chainID, *account, carrierNonce, deadline, installCall)
+	require.NoError(t, err, "building the EIP-712 digest")
+
+	ownerSig, err := crypto.Sign(digest.Bytes(), ownerKey) // raw digest — not EIP-191 wrapped
+	require.NoError(t, err)
+	ownerSig[64] += 27
+
+	deferredData, err := userop.EncodeDeferredActionData(userop.FallbackSignerLocator(), deadline, installCall)
+	require.NoError(t, err)
+
+	// ---- the gateway executes, signing as the controller ---------------------
+
+	auth := &preset.SessionAuthorization{
+		EntityID:       entity,
+		SignerKey:      controllerKey,
+		DeferredData:   deferredData,
+		OwnerSignature: ownerSig,
+	}
+	require.NoError(t, auth.Validate())
+	require.True(t, auth.Deferred(), "this operation must carry the install")
+
+	callData, err := aa.PackExecute(owner, big.NewInt(0), nil)
+	require.NoError(t, err, "packing the executed call")
+
+	op, receipt, err := preset.SendUserOpMAv2(swCfg, owner, callData, account, salt, auth, logger.NewNoOpLogger())
+	require.NoError(t, err, "the grant-carrying operation must succeed")
+	require.NotNil(t, receipt, "no receipt — the operation did not mine")
+	require.NotNil(t, op)
+	require.NotNil(t, op.Factory, "the first operation must also deploy the account")
+
+	deployed, err := chain.CodeAt(ctx, *account, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, deployed, "the account should exist after its first operation")
+
+	// ---- the point: the controller now has authority it did not have ---------
+
+	followUp := &preset.SessionAuthorization{EntityID: entity, SignerKey: controllerKey}
+	require.False(t, followUp.Deferred(), "the install must not be replayed")
+
+	op2, receipt2, err := preset.SendUserOpMAv2(swCfg, owner, callData, account, salt, followUp, logger.NewNoOpLogger())
+	require.NoError(t, err,
+		"the controller must be able to sign on its own once the grant is installed")
+	require.NotNil(t, receipt2, "the follow-up operation did not mine")
+	require.Nil(t, op2.Factory, "the account already exists; this must not redeploy")
+}

--- a/core/taskengine/mav2_grant_integration_test.go
+++ b/core/taskengine/mav2_grant_integration_test.go
@@ -150,11 +150,19 @@ func TestMAv2SessionGrantEndToEnd(t *testing.T) {
 
 	// ---- the gateway executes, signing as the controller ---------------------
 
+	// The applied-marking callback the resolver installs in production —
+	// captured here to prove the send path invokes it with the carrying
+	// operation's hash once the receipt is in hand.
+	var appliedHash string
 	auth := &preset.SessionAuthorization{
 		EntityID:       entity,
 		SignerKey:      controllerKey,
 		DeferredData:   deferredData,
 		OwnerSignature: ownerSig,
+		OnApplied: func(userOpHash string) error {
+			appliedHash = userOpHash
+			return nil
+		},
 	}
 	require.NoError(t, auth.Validate())
 	require.True(t, auth.Deferred(), "this operation must carry the install")
@@ -167,6 +175,8 @@ func TestMAv2SessionGrantEndToEnd(t *testing.T) {
 	require.NotNil(t, receipt, "no receipt — the operation did not mine")
 	require.NotNil(t, op)
 	require.NotNil(t, op.Factory, "the first operation must also deploy the account")
+	require.NotEmpty(t, appliedHash,
+		"the send path must report the applied install so the stored grant stops attaching it")
 
 	deployed, err := chain.CodeAt(ctx, *account, nil)
 	require.NoError(t, err)

--- a/core/taskengine/schema.go
+++ b/core/taskengine/schema.go
@@ -415,3 +415,29 @@ func FeeRecordKey(chainID int64, owner common.Address, executionID string) []byt
 func FeeRecordPrefix(chainID int64, owner common.Address) []byte {
 	return []byte(fmt.Sprintf("fr:%d:%s:", chainID, strings.ToLower(owner.Hex())))
 }
+
+// SessionPolicyPrefix scans every session policy an owner holds on a chain.
+// Fresh `sp:` namespace — additive, no migration (avs-infra §7.4a).
+func SessionPolicyPrefix(chainID int64, owner common.Address) []byte {
+	return []byte(fmt.Sprintf(
+		"sp:%d:%s:",
+		chainID,
+		strings.ToLower(owner.Hex()),
+	))
+}
+
+// SessionPolicyKey is the primary key for one grant.
+//
+// Keyed by OWNER, not by wallet, because that is who the grant belongs to and
+// who lists them. The wallet lives in the record's Runner field, so resolving
+// "the grant for this wallet" is a prefix scan plus a filter — see
+// core/taskengine/session_policy.go. Note this means entity-id uniqueness is
+// per account while the key is per owner; allocation has to account for that.
+func SessionPolicyKey(chainID int64, owner common.Address, policyID string) []byte {
+	return []byte(fmt.Sprintf(
+		"sp:%d:%s:%s",
+		chainID,
+		strings.ToLower(owner.Hex()),
+		policyID,
+	))
+}

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -1,0 +1,267 @@
+package taskengine
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Creating a session grant is two calls, not one.
+//
+// The owner signs an EIP-712 payload, and that payload cannot exist until the
+// gateway has allocated an entity, chosen a signer, and computed the nonce the
+// carrying operation will use. So the screen asks for the payload (Prepare),
+// the wallet signs it, and the signature comes back (Submit). avs-infra
+// Smart_Wallet_MA_v2_Spend_Policy.md §7.5.
+//
+// Nothing reaches the chain here. The install rides the workflow's first
+// operation, which is what makes the grant gasless to authorize and free to
+// revoke until it is used.
+
+// SessionGrantRequest is what the grant screen asks for.
+type SessionGrantRequest struct {
+	Owner  common.Address
+	Wallet common.Address // the smart wallet being granted on
+
+	AgentLabel    string
+	Justification string
+
+	// Hooks are the encoded permission modules (allowlist, spend cap, time
+	// range). They ride the same installValidation call, so the owner's one
+	// signature covers them too.
+	Hooks [][]byte
+
+	// Selectors scopes the grant. Empty means a global grant, which requires
+	// an execution hook — see aa.SessionGrant.
+	Selectors [][4]byte
+
+	// ValidUntil is the grant's own lifetime (unix ms), enforced on chain by
+	// the TimeRangeModule hook when one is installed.
+	ValidUntil int64
+
+	// SigningWindow bounds how long the owner's signature stays usable before
+	// the grant's first operation. Distinct from ValidUntil. Zero picks
+	// defaultSigningWindow.
+	SigningWindow time.Duration
+}
+
+// defaultSigningWindow bounds the gap between signing a grant and its first
+// use. Long enough that a workflow scheduled for "tomorrow" still fires, short
+// enough that a forgotten authorization does not sit in storage indefinitely.
+// A dormant workflow whose window lapses needs a re-sign, which is why this is
+// not minutes.
+const defaultSigningWindow = 30 * 24 * time.Hour
+
+// PreparedSessionGrant is what the wallet signs, plus everything the gateway
+// must remember to accept the signature back.
+type PreparedSessionGrant struct {
+	// Digest is the EIP-712 hash the owner signs. Signed RAW — the account's
+	// fallback path skips the replay-safe rewrap during validateUserOp, so
+	// this is exactly what eth_signTypedData_v4 must produce.
+	Digest common.Hash
+
+	// The fields below are echoed back to Submit. They are returned rather
+	// than stashed server-side so a prepare that is never completed leaves no
+	// state behind.
+	Policy *model.SessionPolicy
+
+	// DeferredData is the encoded action the signature authorizes.
+	DeferredData []byte
+}
+
+// PrepareSessionGrant allocates the grant and returns the payload to sign.
+//
+// The entity allocation here is READ-ONLY and provisional. It becomes real in
+// SubmitSessionGrant, which must re-check it inside the write — two prepares
+// racing on one wallet would otherwise both see the same free entity, and the
+// second install would overwrite the first grant's signer.
+func PrepareSessionGrant(
+	db storage.Storage,
+	chainID int64,
+	sessionSigner common.Address,
+	policyID string,
+	req SessionGrantRequest,
+) (*PreparedSessionGrant, error) {
+	if policyID == "" {
+		return nil, fmt.Errorf("policy id is required")
+	}
+	if req.Owner == (common.Address{}) || req.Wallet == (common.Address{}) {
+		return nil, fmt.Errorf("owner and wallet are required")
+	}
+	if sessionSigner == (common.Address{}) {
+		return nil, fmt.Errorf("session signer is required")
+	}
+
+	entity, err := NextSessionEntityID(db, chainID, req.Owner, req.Wallet)
+	if err != nil {
+		return nil, err
+	}
+
+	grant := aa.SessionGrant{
+		EntityID:  entity,
+		Signer:    sessionSigner,
+		Selectors: req.Selectors,
+		Hooks:     req.Hooks,
+		Global:    len(req.Selectors) == 0,
+	}
+	installCall, err := aa.PackSessionSignerInstall(grant)
+	if err != nil {
+		return nil, fmt.Errorf("building the grant for wallet %s: %w", req.Wallet.Hex(), err)
+	}
+
+	window := req.SigningWindow
+	if window <= 0 {
+		window = defaultSigningWindow
+	}
+	deadline := uint64(time.Now().Add(window).Unix())
+
+	// The digest commits to the FULL nonce of the operation that will carry
+	// the action. It is knowable now only because a freshly allocated entity
+	// is a fresh nonce key whose sequence is zero.
+	carrierNonce, err := userop.EncodeNonceMAv2(entity,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction, 0)
+	if err != nil {
+		return nil, fmt.Errorf("encoding the carrier nonce: %w", err)
+	}
+
+	digest, err := userop.DeferredActionDigest(
+		big.NewInt(chainID), req.Wallet, carrierNonce, deadline, installCall)
+	if err != nil {
+		return nil, fmt.Errorf("building the grant digest: %w", err)
+	}
+
+	deferredData, err := userop.EncodeDeferredActionData(
+		userop.FallbackSignerLocator(), deadline, installCall)
+	if err != nil {
+		return nil, fmt.Errorf("encoding the deferred action: %w", err)
+	}
+
+	owner, wallet, signer := req.Owner, req.Wallet, sessionSigner
+	return &PreparedSessionGrant{
+		Digest:       digest,
+		DeferredData: deferredData,
+		Policy: &model.SessionPolicy{
+			ID:            policyID,
+			Owner:         &owner,
+			Runner:        &wallet,
+			ChainID:       chainID,
+			EntityID:      entity,
+			SessionSigner: &signer,
+			AgentLabel:    req.AgentLabel,
+			Justification: req.Justification,
+			ValidUntil:    req.ValidUntil,
+			Status:        model.SessionPolicyPending,
+			CreatedAt:     time.Now().UnixMilli(),
+			Grant: &model.SessionGrantAuthorization{
+				InstallCall:           installCall,
+				CarrierNonce:          carrierNonce,
+				Deadline:              deadline,
+				RequiresExecuteUserOp: grant.HasExecutionHook(),
+			},
+		},
+	}, nil
+}
+
+// SubmitSessionGrant records the owner's signature and stores the policy.
+//
+// The signature is verified against the owner before anything is written. A
+// grant that does not recover to the owner would be accepted, stored, and then
+// fail during the first operation's validation — on chain, with an error that
+// names neither this record nor the mismatch.
+func SubmitSessionGrant(db storage.Storage, prepared *PreparedSessionGrant, ownerSignature []byte) (*model.SessionPolicy, error) {
+	if prepared == nil || prepared.Policy == nil {
+		return nil, fmt.Errorf("nothing prepared to submit")
+	}
+	if len(ownerSignature) != 65 {
+		return nil, fmt.Errorf("owner signature is %d bytes, want 65", len(ownerSignature))
+	}
+	policy := prepared.Policy
+
+	if err := verifyGrantSignature(prepared.Digest, ownerSignature, *policy.Owner); err != nil {
+		return nil, err
+	}
+
+	// Re-check the entity inside the write path. PrepareSessionGrant's
+	// allocation was provisional: another grant on this wallet may have
+	// landed in between, and reusing its entity would overwrite that grant's
+	// signer on chain.
+	entity, err := NextSessionEntityID(db, policy.ChainID, *policy.Owner, *policy.Runner)
+	if err != nil {
+		return nil, err
+	}
+	if entity != policy.EntityID {
+		return nil, fmt.Errorf(
+			"entity %d was taken while this grant was being signed (next free is %d); prepare it again",
+			policy.EntityID, entity)
+	}
+
+	policy.Grant.OwnerSignature = ownerSignature
+	if err := StoreSessionPolicy(db, policy); err != nil {
+		return nil, err
+	}
+	return policy, nil
+}
+
+// MarkSessionGrantApplied records that the deferred install reached the chain,
+// so it is never attached to a second operation.
+func MarkSessionGrantApplied(db storage.Storage, policy *model.SessionPolicy, userOpHash string) error {
+	if policy == nil || policy.Grant == nil {
+		return fmt.Errorf("no policy to mark applied")
+	}
+	if policy.Grant.Applied() {
+		return nil // already recorded; marking twice is not an error
+	}
+	policy.Grant.AppliedAt = time.Now().UnixMilli()
+	policy.Grant.AppliedUserOpHash = userOpHash
+	policy.Status = model.SessionPolicyActive
+	return StoreSessionPolicy(db, policy)
+}
+
+// RevokeSessionGrant removes a grant.
+//
+// Before the install reaches the chain this is complete on its own: nothing
+// was installed, so deleting the record removes the authority. After it has
+// applied, this only stops the gateway from using the grant — the module is
+// still installed on the account, and clearing it needs uninstallValidation.
+// The record is retained in that case so the cleanup payload survives.
+func RevokeSessionGrant(db storage.Storage, policy *model.SessionPolicy) (onChainCleanupRequired bool, err error) {
+	if policy == nil {
+		return false, fmt.Errorf("no policy to revoke")
+	}
+	key := SessionPolicyKey(policy.ChainID, *policy.Owner, policy.ID)
+	if !policy.Grant.Applied() {
+		return false, db.Delete(key)
+	}
+	policy.Status = model.SessionPolicyRevoked
+	return true, StoreSessionPolicy(db, policy)
+}
+
+// verifyGrantSignature checks that the signature recovers to the owner.
+//
+// The digest is signed RAW, not EIP-191 wrapped — the account's fallback 1271
+// path skips the replay-safe rewrap during validateUserOp, so recovery here
+// must match that exactly or a valid grant would be rejected.
+func verifyGrantSignature(digest common.Hash, signature []byte, owner common.Address) error {
+	sig := make([]byte, len(signature))
+	copy(sig, signature)
+	// go-ethereum recovers with v in {0,1}; wallets emit 27/28.
+	if sig[64] >= 27 {
+		sig[64] -= 27
+	}
+	pub, err := crypto.SigToPub(digest.Bytes(), sig)
+	if err != nil {
+		return fmt.Errorf("grant signature is malformed: %w", err)
+	}
+	if got := crypto.PubkeyToAddress(*pub); got != owner {
+		return fmt.Errorf("grant was signed by %s, not the wallet owner %s", got.Hex(), owner.Hex())
+	}
+	return nil
+}

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -51,6 +51,12 @@ type SessionGrantRequest struct {
 	// the grant's first operation. Distinct from ValidUntil. Zero picks
 	// defaultSigningWindow.
 	SigningWindow time.Duration
+
+	// AllowSelfAdministration accepts a global grant that carries no execution
+	// hook, which can call the account's own installValidation and escalate
+	// itself. Present so the case is stateable — test fixtures need it — and
+	// deliberately absent from anything the grant screen sends.
+	AllowSelfAdministration bool
 }
 
 // defaultSigningWindow bounds the gap between signing a grant and its first
@@ -111,6 +117,8 @@ func PrepareSessionGrant(
 		Selectors: req.Selectors,
 		Hooks:     req.Hooks,
 		Global:    len(req.Selectors) == 0,
+
+		AllowSelfAdministration: req.AllowSelfAdministration,
 	}
 	installCall, err := aa.PackSessionSignerInstall(grant)
 	if err != nil {

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -1,10 +1,12 @@
 package taskengine
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
+	badger "github.com/dgraph-io/badger/v4"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
@@ -255,6 +257,37 @@ func MarkSessionGrantApplied(db storage.Storage, policy *model.SessionPolicy, us
 	policy.Grant.AppliedUserOpHash = userOpHash
 	policy.Status = model.SessionPolicyActive
 	return StoreSessionPolicy(db, policy)
+}
+
+// MarkSessionGrantAppliedByID is MarkSessionGrantApplied for callers that
+// held the policy EARLIER — the resolver's callback fires after an operation
+// confirms, and by then the record may have moved. It re-reads and only
+// transitions pending → active:
+//
+//   - Record gone: the grant was revoked (pending revokes delete outright)
+//     while its install was in flight. Nothing to update — though if the
+//     operation mined, the entity now exists on-chain with no record behind
+//     it, an orphan only the owner's uninstallValidation can clear. Reported
+//     as nil because there is no state left to make consistent.
+//   - Status not pending: never overwrite. Re-storing a stale in-memory
+//     policy here could resurrect a revoked grant as active, which is why
+//     this exists instead of handing the callback the old pointer.
+func MarkSessionGrantAppliedByID(db storage.Storage, chainID int64, owner common.Address, policyID, userOpHash string) error {
+	raw, err := db.GetKey(SessionPolicyKey(chainID, owner, policyID))
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil // no record — revoked while in flight; see above
+	}
+	if err != nil {
+		return fmt.Errorf("reading session policy %s: %w", policyID, err)
+	}
+	policy := &model.SessionPolicy{}
+	if err := policy.FromStorageData(raw); err != nil {
+		return fmt.Errorf("session policy %s is unreadable: %w", policyID, err)
+	}
+	if policy.Status != model.SessionPolicyPending || policy.Grant.Applied() {
+		return nil
+	}
+	return MarkSessionGrantApplied(db, policy, userOpHash)
 }
 
 // RevokeSessionGrant removes a grant.

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -39,6 +39,20 @@ type SessionGrantRequest struct {
 	// signature covers them too.
 	Hooks [][]byte
 
+	// HooksFor builds the hooks once the entity is known. Hook install data
+	// embeds the entity id, and the entity is allocated inside
+	// PrepareSessionGrant — so a caller that does not already know its entity
+	// (the REST prepare path) supplies this instead of Hooks. When set it
+	// wins over Hooks.
+	HooksFor func(entityID uint32) ([][]byte, error)
+
+	// Deadline pins the signing-window bound to an absolute uint48 unix-
+	// seconds value instead of now+SigningWindow. The submit path needs this:
+	// the deadline is inside the signed digest, so reproducing the prepared
+	// grant deterministically requires the original value, not a fresh clock
+	// reading. Zero means derive from SigningWindow.
+	Deadline uint64
+
 	// Selectors scopes the grant. Empty means a global grant, which requires
 	// an execution hook — see aa.SessionGrant.
 	Selectors [][4]byte
@@ -111,11 +125,18 @@ func PrepareSessionGrant(
 		return nil, err
 	}
 
+	hooks := req.Hooks
+	if req.HooksFor != nil {
+		if hooks, err = req.HooksFor(entity); err != nil {
+			return nil, fmt.Errorf("building hooks for entity %d: %w", entity, err)
+		}
+	}
+
 	grant := aa.SessionGrant{
 		EntityID:  entity,
 		Signer:    sessionSigner,
 		Selectors: req.Selectors,
-		Hooks:     req.Hooks,
+		Hooks:     hooks,
 		Global:    len(req.Selectors) == 0,
 
 		AllowSelfAdministration: req.AllowSelfAdministration,
@@ -125,11 +146,14 @@ func PrepareSessionGrant(
 		return nil, fmt.Errorf("building the grant for wallet %s: %w", req.Wallet.Hex(), err)
 	}
 
-	window := req.SigningWindow
-	if window <= 0 {
-		window = defaultSigningWindow
+	deadline := req.Deadline
+	if deadline == 0 {
+		window := req.SigningWindow
+		if window <= 0 {
+			window = defaultSigningWindow
+		}
+		deadline = uint64(time.Now().Add(window).Unix())
 	}
-	deadline := uint64(time.Now().Add(window).Unix())
 
 	// The digest commits to the FULL nonce of the operation that will carry
 	// the action. It is knowable now only because a freshly allocated entity

--- a/core/taskengine/session_grant_applied_test.go
+++ b/core/taskengine/session_grant_applied_test.go
@@ -1,0 +1,97 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// The applied-marking loop: the resolver hands the send path a callback, the
+// callback transitions the stored record, and the NEXT resolution stops
+// attaching the deferred action. This is what keeps a grant's install from
+// being replayed onto an entity that already exists.
+
+func storedPendingGrant(t *testing.T) (*Engine, *model.User, common.Address, *model.SessionPolicy) {
+	t.Helper()
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.NoError(t, err)
+	return engine, user, wallet, stored
+}
+
+func testResolverKey(controller *ecdsa.PrivateKey) func(common.Address) (*ecdsa.PrivateKey, error) {
+	return func(common.Address) (*ecdsa.PrivateKey, error) { return controller, nil }
+}
+
+func TestResolverMarksAppliedAndStopsAttachingTheInstall(t *testing.T) {
+	engine, user, wallet, stored := storedPendingGrant(t)
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	resolver := NewSessionResolver(engine.db, testResolverKey(controllerKey))
+
+	// First resolution: pending grant → deferred install attached, with the
+	// callback that will record its landing.
+	auth, err := resolver(testPolicyChain, user.Address, wallet)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	require.True(t, auth.Deferred(), "a pending grant's first operation carries the install")
+	require.NotNil(t, auth.OnApplied, "the send path needs a way to record the landing")
+
+	// The send path saw the receipt.
+	require.NoError(t, auth.OnApplied("0xabc123"))
+
+	updated, err := engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.Equal(t, model.SessionPolicyActive, updated.Status)
+	require.Equal(t, "0xabc123", updated.Grant.AppliedUserOpHash)
+	require.True(t, updated.Grant.Applied())
+
+	// Second resolution: the install is history; the operation runs plain.
+	auth, err = resolver(testPolicyChain, user.Address, wallet)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	require.False(t, auth.Deferred(), "an applied install must never be attached again")
+	require.Nil(t, auth.OnApplied)
+	require.EqualValues(t, stored.EntityID, auth.EntityID)
+}
+
+func TestMarkAppliedByIDIsIdempotentAndRaceSafe(t *testing.T) {
+	engine, user, wallet, stored := storedPendingGrant(t)
+	owner := user.Address
+
+	// Idempotent: marking twice keeps the first record.
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xfirst"))
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xsecond"))
+	updated, err := engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.Equal(t, "0xfirst", updated.Grant.AppliedUserOpHash)
+
+	// Revoked-in-flight: the record moved on; a late mark must not resurrect
+	// it as active.
+	_, cleanup, err := engine.RevokeSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.True(t, cleanup, "an applied grant's revoke leaves on-chain state")
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xlate"))
+	after, err := ListSessionPolicies(engine.db, testPolicyChain, owner)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.Equal(t, model.SessionPolicyRevoked, after[0].Status, "a late mark must never resurrect a revoked grant")
+
+	// Deleted-in-flight (a PENDING grant revoked while its op was in the
+	// mempool): no record left; the mark is a no-op, not an error.
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, "01jarbitrarymissingpolicyid", ""))
+}

--- a/core/taskengine/session_grant_test.go
+++ b/core/taskengine/session_grant_test.go
@@ -1,0 +1,223 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// The whole grant flow, without a chain: the gateway prepares a payload, the
+// owner signs it, the gateway stores it, and the send path then resolves an
+// authorization that carries the install exactly once.
+func TestSessionGrantRoundTrip(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	ownerKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	signerKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(signerKey.PublicKey)
+
+	prepared, err := PrepareSessionGrant(db, spChain, signer, "p1", SessionGrantRequest{
+		Owner:      owner,
+		Wallet:     spWallet,
+		AgentLabel: "TradingBot",
+		// A global grant needs an execution hook, so give it one — this also
+		// exercises RequiresExecuteUserOp being derived rather than asserted.
+		Hooks: [][]byte{aa.AllowlistExecHook(1)},
+	})
+	if err != nil {
+		t.Fatalf("PrepareSessionGrant: %v", err)
+	}
+	if prepared.Policy.EntityID != 1 {
+		t.Errorf("first grant should take entity 1, got %d", prepared.Policy.EntityID)
+	}
+	if !prepared.Policy.Grant.RequiresExecuteUserOp {
+		t.Error("a grant carrying an execution hook must require executeUserOp wrapping")
+	}
+	if prepared.Policy.Grant.CarrierNonce == nil {
+		t.Fatal("no carrier nonce — it cannot be recomputed later")
+	}
+
+	// Nothing is stored until the owner signs.
+	if got, _ := ActiveSessionPolicyForWallet(db, spChain, owner, spWallet); got != nil {
+		t.Error("preparing a grant must not persist anything")
+	}
+
+	sig, err := crypto.Sign(prepared.Digest.Bytes(), ownerKey) // raw digest
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig[64] += 27
+
+	policy, err := SubmitSessionGrant(db, prepared, sig)
+	if err != nil {
+		t.Fatalf("SubmitSessionGrant: %v", err)
+	}
+	if policy.Status != model.SessionPolicyPending {
+		t.Errorf("a submitted grant starts pending, got %q", policy.Status)
+	}
+
+	// The send path can now resolve it, and the install rides along exactly
+	// once: attached while pending, dropped after it is marked applied.
+	resolve := NewSessionResolver(db, func(a common.Address) (*ecdsa.PrivateKey, error) {
+		if a != signer {
+			return nil, fmt.Errorf("unexpected signer %s", a.Hex())
+		}
+		return signerKey, nil
+	})
+	auth, err := resolve(spChain, owner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth == nil || !auth.Deferred() {
+		t.Fatal("a pending grant's first operation must carry the install")
+	}
+	if !auth.WrapExecuteUserOp {
+		t.Error("the hook-carrying grant must wrap in user-op context")
+	}
+
+	if err := MarkSessionGrantApplied(db, policy, "0xdeadbeef"); err != nil {
+		t.Fatalf("MarkSessionGrantApplied: %v", err)
+	}
+	auth, err = resolve(spChain, owner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve after apply: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("an applied grant still authorizes execution")
+	}
+	if auth.Deferred() {
+		t.Error("the install must not be attached a second time")
+	}
+}
+
+// A signature from anyone but the owner must be refused before storage. A
+// stored bad grant fails later, on chain, naming neither the record nor the
+// mismatch.
+func TestSubmitSessionGrantRejectsAForeignSignature(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	ownerKey, _ := crypto.GenerateKey()
+	strangerKey, _ := crypto.GenerateKey()
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	signer := crypto.PubkeyToAddress(strangerKey.PublicKey)
+
+	prepared, err := PrepareSessionGrant(db, spChain, signer, "p1", SessionGrantRequest{
+		Owner: owner, Wallet: spWallet, Hooks: [][]byte{aa.AllowlistExecHook(1)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, _ := crypto.Sign(prepared.Digest.Bytes(), strangerKey)
+	sig[64] += 27
+
+	if _, err := SubmitSessionGrant(db, prepared, sig); err == nil {
+		t.Fatal("a grant signed by someone other than the owner must be refused")
+	}
+	if got, _ := ActiveSessionPolicyForWallet(db, spChain, owner, spWallet); got != nil {
+		t.Error("a rejected grant must not be stored")
+	}
+}
+
+// Two grants prepared concurrently on one wallet both see the same free
+// entity. The second submit must lose rather than overwrite the first grant's
+// signer on chain.
+func TestConcurrentPreparesCannotCollideOnAnEntity(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	ownerKey, _ := crypto.GenerateKey()
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	signerKey, _ := crypto.GenerateKey()
+	signer := crypto.PubkeyToAddress(signerKey.PublicKey)
+
+	req := SessionGrantRequest{Owner: owner, Wallet: spWallet, Hooks: [][]byte{aa.AllowlistExecHook(1)}}
+	first, err := PrepareSessionGrant(db, spChain, signer, "p1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := PrepareSessionGrant(db, spChain, signer, "p2", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Policy.EntityID != second.Policy.EntityID {
+		t.Fatal("precondition: both prepares should have seen the same free entity")
+	}
+
+	sign := func(p *PreparedSessionGrant) []byte {
+		s, _ := crypto.Sign(p.Digest.Bytes(), ownerKey)
+		s[64] += 27
+		return s
+	}
+	if _, err := SubmitSessionGrant(db, first, sign(first)); err != nil {
+		t.Fatalf("the first submit should succeed: %v", err)
+	}
+	if _, err := SubmitSessionGrant(db, second, sign(second)); err == nil {
+		t.Error("the second submit must be refused; its entity was taken while it was being signed")
+	}
+}
+
+// Revocation splits on whether the install ever reached the chain.
+func TestRevokeSessionGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	t.Run("before first use it is free and complete", func(t *testing.T) {
+		p := spPolicy("p1", spWallet, 1, model.SessionPolicyPending)
+		if err := StoreSessionPolicy(db, p); err != nil {
+			t.Fatal(err)
+		}
+		onChain, err := RevokeSessionGrant(db, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if onChain {
+			t.Error("an unapplied grant needs no on-chain cleanup")
+		}
+		got, _ := ActiveSessionPolicyForWallet(db, spChain, spOwner, spWallet)
+		if got != nil {
+			t.Error("the record should be gone")
+		}
+	})
+
+	t.Run("after install it needs uninstallValidation", func(t *testing.T) {
+		p := spPolicy("p2", spWallet2, 1, model.SessionPolicyActive)
+		p.Grant.AppliedAt = 1_753_000_000_000
+		if err := StoreSessionPolicy(db, p); err != nil {
+			t.Fatal(err)
+		}
+		onChain, err := RevokeSessionGrant(db, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !onChain {
+			t.Error("an applied grant leaves a module installed on the account")
+		}
+		// Retained, not deleted: the cleanup payload is the same tuple as the
+		// install, so the record has to survive to reproduce it.
+		got, err := ActiveSessionPolicyForWallet(db, spChain, spOwner, spWallet2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Error("a revoked grant must not authorize anything")
+		}
+	})
+}

--- a/core/taskengine/session_grant_testhelper_test.go
+++ b/core/taskengine/session_grant_testhelper_test.go
@@ -1,0 +1,144 @@
+package taskengine
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Live-chain tests execute through the gateway, and the gateway cannot sign as
+// a wallet's owner — a stock MA v2 account trusts only its fallback signer.
+// Every such test therefore needs a session grant in place before it runs, the
+// same one the grant screen will create in production.
+//
+// grantControllerAuthority builds that grant and installs a resolver over the
+// test's own database, so the test exercises the real resolution path rather
+// than injecting an authorization directly.
+//
+// It is idempotent against the CHAIN, which matters because these wallets are
+// long-lived Sepolia fixtures: if the controller is already installed at the
+// entity, the stored grant is marked applied so the deferred install is not
+// replayed onto an entity that already exists. Otherwise it stays pending and
+// rides the test's first operation.
+func grantControllerAuthority(
+	t *testing.T,
+	db storage.Storage,
+	swCfg *config.SmartWalletConfig,
+	owner common.Address,
+	wallet common.Address,
+) {
+	t.Helper()
+
+	ownerKey := requireOwnerKey(t)
+	if got := crypto.PubkeyToAddress(ownerKey.PublicKey); got != owner {
+		t.Fatalf("TEST_PRIVATE_KEY is %s but the test's owner is %s; they must match to authorize a grant",
+			got.Hex(), owner.Hex())
+	}
+	if swCfg.ControllerPrivateKey == nil {
+		t.Fatal("no controller key configured; the gateway cannot be granted anything")
+	}
+	controller := crypto.PubkeyToAddress(swCfg.ControllerPrivateKey.PublicKey)
+
+	prepared, err := PrepareSessionGrant(db, swCfg.ChainID, controller, "test-grant", SessionGrantRequest{
+		Owner:  owner,
+		Wallet: wallet,
+		// Global with no hooks: a fixture grant, and the API makes that
+		// deliberate rather than accidental. Production grants carry hooks.
+		Selectors: nil,
+		Hooks:     nil,
+		// A bare global grant is refused unless acknowledged. Fixtures may be
+		// self-administering; production grants carry hooks or scoping.
+		AllowSelfAdministration: true,
+	})
+	if err != nil {
+		t.Fatalf("preparing the test grant: %v", err)
+	}
+
+	sig, err := crypto.Sign(prepared.Digest.Bytes(), ownerKey) // raw digest
+	if err != nil {
+		t.Fatalf("signing the grant: %v", err)
+	}
+	sig[64] += 27
+
+	policy, err := SubmitSessionGrant(db, prepared, sig)
+	if err != nil {
+		t.Fatalf("submitting the grant: %v", err)
+	}
+
+	// If the entity already holds the controller on chain, the install has
+	// happened in a previous run. Replaying it would re-run installValidation
+	// on an existing entity.
+	if installedOnChain(t, swCfg, wallet, policy.EntityID, controller) {
+		if err := MarkSessionGrantApplied(db, policy, "pre-existing"); err != nil {
+			t.Fatalf("marking the grant applied: %v", err)
+		}
+		t.Logf("grant: entity %d already installed on %s; not replaying the install",
+			policy.EntityID, wallet.Hex())
+	} else {
+		t.Logf("grant: entity %d pending on %s; the install rides the first operation",
+			policy.EntityID, wallet.Hex())
+	}
+
+	preset.SetSessionResolver(NewSessionResolver(db, func(a common.Address) (*ecdsa.PrivateKey, error) {
+		if a != controller {
+			return nil, fmt.Errorf("no key for session signer %s", a.Hex())
+		}
+		return swCfg.ControllerPrivateKey, nil
+	}))
+	t.Cleanup(func() { preset.SetSessionResolver(nil) })
+}
+
+// requireOwnerKey loads the owner key these tests cannot authorize without.
+func requireOwnerKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	raw := os.Getenv("TEST_PRIVATE_KEY")
+	if raw == "" {
+		t.Fatal("TEST_PRIVATE_KEY must be set: the gateway cannot sign for a wallet without a grant, " +
+			"and only the owner can authorize one")
+	}
+	key, err := crypto.HexToECDSA(strings.TrimPrefix(raw, "0x"))
+	if err != nil {
+		t.Fatalf("TEST_PRIVATE_KEY is not a valid hex private key: %v", err)
+	}
+	return key
+}
+
+// installedOnChain reports whether the entity already names this signer.
+func installedOnChain(t *testing.T, swCfg *config.SmartWalletConfig, wallet common.Address, entity uint32, signer common.Address) bool {
+	t.Helper()
+	client, err := ethclient.Dial(swCfg.EthRpcUrl)
+	if err != nil {
+		t.Fatalf("dialing the chain to check the grant: %v", err)
+	}
+	defer client.Close()
+
+	data := append(common.FromHex(selectorSSVMSigners), padWord(entity)...)
+	data = append(data, common.LeftPadBytes(wallet.Bytes(), 32)...)
+	module := aa.SingleSignerValidationModuleAddress()
+	out, err := client.CallContract(context.Background(), ethereum.CallMsg{To: &module, Data: data}, nil)
+	if err != nil || len(out) < 32 {
+		return false
+	}
+	return common.BytesToAddress(out[12:32]) == signer
+}
+
+// selectorSSVMSigners is SingleSignerValidationModule.signers(uint32,address).
+const selectorSSVMSigners = "0x217178fb"
+
+func padWord(v uint32) []byte {
+	return common.LeftPadBytes(big.NewInt(int64(v)).Bytes(), 32)
+}

--- a/core/taskengine/session_permissions.go
+++ b/core/taskengine/session_permissions.go
@@ -1,0 +1,128 @@
+package taskengine
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// SessionPermissions is the declared §7.2 permission set — allowed actions,
+// ERC-20 spend cap, expiry — and its translation into the hook entries a
+// grant installs. This is the only place that translation lives: the REST
+// layer hands over declared permissions, never raw hook bytes, so a client
+// cannot smuggle an encoding the grant screen did not show.
+//
+// v1 requires all three permissions. That is not just product scope: the cap
+// installs the allowlist's EXECUTION hook, and per the revoke spike (results
+// doc §3.5) that hook is what stops a global session validation from
+// self-administering the account. A capless global grant would need
+// selector-scoping instead, which is not yet exercised on-chain.
+type SessionPermissions struct {
+	AllowedActions []model.AllowedAction
+	SpendCap       *model.ERC20SpendCap
+	ValidUntilMs   int64
+}
+
+// Validate rejects a permission set the grant screen could not have produced.
+func (p SessionPermissions) Validate() error {
+	if len(p.AllowedActions) == 0 {
+		return fmt.Errorf("a grant needs at least one allowed action")
+	}
+	for i, action := range p.AllowedActions {
+		if action.Target == nil || *action.Target == (common.Address{}) {
+			return fmt.Errorf("allowed action %d has no target", i)
+		}
+		if len(action.Selectors) == 0 {
+			return fmt.Errorf("allowed action %d on %s has no selectors; an any-function grant is not offered", i, action.Target.Hex())
+		}
+		for _, s := range action.Selectors {
+			if _, err := parseSelector(s); err != nil {
+				return fmt.Errorf("allowed action %d: %w", i, err)
+			}
+		}
+	}
+	if p.SpendCap == nil || p.SpendCap.Token == nil {
+		return fmt.Errorf("a grant needs an ERC-20 spend cap")
+	}
+	if amount, ok := new(big.Int).SetString(p.SpendCap.Amount, 10); !ok || amount.Sign() <= 0 {
+		return fmt.Errorf("spend cap amount %q is not a positive decimal integer", p.SpendCap.Amount)
+	}
+	capCovered := false
+	for _, action := range p.AllowedActions {
+		if action.Target != nil && *action.Target == *p.SpendCap.Token {
+			capCovered = true
+			break
+		}
+	}
+	if !capCovered {
+		return fmt.Errorf("the cap token %s is not an allowed-action target; cap a token the agent may actually call", p.SpendCap.Token.Hex())
+	}
+	if p.ValidUntilMs <= time.Now().UnixMilli() {
+		return fmt.Errorf("validUntil is in the past")
+	}
+	return nil
+}
+
+// HooksFor builds the grant's hook entries for its allocated entity:
+// the allowlist validation hook (targets, selectors, and the cap's limit in
+// one install payload), the allowlist execution hook that enforces the cap,
+// and the time-range hook that expires the grant.
+func (p SessionPermissions) HooksFor(entityID uint32) ([][]byte, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+
+	inputs := make([]aa.AllowlistInput, 0, len(p.AllowedActions))
+	capAmount, _ := new(big.Int).SetString(p.SpendCap.Amount, 10)
+	for _, action := range p.AllowedActions {
+		selectors := make([][4]byte, 0, len(action.Selectors))
+		for _, s := range action.Selectors {
+			sel, err := parseSelector(s)
+			if err != nil {
+				return nil, err
+			}
+			selectors = append(selectors, sel)
+		}
+		input := aa.AllowlistInput{
+			Target:               *action.Target,
+			HasSelectorAllowlist: true,
+			Selectors:            selectors,
+		}
+		if *action.Target == *p.SpendCap.Token {
+			input.HasERC20SpendLimit = true
+			input.ERC20SpendLimit = capAmount
+		}
+		inputs = append(inputs, input)
+	}
+
+	allowlistHook, err := aa.AllowlistValidationHook(entityID, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("building the allowlist hook: %w", err)
+	}
+	timeRangeHook, err := aa.TimeRangeValidationHook(entityID, uint64(p.ValidUntilMs/1000), 0)
+	if err != nil {
+		return nil, fmt.Errorf("building the time-range hook: %w", err)
+	}
+	return [][]byte{allowlistHook, aa.AllowlistExecHook(entityID), timeRangeHook}, nil
+}
+
+func parseSelector(s string) ([4]byte, error) {
+	var out [4]byte
+	raw := strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	if len(raw) != 8 {
+		return out, fmt.Errorf("selector %q is not 4 bytes", s)
+	}
+	b, err := hex.DecodeString(raw)
+	if err != nil {
+		return out, fmt.Errorf("selector %q is not hex: %w", s, err)
+	}
+	copy(out[:], b)
+	return out, nil
+}

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -1,0 +1,148 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Session-policy storage and the resolver that connects it to the send path.
+//
+// A stock Modular Account v2 trusts only its fallback signer — the user's EOA,
+// whose key the gateway does not hold. Everything the gateway executes
+// therefore runs as an installed validation entity, and the grant that
+// installed it lives here.
+
+// ListSessionPolicies returns every policy an owner holds on a chain.
+//
+// Records that fail to deserialize are an error rather than a silent skip: a
+// dropped policy reads downstream as "this wallet has no grant", which sends
+// the operation to the owner's fallback signer and fails on chain with nothing
+// pointing back at the unreadable record.
+func ListSessionPolicies(db storage.Storage, chainID int64, owner common.Address) ([]*model.SessionPolicy, error) {
+	items, err := db.GetByPrefix(SessionPolicyPrefix(chainID, owner))
+	if err != nil {
+		return nil, fmt.Errorf("listing session policies for %s on chain %d: %w", owner.Hex(), chainID, err)
+	}
+	out := make([]*model.SessionPolicy, 0, len(items))
+	for _, item := range items {
+		policy := &model.SessionPolicy{}
+		if err := policy.FromStorageData(item.Value); err != nil {
+			return nil, fmt.Errorf("session policy at %s is unreadable: %w", string(item.Key), err)
+		}
+		out = append(out, policy)
+	}
+	return out, nil
+}
+
+// StoreSessionPolicy persists a grant.
+func StoreSessionPolicy(db storage.Storage, policy *model.SessionPolicy) error {
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	body, err := policy.ToJSON()
+	if err != nil {
+		return fmt.Errorf("serializing session policy %s: %w", policy.ID, err)
+	}
+	return db.Set(SessionPolicyKey(policy.ChainID, *policy.Owner, policy.ID), body)
+}
+
+// ActiveSessionPolicyForWallet returns the usable grant for one wallet.
+//
+// Exactly one usable grant per wallet is expected. More than one is refused
+// rather than resolved by picking: two grants mean two entities, and silently
+// choosing would sign under one while the caller may have provisioned the
+// other — an authority question is not a place for a heuristic.
+func ActiveSessionPolicyForWallet(db storage.Storage, chainID int64, owner, wallet common.Address) (*model.SessionPolicy, error) {
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	if err != nil {
+		return nil, err
+	}
+	var found *model.SessionPolicy
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != wallet || !p.Usable() {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf(
+				"wallet %s has more than one usable session policy (%s, %s); revoke one before executing",
+				wallet.Hex(), found.ID, p.ID)
+		}
+		found = p
+	}
+	return found, nil
+}
+
+// NextSessionEntityID picks an unused validation entity for a wallet.
+//
+// Uniqueness is per ACCOUNT while the storage key is per owner, so this scans
+// the owner's policies and filters by runner. It is deliberately NOT safe to
+// call outside the transaction that writes the resulting policy: two
+// concurrent grants on one wallet would read the same maximum, and the second
+// install would overwrite the first grant's signer at the same entity. See
+// avs-infra §7.4a.
+func NextSessionEntityID(db storage.Storage, chainID int64, owner, wallet common.Address) (uint32, error) {
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	if err != nil {
+		return 0, err
+	}
+	// Revoked policies still count: their entity may hold module state that
+	// was never cleaned up, and reusing it would collide with the leftovers.
+	next := uint32(1)
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != wallet {
+			continue
+		}
+		if p.EntityID >= next {
+			next = p.EntityID + 1
+		}
+	}
+	return next, nil
+}
+
+// NewSessionResolver builds the resolver the send path consults, backed by
+// storage and a key lookup.
+//
+// signerKeyFor maps a session-signer ADDRESS to its private key. It is a
+// callback rather than a map so key material stays wherever the gateway keeps
+// it and never has to live on this record.
+func NewSessionResolver(
+	db storage.Storage,
+	signerKeyFor func(signer common.Address) (*ecdsa.PrivateKey, error),
+) preset.SessionResolver {
+	return func(chainID int64, owner, wallet common.Address) (*preset.SessionAuthorization, error) {
+		policy, err := ActiveSessionPolicyForWallet(db, chainID, owner, wallet)
+		if err != nil {
+			return nil, err
+		}
+		if policy == nil {
+			// No grant. The operation stays on the owner's fallback signer,
+			// which the gateway cannot sign — but that failure belongs to the
+			// caller that asked for an operation it has no authority for, and
+			// it reads more clearly than a fabricated authorization.
+			return nil, nil
+		}
+		key, err := signerKeyFor(*policy.SessionSigner)
+		if err != nil {
+			return nil, fmt.Errorf("session policy %s: %w", policy.ID, err)
+		}
+		auth := &preset.SessionAuthorization{
+			EntityID:          policy.EntityID,
+			SignerKey:         key,
+			WrapExecuteUserOp: policy.Grant.RequiresExecuteUserOp,
+		}
+		// The install rides the grant's FIRST operation only. Replaying an
+		// applied action would re-run installValidation on an entity that
+		// already exists.
+		if !policy.Grant.Applied() {
+			auth.DeferredData = policy.Grant.InstallCall
+			auth.OwnerSignature = policy.Grant.OwnerSignature
+		}
+		return auth, nil
+	}
+}

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -140,10 +140,18 @@ func NewSessionResolver(
 		}
 		// The install rides the grant's FIRST operation only. Replaying an
 		// applied action would re-run installValidation on an entity that
-		// already exists.
+		// already exists. OnApplied is how the send path closes that loop:
+		// it fires when the install is known to be on-chain (receipt in
+		// hand, or the carrier nonce found consumed), and the ByID variant
+		// re-reads the record so a grant revoked mid-flight is never
+		// resurrected by a stale pointer.
 		if !policy.Grant.Applied() {
 			auth.DeferredData = policy.Grant.InstallCall
 			auth.OwnerSignature = policy.Grant.OwnerSignature
+			policyID, policyChain, policyOwner := policy.ID, policy.ChainID, *policy.Owner
+			auth.OnApplied = func(userOpHash string) error {
+				return MarkSessionGrantAppliedByID(db, policyChain, policyOwner, policyID, userOpHash)
+			}
 		}
 		return auth, nil
 	}

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -107,6 +107,22 @@ func NextSessionEntityID(db storage.Storage, chainID int64, owner, wallet common
 	return next, nil
 }
 
+// InstallSessionResolver wires the send path to this engine's session-policy
+// storage. Without it every MA v2 operation is signed as the account's
+// fallback signer — the user's EOA, whose key the gateway does not hold — so
+// nothing the gateway executes validates.
+//
+// Called once at aggregator startup, deliberately NOT from New: the resolver
+// is process-global (the preset package has no per-engine context), and test
+// suites construct many engines whose constructors would silently overwrite
+// each other's resolver — the last-built engine would then answer authority
+// questions for all of them. The single production engine installs it
+// explicitly; tests that need one install their own scoped to their own
+// database.
+func (n *Engine) InstallSessionResolver() {
+	preset.SetSessionResolver(NewSessionResolver(n.db, controllerSessionSigner(n.config)))
+}
+
 // NewSessionResolver builds the resolver the send path consults, backed by
 // storage and a key lookup.
 //

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
@@ -144,5 +146,37 @@ func NewSessionResolver(
 			auth.OwnerSignature = policy.Grant.OwnerSignature
 		}
 		return auth, nil
+	}
+}
+
+// controllerSessionSigner resolves a session signer to its key.
+//
+// Today every policy is signed by the gateway's controller key, so this
+// accepts exactly that address and refuses anything else. That is a deliberate
+// interim: avs-infra §7.4 describes session_signer as gateway-ASSIGNED, one
+// fresh key per policy, which needs key generation and custody this gateway
+// does not have yet.
+//
+// What matters is that the interim does not weaken the model. Authority is
+// still per grant, because each policy occupies its own validation ENTITY —
+// and the entity, not the key, is what carries the hooks, the revocation
+// target, and the nonce space that makes grant-time signing work. Sharing one
+// key across entities means a compromised controller reaches every grant, but
+// that is already true of the controller today.
+//
+// Refusing an unknown signer is the important half: a policy naming a key we
+// cannot produce must fail loudly here, not sign with the wrong one.
+func controllerSessionSigner(cfg *config.Config) func(common.Address) (*ecdsa.PrivateKey, error) {
+	return func(signer common.Address) (*ecdsa.PrivateKey, error) {
+		if cfg == nil || cfg.SmartWallet == nil || cfg.SmartWallet.ControllerPrivateKey == nil {
+			return nil, fmt.Errorf("no controller key configured; cannot sign as session signer %s", signer.Hex())
+		}
+		controller := crypto.PubkeyToAddress(cfg.SmartWallet.ControllerPrivateKey.PublicKey)
+		if signer != controller {
+			return nil, fmt.Errorf(
+				"session signer %s is not the gateway controller %s; per-policy signer keys are not implemented",
+				signer.Hex(), controller.Hex())
+		}
+		return cfg.SmartWallet.ControllerPrivateKey, nil
 	}
 }

--- a/core/taskengine/session_policy_test.go
+++ b/core/taskengine/session_policy_test.go
@@ -1,0 +1,239 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+const spChain = int64(11155111)
+
+var (
+	spOwner   = common.HexToAddress("0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557")
+	spWallet  = common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	spWallet2 = common.HexToAddress("0xD683400781b73a432b2602dA73a5117F4F445744")
+	spSigner  = common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+)
+
+func spPolicy(id string, wallet common.Address, entity uint32, status model.SessionPolicyStatus) *model.SessionPolicy {
+	owner, w, signer := spOwner, wallet, spSigner
+	return &model.SessionPolicy{
+		ID: id, Owner: &owner, Runner: &w, ChainID: spChain,
+		EntityID: entity, SessionSigner: &signer, Status: status,
+		Grant: &model.SessionGrantAuthorization{
+			InstallCall:    []byte{0x1b, 0xbf, 0x56, 0x4c, 0x01},
+			CarrierNonce:   big.NewInt(1),
+			Deadline:       1785541743,
+			OwnerSignature: make([]byte, 65),
+		},
+	}
+}
+
+func spKeyFor(t *testing.T) (func(common.Address) (*ecdsa.PrivateKey, error), *ecdsa.PrivateKey) {
+	t.Helper()
+	k, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(a common.Address) (*ecdsa.PrivateKey, error) {
+		if a != spSigner {
+			return nil, fmt.Errorf("no key for %s", a.Hex())
+		}
+		return k, nil
+	}, k
+}
+
+func TestSessionResolverReturnsTheWalletsGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, key := spKeyFor(t)
+
+	if err := StoreSessionPolicy(db, spPolicy("p1", spWallet, 1, model.SessionPolicyPending)); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+	// A grant on a DIFFERENT wallet the same owner holds must not leak across.
+	if err := StoreSessionPolicy(db, spPolicy("p2", spWallet2, 1, model.SessionPolicyActive)); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+
+	resolve := NewSessionResolver(db, keyFor)
+	auth, err := resolve(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("expected an authorization for a wallet that has a grant")
+	}
+	if auth.EntityID != 1 || auth.SignerKey != key {
+		t.Errorf("wrong entity/key: %d %v", auth.EntityID, auth.SignerKey == key)
+	}
+	// Pending means the install has not been applied, so it must ride along.
+	if !auth.Deferred() {
+		t.Error("a pending grant's first operation must carry the install")
+	}
+}
+
+// The install is a bearer authorization for exactly its calldata. Replaying it
+// would re-run installValidation on an entity that already exists.
+func TestSessionResolverDoesNotReplayAnAppliedGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+
+	p := spPolicy("p1", spWallet, 1, model.SessionPolicyActive)
+	p.Grant.AppliedAt = 1_753_000_000_000
+	p.Grant.AppliedUserOpHash = "0xdeadbeef"
+	if err := StoreSessionPolicy(db, p); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+
+	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("an applied grant still authorizes execution")
+	}
+	if auth.Deferred() {
+		t.Error("an applied grant must not re-attach its install")
+	}
+}
+
+func TestSessionResolverNoGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth != nil {
+		t.Error("a wallet with no grant must resolve to nil, leaving the owner's signer")
+	}
+}
+
+// Revoked grants authorize nothing, but their entity is not reusable: module
+// state may survive an incomplete cleanup.
+func TestRevokedGrantIsNotUsableButStillConsumesItsEntity(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+	if err := StoreSessionPolicy(db, spPolicy("p1", spWallet, 1, model.SessionPolicyRevoked)); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+
+	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth != nil {
+		t.Error("a revoked grant must not authorize anything")
+	}
+	next, err := NextSessionEntityID(db, spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("NextSessionEntityID: %v", err)
+	}
+	if next != 2 {
+		t.Errorf("next entity = %d, want 2 — a revoked entity may hold stranded module state", next)
+	}
+}
+
+// Two usable grants on one wallet is an authority question, and picking one
+// would sign under an entity the caller may not have provisioned.
+func TestTwoUsableGrantsOnOneWalletIsRefused(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+	for _, p := range []*model.SessionPolicy{
+		spPolicy("p1", spWallet, 1, model.SessionPolicyActive),
+		spPolicy("p2", spWallet, 2, model.SessionPolicyPending),
+	} {
+		if err := StoreSessionPolicy(db, p); err != nil {
+			t.Fatalf("StoreSessionPolicy: %v", err)
+		}
+	}
+	if _, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet); err == nil {
+		t.Error("expected a refusal when a wallet has two usable grants")
+	}
+}
+
+// Entity ids are unique per ACCOUNT while the key is per owner, so allocation
+// must not be confused by the owner's other wallets.
+func TestNextSessionEntityIDIsPerAccount(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	if err := StoreSessionPolicy(db, spPolicy("p1", spWallet, 4, model.SessionPolicyActive)); err != nil {
+		t.Fatal(err)
+	}
+	if err := StoreSessionPolicy(db, spPolicy("p2", spWallet2, 9, model.SessionPolicyActive)); err != nil {
+		t.Fatal(err)
+	}
+	next, err := NextSessionEntityID(db, spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != 5 {
+		t.Errorf("next entity for %s = %d, want 5 (the other wallet's 9 is irrelevant)", spWallet.Hex(), next)
+	}
+	first, err := NextSessionEntityID(db, spChain, spOwner, common.HexToAddress("0x1234"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != 1 {
+		t.Errorf("a fresh wallet's first entity = %d, want 1 (0 is the owner's)", first)
+	}
+}
+
+func TestSessionPolicyValidateRejectsUnusableRecords(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*model.SessionPolicy)
+	}{
+		{"entity 0 is the owner's", func(p *model.SessionPolicy) { p.EntityID = 0 }},
+		{"no install calldata", func(p *model.SessionPolicy) { p.Grant.InstallCall = nil }},
+		{"no owner signature", func(p *model.SessionPolicy) { p.Grant.OwnerSignature = nil }},
+		// The digest commits to it and it cannot be recomputed after the fact.
+		{"no carrier nonce", func(p *model.SessionPolicy) { p.Grant.CarrierNonce = nil }},
+		{"no grant at all", func(p *model.SessionPolicy) { p.Grant = nil }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := spPolicy("p1", spWallet, 1, model.SessionPolicyPending)
+			tt.mutate(p)
+			if err := p.Validate(); err == nil {
+				t.Error("expected Validate to reject this record")
+			}
+		})
+	}
+}
+
+// Round-trip through storage: the grant's bytes and big.Int must survive.
+func TestSessionPolicyRoundTrip(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	p := spPolicy("p1", spWallet, 3, model.SessionPolicyPending)
+	p.Grant.CarrierNonce, _ = new(big.Int).SetString("18446744073709551617", 10) // > uint64
+	if err := StoreSessionPolicy(db, p); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ActiveSessionPolicyForWallet(db, spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("policy not found after storing")
+	}
+	if got.Grant.CarrierNonce.Cmp(p.Grant.CarrierNonce) != 0 {
+		t.Errorf("carrier nonce round-tripped as %s, want %s", got.Grant.CarrierNonce, p.Grant.CarrierNonce)
+	}
+	if string(got.Grant.InstallCall) != string(p.Grant.InstallCall) {
+		t.Error("install calldata did not round-trip")
+	}
+}

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -69,6 +69,12 @@ func TestSimulateTask_StopLossWorkflow_Sepolia(t *testing.T) {
 		"wallet must hold at least 2 USDC; fund %s", smartWalletAddr.Hex())
 
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddr)
+
 	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
 
 	engine := New(db, cfg, nil, testutil.GetLogger())

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -170,6 +170,7 @@ return { inputBalance, hasEnoughBalance, swapAmount };
 		TaskType: &avsproto.TaskNode_ContractWrite{
 			ContractWrite: &avsproto.ContractWriteNode{
 				Config: &avsproto.ContractWriteNode_Config{
+					ChainId:         cfg.SmartWallet.ChainID,
 					ContractAddress: SEPOLIA_USDC,
 					ContractAbi: []*structpb.Value{sv(t, map[string]interface{}{
 						"type": "function", "name": "approve", "stateMutability": "nonpayable",
@@ -196,6 +197,7 @@ return { inputBalance, hasEnoughBalance, swapAmount };
 		TaskType: &avsproto.TaskNode_ContractRead{
 			ContractRead: &avsproto.ContractReadNode{
 				Config: &avsproto.ContractReadNode_Config{
+					ChainId:         cfg.SmartWallet.ChainID,
 					ContractAddress: SEPOLIA_QUOTER_V2,
 					ContractAbi: []*structpb.Value{sv(t, map[string]interface{}{
 						"type": "function", "name": "quoteExactInputSingle", "stateMutability": "nonpayable",
@@ -258,6 +260,7 @@ return { amountOutMinimum: amountOutMinimum.toString() };
 		TaskType: &avsproto.TaskNode_ContractWrite{
 			ContractWrite: &avsproto.ContractWriteNode{
 				Config: &avsproto.ContractWriteNode_Config{
+					ChainId:         cfg.SmartWallet.ChainID,
 					ContractAddress: SEPOLIA_SWAPROUTER,
 					ContractAbi: []*structpb.Value{sv(t, map[string]interface{}{
 						"type": "function", "name": "exactInputSingle", "stateMutability": "payable",

--- a/core/taskengine/userops_batch_swap_test.go
+++ b/core/taskengine/userops_batch_swap_test.go
@@ -149,6 +149,12 @@ func TestUserOpAtomicBatch_Sepolia(t *testing.T) {
 	inputVars := map[string]interface{}{"settings": settings}
 
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddress)
+
 	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
 	engine := New(db, cfg, nil, testutil.GetLogger())
 	t.Cleanup(func() { engine.Stop() })

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -73,6 +73,12 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 
 	// Create engine for RunNodeImmediately execution
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddress)
+
 	t.Cleanup(func() {
 		storage.Destroy(db.(*storage.BadgerStorage))
 	})
@@ -535,6 +541,10 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 
 	// Create engine for RunNodeImmediately execution
 	db := testutil.TestMustDB()
+
+	// Same as above: without a grant the gateway would sign as the wallet's
+	// owner, whose key it does not hold.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddress)
 	t.Cleanup(func() {
 		storage.Destroy(db.(*storage.BadgerStorage))
 	})

--- a/core/taskengine/vm_runner_contract_write_batch_test.go
+++ b/core/taskengine/vm_runner_contract_write_batch_test.go
@@ -204,7 +204,10 @@ func TestAtomicBatchOnDemand(t *testing.T) {
 		require.Equal(t, 1, callCount, "still one UserOp")
 
 		require.GreaterOrEqual(t, len(captured), 4)
-		assert.Equal(t, "c3ff72fc", common.Bytes2Hex(captured[:4]), "value-bearing batch must use executeBatchWithValues")
+		// MA v2 (the default provider) carries per-call values natively in
+		// its executeBatch tuples — the v0.6 fork's executeBatchWithValues
+		// (0xc3ff72fc) has no successor and needs none.
+		assert.Equal(t, "34fcd5be", common.Bytes2Hex(captured[:4]), "value-bearing batch must use the MA v2 executeBatch")
 		_, values, _, err := aa.UnpackExecuteCalldata(captured)
 		require.NoError(t, err)
 		require.Len(t, values, 2)

--- a/model/session_policy.go
+++ b/model/session_policy.go
@@ -41,6 +41,14 @@ type SessionPolicy struct {
 	AgentLabel    string `json:"agent_label,omitempty"`
 	Justification string `json:"justification,omitempty"`
 
+	// AllowedActions and ERC20SpendCap are the grant's declared permissions
+	// (master §7.2 P1/P2), stored for the manage screen and for rebuilding
+	// the module-cleanup payload at revocation. Display/rebuild data only:
+	// what the owner actually authorized is Grant.InstallCall, and these must
+	// never be re-encoded into it after signing.
+	AllowedActions []AllowedAction `json:"allowed_actions,omitempty"`
+	ERC20SpendCap  *ERC20SpendCap  `json:"erc20_spend_cap,omitempty"`
+
 	// Grant is the owner's authorization. Absent once applied is not a valid
 	// state: it is retained so revocation can reproduce the module cleanup
 	// payload, which is the same (entityId, inputs) tuple as the install.
@@ -53,6 +61,22 @@ type SessionPolicy struct {
 
 	Status    SessionPolicyStatus `json:"status"`
 	CreatedAt int64               `json:"created_at"`
+}
+
+// AllowedAction is one contract the grant's agent may call, scoped to
+// function selectors (master §7.2 P1).
+type AllowedAction struct {
+	Target    *common.Address `json:"target"`
+	Selectors []string        `json:"selectors"` // 0x-prefixed 4-byte selectors
+}
+
+// ERC20SpendCap is the grant's cumulative token cap (master §7.2 P2).
+// GrantedCap preserves the original total for "used X of Y" rendering — the
+// on-chain module only exposes the remainder.
+type ERC20SpendCap struct {
+	Token      *common.Address `json:"token"`
+	Amount     string          `json:"amount"`      // smallest unit, decimal string
+	GrantedCap string          `json:"granted_cap"` // == Amount at grant time
 }
 
 // SessionGrantAuthorization is the owner's signed deferred action.

--- a/model/session_policy.go
+++ b/model/session_policy.go
@@ -1,0 +1,154 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SessionPolicy is one grant of execution authority on one smart wallet: the
+// record behind the grant screen, and the thing the send path resolves before
+// it can sign anything.
+//
+// Shape and rationale: avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §7.4a.
+// Two things about it are easy to get wrong:
+//
+//   - The grant is a BEARER authorization for exactly its committed calldata.
+//     It authorizes execution against the user's wallet, so it gets the same
+//     handling as a secret: not logged, not returned in list responses,
+//     deleted on revoke.
+//
+//   - InstallCall is stored rather than re-derived. Re-building it from the
+//     policy fields at execution time would let a later code change silently
+//     alter what the owner signed — the signature would then fail, but only
+//     on chain, at execution, for a user who already consented.
+type SessionPolicy struct {
+	ID      string          `json:"id"`
+	Owner   *common.Address `json:"owner"`
+	Runner  *common.Address `json:"runner"` // the smart wallet this grants on
+	ChainID int64           `json:"chain_id"`
+
+	// EntityID is the validation entity this grant occupies on the account.
+	// Unique per ACCOUNT, allocated when the policy is created, never 0 —
+	// entity 0 is the owner's fallback signer.
+	EntityID uint32 `json:"entity_id"`
+
+	// SessionSigner is the key the gateway signs with as that entity.
+	SessionSigner *common.Address `json:"session_signer"`
+
+	AgentLabel    string `json:"agent_label,omitempty"`
+	Justification string `json:"justification,omitempty"`
+
+	// Grant is the owner's authorization. Absent once applied is not a valid
+	// state: it is retained so revocation can reproduce the module cleanup
+	// payload, which is the same (entityId, inputs) tuple as the install.
+	Grant *SessionGrantAuthorization `json:"grant,omitempty"`
+
+	// ValidUntil is the grant's own lifetime (the TimeRangeModule hook),
+	// distinct from Grant.Deadline which only bounds the signing→first-use
+	// window. Unix milliseconds.
+	ValidUntil int64 `json:"valid_until,omitempty"`
+
+	Status    SessionPolicyStatus `json:"status"`
+	CreatedAt int64               `json:"created_at"`
+}
+
+// SessionGrantAuthorization is the owner's signed deferred action.
+type SessionGrantAuthorization struct {
+	// InstallCall is the exact installValidation calldata the signature
+	// commits to.
+	InstallCall []byte `json:"install_call"`
+
+	// CarrierNonce is the FULL 256-bit nonce of the operation that will carry
+	// the action. The digest commits to it, so the carrying operation must use
+	// exactly this value. Computable at grant time only because a fresh entity
+	// is a fresh nonce key whose sequence is zero — it cannot be recomputed
+	// later.
+	CarrierNonce *big.Int `json:"carrier_nonce"`
+
+	// Deadline bounds the window between signing and first execution (uint48
+	// unix seconds). Not the grant's lifetime — see SessionPolicy.ValidUntil.
+	Deadline uint64 `json:"deadline"`
+
+	OwnerSignature []byte `json:"owner_signature"`
+
+	// AppliedAt is the replay marker. The payload authorizes exactly its
+	// committed calldata; attaching it twice must be impossible, and a
+	// non-zero AppliedAt is the check. Unix milliseconds.
+	AppliedAt         int64  `json:"applied_at,omitempty"`
+	AppliedUserOpHash string `json:"applied_userop_hash,omitempty"`
+
+	// RequiresExecuteUserOp is true when the grant installs an EXECUTION hook
+	// (an ERC-20 spend cap does; a time range does not). Every operation under
+	// such a grant must be executeUserOp-wrapped, including the one carrying
+	// this install. Recorded at grant time so the send path does not have to
+	// re-parse the install calldata to find out.
+	RequiresExecuteUserOp bool `json:"requires_execute_user_op,omitempty"`
+}
+
+// SessionPolicyStatus tracks how far a grant has got.
+type SessionPolicyStatus string
+
+const (
+	// SessionPolicyPending is signed and stored but not yet on chain.
+	// Revoking is free here: delete the record, nothing was installed.
+	SessionPolicyPending SessionPolicyStatus = "pending"
+	// SessionPolicyActive means the install applied on chain. Revoking now
+	// needs uninstallValidation.
+	SessionPolicyActive SessionPolicyStatus = "active"
+	// SessionPolicyRevoked is retained for audit; it grants nothing.
+	SessionPolicyRevoked SessionPolicyStatus = "revoked"
+)
+
+// Applied reports whether the deferred action has already been consumed.
+func (g *SessionGrantAuthorization) Applied() bool {
+	return g != nil && g.AppliedAt > 0
+}
+
+// Usable reports whether this policy can authorize an operation right now.
+func (p *SessionPolicy) Usable() bool {
+	if p == nil || p.Grant == nil {
+		return false
+	}
+	return p.Status == SessionPolicyPending || p.Status == SessionPolicyActive
+}
+
+// Validate rejects a record that cannot produce a working authorization.
+func (p *SessionPolicy) Validate() error {
+	if p.ID == "" {
+		return fmt.Errorf("session policy has no id")
+	}
+	if p.Owner == nil || *p.Owner == (common.Address{}) {
+		return fmt.Errorf("session policy %s has no owner", p.ID)
+	}
+	if p.Runner == nil || *p.Runner == (common.Address{}) {
+		return fmt.Errorf("session policy %s has no runner", p.ID)
+	}
+	if p.EntityID == 0 {
+		return fmt.Errorf("session policy %s uses entity 0, which is the owner's fallback signer", p.ID)
+	}
+	if p.SessionSigner == nil || *p.SessionSigner == (common.Address{}) {
+		return fmt.Errorf("session policy %s has no session signer", p.ID)
+	}
+	if p.Grant == nil {
+		return fmt.Errorf("session policy %s has no grant", p.ID)
+	}
+	if len(p.Grant.InstallCall) == 0 {
+		return fmt.Errorf("session policy %s has no install calldata", p.ID)
+	}
+	if len(p.Grant.OwnerSignature) == 0 {
+		return fmt.Errorf("session policy %s has no owner signature", p.ID)
+	}
+	if p.Grant.CarrierNonce == nil {
+		return fmt.Errorf("session policy %s has no carrier nonce; it cannot be recomputed", p.ID)
+	}
+	return nil
+}
+
+func (p *SessionPolicy) ToJSON() ([]byte, error) { return json.Marshal(p) }
+
+func (p *SessionPolicy) FromStorageData(body []byte) error {
+	return json.Unmarshal(body, p)
+}

--- a/pkg/erc4337/preset/builder_test.go
+++ b/pkg/erc4337/preset/builder_test.go
@@ -39,6 +39,16 @@ func mockGetBaseTestSmartWalletConfig() *config.SmartWalletConfig {
 func TestSendUserOp(t *testing.T) {
 	smartWalletConfig := mockGetBaseTestSmartWalletConfig()
 
+	// SendUserOp is the v0.6 path — v0.6 EntryPoint, executeBatchWithValues
+	// calldata — so it must derive a v0.6 SimpleAccount. Pin the provider
+	// explicitly: the default flipped to modular_account_v2 in the cutover
+	// (#694), which would otherwise resolve this owner+salt to an MA v2
+	// account that rejects a v0.6 UserOp at validation (nonce 0 carries no
+	// validation locator → ValidationFunctionMissing → the bundler's AA23).
+	// When the v0.6 path is removed post-cutover, this test goes with it.
+	smartWalletConfig.AccountProvider = config.AccountProviderSimpleAccount
+	smartWalletConfig.FactoryAddress = common.HexToAddress(config.DefaultFactoryProxyAddressHex)
+
 	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
 		t.Fatalf("setting global factory: %v", err)
 	}

--- a/pkg/erc4337/preset/builder_v07.go
+++ b/pkg/erc4337/preset/builder_v07.go
@@ -62,8 +62,22 @@ const selectorGetNonce = "0x35567e1a"
 const (
 	seedVerificationGasDeploying = 200_000 // ~160k actual -> ~0.8 efficiency
 	seedVerificationGasDeployed  = 60_000  // ~45k actual  -> ~0.75 efficiency
-	initialCallGasLimit          = 500_000
-	initialPreVerificationGas    = 100_000
+
+	// Session-entity seeds, all measured on Sepolia rather than derived. Each
+	// step up is a specific cost the previous seed did not cover:
+	//
+	//   module entity      60k AA26s — validating through an installed module
+	//                      is an external call, and the entity's first use
+	//                      writes a cold nonce-key slot (~22k)
+	//   deferred install   300k AA26s — the install itself runs inside
+	//                      validation, writing cold module storage
+	//   + permission hooks 300k AA26s again — every allowlist entry is its
+	//                      own cold SSTORE, so cost scales with grant contents
+	seedVerificationGasModuleEntity  = 100_000
+	seedVerificationGasDeferredBare  = 400_000
+	seedVerificationGasDeferredHooks = 700_000
+	initialCallGasLimit              = 500_000
+	initialPreVerificationGas        = 100_000
 
 	// verificationGasEfficiencyFloor is Rundler's published threshold.
 	verificationGasEfficiencyFloor = 0.4

--- a/pkg/erc4337/preset/nonce_v07.go
+++ b/pkg/erc4337/preset/nonce_v07.go
@@ -1,0 +1,154 @@
+package preset
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// v0.7 nonce management.
+//
+// EntryPoint.getNonce reflects MINED state only. A workflow with two
+// sequential contract writes sends the second operation while the first sits
+// in the bundler's mempool — a fresh getNonce returns the same sequence and
+// the send dies AA25 invalid account nonce. The v0.6 path solved this with a
+// per-sender cache (bundler.NonceManager); this is its v0.7 counterpart, with
+// one structural difference that is the whole reason it is a separate type:
+//
+// MA v2 sequences are per NONCE KEY, not per sender. The 192-bit key encodes
+// the validation entity and the option bits, so one account has independent
+// counters for entity 1 plain, entity 1 deferred, entity 2, and so on. A
+// sender-keyed cache would see entity 2's first operation, find entity 1's
+// cached value, and hand out a sequence from the wrong counter. The cache key
+// here is (sender, nonce key).
+//
+// Semantics are v0.6 parity, proven in production there:
+//
+//   - read     → max(on-chain, cached): the chain wins when pending work
+//     mined or was dropped; the cache wins while work is in flight.
+//   - accepted → cache = used+1, recorded when the BUNDLER accepts, not when
+//     the operation mines. That is what lets the next operation overlap the
+//     mempool — and it also covers the subtler failure where the operation
+//     HAS mined but a load-balanced RPC replica serves a pre-mine getNonce.
+//   - failure  → drop the slot; the next read is authoritative chain state.
+//     AA25 covers both a duplicate (cache behind) and a gap (cache ahead
+//     after a drop), so the caller's response to it is invalidate + re-read.
+//
+// Deferred operations NEVER go through the cache. A grant's carrying
+// operation uses the nonce the owner signed over at grant time — sequence
+// zero of a fresh key — and no cache may substitute another value: the
+// digest would no longer match and the account would revert
+// DeferredActionSignatureInvalid with nothing pointing at the nonce. See
+// VerifyDeferredNonceUnused for the check that replaces caching there.
+//
+// Known limit, inherited from v0.6: reads do not RESERVE. Two goroutines
+// racing the same (sender, key) between read and accept can draw the same
+// sequence; the loser gets AA25 and heals through invalidate + retry. Node
+// execution within a workflow is sequential, so this window only matters for
+// concurrent tasks on one wallet.
+type nonceManagerV07 struct {
+	mu   sync.Mutex
+	next map[nonceSlotV07]*big.Int
+}
+
+// nonceSlotV07 identifies one sequence counter: an account and one of its
+// 192-bit nonce keys (entity + options), string-keyed for comparability.
+type nonceSlotV07 struct {
+	sender common.Address
+	key    string
+}
+
+var globalNonceManagerV07 = &nonceManagerV07{next: make(map[nonceSlotV07]*big.Int)}
+
+func slotV07(sender common.Address, entityID uint32, options uint8) (nonceSlotV07, error) {
+	key, err := userop.NonceKeyMAv2(entityID, options)
+	if err != nil {
+		return nonceSlotV07{}, err
+	}
+	return nonceSlotV07{sender: sender, key: key.String()}, nil
+}
+
+// NextNonceV07Managed returns the nonce the next operation should use for
+// this (sender, entity, options): the on-chain value, or the cached
+// next-after-pending value when that is ahead.
+func NextNonceV07Managed(ctx context.Context, client *rpc.Client, entryPoint, sender common.Address, entityID uint32, options uint8) (*big.Int, error) {
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil {
+		return nil, err
+	}
+	onChain, err := NextNonceV07(ctx, client, entryPoint, sender, entityID, options)
+	if err != nil {
+		return nil, err
+	}
+
+	m := globalNonceManagerV07
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if cached, ok := m.next[slot]; ok && cached.Cmp(onChain) > 0 {
+		return new(big.Int).Set(cached), nil
+	}
+	return onChain, nil
+}
+
+// NoteUserOpAccepted records that the bundler accepted an operation at
+// usedNonce, so the next operation on the same key overlaps it in the
+// mempool instead of colliding with it.
+func NoteUserOpAccepted(sender common.Address, entityID uint32, options uint8, usedNonce *big.Int) {
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil || usedNonce == nil {
+		return // an unencodable slot was never cached; nothing to record
+	}
+	m := globalNonceManagerV07
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.next[slot] = new(big.Int).Add(usedNonce, big.NewInt(1))
+}
+
+// InvalidateNonce drops the cached counter so the next read is authoritative
+// chain state. Call it when a send fails for any reason — a rejected
+// operation was never pending, and a stale cache is worse than none.
+func InvalidateNonce(sender common.Address, entityID uint32, options uint8) {
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil {
+		return
+	}
+	m := globalNonceManagerV07
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.next, slot)
+}
+
+// isInvalidNonceError recognises the EntryPoint's AA25 in a bundler error.
+// (The v0.6 path also matches Voltaire's mempool-replacement phrasing; the
+// v0.7 path only ever talks to Rundler, which surfaces AA25 verbatim.)
+func isInvalidNonceError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "AA25")
+}
+
+// VerifyDeferredNonceUnused is the deferred path's replacement for nonce
+// management: the owner's signature committed to sequence zero of the
+// grant's key, so the only question is whether that nonce is still available.
+// A consumed sequence means the grant was already applied (or a duplicate
+// send is racing this one), and the answer is a clear error here rather than
+// DeferredActionSignatureInvalid from the account with nothing pointing at
+// the nonce.
+func VerifyDeferredNonceUnused(liveNonce *big.Int) error {
+	if liveNonce == nil {
+		return fmt.Errorf("nil nonce")
+	}
+	_, _, sequence, err := userop.DecodeNonceMAv2(liveNonce)
+	if err != nil {
+		return err
+	}
+	if sequence != 0 {
+		return fmt.Errorf("the grant's nonce key already has sequence %d on-chain — its deferred action was already applied (or a duplicate send is in flight); this grant cannot be replayed", sequence)
+	}
+	return nil
+}

--- a/pkg/erc4337/preset/nonce_v07.go
+++ b/pkg/erc4337/preset/nonce_v07.go
@@ -100,15 +100,30 @@ func NextNonceV07Managed(ctx context.Context, client *rpc.Client, entryPoint, se
 // NoteUserOpAccepted records that the bundler accepted an operation at
 // usedNonce, so the next operation on the same key overlaps it in the
 // mempool instead of colliding with it.
+//
+// The successor is built by re-encoding sequence+1 under the slot's own key
+// rather than adding 1 to the full 256-bit nonce: the layout is
+// [192-bit key][64-bit sequence], and a bare +1 at the sequence ceiling
+// would carry into the key half and cache a nonce for a different validation
+// entirely. Unrepresentable states drop the record — a missing cache entry
+// costs a chain read; a corrupt one costs an AA25.
 func NoteUserOpAccepted(sender common.Address, entityID uint32, options uint8, usedNonce *big.Int) {
 	slot, err := slotV07(sender, entityID, options)
 	if err != nil || usedNonce == nil {
 		return // an unencodable slot was never cached; nothing to record
 	}
+	_, _, sequence, err := userop.DecodeNonceMAv2(usedNonce)
+	if err != nil || sequence == ^uint64(0) {
+		return
+	}
+	next, err := userop.EncodeNonceMAv2(entityID, options, sequence+1)
+	if err != nil {
+		return
+	}
 	m := globalNonceManagerV07
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.next[slot] = new(big.Int).Add(usedNonce, big.NewInt(1))
+	m.next[slot] = next
 }
 
 // InvalidateNonce drops the cached counter so the next read is authoritative

--- a/pkg/erc4337/preset/nonce_v07_test.go
+++ b/pkg/erc4337/preset/nonce_v07_test.go
@@ -1,0 +1,148 @@
+package preset
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// The manager is package state; each test claims distinct senders so they do
+// not interfere.
+
+func mustNonce(t *testing.T, entityID uint32, options uint8, seq uint64) *big.Int {
+	t.Helper()
+	n, err := userop.EncodeNonceMAv2(entityID, options, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// cacheAhead reads the cached value the way NextNonceV07Managed does once the
+// chain read is in hand, without needing a live RPC.
+func cachedNext(t *testing.T, sender common.Address, entityID uint32, options uint8) (*big.Int, bool) {
+	t.Helper()
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	globalNonceManagerV07.mu.Lock()
+	defer globalNonceManagerV07.mu.Unlock()
+	v, ok := globalNonceManagerV07.next[slot]
+	if !ok {
+		return nil, false
+	}
+	return new(big.Int).Set(v), true
+}
+
+func TestNonceManagerV07AcceptedAdvancesTheSlot(t *testing.T) {
+	sender := common.HexToAddress("0x00000000000000000000000000000000000000A1")
+	used := mustNonce(t, 1, userop.ValidationOptionGlobal, 0)
+
+	NoteUserOpAccepted(sender, 1, userop.ValidationOptionGlobal, used)
+
+	next, ok := cachedNext(t, sender, 1, userop.ValidationOptionGlobal)
+	if !ok {
+		t.Fatal("acceptance did not populate the slot")
+	}
+	want := mustNonce(t, 1, userop.ValidationOptionGlobal, 1)
+	if next.Cmp(want) != 0 {
+		t.Fatalf("cached next = %s, want %s (used+1)", next, want)
+	}
+
+	InvalidateNonce(sender, 1, userop.ValidationOptionGlobal)
+	if _, ok := cachedNext(t, sender, 1, userop.ValidationOptionGlobal); ok {
+		t.Fatal("invalidate did not drop the slot")
+	}
+}
+
+// One account's counters are per (entity, options) — the whole reason this is
+// not the v0.6 sender-keyed manager. Entity 1 plain, entity 1 deferred, and
+// entity 2 must be three independent slots.
+func TestNonceManagerV07SlotsAreIndependent(t *testing.T) {
+	sender := common.HexToAddress("0x00000000000000000000000000000000000000A2")
+	deferredOpts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+
+	NoteUserOpAccepted(sender, 1, userop.ValidationOptionGlobal, mustNonce(t, 1, userop.ValidationOptionGlobal, 4))
+
+	if _, ok := cachedNext(t, sender, 1, deferredOpts); ok {
+		t.Fatal("entity 1's plain acceptance leaked into its deferred slot")
+	}
+	if _, ok := cachedNext(t, sender, 2, userop.ValidationOptionGlobal); ok {
+		t.Fatal("entity 1's acceptance leaked into entity 2's slot")
+	}
+
+	next, ok := cachedNext(t, sender, 1, userop.ValidationOptionGlobal)
+	if !ok || next.Cmp(mustNonce(t, 1, userop.ValidationOptionGlobal, 5)) != 0 {
+		t.Fatalf("entity 1 plain slot = %v, want sequence 5", next)
+	}
+}
+
+func TestNonceManagerV07SendersAreIndependent(t *testing.T) {
+	a := common.HexToAddress("0x00000000000000000000000000000000000000A3")
+	b := common.HexToAddress("0x00000000000000000000000000000000000000A4")
+
+	NoteUserOpAccepted(a, 1, userop.ValidationOptionGlobal, mustNonce(t, 1, userop.ValidationOptionGlobal, 7))
+	if _, ok := cachedNext(t, b, 1, userop.ValidationOptionGlobal); ok {
+		t.Fatal("sender A's acceptance leaked into sender B's slot")
+	}
+}
+
+func TestVerifyDeferredNonceUnused(t *testing.T) {
+	deferredOpts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+
+	if err := VerifyDeferredNonceUnused(mustNonce(t, 1, deferredOpts, 0)); err != nil {
+		t.Fatalf("sequence 0 must be usable: %v", err)
+	}
+	err := VerifyDeferredNonceUnused(mustNonce(t, 1, deferredOpts, 1))
+	if err == nil {
+		t.Fatal("a consumed sequence must be rejected")
+	}
+	if !errorsMentionsReplay(err) {
+		t.Fatalf("the error should say the grant cannot be replayed, got: %v", err)
+	}
+	if err := VerifyDeferredNonceUnused(nil); err == nil {
+		t.Fatal("nil nonce must be rejected")
+	}
+}
+
+func errorsMentionsReplay(err error) bool {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if containsAll(e.Error(), "already", "replay") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestIsInvalidNonceError(t *testing.T) {
+	if !isInvalidNonceError(errors.New("eth_sendUserOperation: validation reverted: [reason]: AA25 invalid account nonce")) {
+		t.Fatal("AA25 not recognised")
+	}
+	if isInvalidNonceError(errors.New("AA23 reverted")) {
+		t.Fatal("AA23 misclassified as a nonce error")
+	}
+	if isInvalidNonceError(nil) {
+		t.Fatal("nil error misclassified")
+	}
+}

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -48,12 +48,6 @@ func SendUserOpMAv2(
 	if err := auth.Validate(); err != nil {
 		return nil, nil, err
 	}
-	// Without a session authorization the operation runs as the account's
-	// fallback signer, which only the OWNER's key can do. The gateway does not
-	// hold it, so this path exists for callers that supply their own signer.
-	if auth == nil && smartWalletConfig.ControllerPrivateKey == nil {
-		return nil, nil, fmt.Errorf("no controller private key configured")
-	}
 
 	bundlerURL, err := smartWalletConfig.ActiveBundlerURL()
 	if err != nil {
@@ -89,6 +83,27 @@ func SendUserOpMAv2(
 	sender, err := resolveSenderV07(chainRPC, owner, factory, salt, senderOverride)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// A caller that supplies no authorization gets the stored grant for THIS
+	// wallet — looked up only now, because grants are keyed by the smart
+	// wallet's address and the sender is not known until it is resolved.
+	// Resolving earlier against the owner EOA (or a guessed wallet) finds
+	// nothing and signs as the fallback entity the gateway cannot validate
+	// for.
+	if auth == nil {
+		if auth, err = resolveSession(smartWalletConfig.ChainID, owner, sender); err != nil {
+			return nil, nil, fmt.Errorf("resolving session authorization for %s: %w", sender.Hex(), err)
+		}
+		if err = auth.Validate(); err != nil {
+			return nil, nil, err
+		}
+	}
+	// Without a session authorization the operation runs as the account's
+	// fallback signer, which only the OWNER's key can do. The gateway does not
+	// hold it, so this path exists for callers that supply their own signer.
+	if auth == nil && smartWalletConfig.ControllerPrivateKey == nil {
+		return nil, nil, fmt.Errorf("no controller private key configured")
 	}
 
 	// A grant carrying execution hooks requires user-op context on EVERY

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -38,13 +38,20 @@ func SendUserOpMAv2(
 	callData []byte,
 	senderOverride *common.Address,
 	saltOverride *big.Int,
+	auth *SessionAuthorization,
 	lgr logger.Logger,
 ) (*userop.UserOperationV07, *types.Receipt, error) {
 	l := logger.EnsureLogger(lgr)
 	if smartWalletConfig == nil {
 		return nil, nil, fmt.Errorf("nil smart wallet config")
 	}
-	if smartWalletConfig.ControllerPrivateKey == nil {
+	if err := auth.Validate(); err != nil {
+		return nil, nil, err
+	}
+	// Without a session authorization the operation runs as the account's
+	// fallback signer, which only the OWNER's key can do. The gateway does not
+	// hold it, so this path exists for callers that supply their own signer.
+	if auth == nil && smartWalletConfig.ControllerPrivateKey == nil {
 		return nil, nil, fmt.Errorf("no controller private key configured")
 	}
 
@@ -84,6 +91,17 @@ func SendUserOpMAv2(
 		return nil, nil, err
 	}
 
+	// A grant carrying execution hooks requires user-op context on EVERY
+	// operation under it — including the one that installs the grant, since
+	// the hooks are live from the moment the install applies mid-validation.
+	if auth != nil && auth.WrapExecuteUserOp {
+		wrapped, wrapErr := aa.WrapExecuteUserOp(callData)
+		if wrapErr != nil {
+			return nil, nil, fmt.Errorf("wrapping calldata for user-op context: %w", wrapErr)
+		}
+		callData = wrapped
+	}
+
 	op := &userop.UserOperationV07{
 		Sender:               sender,
 		CallData:             callData,
@@ -108,13 +126,13 @@ func SendUserOpMAv2(
 		op.Factory = &deployFactory
 		op.FactoryData = factoryData
 	}
-	op.VerificationGasLimit = seedVerificationGas(op)
+	op.VerificationGasLimit = seedVerificationGasFor(op, auth)
 
 	// MA v2 selects its validation function from the NONCE, not the signature.
 	// A zero nonce reverts with ValidationFunctionMissing rather than as a
 	// nonce error, which is the single most misleading failure on this path.
-	nonce, err := NextNonceV07(ctx, bundlerRPC, entryPoint, sender,
-		userop.FallbackSignerEntityID, userop.ValidationOptionGlobal)
+	nonceEntity, nonceOptions := auth.nonceEntity()
+	nonce, err := NextNonceV07(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading nonce: %w", err)
 	}
@@ -128,18 +146,27 @@ func SendUserOpMAv2(
 	// to come after pricing. SendUserOpV07WithRetry only RE-signs, and only
 	// when it tightens the verification gas limit — it will not sign an
 	// unsigned operation, it rejects one.
-	if err := SignUserOpV07(op, entryPoint, chainID, smartWalletConfig.ControllerPrivateKey); err != nil {
+	signingKey := smartWalletConfig.ControllerPrivateKey
+	if auth != nil {
+		signingKey = auth.SignerKey
+	}
+	if auth.Deferred() {
+		if err := SignUserOpV07Deferred(op, entryPoint, chainID, signingKey,
+			auth.DeferredData, auth.OwnerSignature); err != nil {
+			return op, nil, fmt.Errorf("signing user operation with deferred action: %w", err)
+		}
+	} else if err := SignUserOpV07(op, entryPoint, chainID, signingKey); err != nil {
 		return op, nil, fmt.Errorf("signing user operation: %w", err)
 	}
 
-	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID,
-		smartWalletConfig.ControllerPrivateKey)
+	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID, signingKey)
 	if err != nil {
 		return op, nil, fmt.Errorf("sending user operation: %w", err)
 	}
 	l.Info("v0.7 user operation sent",
 		"sender", sender.Hex(), "userop_hash", opHash.Hex(),
-		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil)
+		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil,
+		"entity", nonceEntity, "installs_grant", auth.Deferred())
 
 	// Reuses the v0.6 confirmation watcher: UserOperationEvent is unchanged
 	// between EntryPoint versions, so only the EntryPoint address differs.

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -67,6 +67,12 @@ func SendUserOpMAv2(
 	}
 	defer bundlerRPC.Close()
 
+	// Nonce reads are plain eth_calls and go to the CHAIN rpc. The bundler
+	// endpoint only advertises the ERC-4337 namespace on some providers
+	// (Voltaire answers eth_call with Method-not-found; Alchemy happens to
+	// serve both from one URL, which is how this hid during development).
+	nonceRPC := chainRPC.Client()
+
 	entryPoint := EntryPointV07()
 	chainID := big.NewInt(smartWalletConfig.ChainID)
 
@@ -155,7 +161,7 @@ func SendUserOpMAv2(
 	nonceEntity, nonceOptions := auth.nonceEntity()
 	var nonce *big.Int
 	if auth.Deferred() {
-		nonce, err = NextNonceV07(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+		nonce, err = NextNonceV07(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
 		if err == nil {
 			var sequence uint64
 			if _, _, sequence, err = userop.DecodeNonceMAv2(nonce); err == nil && sequence != 0 {
@@ -177,11 +183,11 @@ func SendUserOpMAv2(
 				nonceEntity, nonceOptions = auth.nonceEntity()
 				op.Signature = nil
 				op.VerificationGasLimit = seedVerificationGasFor(op, auth)
-				nonce, err = NextNonceV07Managed(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+				nonce, err = NextNonceV07Managed(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
 			}
 		}
 	} else {
-		nonce, err = NextNonceV07Managed(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+		nonce, err = NextNonceV07Managed(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading nonce: %w", err)
@@ -233,7 +239,7 @@ func SendUserOpMAv2(
 		// once. Deferred operations are excluded — their nonce is committed
 		// by the owner's signature and cannot be substituted.
 		InvalidateNonce(sender, nonceEntity, nonceOptions)
-		freshNonce, nonceErr := NextNonceV07Managed(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+		freshNonce, nonceErr := NextNonceV07Managed(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
 		if nonceErr == nil && freshNonce.Cmp(op.Nonce) != 0 {
 			l.Info("retrying after AA25 with the chain's nonce",
 				"sender", sender.Hex(), "stale", op.Nonce.String(), "fresh", freshNonce.String())

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -136,14 +136,34 @@ func SendUserOpMAv2(
 	// overlap the first in the mempool (getNonce alone reads mined state and
 	// AA25s any sequential pair). Deferred operations bypass it: the owner's
 	// signature committed to sequence zero at grant time, so no cached value
-	// may substitute — the only question is whether that nonce is still
-	// unused, checked explicitly for a clear error.
+	// may substitute.
 	nonceEntity, nonceOptions := auth.nonceEntity()
 	var nonce *big.Int
 	if auth.Deferred() {
 		nonce, err = NextNonceV07(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
 		if err == nil {
-			err = VerifyDeferredNonceUnused(nonce)
+			var sequence uint64
+			if _, _, sequence, err = userop.DecodeNonceMAv2(nonce); err == nil && sequence != 0 {
+				// The carrier sequence is consumed, and the only operation
+				// that ever uses a grant's deferred key is its install: the
+				// install MINED without this process seeing the receipt (a
+				// confirmation timeout, or a crash between send and record).
+				// Not an error — record the fact and run this operation as
+				// an ordinary one under the now-installed entity.
+				l.Info("grant install found already applied on-chain; recording and continuing plain",
+					"sender", sender.Hex(), "entity", auth.EntityID, "sequence", sequence)
+				if auth.OnApplied != nil {
+					if markErr := auth.OnApplied(""); markErr != nil {
+						l.Error("grant is applied on-chain but could not be recorded; the next operation will retry",
+							"sender", sender.Hex(), "error", markErr)
+					}
+				}
+				auth.DeferredData, auth.OwnerSignature = nil, nil
+				nonceEntity, nonceOptions = auth.nonceEntity()
+				op.Signature = nil
+				op.VerificationGasLimit = seedVerificationGasFor(op, auth)
+				nonce, err = NextNonceV07Managed(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+			}
 		}
 	} else {
 		nonce, err = NextNonceV07Managed(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
@@ -233,9 +253,34 @@ func SendUserOpMAv2(
 			l.Warn("websocket dial failed, polling for the receipt instead", "error", wsErr)
 		}
 	}
+	installsGrant := auth.Deferred()
 	receipt, err := waitForUserOpConfirmation(chainRPC, wsClient, entryPoint, opHash.Hex(), l)
 	if err != nil {
+		// Includes the mined-but-execution-reverted case — in which the
+		// install DID apply (it runs in the validation frame, which an
+		// execution revert does not roll back, results doc §3.4). Not marked
+		// here because this path cannot distinguish that from a true
+		// validation-level failure; the next operation heals it through the
+		// consumed-carrier-nonce path above.
 		return op, nil, err
+	}
+	if installsGrant {
+		if receipt == nil {
+			// Confirmation timed out with the operation still pending. The
+			// grant stays recorded as pending; if the install mines later,
+			// the next operation discovers the consumed carrier nonce and
+			// records it then.
+			l.Info("grant install sent but unconfirmed; recording deferred to the next operation",
+				"sender", sender.Hex(), "userop_hash", opHash.Hex())
+		} else if auth.OnApplied != nil {
+			// The install is on-chain. Record it so the stored grant stops
+			// attaching the deferred action — attaching a consumed one would
+			// fail every subsequent operation on this wallet.
+			if markErr := auth.OnApplied(opHash.Hex()); markErr != nil {
+				l.Error("grant applied on-chain but could not be recorded; the next operation will retry",
+					"sender", sender.Hex(), "userop_hash", opHash.Hex(), "error", markErr)
+			}
+		}
 	}
 	return op, receipt, nil
 }

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -131,8 +131,23 @@ func SendUserOpMAv2(
 	// MA v2 selects its validation function from the NONCE, not the signature.
 	// A zero nonce reverts with ValidationFunctionMissing rather than as a
 	// nonce error, which is the single most misleading failure on this path.
+	//
+	// Plain operations read through the nonce manager so a second write can
+	// overlap the first in the mempool (getNonce alone reads mined state and
+	// AA25s any sequential pair). Deferred operations bypass it: the owner's
+	// signature committed to sequence zero at grant time, so no cached value
+	// may substitute — the only question is whether that nonce is still
+	// unused, checked explicitly for a clear error.
 	nonceEntity, nonceOptions := auth.nonceEntity()
-	nonce, err := NextNonceV07(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+	var nonce *big.Int
+	if auth.Deferred() {
+		nonce, err = NextNonceV07(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+		if err == nil {
+			err = VerifyDeferredNonceUnused(nonce)
+		}
+	} else {
+		nonce, err = NextNonceV07Managed(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading nonce: %w", err)
 	}
@@ -175,9 +190,33 @@ func SendUserOpMAv2(
 	}
 
 	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID, signingKey)
+	if err != nil && !auth.Deferred() && isInvalidNonceError(err) {
+		// AA25 covers both directions of cache drift — a duplicate (another
+		// operation took this sequence) and a gap (a cached pending operation
+		// was dropped). Either way the cache is wrong: drop it, take the
+		// chain's answer, re-sign (the nonce is in the userOpHash), retry
+		// once. Deferred operations are excluded — their nonce is committed
+		// by the owner's signature and cannot be substituted.
+		InvalidateNonce(sender, nonceEntity, nonceOptions)
+		freshNonce, nonceErr := NextNonceV07Managed(ctx, bundlerRPC, entryPoint, sender, nonceEntity, nonceOptions)
+		if nonceErr == nil && freshNonce.Cmp(op.Nonce) != 0 {
+			l.Info("retrying after AA25 with the chain's nonce",
+				"sender", sender.Hex(), "stale", op.Nonce.String(), "fresh", freshNonce.String())
+			op.Nonce = freshNonce
+			if signErr := SignUserOpV07(op, entryPoint, chainID, signingKey); signErr == nil {
+				opHash, err = SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID, signingKey)
+			}
+		}
+	}
 	if err != nil {
+		InvalidateNonce(sender, nonceEntity, nonceOptions)
 		return op, nil, fmt.Errorf("sending user operation: %w", err)
 	}
+	// Record acceptance NOW — the bundler holds the operation, so the next
+	// one on this key must use the following sequence even though nothing has
+	// mined yet. This is the line that lets sequential contract writes
+	// overlap the mempool instead of dying AA25.
+	NoteUserOpAccepted(sender, nonceEntity, nonceOptions, op.Nonce)
 	l.Info("v0.7 user operation sent",
 		"sender", sender.Hex(), "userop_hash", opHash.Hex(),
 		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil,

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -138,6 +138,21 @@ func SendUserOpMAv2(
 	}
 	op.Nonce = nonce
 
+	// Estimation of a deferred operation must carry the REAL owner grant.
+	// Ordinary signature validation fails gracefully so estimation can
+	// proceed, but a bad deferred-action signature REVERTS
+	// (DeferredActionSignatureInvalid) — so estimating with the plain dummy
+	// gets AA23 with nothing pointing at the missing grant. Only the
+	// controller's half may be a dummy here; the real one is installed below,
+	// after pricing, because the signature covers the gas fields.
+	if auth.Deferred() {
+		estSig, estErr := DeferredEstimationSignature(auth.DeferredData, auth.OwnerSignature)
+		if estErr != nil {
+			return nil, nil, fmt.Errorf("building the estimation signature: %w", estErr)
+		}
+		op.Signature = estSig
+	}
+
 	if err := priceOperationV07(ctx, chainRPC, bundlerRPC, op, entryPoint, smartWalletConfig, l); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/erc4337/preset/sent_userop.go
+++ b/pkg/erc4337/preset/sent_userop.go
@@ -72,7 +72,18 @@ func SendUserOpAuto(
 	}
 
 	if smartWalletConfig.UsesModularAccountV2() {
-		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, lgr)
+		// The gateway cannot sign as the account's owner, so anything it
+		// executes runs under a session grant. The resolver is how storage
+		// reaches this path without the send path reaching into storage.
+		wallet := owner
+		if senderOverride != nil {
+			wallet = *senderOverride
+		}
+		auth, authErr := resolveSession(smartWalletConfig.ChainID, owner, wallet)
+		if authErr != nil {
+			return nil, nil, fmt.Errorf("resolving session authorization for %s: %w", wallet.Hex(), authErr)
+		}
+		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, auth, lgr)
 		sent, convErr := sentFromV07(op, big.NewInt(smartWalletConfig.ChainID))
 		if err != nil {
 			// Report the send failure, not the conversion: the send is why

--- a/pkg/erc4337/preset/sent_userop.go
+++ b/pkg/erc4337/preset/sent_userop.go
@@ -72,18 +72,12 @@ func SendUserOpAuto(
 	}
 
 	if smartWalletConfig.UsesModularAccountV2() {
-		// The gateway cannot sign as the account's owner, so anything it
-		// executes runs under a session grant. The resolver is how storage
-		// reaches this path without the send path reaching into storage.
-		wallet := owner
-		if senderOverride != nil {
-			wallet = *senderOverride
-		}
-		auth, authErr := resolveSession(smartWalletConfig.ChainID, owner, wallet)
-		if authErr != nil {
-			return nil, nil, fmt.Errorf("resolving session authorization for %s: %w", wallet.Hex(), authErr)
-		}
-		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, auth, lgr)
+		// nil auth: SendUserOpMAv2 resolves the session grant itself, AFTER
+		// it has resolved the actual sender. Grants are stored per
+		// smart-wallet address, and callers do not always pass an override —
+		// resolving here against the owner EOA used to find nothing and sign
+		// as the fallback entity the gateway cannot validate for.
+		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, nil, lgr)
 		sent, convErr := sentFromV07(op, big.NewInt(smartWalletConfig.ChainID))
 		if err != nil {
 			// Report the send failure, not the conversion: the send is why

--- a/pkg/erc4337/preset/session_auth.go
+++ b/pkg/erc4337/preset/session_auth.go
@@ -1,0 +1,158 @@
+package preset
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// SessionAuthorization is how an operation runs under a session grant rather
+// than as the account's owner.
+//
+// A stock Modular Account v2 trusts its fallback signer — the user's EOA — and
+// the gateway does not hold that key. Everything the gateway executes
+// therefore runs as an installed validation entity, and this carries what that
+// requires: which entity, which key signs, and (on the grant's first
+// operation) the owner's deferred authorization that installs it.
+//
+// This is deliberately a plain struct rather than a storage lookup. The
+// gateway reads a SessionPolicy and builds one of these; the send path never
+// touches BadgerDB. See avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §7.4a for
+// the record these fields come from.
+type SessionAuthorization struct {
+	// EntityID is the validation entity the grant installed. It keys the
+	// nonce, so it must match the entity the deferred action installs.
+	EntityID uint32
+
+	// SignerKey signs the operation as that entity.
+	SignerKey *ecdsa.PrivateKey
+
+	// DeferredData and OwnerSignature carry the grant itself. Set on a
+	// grant's FIRST operation only: the account applies the install during
+	// validation, then validates this same operation against the entity it
+	// just installed. Once applied they must never be replayed — the stored
+	// record's applied_at is the marker.
+	DeferredData   []byte
+	OwnerSignature []byte
+
+	// WrapExecuteUserOp opts the operation into user-op context, which every
+	// operation under a grant carrying EXECUTION hooks must do. It is derived
+	// from the stored grant's contents, not guessed: an ERC-20 spend cap
+	// installs an execution hook, a time range does not.
+	WrapExecuteUserOp bool
+}
+
+// Deferred reports whether this operation carries the grant's install.
+func (s *SessionAuthorization) Deferred() bool {
+	return s != nil && len(s.DeferredData) > 0 && len(s.OwnerSignature) > 0
+}
+
+// Validate rejects an authorization that cannot produce a valid operation.
+func (s *SessionAuthorization) Validate() error {
+	if s == nil {
+		return nil
+	}
+	if s.EntityID < aa.MinSessionEntityID {
+		return fmt.Errorf("session entity %d is reserved (0 is the owner's fallback signer)", s.EntityID)
+	}
+	if s.SignerKey == nil {
+		return fmt.Errorf("session authorization has no signing key")
+	}
+	// Half a deferred action is worse than none: the operation would be signed
+	// as an entity that does not exist yet and fail validation on chain, with
+	// nothing pointing at the missing half.
+	if len(s.DeferredData) > 0 && len(s.OwnerSignature) == 0 {
+		return fmt.Errorf("deferred action has no owner signature")
+	}
+	if len(s.OwnerSignature) > 0 && len(s.DeferredData) == 0 {
+		return fmt.Errorf("owner signature has no deferred action to authorize")
+	}
+	return nil
+}
+
+// nonceEntity returns the entity whose nonce key this operation uses, and the
+// nonce options. Without an authorization the owner's fallback signer runs the
+// operation, which is the path used to sign a grant directly.
+func (s *SessionAuthorization) nonceEntity() (entityID uint32, options uint8) {
+	options = userop.ValidationOptionGlobal
+	if s == nil {
+		return userop.FallbackSignerEntityID, options
+	}
+	if s.Deferred() {
+		options |= userop.ValidationOptionDeferredAction
+	}
+	return s.EntityID, options
+}
+
+// seedVerificationGasFor sizes the verification limit for what this operation
+// actually does during validation.
+//
+// The numbers come from Sepolia, not from theory (avs-infra
+// MA_v2_Authority_Model_And_Spike_Results.md §3.2–§3.4). Validation cost grows
+// with what the operation installs: a bare deferred install AA26s at 300k
+// because module storage is cold, and a hook-carrying install AA26s at 300k
+// again because every allowlist entry is its own cold SSTORE. Seeding must
+// therefore scale with the grant's contents rather than with a single
+// deploying/deployed flag.
+//
+// Over-seeding is not free either — Rundler refuses an operation whose
+// verification efficiency falls under 0.4 — so these are sized to land inside
+// that window, and SendUserOpV07WithRetry tightens from the bundler's own
+// ratio when they miss.
+func seedVerificationGasFor(op *userop.UserOperationV07, auth *SessionAuthorization) *big.Int {
+	if auth.Deferred() {
+		if auth.WrapExecuteUserOp {
+			// Hook-carrying grant: allowlist entries plus the exec hook.
+			return big.NewInt(seedVerificationGasDeferredHooks)
+		}
+		return big.NewInt(seedVerificationGasDeferredBare)
+	}
+	if auth != nil {
+		// Validating as an installed module entity rather than the bytecode
+		// fallback signer: an external call plus, on the entity's first use, a
+		// cold nonce-key slot.
+		return big.NewInt(seedVerificationGasModuleEntity)
+	}
+	return seedVerificationGas(op)
+}
+
+// SessionResolver answers "under what authority may the gateway execute for
+// this wallet?" — returning nil when there is no grant, which leaves the
+// operation on the owner's fallback signer.
+//
+// This exists so the send path never reaches into storage. The gateway
+// installs one resolver at boot that reads SessionPolicy records; tests and
+// the v0.6 path leave it unset and nothing changes.
+type SessionResolver func(chainID int64, owner, wallet common.Address) (*SessionAuthorization, error)
+
+var (
+	sessionResolverMu sync.RWMutex
+	sessionResolver   SessionResolver
+)
+
+// SetSessionResolver installs the resolver. Call once at gateway startup.
+func SetSessionResolver(r SessionResolver) {
+	sessionResolverMu.Lock()
+	defer sessionResolverMu.Unlock()
+	sessionResolver = r
+}
+
+// resolveSession looks up the authorization for a wallet. A resolver error is
+// returned rather than swallowed: falling back to the fallback signer would
+// mean signing with a key the gateway does not have, and the operation would
+// fail on chain with nothing pointing at the storage read that failed.
+func resolveSession(chainID int64, owner, wallet common.Address) (*SessionAuthorization, error) {
+	sessionResolverMu.RLock()
+	r := sessionResolver
+	sessionResolverMu.RUnlock()
+	if r == nil {
+		return nil, nil
+	}
+	return r(chainID, owner, wallet)
+}

--- a/pkg/erc4337/preset/session_auth.go
+++ b/pkg/erc4337/preset/session_auth.go
@@ -46,6 +46,21 @@ type SessionAuthorization struct {
 	// from the stored grant's contents, not guessed: an ERC-20 spend cap
 	// installs an execution hook, a time range does not.
 	WrapExecuteUserOp bool
+
+	// OnApplied is how the send path reports that the grant's install reached
+	// the chain, so the stored record stops attaching the deferred action.
+	// Set by the resolver alongside DeferredData; carried as a callback
+	// because the record lives above this package (BadgerDB, taskengine) and
+	// the send path must not reach into storage.
+	//
+	// Invoked with the carrying operation's userOpHash once its receipt is
+	// seen — or with "" when the install is discovered indirectly, by finding
+	// the carrier nonce already consumed (the only operation that ever uses a
+	// grant's deferred key is its install, so a consumed sequence IS the
+	// receipt). An error is logged by the caller, never fatal: the install
+	// succeeded on-chain, and an unrecorded one heals on the next operation
+	// through that same consumed-nonce path.
+	OnApplied func(userOpHash string) error
 }
 
 // Deferred reports whether this operation carries the grant's install.

--- a/pkg/erc4337/preset/session_auth_test.go
+++ b/pkg/erc4337/preset/session_auth_test.go
@@ -1,0 +1,170 @@
+package preset
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func testKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return k
+}
+
+// The nonce selects the validation entity on MA v2 — not the signature. Get
+// this wrong and the account validates against a different entity than the one
+// that signed, which surfaces as an opaque signature failure.
+func TestSessionAuthNonceEntity(t *testing.T) {
+	t.Run("no authorization runs as the owner's fallback signer", func(t *testing.T) {
+		var auth *SessionAuthorization
+		entity, opts := auth.nonceEntity()
+		if entity != userop.FallbackSignerEntityID {
+			t.Errorf("entity = %d, want the fallback signer %d", entity, userop.FallbackSignerEntityID)
+		}
+		if opts&userop.ValidationOptionDeferredAction != 0 {
+			t.Error("no authorization must not set the deferred bit")
+		}
+	})
+
+	t.Run("a grant runs as its own entity", func(t *testing.T) {
+		auth := &SessionAuthorization{EntityID: 7, SignerKey: testKey(t)}
+		entity, opts := auth.nonceEntity()
+		if entity != 7 {
+			t.Errorf("entity = %d, want 7", entity)
+		}
+		if opts&userop.ValidationOptionDeferredAction != 0 {
+			t.Error("a grant with no deferred action must not set the deferred bit")
+		}
+	})
+
+	// The bit is what tells the account to apply the install during
+	// validation. Without it the deferred payload is ignored and the operation
+	// validates against an entity that does not exist yet.
+	t.Run("the grant's first operation sets the deferred bit", func(t *testing.T) {
+		auth := &SessionAuthorization{
+			EntityID: 7, SignerKey: testKey(t),
+			DeferredData: []byte{0x01}, OwnerSignature: bytes.Repeat([]byte{0x02}, 65),
+		}
+		if !auth.Deferred() {
+			t.Fatal("Deferred() should be true when both halves are present")
+		}
+		_, opts := auth.nonceEntity()
+		if opts&userop.ValidationOptionDeferredAction == 0 {
+			t.Error("the deferred bit must be set on the install-carrying operation")
+		}
+	})
+}
+
+func TestSessionAuthValidate(t *testing.T) {
+	sig := bytes.Repeat([]byte{0x02}, 65)
+	for _, tt := range []struct {
+		name    string
+		auth    *SessionAuthorization
+		wantErr bool
+	}{
+		{"nil is fine — the owner signs", nil, false},
+		{"valid", &SessionAuthorization{EntityID: 1, SignerKey: testKey(t)}, false},
+		{"entity 0 is the owner's", &SessionAuthorization{EntityID: 0, SignerKey: testKey(t)}, true},
+		{"no key", &SessionAuthorization{EntityID: 1}, true},
+		// Half a deferred action signs as an entity that does not exist yet.
+		{"deferred data without a signature", &SessionAuthorization{EntityID: 1, SignerKey: testKey(t), DeferredData: []byte{0x01}}, true},
+		{"signature without deferred data", &SessionAuthorization{EntityID: 1, SignerKey: testKey(t), OwnerSignature: sig}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.auth.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Seeds are measured, and each tier covers a cost the one below it does not.
+// A seed that is too low AA26s; too high and Rundler refuses the operation for
+// falling under its 0.4 verification-efficiency floor.
+func TestSeedVerificationGasScalesWithGrantContents(t *testing.T) {
+	op := &userop.UserOperationV07{}
+	sig := bytes.Repeat([]byte{0x02}, 65)
+
+	none := seedVerificationGasFor(op, nil)
+	entity := seedVerificationGasFor(op, &SessionAuthorization{EntityID: 1, SignerKey: testKey(t)})
+	bare := seedVerificationGasFor(op, &SessionAuthorization{
+		EntityID: 1, SignerKey: testKey(t), DeferredData: []byte{0x01}, OwnerSignature: sig})
+	hooks := seedVerificationGasFor(op, &SessionAuthorization{
+		EntityID: 1, SignerKey: testKey(t), DeferredData: []byte{0x01}, OwnerSignature: sig,
+		WrapExecuteUserOp: true})
+
+	if !(none.Cmp(entity) < 0 && entity.Cmp(bare) < 0 && bare.Cmp(hooks) < 0) {
+		t.Errorf("seeds must increase with validation work: none=%s entity=%s deferred=%s hooks=%s",
+			none, entity, bare, hooks)
+	}
+	// §3.4 measured the hook-carrying install AA26-ing at 300k.
+	if hooks.Cmp(big.NewInt(300_000)) <= 0 {
+		t.Errorf("hook-carrying seed %s is at or below the measured AA26 threshold", hooks)
+	}
+}
+
+// The resolver is the only way storage reaches the send path. An unset
+// resolver must leave every existing caller untouched.
+func TestSessionResolver(t *testing.T) {
+	t.Cleanup(func() { SetSessionResolver(nil) })
+
+	SetSessionResolver(nil)
+	got, err := resolveSession(11155111, common.Address{}, common.Address{})
+	if err != nil || got != nil {
+		t.Errorf("an unset resolver must return (nil, nil), got (%v, %v)", got, err)
+	}
+
+	want := &SessionAuthorization{EntityID: 3, SignerKey: testKey(t)}
+	var sawChain int64
+	var sawWallet common.Address
+	SetSessionResolver(func(chainID int64, owner, wallet common.Address) (*SessionAuthorization, error) {
+		sawChain, sawWallet = chainID, wallet
+		return want, nil
+	})
+	wallet := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	got, err = resolveSession(11155111, common.Address{}, wallet)
+	if err != nil {
+		t.Fatalf("resolveSession: %v", err)
+	}
+	if got != want {
+		t.Error("resolver result was not returned")
+	}
+	// The grant is per (wallet, chain) — resolving by owner alone would hand a
+	// user's grant on one wallet to a different wallet they also own.
+	if sawChain != 11155111 || sawWallet != wallet {
+		t.Errorf("resolver saw chain=%d wallet=%s; both must identify the grant", sawChain, sawWallet)
+	}
+}
+
+func TestSessionAuthEntityMatchesInstallEntity(t *testing.T) {
+	// The authorization's entity keys the nonce; the grant's entity is what
+	// the install writes. If they disagree the account installs one entity and
+	// validates against another.
+	const entity = uint32(5)
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	call, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: entity, Signer: signer, Global: true, AllowSelfAdministration: true,
+	})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	auth := &SessionAuthorization{EntityID: entity, SignerKey: testKey(t)}
+	gotEntity, _ := auth.nonceEntity()
+
+	cfg := call[4:29]
+	installEntity := uint32(cfg[20])<<24 | uint32(cfg[21])<<16 | uint32(cfg[22])<<8 | uint32(cfg[23])
+	if gotEntity != installEntity {
+		t.Errorf("nonce entity %d != installed entity %d", gotEntity, installEntity)
+	}
+}

--- a/pkg/erc4337/userop/deferred_action.go
+++ b/pkg/erc4337/userop/deferred_action.go
@@ -6,7 +6,10 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
 // Deferred actions — the mechanism that lets the owner authorize the
@@ -131,6 +134,37 @@ func DeferredActionDigest(chainID *big.Int, account common.Address, nonce *big.I
 	structHash := crypto.Keccak256(structData)
 
 	return crypto.Keccak256Hash([]byte{0x19, 0x01}, domainSeparator, structHash), nil
+}
+
+// DeferredActionTypedData builds the eth_signTypedData_v4 payload whose hash
+// is DeferredActionDigest — the exact JSON a wallet needs to produce the
+// owner's grant signature. Digest parity between this construction and the
+// manual assembly is pinned by TestDeferredActionDigestMatchesTypedData; a
+// drift between them would produce signatures the account rejects.
+func DeferredActionTypedData(chainID *big.Int, account common.Address, nonce *big.Int, deadline uint64, call []byte) apitypes.TypedData {
+	return apitypes.TypedData{
+		Types: apitypes.Types{
+			"EIP712Domain": []apitypes.Type{
+				{Name: "chainId", Type: "uint256"},
+				{Name: "verifyingContract", Type: "address"},
+			},
+			"DeferredAction": []apitypes.Type{
+				{Name: "nonce", Type: "uint256"},
+				{Name: "deadline", Type: "uint48"},
+				{Name: "call", Type: "bytes"},
+			},
+		},
+		PrimaryType: "DeferredAction",
+		Domain: apitypes.TypedDataDomain{
+			ChainId:           (*math.HexOrDecimal256)(chainID),
+			VerifyingContract: account.Hex(),
+		},
+		Message: apitypes.TypedDataMessage{
+			"nonce":    (*math.HexOrDecimal256)(nonce),
+			"deadline": (*math.HexOrDecimal256)(new(big.Int).SetUint64(deadline)),
+			"call":     hexutil.Bytes(call),
+		},
+	}
 }
 
 // WrapSignatureMAv2Deferred assembles the full UserOperation signature for an

--- a/pkg/erc4337/userop/deferred_action_test.go
+++ b/pkg/erc4337/userop/deferred_action_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
@@ -89,29 +88,9 @@ func TestDeferredActionDigestMatchesTypedData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	typed := apitypes.TypedData{
-		Types: apitypes.Types{
-			"EIP712Domain": []apitypes.Type{
-				{Name: "chainId", Type: "uint256"},
-				{Name: "verifyingContract", Type: "address"},
-			},
-			"DeferredAction": []apitypes.Type{
-				{Name: "nonce", Type: "uint256"},
-				{Name: "deadline", Type: "uint48"},
-				{Name: "call", Type: "bytes"},
-			},
-		},
-		PrimaryType: "DeferredAction",
-		Domain: apitypes.TypedDataDomain{
-			ChainId:           (*math.HexOrDecimal256)(chainID),
-			VerifyingContract: account.Hex(),
-		},
-		Message: apitypes.TypedDataMessage{
-			"nonce":    (*math.HexOrDecimal256)(nonce),
-			"deadline": (*math.HexOrDecimal256)(new(big.Int).SetUint64(deadline)),
-			"call":     hexutil.Bytes(call),
-		},
-	}
+	// The PRODUCTION helper builds the payload — this pins wallet parity for
+	// what the /policies prepare response actually returns, not a test copy.
+	typed := DeferredActionTypedData(chainID, account, nonce, deadline, call)
 	walletDigest, _, err := apitypes.TypedDataAndHash(typed)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
- **feat(erc4337): run operations under a session grant, not the owner's key**

The send path signed every MA v2 operation as the account's fallback signer --
the user's EOA, whose key the gateway does not hold. That was the last thing
keeping the cutover from executing: derivation, dispatch, grants, hooks and
revocation were all proven, and nothing connected them to the orchestrator.

SessionAuthorization carries what executing under a grant requires: which
validation entity, which key signs as it, and on the grant's FIRST operation
the owner's deferred authorization that installs it. Three behaviours follow
from it, each measured rather than assumed:

  - the nonce keys to the grant's entity. On MA v2 the nonce selects the
    validation function, not the signature, so this is what makes the account
    validate against the entity that actually signed.

  - operations under a grant carrying EXECUTION hooks are executeUserOp-wrapped
    -- including the install-carrying one, since hooks go live the moment the
    install applies mid-validation. Derived from the stored grant's contents,
    not guessed: an ERC-20 cap installs an execution hook, a time range does
    not.

  - the verification seed scales with what validation does. A module entity
    costs more than the bytecode fallback signer (external call plus a cold
    nonce slot), a deferred install more again (cold module storage), and a
    hook-carrying install more still (every allowlist entry its own cold
    SSTORE). One seed cannot cover all four; the measured tiers are in
    builder_v07.go.

Storage reaches this through a resolver rather than the send path reaching
into storage. That also keeps the change from rippling: SendUserOpAuto
consults it, so no execution call site, no SendUserOpFunc signature, and no
test double changes. An unset resolver returns nil and every existing caller
behaves exactly as before, which is what the v0.6 path and the tests rely on.

A resolver ERROR is propagated rather than swallowed. Falling back to the
fallback signer would mean signing with a key we do not have, and the failure
would surface on chain with nothing pointing at the storage read that failed.

Half a deferred action is rejected up front for the same reason: an operation
signed as an entity that does not exist yet fails validation opaquely.

Still to come: the gateway-side resolver implementation over SessionPolicy
records (avs-infra §7.4a), and the SDK/Studio signing surface.


- **test(erc4337): fold the deferred-grant spike into the integration suite**

scripts/spike/deferred_action proved the production MA v2 path but only when
someone remembered to run a main.go by hand. Promoted to a real test so the
flow is protected: owner authorizes a grant with one off-chain signature, the
gateway deploys the account, installs the grant during validation, and
executes -- then signs a second operation on its own to prove the authority
persisted and the install was not replayed.

Written against the public API (aa.SessionGrant, preset.SessionAuthorization,
preset.SendUserOpMAv2) rather than harness internals, so it fails when the
contract the gateway depends on changes rather than when the harness does.

Prerequisites are REQUIRED, not skipped. A test that skips on a missing key
reports success for a path it never ran, which is the failure mode worth
avoiding on something this load-bearing. Missing prerequisites now produce an
actionable message naming the variable. The same applies to state: an already
deployed account fails and says to pick an unused salt, since the test proves
the FIRST operation specifically, and an unfunded one says so rather than
failing later inside the bundler.

Behind the integration build tag, so `make test` is unaffected and this runs
under `make test/integration`.

Not folded in: the permission-hooks and revoke harnesses. Both deploy
contracts and consume testnet funds beyond a single account's gas, so they
need a funding story before they belong in a suite. Their findings are
recorded in avs-infra MA_v2_Authority_Model_And_Spike_Results.md §3.4/§3.5.


- **feat(taskengine): session-policy storage and the resolver behind it**

The send path knows how to run under a grant; this is where the grant comes
from. model.SessionPolicy is the record from avs-infra §7.4a, and
NewSessionResolver turns it into the preset.SessionAuthorization the
orchestrator consults -- so storage reaches execution without execution
reaching into storage.

Decisions the record forces, made here rather than left to the caller:

  - InstallCall is STORED, not re-derived. Rebuilding it from the policy
    fields at execution time would let a later code change silently alter what
    the owner signed; the signature would then fail on chain, at execution,
    for a user who already consented.

  - CarrierNonce is stored because the digest commits to the full nonce and it
    is not recomputable afterwards -- it is knowable at grant time only
    because a fresh entity is a fresh nonce key whose sequence is zero.

  - AppliedAt is the replay marker. The grant is a bearer authorization for
    exactly its calldata, so the resolver attaches the install on the FIRST
    operation and never again.

  - RequiresExecuteUserOp is recorded at grant time rather than re-parsed from
    the install calldata, since it depends on whether a hook runs at execution
    (an ERC-20 cap does, a time range does not).

Three refusals rather than heuristics. Two usable grants on one wallet is an
error, not a pick: they mean two entities, and choosing silently could sign
under one while the caller provisioned the other. An unreadable record is an
error, not a skip, because a dropped policy reads downstream as "no grant" and
sends the operation to a signer we do not have. A revoked grant authorizes
nothing but still consumes its entity id -- an incomplete module cleanup can
strand state that reusing the entity would collide with.

Entity allocation is per ACCOUNT while the key is per owner, so
NextSessionEntityID scans the owner and filters by runner. It is documented as
unsafe to call outside the writing transaction: two concurrent grants on one
wallet would read the same maximum and the second install would overwrite the
first grant's signer.

`make storage-check`: sp: is a new namespace, additive, no migration.


- **fix(erc4337): estimate deferred operations with the real owner grant**

Running the folded-in integration test for the first time failed at
estimation with AA23, before the operation was ever sent.

Ordinary signature validation fails gracefully so estimation can proceed, so
EstimateUserOpGasV07 supplies a dummy signature. A deferred action does not
work that way: an invalid one REVERTS with DeferredActionSignatureInvalid.
Estimating a grant-carrying operation with the plain dummy therefore reverts,
and the error names neither the deferred action nor the missing grant.

The orchestrator estimated before attaching anything, so every first operation
under a grant would have failed this way. DeferredEstimationSignature already
existed for exactly this -- real owner half, dummy controller half -- and was
simply never called.

The real signature is still installed after pricing, because it covers the gas
fields.

This is the bug the spike could not catch: the harness estimated and signed in
one hand-rolled sequence, so it never exercised the orchestrator's ordering.
TestMAv2SessionGrantEndToEnd now passes end to end on Sepolia -- one owner
signature deploys the account, installs the grant mid-validation, executes,
and a second controller-signed operation confirms the authority persisted and
the install was not replayed.


- **feat(taskengine): grant creation and the resolver installed at boot**

Two gaps kept the plumbing inert: nothing installed the resolver, and nothing
could create a grant for it to resolve.

Engine.New now installs the resolver. Without it every MA v2 operation is
signed as the account's fallback signer -- the user's EOA, whose key we do not
hold -- so nothing the gateway executes validates.

Grant creation is deliberately TWO calls. The owner signs an EIP-712 payload
that cannot exist until the gateway has allocated an entity, chosen a signer,
and computed the nonce the carrying operation will use, so the screen asks for
the payload (Prepare), the wallet signs it, and the signature comes back
(Submit). §7.5's single "persist" step could not have worked.

Nothing reaches the chain here. The install rides the workflow's first
operation, which is what makes the grant gasless to authorize and free to
revoke until used.

Three things the flow refuses:

  - a signature that does not recover to the owner, checked BEFORE storage.
    Stored and it would fail during the first operation's validation, on
    chain, naming neither this record nor the mismatch. Recovery matches the
    account: raw digest, no EIP-191 wrap, since the fallback 1271 path skips
    the replay-safe rewrap during validateUserOp.

  - a submit whose entity was taken while the owner was signing. Prepare's
    allocation is provisional and re-checked in the write path; without that,
    two grants racing on one wallet would both install at the same entity and
    the second would overwrite the first grant's signer.

  - a session signer the gateway has no key for. Today that is the controller
    and only the controller: per-policy signer keys need generation and
    custody we do not have yet. The interim does not weaken the model --
    authority is still per grant, because each policy holds its own validation
    ENTITY, and the entity is what carries the hooks, the revocation target,
    and the nonce space that makes grant-time signing work.

Revocation splits on whether the install landed. Before first use, deleting the
record removes the authority outright. After, the module is still installed and
the record is RETAINED, because the cleanup payload is the same (entityId,
inputs) tuple as the install and cannot be rebuilt without it.

`make storage-check`: still additive.

Remaining for onboarding: the transport surface (protobuf + REST/gRPC) over
these engine calls, and the SDK/Studio signing screen.


- **test(taskengine): give the live Sepolia tests a session grant**

The four _Sepolia tests execute through the gateway, and since the cutover the
gateway cannot sign as a wallet's owner -- a stock MA v2 account trusts only
its fallback signer. They failed with "Invalid account signature", which is
the cutover working as designed rather than a regression.

grantControllerAuthority creates the grant the same way production will
(prepare, owner signs, submit) and installs a resolver over the test's own
database, so the tests exercise the real resolution path instead of injecting
an authorization directly.

It is idempotent against the CHAIN, which these long-lived Sepolia fixtures
need: if the entity already names the controller, the grant is stored as
applied so the deferred install is not replayed onto an entity that exists.
Otherwise it stays pending and rides the test's first operation. The check
reads SingleSignerValidationModule.signers directly.

Results: TestUserOpAtomicBatch_Sepolia and TestUserOpETHWithdrawal_Sepolia now
pass. The other two fail for reasons unrelated to authority, and both are
environmental rather than code:

  - SequentialContractWrites: "chain-aware node requires an explicit chain_id
    (got 0)" -- fallout from the chain-decoupling work, which removed the
    task-level default this test still relies on.
  - StopLossWorkflow: the MA v2 wallet holds no USDC. The cutover moved the
    address, and the fixture funding did not follow.

SessionGrantRequest gained AllowSelfAdministration so a fixture grant can be
stated rather than smuggled: a global grant with no execution hook can
administer itself, and the guard that refuses it should not be worked around
silently. The grant screen never sets it.


- **test(taskengine): give chain-aware nodes an explicit chain_id**

Two live tests failed with "chain-aware node requires an explicit chain_id
(got 0); a task no longer provides a default chain". The tests were stale, not
the code: the chain-decoupling work (G5) deliberately removed the task-level
default so a node cannot silently execute against the wrong chain -- the
footgun behind Sentry EIGENLAYER-AVS-1N/1M. Neither test set ChainId anywhere.

Every chain-aware node config in both now carries cfg.SmartWallet.ChainID.

TestSimulateTask_StopLossWorkflow_Sepolia passes as a result (once its wallet
held USDC and the local test config had a Moralis key -- both environment, not
code).

TestExecuteTask_SequentialContractWrites_Sepolia now gets further and fails on
AA25 for the SECOND of its two operations, which is a genuine gap rather than
a stale test: the v0.7 orchestrator reads EntryPoint.getNonce fresh for every
operation, so a second operation sent while the first is still in the mempool
reads the same nonce. The v0.6 path carried a globalNonceManager plus mempool
inspection for exactly this; nothing equivalent exists on the v0.7 side yet.
Left failing rather than papered over.


- **fix(erc4337): v0.7 nonce manager keyed by (sender, nonce key); refuse partner assertions on policy surface**

Two handoff items closed.

Sequential writes (AA25): EntryPoint.getNonce reflects mined state only, so
a workflow's second contract write — sent while the first sits in the
mempool — read the same sequence and died AA25. v0.6 had a per-sender nonce
cache; MA v2 sequences are per NONCE KEY (entity + option bits), so the
v0.7 manager is keyed by (sender, 192-bit key) — entity 1 plain, entity 1
deferred, and entity 2 are independent counters and a sender-keyed cache
would cross them. Semantics are v0.6 parity: max(chain, cached) reads,
cache=used+1 recorded at bundler ACCEPT (which also covers a mined op read
through a lagging RPC replica), invalidate + one re-signed retry on AA25.
Deferred operations bypass the cache entirely — their nonce is committed by
the owner's 712 signature — and get an explicit consumed-grant error
instead of the account's opaque DeferredActionSignatureInvalid.
TestExecuteTask_SequentialContractWrites_Sepolia now passes: approve and
swap both mined through the bundler, the swap drawing nonce+1 from the
cache with no retry.

Partner assertions on the policy surface: session-policy management is
fund authority, and the decision on record is explicit refusal, not silent
non-consultation. refusePartnerAssertion returns a reasoned 403
(PARTNER_DELEGATION_UNSUPPORTED) whenever X-Partner-Assertion is present —
without verifying it, valid or not, so the boundary is categorical and the
endpoint is no validity oracle. It must be the first line of every
/policies handler when those routes land; tests pin the contract including
the valid-assertion case.


- **feat(rest): /policies — the grant screen's backend, prepare → sign → submit**

The wallet-scoped session-policy surface (master doc §7.3 as reshaped by
§7.4a): POST /wallets/{address}/policies:prepare and :submit, plus list,
get, and revoke. Granting is three steps because the screen needs the
EIP-712 payload before the owner can sign it — prepare allocates the
policy id, entity, and signer, builds the exact installValidation calldata,
and returns the typed data plus digest; the wallet signs; submit persists
the grant as pending. The install itself still rides the workflow's first
operation.

Two properties carry the design:

- Prepare stores nothing; submit trusts nothing. An abandoned screen
  leaves no state, and the submit recomputes the entire grant — calldata,
  carrier nonce, digest — from the echoed declared permissions and the
  pinned (policyId, entityId, deadline). The client's echo is input, never
  truth: a tampered cap or action list produces a digest the owner never
  signed and dies as a signature mismatch. validUntil echoes as an
  ABSOLUTE value because it is baked into the signed calldata.
- Permissions are declared, not encoded, by the client (§7.2: allowed
  actions, ERC-20 cap, expiry); the gateway builds the hook bytes. v1
  requires all three — the cap installs the execution hook that stops a
  global grant from self-administering the account (§3.5), so a capless
  grant is refused rather than quietly shipped unprotected.

Also: every handler leads with refusePartnerAssertion (the decision the
guard was built for — a policy is fund authority); entity races between
prepare and submit surface as 409 rather than an on-chain signer
overwrite; revocation reports deleted (pending, free) vs revoked with
onChainCleanupRequired; grant material (calldata, nonce, owner signature)
is secret-grade and never leaves storage; userop.DeferredActionTypedData
is promoted to production and the wallet-parity test now pins the exact
payload prepare returns.

Tests: offline engine round trip (prepare/sign/submit/list/get/revoke),
tampered-echo and wrong-signer rejection, the entity race, the ownership
gate; HTTP-level round trip proving the returned typed data hashes to the
returned digest, partner refusal on all five routes, and grant-material
leak checks. make storage-check: additive only.


- **feat(erc4337): record a grant's install once it reaches the chain**

Closes the last seam in the grant lifecycle: MarkSessionGrantApplied
existed but nothing called it, so a stored grant stayed pending forever
and the resolver would have attached the consumed deferred action to every
subsequent operation.

The marker travels as a callback (SessionAuthorization.OnApplied) because
the record lives above the send path's package — same layering as the
resolver itself. NewSessionResolver sets it alongside the deferred data;
SendUserOpMAv2 invokes it when the install is KNOWN to be on-chain:

- Receipt in hand for the carrying operation → mark with its userOpHash.
- Carrier nonce found already consumed at build time → the install mined
  without this process seeing it (confirmation timeout, or a crash between
  send and record). The only operation that ever uses a grant's deferred
  key is its install, so a consumed sequence IS the receipt: mark, strip
  the deferred fields, and run the operation plain under the now-installed
  entity. This self-heal replaces the previous hard error and converts
  every missed-receipt case into automatic recovery on the next operation.
- Confirmation timeout or mined-but-execution-reverted (where the install
  DID apply — validation-frame state survives an execution revert, §3.4):
  not marked, deliberately; the consumed-nonce path heals it next time.

Marking goes through MarkSessionGrantAppliedByID, which re-reads the
record and transitions pending→active only — a grant revoked while its
install was in flight is never resurrected by a stale pointer, and a
record deleted mid-flight is a no-op (the orphaned-entity caveat is
documented at the function).

A marking failure is logged, never fatal: the operation succeeded
on-chain, and an unrecorded install heals through the same consumed-nonce
path.

Tests: resolver round trip (pending attaches install + callback; marked
grant attaches neither), idempotence, the revoked-in-flight and
deleted-in-flight races. TestMAv2SessionGrantEndToEnd (live Sepolia,
salt 10) now asserts OnApplied fires with the carrier's hash: install
mined, callback fired, follow-up ran plain — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)