### PR TITLE
feat: MA v2 + EntryPoint v0.7 cutover, session-grant execution, /policies surface

### DIFF
--- a/.github/actions/setup-test-config/action.yml
+++ b/.github/actions/setup-test-config/action.yml
@@ -22,6 +22,13 @@ inputs:
   owner-eoa:
     description: 'Owner EOA address for test smart wallet derivation (controller signs UserOps)'
     required: true
+  test-private-key:
+    description: |
+      Private key for the owner EOA. Under MA v2 the gateway holds no
+      authority until the owner signs a session grant, and only the owner's
+      key can sign one — so live tests need the key, not just owner-eoa.
+      Optional: jobs that do not run live tests (e.g. lint) can omit it.
+    required: false
   moralis-api-key:
     description: 'Moralis Web3 Data API key for token balance integration tests'
     required: false
@@ -45,3 +52,14 @@ runs:
         MORALIS_API_KEY: "${{ inputs.moralis-api-key }}"
       shell: bash
       run: ./.github/scripts/generate-test-config.sh
+
+    # The live-test fixtures read TEST_PRIVATE_KEY from the ENVIRONMENT
+    # (os.Getenv), not from config/test.yaml — so export it to the job so
+    # every later step sees it. Referenced via $env, not interpolated into
+    # the script body, so the secret never appears verbatim in the command.
+    - name: Export the owner key to the job environment
+      if: ${{ inputs.test-private-key != '' }}
+      shell: bash
+      env:
+        TEST_PRIVATE_KEY: "${{ inputs.test-private-key }}"
+      run: echo "TEST_PRIVATE_KEY=${TEST_PRIVATE_KEY}" >> "$GITHUB_ENV"

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -157,6 +157,12 @@ jobs:
           controller-private-key: ${{ secrets.CONTROLLER_PRIVATE_KEY }}
           tenderly-access-key: ${{ secrets.TENDERLY_ACCESS_KEY }}
           owner-eoa: ${{ vars.OWNER_EOA }}
+          # The owner's key, not just its address: MA v2 wallets grant the
+          # gateway nothing by default, so live tests authorize a session
+          # grant the way production owners do, and only the owner's key can
+          # sign one (core/taskengine/session_grant_testhelper_test.go). The
+          # action exports it to the job environment for the test step.
+          test-private-key: ${{ secrets.TEST_PRIVATE_KEY }}
           moralis-api-key: ${{ secrets.MORALIS_API_KEY }}
 
       - name: Run Go test

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ tmp/rehearsal-gateway-backup/
 
 # Local Claude Code agent state (session locks, project-local skills, etc.)
 .claude/
+
+# spike harness build outputs
+/deferred_action
+/permission_hooks

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -280,7 +280,9 @@ func (agg *Aggregator) init() {
 	}
 
 	// Setup account abstraction config
-	aa.SetFactoryAddress(agg.config.SmartWallet.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(agg.config.SmartWallet); err != nil {
+		panic(fmt.Sprintf("smart_wallet: cannot resolve account factory: %v", err))
+	}
 	aa.SetEntrypointAddress(agg.config.SmartWallet.EntrypointAddress)
 }
 

--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -74,6 +74,21 @@ type ServerInterface interface {
 	// Update wallet properties
 	// (PATCH /wallets/{address})
 	UpdateWallet(ctx echo.Context, address EthereumAddress) error
+	// List the wallet's session policies
+	// (GET /wallets/{address}/policies)
+	ListWalletPolicies(ctx echo.Context, address EthereumAddress, params ListWalletPoliciesParams) error
+	// Revoke a session policy
+	// (DELETE /wallets/{address}/policies/{policyId})
+	RevokeWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params RevokeWalletPolicyParams) error
+	// Get one session policy
+	// (GET /wallets/{address}/policies/{policyId})
+	GetWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params GetWalletPolicyParams) error
+	// Allocate a grant and return the EIP-712 payload the owner signs
+	// (POST /wallets/{address}/policies:prepare)
+	PrepareWalletPolicy(ctx echo.Context, address EthereumAddress) error
+	// Submit the owner's signature and persist the grant
+	// (POST /wallets/{address}/policies:submit)
+	SubmitWalletPolicy(ctx echo.Context, address EthereumAddress) error
 	// Get the smart wallet's current nonce
 	// (GET /wallets/{address}:getNonce)
 	GetWalletNonce(ctx echo.Context, address EthereumAddress, params GetWalletNonceParams) error
@@ -534,6 +549,139 @@ func (w *ServerInterfaceWrapper) UpdateWallet(ctx echo.Context) error {
 	return err
 }
 
+// ListWalletPolicies converts echo context to params.
+func (w *ServerInterfaceWrapper) ListWalletPolicies(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListWalletPoliciesParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ListWalletPolicies(ctx, address, params)
+	return err
+}
+
+// RevokeWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) RevokeWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	// ------------- Path parameter "policyId" -------------
+	var policyId Ulid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyId", ctx.Param("policyId"), &policyId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter policyId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params RevokeWalletPolicyParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.RevokeWalletPolicy(ctx, address, policyId, params)
+	return err
+}
+
+// GetWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) GetWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	// ------------- Path parameter "policyId" -------------
+	var policyId Ulid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyId", ctx.Param("policyId"), &policyId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter policyId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetWalletPolicyParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetWalletPolicy(ctx, address, policyId, params)
+	return err
+}
+
+// PrepareWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) PrepareWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.PrepareWalletPolicy(ctx, address)
+	return err
+}
+
+// SubmitWalletPolicy converts echo context to params.
+func (w *ServerInterfaceWrapper) SubmitWalletPolicy(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "address" -------------
+	var address EthereumAddress
+
+	err = runtime.BindStyledParameterWithOptions("simple", "address", ctx.Param("address"), &address, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.SubmitWalletPolicy(ctx, address)
+	return err
+}
+
 // GetWalletNonce converts echo context to params.
 func (w *ServerInterfaceWrapper) GetWalletNonce(ctx echo.Context) error {
 	var err error
@@ -865,6 +1013,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/wallets", wrapper.ListWallets)
 	router.POST(baseURL+"/wallets", wrapper.CreateWallet)
 	router.PATCH(baseURL+"/wallets/:address", wrapper.UpdateWallet)
+	router.GET(baseURL+"/wallets/:address/policies", wrapper.ListWalletPolicies)
+	router.DELETE(baseURL+"/wallets/:address/policies/:policyId", wrapper.RevokeWalletPolicy)
+	router.GET(baseURL+"/wallets/:address/policies/:policyId", wrapper.GetWalletPolicy)
+	router.POST(baseURL+"/wallets/:address/policies:prepare", wrapper.PrepareWalletPolicy)
+	router.POST(baseURL+"/wallets/:address/policies:submit", wrapper.SubmitWalletPolicy)
 	router.GET(baseURL+"/wallets/:address:getNonce", wrapper.GetWalletNonce)
 	router.POST(baseURL+"/wallets/:address:withdraw", wrapper.WithdrawWallet)
 	router.GET(baseURL+"/workflows", wrapper.ListWorkflows)
@@ -1611,6 +1764,294 @@ func (response UpdateWallet404ApplicationProblemPlusJSONResponse) VisitUpdateWal
 	return json.NewEncoder(w).Encode(response)
 }
 
+type ListWalletPoliciesRequestObject struct {
+	Address EthereumAddress `json:"address"`
+	Params  ListWalletPoliciesParams
+}
+
+type ListWalletPoliciesResponseObject interface {
+	VisitListWalletPoliciesResponse(w http.ResponseWriter) error
+}
+
+type ListWalletPolicies200JSONResponse SessionPolicyList
+
+func (response ListWalletPolicies200JSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListWalletPolicies401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response ListWalletPolicies401ApplicationProblemPlusJSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListWalletPolicies403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response ListWalletPolicies403ApplicationProblemPlusJSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListWalletPolicies404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response ListWalletPolicies404ApplicationProblemPlusJSONResponse) VisitListWalletPoliciesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicyRequestObject struct {
+	Address  EthereumAddress `json:"address"`
+	PolicyId Ulid            `json:"policyId"`
+	Params   RevokeWalletPolicyParams
+}
+
+type RevokeWalletPolicyResponseObject interface {
+	VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type RevokeWalletPolicy200JSONResponse RevokePolicyResponse
+
+func (response RevokeWalletPolicy200JSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response RevokeWalletPolicy401ApplicationProblemPlusJSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response RevokeWalletPolicy403ApplicationProblemPlusJSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response RevokeWalletPolicy404ApplicationProblemPlusJSONResponse) VisitRevokeWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicyRequestObject struct {
+	Address  EthereumAddress `json:"address"`
+	PolicyId Ulid            `json:"policyId"`
+	Params   GetWalletPolicyParams
+}
+
+type GetWalletPolicyResponseObject interface {
+	VisitGetWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type GetWalletPolicy200JSONResponse SessionPolicy
+
+func (response GetWalletPolicy200JSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response GetWalletPolicy401ApplicationProblemPlusJSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response GetWalletPolicy403ApplicationProblemPlusJSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response GetWalletPolicy404ApplicationProblemPlusJSONResponse) VisitGetWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicyRequestObject struct {
+	Address EthereumAddress `json:"address"`
+	Body    *PrepareWalletPolicyJSONRequestBody
+}
+
+type PrepareWalletPolicyResponseObject interface {
+	VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type PrepareWalletPolicy200JSONResponse PreparedPolicy
+
+func (response PrepareWalletPolicy200JSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy400ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy401ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy403ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PrepareWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response PrepareWalletPolicy404ApplicationProblemPlusJSONResponse) VisitPrepareWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicyRequestObject struct {
+	Address EthereumAddress `json:"address"`
+	Body    *SubmitWalletPolicyJSONRequestBody
+}
+
+type SubmitWalletPolicyResponseObject interface {
+	VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error
+}
+
+type SubmitWalletPolicy201JSONResponse SessionPolicy
+
+func (response SubmitWalletPolicy201JSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy400ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy401ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy403ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response SubmitWalletPolicy404ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SubmitWalletPolicy409ApplicationProblemPlusJSONResponse Problem
+
+func (response SubmitWalletPolicy409ApplicationProblemPlusJSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetWalletNonceRequestObject struct {
 	Address EthereumAddress `json:"address"`
 	Params  GetWalletNonceParams
@@ -2266,6 +2707,21 @@ type StrictServerInterface interface {
 	// Update wallet properties
 	// (PATCH /wallets/{address})
 	UpdateWallet(ctx context.Context, request UpdateWalletRequestObject) (UpdateWalletResponseObject, error)
+	// List the wallet's session policies
+	// (GET /wallets/{address}/policies)
+	ListWalletPolicies(ctx context.Context, request ListWalletPoliciesRequestObject) (ListWalletPoliciesResponseObject, error)
+	// Revoke a session policy
+	// (DELETE /wallets/{address}/policies/{policyId})
+	RevokeWalletPolicy(ctx context.Context, request RevokeWalletPolicyRequestObject) (RevokeWalletPolicyResponseObject, error)
+	// Get one session policy
+	// (GET /wallets/{address}/policies/{policyId})
+	GetWalletPolicy(ctx context.Context, request GetWalletPolicyRequestObject) (GetWalletPolicyResponseObject, error)
+	// Allocate a grant and return the EIP-712 payload the owner signs
+	// (POST /wallets/{address}/policies:prepare)
+	PrepareWalletPolicy(ctx context.Context, request PrepareWalletPolicyRequestObject) (PrepareWalletPolicyResponseObject, error)
+	// Submit the owner's signature and persist the grant
+	// (POST /wallets/{address}/policies:submit)
+	SubmitWalletPolicy(ctx context.Context, request SubmitWalletPolicyRequestObject) (SubmitWalletPolicyResponseObject, error)
 	// Get the smart wallet's current nonce
 	// (GET /wallets/{address}:getNonce)
 	GetWalletNonce(ctx context.Context, request GetWalletNonceRequestObject) (GetWalletNonceResponseObject, error)
@@ -2822,6 +3278,148 @@ func (sh *strictHandler) UpdateWallet(ctx echo.Context, address EthereumAddress)
 		return err
 	} else if validResponse, ok := response.(UpdateWalletResponseObject); ok {
 		return validResponse.VisitUpdateWalletResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// ListWalletPolicies operation middleware
+func (sh *strictHandler) ListWalletPolicies(ctx echo.Context, address EthereumAddress, params ListWalletPoliciesParams) error {
+	var request ListWalletPoliciesRequestObject
+
+	request.Address = address
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.ListWalletPolicies(ctx.Request().Context(), request.(ListWalletPoliciesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListWalletPolicies")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(ListWalletPoliciesResponseObject); ok {
+		return validResponse.VisitListWalletPoliciesResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// RevokeWalletPolicy operation middleware
+func (sh *strictHandler) RevokeWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params RevokeWalletPolicyParams) error {
+	var request RevokeWalletPolicyRequestObject
+
+	request.Address = address
+	request.PolicyId = policyId
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.RevokeWalletPolicy(ctx.Request().Context(), request.(RevokeWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RevokeWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(RevokeWalletPolicyResponseObject); ok {
+		return validResponse.VisitRevokeWalletPolicyResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// GetWalletPolicy operation middleware
+func (sh *strictHandler) GetWalletPolicy(ctx echo.Context, address EthereumAddress, policyId Ulid, params GetWalletPolicyParams) error {
+	var request GetWalletPolicyRequestObject
+
+	request.Address = address
+	request.PolicyId = policyId
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetWalletPolicy(ctx.Request().Context(), request.(GetWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetWalletPolicyResponseObject); ok {
+		return validResponse.VisitGetWalletPolicyResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// PrepareWalletPolicy operation middleware
+func (sh *strictHandler) PrepareWalletPolicy(ctx echo.Context, address EthereumAddress) error {
+	var request PrepareWalletPolicyRequestObject
+
+	request.Address = address
+
+	var body PrepareWalletPolicyJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PrepareWalletPolicy(ctx.Request().Context(), request.(PrepareWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PrepareWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(PrepareWalletPolicyResponseObject); ok {
+		return validResponse.VisitPrepareWalletPolicyResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// SubmitWalletPolicy operation middleware
+func (sh *strictHandler) SubmitWalletPolicy(ctx echo.Context, address EthereumAddress) error {
+	var request SubmitWalletPolicyRequestObject
+
+	request.Address = address
+
+	var body SubmitWalletPolicyJSONRequestBody
+	if err := ctx.Bind(&body); err != nil {
+		return err
+	}
+	request.Body = &body
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.SubmitWalletPolicy(ctx.Request().Context(), request.(SubmitWalletPolicyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "SubmitWalletPolicy")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(SubmitWalletPolicyResponseObject); ok {
+		return validResponse.VisitSubmitWalletPolicyResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -200,11 +200,24 @@ const (
 	PUT     RestAPINodeConfigMethod = "PUT"
 )
 
+// Defines values for RevokePolicyResponseStatus.
+const (
+	Deleted RevokePolicyResponseStatus = "deleted"
+	Revoked RevokePolicyResponseStatus = "revoked"
+)
+
 // Defines values for SecretScope.
 const (
 	SecretScopeOrg      SecretScope = "org"
 	SecretScopeUser     SecretScope = "user"
 	SecretScopeWorkflow SecretScope = "workflow"
+)
+
+// Defines values for SessionPolicyStatus.
+const (
+	SessionPolicyStatusActive  SessionPolicyStatus = "active"
+	SessionPolicyStatusPending SessionPolicyStatus = "pending"
+	SessionPolicyStatusRevoked SessionPolicyStatus = "revoked"
 )
 
 // Defines values for SignalExecutionRequestDecision.
@@ -251,12 +264,21 @@ const (
 
 // Defines values for WorkflowStatus.
 const (
-	Completed WorkflowStatus = "completed"
-	Disabled  WorkflowStatus = "disabled"
-	Enabled   WorkflowStatus = "enabled"
-	Failed    WorkflowStatus = "failed"
-	Running   WorkflowStatus = "running"
+	WorkflowStatusCompleted WorkflowStatus = "completed"
+	WorkflowStatusDisabled  WorkflowStatus = "disabled"
+	WorkflowStatusEnabled   WorkflowStatus = "enabled"
+	WorkflowStatusFailed    WorkflowStatus = "failed"
+	WorkflowStatusRunning   WorkflowStatus = "running"
 )
+
+// AllowedAction One contract the agent may call, scoped to selectors.
+type AllowedAction struct {
+	// Selectors 4-byte function selectors permitted on the target.
+	Selectors []string `json:"selectors"`
+
+	// Target Lowercase or checksummed hex EOA / contract address.
+	Target EthereumAddress `json:"target"`
+}
 
 // AuthExchangeRequest defines model for AuthExchangeRequest.
 type AuthExchangeRequest struct {
@@ -587,6 +609,16 @@ type Edge struct {
 
 	// Target Node ID where this edge ends.
 	Target string `json:"target"`
+}
+
+// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+// token must appear as an `allowedActions` target.
+type Erc20SpendCap struct {
+	// Amount Total cap in the token's smallest unit (decimal string, no reset).
+	Amount string `json:"amount"`
+
+	// Token Lowercase or checksummed hex EOA / contract address.
+	Token EthereumAddress `json:"token"`
 }
 
 // EstimateFeesRequest defines model for EstimateFeesRequest.
@@ -1082,6 +1114,54 @@ type PageInfo struct {
 	StartCursor *string `json:"startCursor,omitempty"`
 }
 
+// PreparePolicyRequest defines model for PreparePolicyRequest.
+type PreparePolicyRequest struct {
+	AgentLabel     string          `json:"agentLabel"`
+	AllowedActions []AllowedAction `json:"allowedActions"`
+
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
+
+	// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+	// token must appear as an `allowedActions` target.
+	Erc20SpendCap Erc20SpendCap `json:"erc20SpendCap"`
+
+	// ExpiresInSeconds Grant lifetime, relative (skew-proof). Becomes an absolute validUntil.
+	ExpiresInSeconds int64   `json:"expiresInSeconds"`
+	Justification    *string `json:"justification,omitempty"`
+}
+
+// PreparedPolicy defines model for PreparedPolicy.
+type PreparedPolicy struct {
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
+
+	// Deadline Unix seconds; bounds signing → first use, NOT the grant lifetime.
+	Deadline int64 `json:"deadline"`
+
+	// Digest The EIP-712 hash the typed data produces, for client-side verification.
+	Digest string `json:"digest"`
+
+	// EntityId The validation entity allocated for this grant (provisional until submit).
+	EntityId int64 `json:"entityId"`
+
+	// PolicyId ULID identifier (26-char Crockford base32).
+	PolicyId Ulid `json:"policyId"`
+
+	// SessionSigner Lowercase or checksummed hex EOA / contract address.
+	SessionSigner EthereumAddress `json:"sessionSigner"`
+
+	// TypedData The exact eth_signTypedData_v4 payload for the owner's wallet.
+	TypedData map[string]interface{} `json:"typedData"`
+
+	// ValidUntil Absolute grant expiry, unix milliseconds. Echo verbatim to submit.
+	ValidUntil int64 `json:"validUntil"`
+}
+
 // Problem RFC 7807 problem+json. Returned as `application/problem+json` on any
 // 4xx/5xx response. `type` and `title` describe the error class; `detail`
 // is human-readable; `instance` is a per-request identifier suitable for
@@ -1166,6 +1246,19 @@ type RestAPINodeConfig_Options struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
+// RevokePolicyResponse defines model for RevokePolicyResponse.
+type RevokePolicyResponse struct {
+	// OnChainCleanupRequired True when the grant's validation is still installed on the
+	// account and needs the owner's uninstallValidation to clear.
+	OnChainCleanupRequired bool `json:"onChainCleanupRequired"`
+
+	// Status deleted = was pending, nothing was ever installed. revoked = retained for audit.
+	Status RevokePolicyResponseStatus `json:"status"`
+}
+
+// RevokePolicyResponseStatus deleted = was pending, nothing was ever installed. revoked = retained for audit.
+type RevokePolicyResponseStatus string
+
 // RunNodeRequest defines model for RunNodeRequest.
 type RunNodeRequest struct {
 	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
@@ -1244,6 +1337,51 @@ type SecretList struct {
 	PageInfo PageInfo `json:"pageInfo"`
 }
 
+// SessionPolicy defines model for SessionPolicy.
+type SessionPolicy struct {
+	AgentLabel     string           `json:"agentLabel"`
+	AllowedActions *[]AllowedAction `json:"allowedActions,omitempty"`
+
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
+
+	// CreatedAt Unix milliseconds.
+	CreatedAt int64 `json:"createdAt"`
+	EntityId  int64 `json:"entityId"`
+
+	// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+	// token must appear as an `allowedActions` target.
+	Erc20SpendCap *Erc20SpendCap `json:"erc20SpendCap,omitempty"`
+
+	// Id ULID identifier (26-char Crockford base32).
+	Id            Ulid    `json:"id"`
+	Justification *string `json:"justification,omitempty"`
+
+	// Runner Lowercase or checksummed hex EOA / contract address.
+	Runner EthereumAddress `json:"runner"`
+
+	// SessionSigner Lowercase or checksummed hex EOA / contract address.
+	SessionSigner EthereumAddress `json:"sessionSigner"`
+
+	// Status pending = signed and stored, install not yet on-chain (revocable
+	// for free). active = install applied. revoked = grants nothing.
+	Status SessionPolicyStatus `json:"status"`
+
+	// ValidUntil Unix milliseconds.
+	ValidUntil int64 `json:"validUntil"`
+}
+
+// SessionPolicyStatus pending = signed and stored, install not yet on-chain (revocable
+// for free). active = install applied. revoked = grants nothing.
+type SessionPolicyStatus string
+
+// SessionPolicyList defines model for SessionPolicyList.
+type SessionPolicyList struct {
+	Items []SessionPolicy `json:"items"`
+}
+
 // SignalExecutionRequest defines model for SignalExecutionRequest.
 type SignalExecutionRequest struct {
 	// Decision The approver's decision.
@@ -1272,6 +1410,33 @@ type SimulateWorkflowRequest struct {
 	InputVariables InputVariables `json:"inputVariables"`
 	Nodes          []Node         `json:"nodes"`
 	Trigger        Trigger        `json:"trigger"`
+}
+
+// SubmitPolicyRequest defines model for SubmitPolicyRequest.
+type SubmitPolicyRequest struct {
+	AgentLabel     string          `json:"agentLabel"`
+	AllowedActions []AllowedAction `json:"allowedActions"`
+
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId  ChainId `json:"chainId"`
+	Deadline int64   `json:"deadline"`
+	EntityId int64   `json:"entityId"`
+
+	// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+	// token must appear as an `allowedActions` target.
+	Erc20SpendCap Erc20SpendCap `json:"erc20SpendCap"`
+	Justification *string       `json:"justification,omitempty"`
+
+	// PolicyId ULID identifier (26-char Crockford base32).
+	PolicyId Ulid `json:"policyId"`
+
+	// Signature The owner's 65-byte signature over the prepared digest.
+	Signature string `json:"signature"`
+
+	// ValidUntil The ABSOLUTE expiry from prepare. It is baked into the signed calldata; recomputing it would change the digest.
+	ValidUntil int64 `json:"validUntil"`
 }
 
 // Timestamp RFC 3339 timestamp.
@@ -1643,6 +1808,27 @@ type GetTokenParams struct {
 	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 
+// ListWalletPoliciesParams defines parameters for ListWalletPolicies.
+type ListWalletPoliciesParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
+// RevokeWalletPolicyParams defines parameters for RevokeWalletPolicy.
+type RevokeWalletPolicyParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
+// GetWalletPolicyParams defines parameters for GetWalletPolicy.
+type GetWalletPolicyParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
 // GetWalletNonceParams defines parameters for GetWalletNonce.
 type GetWalletNonceParams struct {
 	// ChainId The chain to operate on (a single value). Omit to use the aggregator
@@ -1706,6 +1892,12 @@ type CreateWalletJSONRequestBody = CreateWalletRequest
 
 // UpdateWalletJSONRequestBody defines body for UpdateWallet for application/json ContentType.
 type UpdateWalletJSONRequestBody = UpdateWalletRequest
+
+// PrepareWalletPolicyJSONRequestBody defines body for PrepareWalletPolicy for application/json ContentType.
+type PrepareWalletPolicyJSONRequestBody = PreparePolicyRequest
+
+// SubmitWalletPolicyJSONRequestBody defines body for SubmitWalletPolicy for application/json ContentType.
+type SubmitWalletPolicyJSONRequestBody = SubmitPolicyRequest
 
 // WithdrawWalletJSONRequestBody defines body for WithdrawWallet for application/json ContentType.
 type WithdrawWalletJSONRequestBody = WithdrawRequest

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -1,0 +1,329 @@
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// /wallets/{address}/policies — the grant screen's backend.
+//
+// Granting is prepare → sign → submit (master doc §7.5 as reshaped by
+// §7.4a): prepare allocates and returns the EIP-712 payload, the owner's
+// wallet signs it, submit verifies and persists. Prepare stores nothing;
+// submit trusts nothing — the grant is recomputed from the echoed fields and
+// the signature is the only authority.
+//
+// Every handler leads with refusePartnerAssertion: a policy is fund
+// authority, and the refusal must be explicit rather than a handler that
+// silently never consults the header.
+
+const policyCapability = "Session-policy management"
+
+// policyChainID resolves the chain: explicit value wins, then the JWT's
+// audience chain. Zero means unresolvable (single-chain deployments have an
+// aud; a request with neither is malformed).
+func policyChainID(ctx echo.Context, explicit *int64) int64 {
+	if explicit != nil && *explicit > 0 {
+		return *explicit
+	}
+	if authed := restmw.UserFromContext(ctx); authed != nil {
+		return authed.ChainID
+	}
+	return 0
+}
+
+// policyAuth is the shared preamble: partner refusal, then user auth, then
+// path-address validation.
+func (s *Server) policyAuth(ctx echo.Context, address generated.EthereumAddress) (*model.User, common.Address, error) {
+	if err := refusePartnerAssertion(ctx, policyCapability); err != nil {
+		return nil, common.Address{}, err
+	}
+	user, err := s.requireUser(ctx)
+	if err != nil {
+		return nil, common.Address{}, err
+	}
+	if !common.IsHexAddress(string(address)) {
+		return nil, common.Address{}, badRequest("POLICIES_BAD_ADDRESS", "Invalid wallet address",
+			"The {address} path parameter must be a valid 0x-prefixed hex address.")
+	}
+	return user, common.HexToAddress(string(address)), nil
+}
+
+// PrepareWalletPolicy allocates a grant and returns the payload to sign.
+func (s *Server) PrepareWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	var req generated.PreparePolicyRequest
+	if err := ctx.Bind(&req); err != nil {
+		return badRequest("POLICIES_BAD_BODY", "Invalid request body", err.Error())
+	}
+	// Matches the published contract (openapi.yaml minimum: 60): a
+	// sub-minute grant expires before its first operation can mine.
+	if req.ExpiresInSeconds < 60 {
+		return badRequest("POLICIES_BAD_EXPIRY", "Invalid expiry", "expiresInSeconds must be at least 60.")
+	}
+	perms, err := permissionsFromAPI(req.AllowedActions, &req.Erc20SpendCap, nowMs()+req.ExpiresInSeconds*1000)
+	if err != nil {
+		return badRequest("POLICIES_BAD_PERMISSIONS", "Invalid permissions", err.Error())
+	}
+
+	prepared, err := s.engine.PrepareSessionPolicy(user, taskengine.SessionPolicyInput{
+		Wallet:        wallet,
+		ChainID:       int64(req.ChainId),
+		AgentLabel:    req.AgentLabel,
+		Justification: deref(req.Justification),
+		Permissions:   perms,
+	})
+	if err != nil {
+		return mapPolicyError(err)
+	}
+
+	policy := prepared.Policy
+	typedData, err := typedDataJSON(policy)
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, generated.PreparedPolicy{
+		PolicyId:      generated.Ulid(policy.ID),
+		ChainId:       generated.ChainId(policy.ChainID),
+		EntityId:      int64(policy.EntityID),
+		SessionSigner: generated.EthereumAddress(policy.SessionSigner.Hex()),
+		Deadline:      int64(policy.Grant.Deadline),
+		ValidUntil:    policy.ValidUntil,
+		Digest:        prepared.Digest.Hex(),
+		TypedData:     typedData,
+	})
+}
+
+// SubmitWalletPolicy verifies the owner's signature and stores the grant.
+func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	var req generated.SubmitPolicyRequest
+	if err := ctx.Bind(&req); err != nil {
+		return badRequest("POLICIES_BAD_BODY", "Invalid request body", err.Error())
+	}
+	signature := common.FromHex(req.Signature)
+	if len(signature) != 65 {
+		return badRequest("POLICIES_BAD_SIGNATURE", "Invalid signature",
+			"signature must be 65 hex-encoded bytes (r ++ s ++ v).")
+	}
+	if req.EntityId <= 0 || req.EntityId > int64(^uint32(0)) {
+		return badRequest("POLICIES_BAD_ENTITY", "Invalid entity id", "entityId is out of range.")
+	}
+	if req.Deadline <= 0 {
+		return badRequest("POLICIES_BAD_DEADLINE", "Invalid deadline", "deadline must be positive.")
+	}
+	perms, err := permissionsFromAPI(req.AllowedActions, &req.Erc20SpendCap, req.ValidUntil)
+	if err != nil {
+		return badRequest("POLICIES_BAD_PERMISSIONS", "Invalid permissions", err.Error())
+	}
+
+	policy, err := s.engine.SubmitSessionPolicy(user, taskengine.SessionPolicyInput{
+		Wallet:        wallet,
+		ChainID:       int64(req.ChainId),
+		AgentLabel:    req.AgentLabel,
+		Justification: deref(req.Justification),
+		Permissions:   perms,
+	}, string(req.PolicyId), uint32(req.EntityId), uint64(req.Deadline), signature)
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	return ctx.JSON(http.StatusCreated, policyToAPI(policy))
+}
+
+// ListWalletPolicies lists the wallet's grants, newest first.
+func (s *Server) ListWalletPolicies(ctx echo.Context, address generated.EthereumAddress, params generated.ListWalletPoliciesParams) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	chainID := policyChainID(ctx, (*int64)(params.ChainId))
+	if chainID <= 0 {
+		return badRequest("POLICIES_BAD_CHAIN_ID", "Chain unresolvable",
+			"Provide ?chainId= or authenticate with a chain-scoped token.")
+	}
+	policies, err := s.engine.ListSessionPoliciesForWallet(user, chainID, wallet)
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	items := make([]generated.SessionPolicy, 0, len(policies))
+	for _, p := range policies {
+		items = append(items, policyToAPI(p))
+	}
+	return ctx.JSON(http.StatusOK, generated.SessionPolicyList{Items: items})
+}
+
+// GetWalletPolicy returns one grant.
+func (s *Server) GetWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.GetWalletPolicyParams) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	chainID := policyChainID(ctx, (*int64)(params.ChainId))
+	if chainID <= 0 {
+		return badRequest("POLICIES_BAD_CHAIN_ID", "Chain unresolvable",
+			"Provide ?chainId= or authenticate with a chain-scoped token.")
+	}
+	policy, err := s.engine.GetSessionPolicyByID(user, chainID, wallet, string(policyID))
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	return ctx.JSON(http.StatusOK, policyToAPI(policy))
+}
+
+// RevokeWalletPolicy revokes one grant.
+func (s *Server) RevokeWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.RevokeWalletPolicyParams) error {
+	user, wallet, err := s.policyAuth(ctx, address)
+	if err != nil {
+		return err
+	}
+	chainID := policyChainID(ctx, (*int64)(params.ChainId))
+	if chainID <= 0 {
+		return badRequest("POLICIES_BAD_CHAIN_ID", "Chain unresolvable",
+			"Provide ?chainId= or authenticate with a chain-scoped token.")
+	}
+	deleted, cleanupRequired, err := s.engine.RevokeSessionPolicyByID(user, chainID, wallet, string(policyID))
+	if err != nil {
+		return mapPolicyError(err)
+	}
+	status := generated.RevokePolicyResponseStatus("revoked")
+	if deleted {
+		status = generated.RevokePolicyResponseStatus("deleted")
+	}
+	return ctx.JSON(http.StatusOK, generated.RevokePolicyResponse{
+		Status:                 status,
+		OnChainCleanupRequired: cleanupRequired,
+	})
+}
+
+// ── mapping ───────────────────────────────────────────────────────────────
+
+// permissionsFromAPI translates wire permissions into the engine's set.
+func permissionsFromAPI(actions []generated.AllowedAction, spendCap *generated.Erc20SpendCap, validUntilMs int64) (taskengine.SessionPermissions, error) {
+	perms := taskengine.SessionPermissions{ValidUntilMs: validUntilMs}
+	for _, a := range actions {
+		if !common.IsHexAddress(string(a.Target)) {
+			return perms, errors.New("allowed action target is not a valid address")
+		}
+		target := common.HexToAddress(string(a.Target))
+		perms.AllowedActions = append(perms.AllowedActions, model.AllowedAction{
+			Target:    &target,
+			Selectors: a.Selectors,
+		})
+	}
+	if spendCap != nil {
+		if !common.IsHexAddress(string(spendCap.Token)) {
+			return perms, errors.New("spend cap token is not a valid address")
+		}
+		token := common.HexToAddress(string(spendCap.Token))
+		perms.SpendCap = &model.ERC20SpendCap{Token: &token, Amount: spendCap.Amount}
+	}
+	return perms, nil
+}
+
+// policyToAPI renders a policy for responses. Grant material — calldata,
+// nonce, the owner's signature — is secret-grade and never leaves storage.
+func policyToAPI(p *model.SessionPolicy) generated.SessionPolicy {
+	out := generated.SessionPolicy{
+		Id:         generated.Ulid(p.ID),
+		ChainId:    generated.ChainId(p.ChainID),
+		Status:     generated.SessionPolicyStatus(p.Status),
+		EntityId:   int64(p.EntityID),
+		AgentLabel: p.AgentLabel,
+		ValidUntil: p.ValidUntil,
+		CreatedAt:  p.CreatedAt,
+	}
+	if p.Runner != nil {
+		out.Runner = generated.EthereumAddress(p.Runner.Hex())
+	}
+	if p.SessionSigner != nil {
+		out.SessionSigner = generated.EthereumAddress(p.SessionSigner.Hex())
+	}
+	if p.Justification != "" {
+		out.Justification = &p.Justification
+	}
+	if len(p.AllowedActions) > 0 {
+		actions := make([]generated.AllowedAction, 0, len(p.AllowedActions))
+		for _, a := range p.AllowedActions {
+			if a.Target == nil {
+				continue
+			}
+			actions = append(actions, generated.AllowedAction{
+				Target:    generated.EthereumAddress(a.Target.Hex()),
+				Selectors: a.Selectors,
+			})
+		}
+		out.AllowedActions = &actions
+	}
+	if p.ERC20SpendCap != nil && p.ERC20SpendCap.Token != nil {
+		out.Erc20SpendCap = &generated.Erc20SpendCap{
+			Token:  generated.EthereumAddress(p.ERC20SpendCap.Token.Hex()),
+			Amount: p.ERC20SpendCap.Amount,
+		}
+	}
+	return out
+}
+
+// typedDataJSON renders the eth_signTypedData_v4 payload for the prepare
+// response — built from the SAME fields the digest was computed over, so the
+// wallet signs exactly what submit will verify.
+func typedDataJSON(policy *model.SessionPolicy) (map[string]interface{}, error) {
+	typed := userop.DeferredActionTypedData(
+		bigChainID(policy.ChainID), *policy.Runner,
+		policy.Grant.CarrierNonce, policy.Grant.Deadline, policy.Grant.InstallCall)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// mapPolicyError translates engine sentinels into REST problems.
+func mapPolicyError(err error) error {
+	switch {
+	case errors.Is(err, taskengine.ErrWalletNotOwned), errors.Is(err, taskengine.ErrSessionPolicyNotFound):
+		// Existence is not confirmed to non-owners: both cases read as 404.
+		return &restmw.HTTPError{Status: http.StatusNotFound, Code: "POLICIES_NOT_FOUND",
+			Title: "Not found", Detail: "No such wallet or policy for this account."}
+	case errors.Is(err, taskengine.ErrSessionEntityTaken):
+		return &restmw.HTTPError{Status: http.StatusConflict, Code: "POLICIES_ENTITY_TAKEN",
+			Title: "Grant allocation superseded", Detail: err.Error() + " Prepare the grant again."}
+	case strings.Contains(err.Error(), "signed by"):
+		return badRequest("POLICIES_BAD_SIGNATURE", "Signature does not match", err.Error())
+	default:
+		return badRequest("POLICIES_REJECTED", "Policy request rejected", err.Error())
+	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func nowMs() int64 { return time.Now().UnixMilli() }
+
+func bigChainID(chainID int64) *big.Int { return big.NewInt(chainID) }

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -1,0 +1,269 @@
+package rest
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// The /policies surface end to end at the HTTP layer: the guard, the
+// prepare → sign → submit round trip (including proof that the returned
+// typed data hashes to the returned digest — what the wallet signs is what
+// submit verifies), and the secret-grade handling of grant material.
+
+const policyTestChain = int64(11155111)
+
+type policyTestRig struct {
+	server   *Server
+	ownerKey *ecdsa.PrivateKey
+	owner    common.Address
+	wallet   common.Address
+}
+
+func newPolicyRig(t *testing.T) *policyTestRig {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	cfg := testutil.GetAggregatorConfig()
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	cfg.SmartWallet.ControllerPrivateKey = controllerKey
+	cfg.SmartWallet.ChainID = policyTestChain
+	engine := taskengine.New(db, cfg, nil, testutil.GetLogger())
+
+	logger, err := sdklogging.NewZapLogger(sdklogging.Development)
+	require.NoError(t, err)
+
+	ownerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	wallet := common.HexToAddress("0x00000000000000000000000000000000000000b2")
+	factory := common.HexToAddress("0x00000000000017c61b5bEe81050EC8eFc9c6fecd")
+	require.NoError(t, taskengine.StoreWallet(db, policyTestChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &wallet, Factory: &factory, Salt: big.NewInt(0),
+	}))
+
+	return &policyTestRig{
+		server:   &Server{engine: engine, logger: logger, config: cfg},
+		ownerKey: ownerKey,
+		owner:    owner,
+		wallet:   wallet,
+	}
+}
+
+// call builds an authed request, runs the handler, and returns the recorder.
+func (r *policyTestRig) call(t *testing.T, body any, handler func(echo.Context) error, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/wallets/x/policies", &buf)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	ctx := echo.New().NewContext(req, rec)
+	ctx.Set("auth.user", &restmw.AuthenticatedUser{Subject: r.owner.Hex(), ChainID: policyTestChain})
+
+	if err := handler(ctx); err != nil {
+		// Match production behavior enough to assert on: structured errors
+		// carry their own status.
+		var httpErr *restmw.HTTPError
+		if ok := asHTTPError(err, &httpErr); ok {
+			rec.Code = httpErr.Status
+			rec.Body.Reset()
+			raw, _ := json.Marshal(httpErr)
+			rec.Body.Write(raw)
+		} else {
+			t.Fatalf("handler returned an unstructured error: %v", err)
+		}
+	}
+	return rec
+}
+
+func asHTTPError(err error, target **restmw.HTTPError) bool {
+	for e := err; e != nil; {
+		if he, ok := e.(*restmw.HTTPError); ok {
+			*target = he
+			return true
+		}
+		u, ok := e.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		e = u.Unwrap()
+	}
+	return false
+}
+
+func prepareBody(chainID int64) generated.PreparePolicyRequest {
+	token := "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+	router := "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E"
+	return generated.PreparePolicyRequest{
+		ChainId:    generated.ChainId(chainID),
+		AgentLabel: "TradingBot",
+		AllowedActions: []generated.AllowedAction{
+			{Target: generated.EthereumAddress(router), Selectors: []string{"0x04e45aaf"}},
+			{Target: generated.EthereumAddress(token), Selectors: []string{"0x095ea7b3"}},
+		},
+		Erc20SpendCap:    generated.Erc20SpendCap{Token: generated.EthereumAddress(token), Amount: "500000000"},
+		ExpiresInSeconds: int64((30 * 24 * time.Hour).Seconds()),
+	}
+}
+
+func TestPoliciesRefusePartnerAssertionsEverywhere(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+	assertion := map[string]string{partnerAssertionHeader: "any-value"}
+
+	handlers := map[string]func(echo.Context) error{
+		"prepare": func(c echo.Context) error { return rig.server.PrepareWalletPolicy(c, address) },
+		"submit":  func(c echo.Context) error { return rig.server.SubmitWalletPolicy(c, address) },
+		"list": func(c echo.Context) error {
+			return rig.server.ListWalletPolicies(c, address, generated.ListWalletPoliciesParams{})
+		},
+		"get": func(c echo.Context) error {
+			return rig.server.GetWalletPolicy(c, address, "01JG2FE5MDVKBPHEG0PEYSDKAC", generated.GetWalletPolicyParams{})
+		},
+		"revoke": func(c echo.Context) error {
+			return rig.server.RevokeWalletPolicy(c, address, "01JG2FE5MDVKBPHEG0PEYSDKAC", generated.RevokeWalletPolicyParams{})
+		},
+	}
+	for name, h := range handlers {
+		rec := rig.call(t, nil, h, assertion)
+		require.Equal(t, http.StatusForbidden, rec.Code, "%s must refuse partner assertions", name)
+		require.Contains(t, rec.Body.String(), "PARTNER_DELEGATION_UNSUPPORTED", "%s refusal must be explicit", name)
+	}
+}
+
+func TestPoliciesPrepareSignSubmitOverHTTP(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+
+	// Prepare.
+	rec := rig.call(t, prepareBody(policyTestChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+	require.NotEmpty(t, prepared.PolicyId)
+	require.EqualValues(t, 1, prepared.EntityId)
+
+	// The returned typed data must hash to the returned digest — what the
+	// owner's wallet displays and signs is exactly what submit verifies.
+	rawTyped, err := json.Marshal(prepared.TypedData)
+	require.NoError(t, err)
+	var typed apitypes.TypedData
+	require.NoError(t, json.Unmarshal(rawTyped, &typed))
+	walletDigest, _, err := apitypes.TypedDataAndHash(typed)
+	require.NoError(t, err)
+	require.Equal(t, prepared.Digest, fmt.Sprintf("0x%x", walletDigest),
+		"typed data and digest disagree; the wallet would sign something submit rejects")
+
+	// Sign as the owner's wallet would.
+	sig, err := crypto.Sign(walletDigest, rig.ownerKey)
+	require.NoError(t, err)
+	sig[64] += 27
+
+	// Submit the echo.
+	body := prepareBody(policyTestChain)
+	submit := generated.SubmitPolicyRequest{
+		ChainId:        body.ChainId,
+		PolicyId:       prepared.PolicyId,
+		EntityId:       prepared.EntityId,
+		Deadline:       prepared.Deadline,
+		ValidUntil:     prepared.ValidUntil,
+		AgentLabel:     body.AgentLabel,
+		AllowedActions: body.AllowedActions,
+		Erc20SpendCap:  body.Erc20SpendCap,
+		Signature:      fmt.Sprintf("0x%x", sig),
+	}
+	rec = rig.call(t, submit, func(c echo.Context) error {
+		return rig.server.SubmitWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var policy generated.SessionPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &policy))
+	require.Equal(t, "pending", string(policy.Status))
+	require.Equal(t, "500000000", policy.Erc20SpendCap.Amount)
+
+	// Grant material is secret-grade: neither the submit response nor the
+	// list may carry calldata, the carrier nonce, or the owner's signature.
+	for _, marker := range []string{"install_call", "owner_signature", "carrier_nonce", "installCall", "ownerSignature"} {
+		require.NotContains(t, rec.Body.String(), marker, "grant material leaked")
+	}
+
+	rec = rig.call(t, nil, func(c echo.Context) error {
+		return rig.server.ListWalletPolicies(c, address, generated.ListWalletPoliciesParams{})
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), string(prepared.PolicyId))
+	require.NotContains(t, rec.Body.String(), "ownerSignature")
+
+	// Revoke: pending → deleted outright, no on-chain cleanup.
+	rec = rig.call(t, nil, func(c echo.Context) error {
+		return rig.server.RevokeWalletPolicy(c, address, prepared.PolicyId, generated.RevokeWalletPolicyParams{})
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var revoked generated.RevokePolicyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &revoked))
+	require.Equal(t, "deleted", string(revoked.Status))
+	require.False(t, revoked.OnChainCleanupRequired)
+}
+
+func TestPoliciesSubmitRejectsTamperedCapOverHTTP(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+
+	rec := rig.call(t, prepareBody(policyTestChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+
+	sig, err := crypto.Sign(common.HexToHash(prepared.Digest).Bytes(), rig.ownerKey)
+	require.NoError(t, err)
+	sig[64] += 27
+
+	body := prepareBody(policyTestChain)
+	body.Erc20SpendCap.Amount = "999999999999" // not what the owner signed
+	submit := generated.SubmitPolicyRequest{
+		ChainId: body.ChainId, PolicyId: prepared.PolicyId, EntityId: prepared.EntityId,
+		Deadline: prepared.Deadline, ValidUntil: prepared.ValidUntil,
+		AgentLabel: body.AgentLabel, AllowedActions: body.AllowedActions,
+		Erc20SpendCap: body.Erc20SpendCap, Signature: fmt.Sprintf("0x%x", sig),
+	}
+	rec = rig.call(t, submit, func(c echo.Context) error {
+		return rig.server.SubmitWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.True(t, strings.Contains(rec.Body.String(), "POLICIES_BAD_SIGNATURE"),
+		"a tampered echo must surface as a signature mismatch, got: %s", rec.Body.String())
+}

--- a/aggregator/rest/partner.go
+++ b/aggregator/rest/partner.go
@@ -135,6 +135,37 @@ func (s *Server) requireWalletDeriveAuth(ctx echo.Context) (*model.User, error) 
 	return user, nil
 }
 
+// refusePartnerAssertion explicitly rejects a request that presents
+// X-Partner-Assertion on an endpoint partner delegation may never reach.
+//
+// Session-policy management is FUND AUTHORITY: a policy record carries the
+// owner's signed grant of on-chain execution rights, and creating, reading,
+// or revoking one is exactly the class of operation the package comment
+// above excludes from delegation. The failure mode this guard exists for is
+// silent non-consultation — a handler that authenticates the user JWT and
+// never looks at the assertion header, leaving a partner integrating against
+// the wrong endpoint to discover the boundary from behavior instead of from
+// an error.
+//
+// The assertion is refused WITHOUT verification, valid or not: the boundary
+// is categorical, verification costs signature checks, and a
+// validity-dependent response would make this endpoint an oracle for
+// assertion validity.
+//
+// MUST be the first line of every /policies handler (avs-infra master doc
+// §7.4a; the decision predates the routes). Returns nil when no assertion is
+// present — user-JWT requests pass through untouched.
+func refusePartnerAssertion(ctx echo.Context, capability string) error {
+	if strings.TrimSpace(ctx.Request().Header.Get(partnerAssertionHeader)) == "" {
+		return nil
+	}
+	return partnerError(http.StatusForbidden, "PARTNER_DELEGATION_UNSUPPORTED",
+		"Partner delegation not supported here",
+		fmt.Sprintf("%s is fund authority and cannot be exercised through a partner assertion. "+
+			"Partner delegation covers the no-fund simulate family only; use the end-user's "+
+			"Bearer JWT (POST /api/v1/auth:exchange) for this endpoint.", capability))
+}
+
 // verifyPartnerAssertion validates the X-Partner-Assertion header against the
 // configured partner registry. It returns:
 //

--- a/aggregator/rest/partner_refusal_test.go
+++ b/aggregator/rest/partner_refusal_test.go
@@ -1,0 +1,59 @@
+package rest
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+)
+
+// The policy surface never honors partner delegation, and the refusal must be
+// explicit — a reasoned 403, not a handler that quietly ignores the header.
+
+func TestRefusePartnerAssertion_NoHeaderPassesThrough(t *testing.T) {
+	if err := refusePartnerAssertion(ctxWithAssertion(""), "Session-policy management"); err != nil {
+		t.Fatalf("a request without an assertion must pass: %v", err)
+	}
+}
+
+func TestRefusePartnerAssertion_RefusesWithoutVerifying(t *testing.T) {
+	// Garbage that could never verify — refused for WHERE it was sent, not
+	// for what it is.
+	err := refusePartnerAssertion(ctxWithAssertion("not-a-jwt"), "Session-policy management")
+	assertDelegationRefusal(t, err)
+}
+
+func TestRefusePartnerAssertion_RefusesEvenAValidAssertion(t *testing.T) {
+	// A fully valid assertion from an active, correctly-scoped partner is
+	// refused identically: the boundary is categorical, and the response must
+	// not become an oracle for assertion validity.
+	_, priv, _ := ed25519.GenerateKey(nil)
+	err := refusePartnerAssertion(
+		ctxWithAssertion(signAssertion(t, priv, validClaims())), "Session-policy management")
+	assertDelegationRefusal(t, err)
+}
+
+func assertDelegationRefusal(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	var httpErr *restmw.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected an HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.Status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", httpErr.Status)
+	}
+	if httpErr.Code != "PARTNER_DELEGATION_UNSUPPORTED" {
+		t.Fatalf("code = %s, want PARTNER_DELEGATION_UNSUPPORTED", httpErr.Code)
+	}
+	// The reason must name the boundary and the way forward.
+	if !strings.Contains(httpErr.Detail, "fund authority") ||
+		!strings.Contains(httpErr.Detail, "Bearer JWT") {
+		t.Fatalf("detail should explain the fund-authority boundary and point at the JWT path, got: %s", httpErr.Detail)
+	}
+}

--- a/aggregator/rest/server.go
+++ b/aggregator/rest/server.go
@@ -372,6 +372,15 @@ func registerColonActionShimRoutes(api *echo.Group, s *Server) {
 		return s.SignalExecution(c, generated.Ulid(c.Param("id")), params)
 	})
 
+	// Session-policy grant flow: prepare → sign → submit. Nested under the
+	// wallet, so the shim path carries the :address parameter.
+	api.POST("/wallets/:address/policies"+colonActionShim+"prepare", func(c echo.Context) error {
+		return s.PrepareWalletPolicy(c, generated.EthereumAddress(c.Param("address")))
+	})
+	api.POST("/wallets/:address/policies"+colonActionShim+"submit", func(c echo.Context) error {
+		return s.SubmitWalletPolicy(c, generated.EthereumAddress(c.Param("address")))
+	})
+
 	// Collection-level actions. Routed via the generated wrapper so the
 	// oapi-codegen runtime handles query-param binding the same way the
 	// non-shim routes would.

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
@@ -383,8 +382,7 @@ func (r *RpcServer) ExecuteWithdraw(ctx context.Context, user *model.User, paylo
 	if userOp != nil {
 		// Get UserOp hash — sign against the chain we actually targeted
 		// so the hash matches what the bundler/paymaster validated.
-		userOpHash := userOp.GetUserOpHash(swCfg.EntrypointAddress, big.NewInt(swCfg.ChainID))
-		resp.UserOpHash = userOpHash.Hex()
+		resp.UserOpHash = userOp.UserOpHash.Hex()
 	}
 
 	if receipt != nil {
@@ -438,7 +436,7 @@ func (r *RpcServer) sendUserOpWithGlobalWs(
 	smartWalletAddress *common.Address,
 	paymasterReq *preset.VerifyingPaymasterRequest,
 	requestedChainID int64,
-) (*userop.UserOperation, *types.Receipt, error) {
+) (*preset.SentUserOp, *types.Receipt, error) {
 	// Gateway mode: route to worker
 	if r.chainRegistry != nil {
 		return r.sendUserOpViaWorker(owner, callData, smartWalletAddress, paymasterReq, requestedChainID)
@@ -447,7 +445,7 @@ func (r *RpcServer) sendUserOpWithGlobalWs(
 	// Use global WebSocket client if available, otherwise fall back to creating new connection
 	// Note: salt=nil here because rpc_server callers (e.g. WithdrawFunds) operate on already-deployed wallets
 	if r.smartWalletWsRpc != nil {
-		return preset.SendUserOpWithWsClient(
+		return preset.SendUserOpAutoWithWsClient(
 			r.config.SmartWallet,
 			owner,
 			callData,
@@ -461,7 +459,7 @@ func (r *RpcServer) sendUserOpWithGlobalWs(
 	} else {
 		// Fallback to original method (creates new WebSocket connection)
 		r.config.Logger.Warn("Global WebSocket client not available, using fallback method")
-		return preset.SendUserOp(
+		return preset.SendUserOpAuto(
 			r.config.SmartWallet,
 			owner,
 			callData,
@@ -482,7 +480,7 @@ func (r *RpcServer) sendUserOpViaWorker(
 	smartWalletAddress *common.Address,
 	paymasterReq *preset.VerifyingPaymasterRequest,
 	chainID int64,
-) (*userop.UserOperation, *types.Receipt, error) {
+) (*preset.SentUserOp, *types.Receipt, error) {
 	worker, err := r.chainRegistry.GetWorker(chainID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("no worker for chain %d: %w", chainID, err)
@@ -517,7 +515,14 @@ func (r *RpcServer) sendUserOpViaWorker(
 		}
 	}
 
-	return nil, receipt, nil
+	// The worker already reports the hash; discarding the operation here left
+	// resp.UserOpHash empty in gateway mode. Only the hash crosses the RPC
+	// boundary, so the rest of SentUserOp stays zero.
+	sent := &preset.SentUserOp{UserOpHash: common.HexToHash(resp.UserOpHash)}
+	if smartWalletAddress != nil {
+		sent.Sender = *smartWalletAddress
+	}
+	return sent, receipt, nil
 }
 
 // (Aggregator-service gRPC handlers — CreateTask, ListTasks, GetTask,

--- a/aggregator/task_engine.go
+++ b/aggregator/task_engine.go
@@ -227,6 +227,11 @@ func (agg *Aggregator) startTaskEngine(ctx context.Context) {
 		agg.queue,
 		agg.logger,
 	)
+	// Teach the send path where session grants live. Installed here — the one
+	// place a single production engine exists — rather than in New, which test
+	// suites call many times per process (the resolver is process-global, and
+	// engines constructed later would silently overwrite earlier ones).
+	agg.engine.InstallSessionResolver()
 
 	// Price service for fee conversion (USD → ETH and ERC20 lookups). When
 	// Moralis isn't configured, it stays nil and callers gracefully degrade

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1639,6 +1639,180 @@ components:
           type: array
           items: { $ref: '#/components/schemas/OperatorInfo' }
 
+    # -------------------------------------------------------------------
+    # Session policies
+    # -------------------------------------------------------------------
+
+    AllowedAction:
+      type: object
+      required: [target, selectors]
+      properties:
+        target:
+          $ref: '#/components/schemas/EthereumAddress'
+        selectors:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            pattern: '^0x[a-fA-F0-9]{8}$'
+          description: 4-byte function selectors permitted on the target.
+      description: One contract the agent may call, scoped to selectors.
+
+    Erc20SpendCap:
+      type: object
+      required: [token, amount]
+      properties:
+        token:
+          $ref: '#/components/schemas/EthereumAddress'
+        amount:
+          type: string
+          pattern: '^[0-9]+$'
+          description: Total cap in the token's smallest unit (decimal string, no reset).
+          example: '500000000'
+      description: |
+        Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+        token must appear as an `allowedActions` target.
+
+    PreparePolicyRequest:
+      type: object
+      required: [chainId, agentLabel, allowedActions, erc20SpendCap, expiresInSeconds]
+      properties:
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        agentLabel:
+          type: string
+          minLength: 1
+          maxLength: 120
+        justification:
+          type: string
+          maxLength: 500
+        allowedActions:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        expiresInSeconds:
+          type: integer
+          format: int64
+          minimum: 60
+          description: Grant lifetime, relative (skew-proof). Becomes an absolute validUntil.
+
+    PreparedPolicy:
+      type: object
+      required: [policyId, chainId, entityId, sessionSigner, deadline, validUntil, digest, typedData]
+      properties:
+        policyId: { $ref: '#/components/schemas/Ulid' }
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        entityId:
+          type: integer
+          format: int64
+          description: The validation entity allocated for this grant (provisional until submit).
+        sessionSigner:
+          $ref: '#/components/schemas/EthereumAddress'
+        deadline:
+          type: integer
+          format: int64
+          description: Unix seconds; bounds signing → first use, NOT the grant lifetime.
+        validUntil:
+          type: integer
+          format: int64
+          description: Absolute grant expiry, unix milliseconds. Echo verbatim to submit.
+        digest:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{64}$'
+          description: The EIP-712 hash the typed data produces, for client-side verification.
+        typedData:
+          type: object
+          additionalProperties: true
+          description: The exact eth_signTypedData_v4 payload for the owner's wallet.
+
+    SubmitPolicyRequest:
+      type: object
+      required: [chainId, policyId, entityId, deadline, validUntil, agentLabel, allowedActions, erc20SpendCap, signature]
+      properties:
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        policyId: { $ref: '#/components/schemas/Ulid' }
+        entityId:
+          type: integer
+          format: int64
+        deadline:
+          type: integer
+          format: int64
+        validUntil:
+          type: integer
+          format: int64
+          description: The ABSOLUTE expiry from prepare. It is baked into the signed calldata; recomputing it would change the digest.
+        agentLabel:
+          type: string
+          minLength: 1
+          maxLength: 120
+        justification:
+          type: string
+          maxLength: 500
+        allowedActions:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        signature:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{130}$'
+          description: The owner's 65-byte signature over the prepared digest.
+
+    SessionPolicy:
+      type: object
+      required: [id, runner, chainId, status, entityId, sessionSigner, agentLabel, validUntil, createdAt]
+      properties:
+        id: { $ref: '#/components/schemas/Ulid' }
+        runner: { $ref: '#/components/schemas/EthereumAddress' }
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        status:
+          type: string
+          enum: [pending, active, revoked]
+          description: |
+            pending = signed and stored, install not yet on-chain (revocable
+            for free). active = install applied. revoked = grants nothing.
+        entityId:
+          type: integer
+          format: int64
+        sessionSigner:
+          $ref: '#/components/schemas/EthereumAddress'
+        agentLabel: { type: string }
+        justification: { type: string }
+        allowedActions:
+          type: array
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        validUntil:
+          type: integer
+          format: int64
+          description: Unix milliseconds.
+        createdAt:
+          type: integer
+          format: int64
+          description: Unix milliseconds.
+
+    SessionPolicyList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/SessionPolicy' }
+
+    RevokePolicyResponse:
+      type: object
+      required: [status, onChainCleanupRequired]
+      properties:
+        status:
+          type: string
+          enum: [deleted, revoked]
+          description: deleted = was pending, nothing was ever installed. revoked = retained for audit.
+        onChainCleanupRequired:
+          type: boolean
+          description: |
+            True when the grant's validation is still installed on the
+            account and needs the owner's uninstallValidation to clear.
+
   responses:
     BadRequest:
       description: Request validation failed.
@@ -2343,6 +2517,153 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/NonceResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # =====================================================================
+  # Session policies — grants of execution authority on a wallet
+  # =====================================================================
+  # A policy is the record behind the grant screen: which agent may act on a
+  # wallet, bounded by allowed actions, an ERC-20 spend cap, and an expiry.
+  # Granting is prepare → sign → submit: the wallet needs the EIP-712 payload
+  # before the owner can sign it, and nothing is stored until the signature
+  # comes back. Fund authority — never reachable through a partner assertion.
+
+  /wallets/{address}/policies:prepare:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+    post:
+      tags: [Policies]
+      summary: Allocate a grant and return the EIP-712 payload the owner signs
+      description: |
+        Allocates the policy id, validation entity, and session signer, builds
+        the exact `installValidation` calldata the signature will commit to,
+        and returns the typed data for `eth_signTypedData_v4`. Stores nothing:
+        a prepare that is never submitted leaves no state behind. The echoed
+        fields must be passed back verbatim to `:submit` — the gateway
+        recomputes everything from them, so tampering only produces a
+        signature that no longer verifies.
+      operationId: prepareWalletPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PreparePolicyRequest' }
+      responses:
+        '200':
+          description: Payload to sign, plus the allocations submit must echo.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PreparedPolicy' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /wallets/{address}/policies:submit:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+    post:
+      tags: [Policies]
+      summary: Submit the owner's signature and persist the grant
+      description: |
+        Recomputes the grant from the echoed prepare fields, verifies the
+        signature recovers to the authenticated owner, re-checks the entity
+        allocation inside the write, and stores the policy as `pending`. The
+        install itself rides the first workflow operation on this wallet —
+        nothing reaches the chain here.
+      operationId: submitWalletPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SubmitPolicyRequest' }
+      responses:
+        '201':
+          description: Grant stored; the gateway may now execute within it.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicy' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: |
+            The validation entity was taken by another grant while this one
+            was being signed. Prepare again.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+
+  /wallets/{address}/policies:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+      - $ref: '#/components/parameters/ChainIdQuery'
+    get:
+      tags: [Policies]
+      summary: List the wallet's session policies
+      description: Grant material (calldata, signatures) is never echoed.
+      operationId: listWalletPolicies
+      responses:
+        '200':
+          description: Policies for this wallet, newest first.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicyList' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /wallets/{address}/policies/{policyId}:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+      - name: policyId
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/Ulid' }
+      - $ref: '#/components/parameters/ChainIdQuery'
+    get:
+      tags: [Policies]
+      summary: Get one session policy
+      operationId: getWalletPolicy
+      responses:
+        '200':
+          description: The policy.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicy' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [Policies]
+      summary: Revoke a session policy
+      description: |
+        A `pending` grant (never used on-chain) is deleted outright — nothing
+        was installed, so nothing remains. An `active` grant stops authorizing
+        immediately, but its on-chain validation still exists until the owner
+        executes `uninstallValidation`; the response says which case applied.
+      operationId: revokeWalletPolicy
+      responses:
+        '200':
+          description: Revocation outcome.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RevokePolicyResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
   # =====================================================================

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -88,15 +88,17 @@ smart_wallet:
   # time. 'self_hosted' remains for a locally-run Voltaire; the shared Voltaire
   # bundlers this example used to assume were retired 2026-07.
   bundler_provider:       alchemy
-  # account_provider selects the smart-account implementation. Unlike
-  # bundler_provider, this defaults to the OLD value (simple_account) and is
-  # opt-in per chain — switching it changes the DERIVED ADDRESS for every
-  # (owner, salt), so flipping it on a chain with existing users moves their
-  # wallets and orphans any task whose runner references the old address.
-  # Roll it out one chain at a time, and re-onboard wallets on that chain.
-  #   simple_account      v0.6 SimpleAccount via smart_wallet.factory_address
-  #   modular_account_v2  Alchemy MA v2 via the canonical AccountFactory
-  account_provider:       simple_account
+  # account_provider selects the smart-account implementation. It now defaults
+  # to modular_account_v2 on every chain; this line names the value rather than
+  # opting in to it.
+  #
+  # Be aware of what it controls: the setting decides the DERIVED ADDRESS for
+  # every (owner, salt). Changing it moves every wallet on the chain, and a
+  # wallet created under the other provider stops executing — dispatch follows
+  # the chain's setting, not the individual wallet.
+  #   modular_account_v2  Alchemy MA v2 via the canonical AccountFactory (v0.7)
+  #   simple_account      legacy v0.6 SimpleAccount via smart_wallet.factory_address
+  account_provider:       modular_account_v2
   alchemy_api_key:        ${ALCHEMY_API_KEY}
   controller_private_key: <testnet-controller-private-key-hex>
   paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92

--- a/core/chainio/aa/aa.go
+++ b/core/chainio/aa/aa.go
@@ -36,25 +36,68 @@ var (
 	factoryAddressMu sync.RWMutex
 )
 
-// SetFactoryAddress sets the factory proxy address from config
-// This should be called during initialization with the value from config.SmartWallet.FactoryAddress
-// which already handles default value and YAML override
+// SetFactoryAddress sets the factory proxy address used by the global-factory
+// helpers (GetSenderAddress, GetNonce...).
+//
+// Prefer SetFactoryAddressForConfig. Passing config.SmartWallet.FactoryAddress
+// straight in is now wrong on any chain running Modular Account v2: that field
+// is the SimpleAccount factory, and since GetSenderAddress infers the account
+// implementation from this value, an MA v2 chain would silently derive v0.6
+// addresses everywhere the global factory is used.
 func SetFactoryAddress(address common.Address) {
 	factoryAddressMu.Lock()
 	defer factoryAddressMu.Unlock()
 	factoryAddress = address
 }
 
-// getFactoryAddress returns the current factory address, with fallback to default from config
+// SetFactoryAddressForConfig sets the global factory to the one this chain's
+// configured account provider actually creates accounts at, which is the only
+// value the global-factory helpers can derive correctly against.
+func SetFactoryAddressForConfig(swCfg *config.SmartWalletConfig) error {
+	effective, err := EffectiveFactory(swCfg)
+	if err != nil {
+		return err
+	}
+	SetFactoryAddress(effective)
+	return nil
+}
+
+// getFactoryAddress returns the current factory address, falling back to the
+// factory of the DEFAULT account provider when nothing has been set.
+//
+// The fallback must track config's default account_provider, which is
+// modular_account_v2. It used to be config.DefaultFactoryProxyAddressHex — the
+// v0.6 SimpleAccountFactory — and that became wrong the moment GetSenderAddress
+// started inferring the account implementation from this value: any caller
+// reaching the global before SetFactoryAddressForConfig ran would derive a v0.6
+// address on an MA v2 chain, silently and with no error to notice.
+//
+// That is not a hypothetical ordering problem. model.LoadDefaultSmartWallet and
+// the preset builders all go through GetSenderAddress, and the whole Go test
+// suite hits this path because most tests never construct an Engine.
 func getFactoryAddress() common.Address {
 	factoryAddressMu.RLock()
 	defer factoryAddressMu.RUnlock()
 	if factoryAddress != (common.Address{}) {
 		return factoryAddress
 	}
-	// Fallback to default if not set (shouldn't happen in normal operation)
-	// This uses the default from config package, which can be overridden in YAML
-	return common.HexToAddress(config.DefaultFactoryProxyAddressHex)
+	return defaultProviderFactory()
+}
+
+// defaultProviderFactory is the factory belonging to config's default
+// account_provider. Resolved through the same routing every other caller uses,
+// so it cannot drift from it.
+func defaultProviderFactory() common.Address {
+	var swCfg config.SmartWalletConfig // zero value == unset provider == the default
+	factory, err := FactoryAddressForProvider(
+		AccountProvider(swCfg.AccountProviderName()),
+		common.HexToAddress(config.DefaultFactoryProxyAddressHex),
+	)
+	if err != nil {
+		// Unreachable: the default provider is by definition a known one.
+		return common.HexToAddress(config.DefaultFactoryProxyAddressHex)
+	}
+	return factory
 }
 
 func SetEntrypointAddress(address common.Address) {
@@ -126,11 +169,17 @@ func computeSmartWalletAddress(factoryAddr common.Address, ownerAddress common.A
 	return common.BytesToAddress(hash[12:]), nil
 }
 
-// GetSenderAddress is a wrapper that uses the factory address from config
-// It calls GetSenderAddressForFactory with the factory address set via SetFactoryAddress()
-// which reads from config (with default value and YAML override support)
+// GetSenderAddress is a wrapper that uses the factory address from config,
+// set via SetFactoryAddress().
+//
+// It routes through DeriveSenderAddressAuto rather than calling
+// GetSenderAddressForFactory directly, so the account implementation follows
+// the configured factory. Callers of SetFactoryAddress must therefore pass the
+// EFFECTIVE factory (see EffectiveFactory) — passing the raw
+// smart_wallet.factory_address on an MA v2 chain would derive the wrong
+// address here, and every global-factory caller would inherit the mistake.
 func GetSenderAddress(conn *ethclient.Client, ownerAddress common.Address, salt *big.Int) (*common.Address, error) {
-	return GetSenderAddressForFactory(conn, ownerAddress, getFactoryAddress(), salt)
+	return DeriveSenderAddressAuto(conn, ownerAddress, getFactoryAddress(), salt)
 }
 
 // GetSenderAddressForFactory computes the smart wallet address using the factory proxy address

--- a/core/chainio/aa/aa.go
+++ b/core/chainio/aa/aa.go
@@ -355,13 +355,14 @@ func PackExecuteBatchWithValues(targetAddresses []common.Address, values []*big.
 	return result, nil
 }
 
-// UnpackExecuteCalldata decodes SimpleAccount smart-wallet calldata — produced by PackExecute,
-// PackExecuteBatch, or PackExecuteBatchWithValues — back into per-call (target, value, data)
-// tuples. It dispatches on the 4-byte function selector via the embedded ABI, so it stays correct
-// regardless of which pack helper produced the calldata:
-//   - execute(address,uint256,bytes)                  → one entry
-//   - executeBatch(address[],bytes[])                 → N entries, all values 0
-//   - executeBatchWithValues(address[],uint256[],bytes[]) → N entries with explicit values
+// UnpackExecuteCalldata decodes smart-wallet execution calldata — produced by any of the pack
+// helpers, v0.6 or MA v2 — back into per-call (target, value, data) tuples. It dispatches on the
+// 4-byte function selector via the embedded ABIs, so it stays correct regardless of which pack
+// helper produced the calldata:
+//   - execute(address,uint256,bytes)                  → one entry (identical in both accounts)
+//   - executeBatch(address[],bytes[])                 → N entries, all values 0 (v0.6)
+//   - executeBatchWithValues(address[],uint256[],bytes[]) → N entries with explicit values (v0.6 fork)
+//   - executeBatch((address,uint256,bytes)[])         → N entries, per-tuple values (MA v2)
 //
 // It is the inverse the paymaster reimbursement wrapper needs to append its own batch entries onto
 // an already-batched call without having to know how that call was originally packed.
@@ -377,7 +378,9 @@ func UnpackExecuteCalldata(calldata []byte) (targets []common.Address, values []
 	selector := calldata[:4]
 	method, err := parsedABI.MethodById(selector)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unrecognized smart-wallet method selector 0x%x: %w", selector, err)
+		// Not a v0.6 SimpleAccount method — try the MA v2 account, whose
+		// batch selector differs (tuple-array form; see ma_v2.go).
+		return unpackExecuteCalldataMAv2(calldata, selector)
 	}
 
 	args, err := method.Inputs.Unpack(calldata[4:])
@@ -440,4 +443,34 @@ func UnpackExecuteCalldata(calldata []byte) (targets []common.Address, values []
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported smart-wallet method %q for reimbursement wrapping", method.Name)
 	}
+}
+
+// unpackExecuteCalldataMAv2 decodes the MA v2 executeBatch tuple form.
+// (MA v2's `execute` shares the v0.6 selector and never reaches here.)
+func unpackExecuteCalldataMAv2(calldata, selector []byte) (targets []common.Address, values []*big.Int, datas [][]byte, err error) {
+	parsedABI, err := ensureModularAccountABI()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	method, err := parsedABI.MethodById(selector)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unrecognized smart-wallet method selector 0x%x: %w", selector, err)
+	}
+	args, err := method.Inputs.Unpack(calldata[4:])
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to unpack MA v2 %s calldata: %w", method.Name, err)
+	}
+	if method.Name != "executeBatch" || len(args) != 1 {
+		return nil, nil, nil, fmt.Errorf("unsupported MA v2 smart-wallet method %q", method.Name)
+	}
+	calls := *abi.ConvertType(args[0], new([]Call)).(*[]Call)
+	targets = make([]common.Address, len(calls))
+	values = make([]*big.Int, len(calls))
+	datas = make([][]byte, len(calls))
+	for i, call := range calls {
+		targets[i] = call.Target
+		values[i] = call.Value
+		datas[i] = call.Data
+	}
+	return targets, values, datas, nil
 }

--- a/core/chainio/aa/derive.go
+++ b/core/chainio/aa/derive.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -13,8 +14,14 @@ import (
 // derived from. The string values match core/config's account_provider so a
 // caller can pass either the raw yaml value or config's normalised
 // AccountProviderName() straight through — both are trimmed and lowercased
-// here. The type is redeclared rather than imported to keep chainio free of a
-// config dependency.
+// here.
+//
+// The type is redeclared rather than imported from config. That was originally
+// justified as keeping chainio free of a config dependency, which is not true:
+// aa.go already imports config. The redeclaration survives because it keeps
+// this file's derivation logic expressible in its own terms, but it does mean
+// two independent sets of string constants — see the cross-package drift guard
+// in core/taskengine, which is what actually holds them together.
 type AccountProvider string
 
 const (
@@ -32,9 +39,9 @@ const (
 // nothing will ever deploy to. Routing both through one function keeps that
 // pairing in a single place.
 //
-// An empty provider is SimpleAccount, matching config's default. That default
-// is deliberate: MA v2 derives different addresses for the same (owner, salt),
-// so silently defaulting to it would move every existing user's wallet.
+// An empty provider is Modular Account v2, matching config's default. Note
+// that this means MA v2 is what an unconfigured caller gets, and MA v2 derives
+// different addresses for the same (owner, salt) than SimpleAccount does.
 func DeriveSenderAddress(conn *ethclient.Client, owner common.Address, salt *big.Int, provider AccountProvider) (*common.Address, error) {
 	switch normaliseProvider(provider) {
 	case ProviderSimpleAccount:
@@ -45,6 +52,135 @@ func DeriveSenderAddress(conn *ethclient.Client, owner common.Address, salt *big
 		return nil, fmt.Errorf("unknown account provider %q; expected %q or %q",
 			provider, ProviderSimpleAccount, ProviderModularAccountV2)
 	}
+}
+
+// DeriveSenderAddressForFactory is DeriveSenderAddress against an explicit
+// factory rather than the package-global one. Most callers want this: the
+// factory is per-chain config, and deriving against the gateway's default
+// factory on a multi-chain task yields an address nothing will deploy to.
+//
+// The factory is honoured for BOTH providers, including MA v2 — whose factory
+// is the same constant on every chain today, but whose caller may be replaying
+// a wallet record written under a different one. Passing the recorded factory
+// back in is what lets an existing wallet re-derive to itself.
+func DeriveSenderAddressForFactory(conn *ethclient.Client, owner, factory common.Address, salt *big.Int, provider AccountProvider) (*common.Address, error) {
+	switch normaliseProvider(provider) {
+	case ProviderSimpleAccount:
+		return GetSenderAddressForFactory(conn, owner, factory, salt)
+	case ProviderModularAccountV2:
+		return GetSenderAddressMAv2ForFactory(conn, owner, factory, salt)
+	default:
+		return nil, fmt.Errorf("unknown account provider %q; expected %q or %q",
+			provider, ProviderSimpleAccount, ProviderModularAccountV2)
+	}
+}
+
+// DeriveSenderAddressAuto derives against a factory, inferring the provider
+// from that factory. Use it when re-deriving an address that already exists —
+// wallet-ownership checks, salt scans, anything replaying a stored record —
+// where the question is "what does THIS factory produce", not "what does this
+// chain create now".
+//
+// Because the factory carries the provider, this needs no extra parameter,
+// which is what keeps the ChainStateReader gRPC interface unchanged across the
+// v0.7 cutover: the worker is already given the factory.
+func DeriveSenderAddressAuto(conn *ethclient.Client, owner, factory common.Address, salt *big.Int) (*common.Address, error) {
+	return DeriveSenderAddressForFactory(conn, owner, factory, salt, ProviderForFactory(factory))
+}
+
+// DeriveInitCodeAuto returns the (factory, factoryData) pair that deploys the
+// account for (owner, salt), inferring the account implementation from the
+// factory — the init-code counterpart to DeriveSenderAddressAuto.
+//
+// The two providers build deployment calldata with different factory methods,
+// so this must route in lockstep with derivation. Building SimpleAccount
+// init code for an address derived as MA v2 produces a UserOperation whose
+// initCode deploys to a different address than its sender field, which the
+// EntryPoint rejects as AA14.
+func DeriveInitCodeAuto(owner, factory common.Address, salt *big.Int) (common.Address, []byte, error) {
+	switch ProviderForFactory(factory) {
+	case ProviderModularAccountV2:
+		return GetInitCodeMAv2ForFactory(owner, factory, salt)
+	default:
+		hexCode, err := GetInitCodeForFactory(owner.Hex(), factory, salt)
+		if err != nil {
+			return common.Address{}, nil, err
+		}
+		raw := common.FromHex(hexCode)
+		// initCode is factory(20 bytes) ++ calldata. Anything shorter means the
+		// builder returned something that is not init code at all.
+		if len(raw) <= common.AddressLength {
+			return common.Address{}, nil, fmt.Errorf("init code is %d bytes, too short to contain a factory and calldata", len(raw))
+		}
+		return factory, raw[common.AddressLength:], nil
+	}
+}
+
+// PackExecuteBatchAuto builds atomic-batch calldata for the account
+// implementation this factory belongs to.
+//
+// Unlike execute(), batching did NOT carry over. MA v2 has a single
+// executeBatch((address,uint256,bytes)[]) that always takes per-call values;
+// the v0.6 account has two entry points, executeBatch(address[],bytes[]) and
+// executeBatchWithValues(...), with different selectors. Sending v0.6 batch
+// calldata to an MA v2 account reverts in validation as AA23, which names
+// neither the batch nor the account type.
+//
+// Callers pass values regardless; the v0.6 branch drops them when every value
+// is zero, because executeBatchWithValues (0xc3ff72fc) is not simulatable by
+// the bundler while plain executeBatch is.
+func PackExecuteBatchAuto(factory common.Address, targets []common.Address, values []*big.Int, datas [][]byte) ([]byte, error) {
+	if len(targets) != len(datas) || len(targets) != len(values) {
+		return nil, fmt.Errorf("batch arity mismatch: %d targets, %d values, %d calldatas",
+			len(targets), len(values), len(datas))
+	}
+	if ProviderForFactory(factory) == ProviderModularAccountV2 {
+		calls := make([]Call, len(targets))
+		for i := range targets {
+			calls[i] = Call{Target: targets[i], Value: values[i], Data: datas[i]}
+		}
+		return PackExecuteBatchMAv2(calls)
+	}
+	anyValue := false
+	for _, v := range values {
+		if v != nil && v.Sign() != 0 {
+			anyValue = true
+			break
+		}
+	}
+	if anyValue {
+		return PackExecuteBatchWithValues(targets, values, datas)
+	}
+	return PackExecuteBatch(targets, datas)
+}
+
+// EffectiveFactory returns the factory this chain creates accounts at NOW,
+// which is the MA v2 constant on an MA v2 chain and the configured
+// smart_wallet.factory_address otherwise.
+//
+// Reach for this anywhere the old code passed swCfg.FactoryAddress into a
+// derivation. Passing the raw configured address after the v0.7 cutover
+// derives a SimpleAccount address on a chain that creates MA v2 accounts —
+// silently, since both calls succeed and return a well-formed address that
+// simply holds nothing.
+func EffectiveFactory(swCfg *config.SmartWalletConfig) (common.Address, error) {
+	if swCfg == nil {
+		return common.Address{}, fmt.Errorf("nil smart wallet config")
+	}
+	return FactoryAddressForProvider(AccountProvider(swCfg.AccountProviderName()), swCfg.FactoryAddress)
+}
+
+// ProviderForFactory reports which provider created an account at this
+// factory. This is the per-WALLET counterpart to config's per-chain setting,
+// and the two are not interchangeable: after the v0.7 cutover a chain's config
+// says modular_account_v2 while wallets created before it still carry the
+// SimpleAccount factory on their stored record. Execution has to follow the
+// wallet, not the chain, or it sends a v0.7 operation to a v0.6 account.
+func ProviderForFactory(factory common.Address) AccountProvider {
+	if factory == MAv2FactoryAddress() {
+		return ProviderModularAccountV2
+	}
+	return ProviderSimpleAccount
 }
 
 // FactoryAddressForProvider returns the factory an account of this provider is
@@ -77,7 +213,7 @@ func FactoryAddressForProvider(provider AccountProvider, simpleAccountFactory co
 func normaliseProvider(p AccountProvider) AccountProvider {
 	n := AccountProvider(strings.ToLower(strings.TrimSpace(string(p))))
 	if n == "" {
-		return ProviderSimpleAccount
+		return ProviderModularAccountV2
 	}
 	return n
 }

--- a/core/chainio/aa/derive_routing_test.go
+++ b/core/chainio/aa/derive_routing_test.go
@@ -1,0 +1,207 @@
+package aa
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// A SimpleAccount factory is any address that is not the MA v2 constant.
+var simpleAccountFactory = common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
+
+// The whole cutover rests on this: the factory address carries the provider,
+// which is what lets ChainStateReader (and its gRPC surface) stay unchanged
+// while derivation switches implementation.
+func TestProviderForFactory(t *testing.T) {
+	if got := ProviderForFactory(MAv2FactoryAddress()); got != ProviderModularAccountV2 {
+		t.Errorf("MA v2 factory resolved to %q, want %q", got, ProviderModularAccountV2)
+	}
+	if got := ProviderForFactory(simpleAccountFactory); got != ProviderSimpleAccount {
+		t.Errorf("SimpleAccount factory resolved to %q, want %q", got, ProviderSimpleAccount)
+	}
+	// The zero address is not the MA v2 factory, so it must not be treated as
+	// one. Deriving MA v2 against a zero factory would silently produce an
+	// address for an account nothing can deploy.
+	if got := ProviderForFactory(common.Address{}); got != ProviderSimpleAccount {
+		t.Errorf("zero factory resolved to %q, want %q", got, ProviderSimpleAccount)
+	}
+}
+
+func TestEffectiveFactory(t *testing.T) {
+	t.Run("MA v2 chain ignores the configured SimpleAccount factory", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{
+			FactoryAddress:  simpleAccountFactory,
+			AccountProvider: config.AccountProviderModularAccountV2,
+		}
+		got, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("EffectiveFactory: %v", err)
+		}
+		if got != MAv2FactoryAddress() {
+			t.Errorf("factory = %s, want %s", got.Hex(), MAv2FactoryAddress().Hex())
+		}
+	})
+
+	t.Run("unset provider is MA v2, matching the post-cutover default", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{FactoryAddress: simpleAccountFactory}
+		got, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("EffectiveFactory: %v", err)
+		}
+		if got != MAv2FactoryAddress() {
+			t.Errorf("factory = %s, want the MA v2 factory %s", got.Hex(), MAv2FactoryAddress().Hex())
+		}
+	})
+
+	t.Run("pinned simple_account keeps the configured factory", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{
+			FactoryAddress:  simpleAccountFactory,
+			AccountProvider: config.AccountProviderSimpleAccount,
+		}
+		got, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("EffectiveFactory: %v", err)
+		}
+		if got != simpleAccountFactory {
+			t.Errorf("factory = %s, want %s", got.Hex(), simpleAccountFactory.Hex())
+		}
+	})
+
+	t.Run("nil config is an error, not a zero address", func(t *testing.T) {
+		if _, err := EffectiveFactory(nil); err == nil {
+			t.Error("expected an error for a nil config")
+		}
+	})
+
+	t.Run("simple_account with no configured factory is an error", func(t *testing.T) {
+		swCfg := &config.SmartWalletConfig{AccountProvider: config.AccountProviderSimpleAccount}
+		if _, err := EffectiveFactory(swCfg); err == nil {
+			t.Error("expected an error when simple_account has no factory configured")
+		}
+	})
+}
+
+// The round trip that keeps the two halves of the cutover honest: whatever
+// EffectiveFactory hands out must resolve back to the provider the config
+// asked for. If it doesn't, addresses get derived under one implementation and
+// recorded under another.
+func TestEffectiveFactoryRoundTripsToItsProvider(t *testing.T) {
+	for _, provider := range []string{
+		config.AccountProviderSimpleAccount,
+		config.AccountProviderModularAccountV2,
+		"", // the default
+	} {
+		swCfg := &config.SmartWalletConfig{
+			FactoryAddress:  simpleAccountFactory,
+			AccountProvider: provider,
+		}
+		factory, err := EffectiveFactory(swCfg)
+		if err != nil {
+			t.Fatalf("provider %q: %v", provider, err)
+		}
+		got := string(ProviderForFactory(factory))
+		if want := swCfg.AccountProviderName(); got != want {
+			t.Errorf("provider %q: factory %s resolves back to %q, want %q",
+				provider, factory.Hex(), got, want)
+		}
+	}
+}
+
+// Init code must route in lockstep with address derivation. If they disagree,
+// the UserOperation's initCode deploys to an address other than its sender and
+// the EntryPoint rejects it as AA14 — a failure that points nowhere near here.
+func TestDeriveInitCodeAutoRoutesOnFactory(t *testing.T) {
+	owner := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	salt := big.NewInt(0)
+
+	maFactory, maData, err := DeriveInitCodeAuto(owner, MAv2FactoryAddress(), salt)
+	if err != nil {
+		t.Fatalf("MA v2 init code: %v", err)
+	}
+	if maFactory != MAv2FactoryAddress() {
+		t.Errorf("MA v2 factory = %s, want %s", maFactory.Hex(), MAv2FactoryAddress().Hex())
+	}
+	if len(maData) == 0 {
+		t.Error("MA v2 factory data is empty")
+	}
+
+	simpleFactoryOut, simpleData, err := DeriveInitCodeAuto(owner, simpleAccountFactory, salt)
+	if err != nil {
+		t.Fatalf("SimpleAccount init code: %v", err)
+	}
+	if simpleFactoryOut != simpleAccountFactory {
+		t.Errorf("SimpleAccount factory = %s, want %s", simpleFactoryOut.Hex(), simpleAccountFactory.Hex())
+	}
+	if len(simpleData) == 0 {
+		t.Error("SimpleAccount factory data is empty")
+	}
+
+	// Different factory methods mean different selectors. Identical calldata
+	// would mean one branch is building the other's deployment.
+	if string(maData) == string(simpleData) {
+		t.Error("both providers produced identical factory data; the routing is not switching")
+	}
+}
+
+func TestDeriveInitCodeAutoStripsTheFactoryPrefix(t *testing.T) {
+	owner := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	_, data, err := DeriveInitCodeAuto(owner, simpleAccountFactory, big.NewInt(0))
+	if err != nil {
+		t.Fatalf("DeriveInitCodeAuto: %v", err)
+	}
+	// factoryData is the constructor call alone; leaving the 20-byte factory
+	// prefix on it would make the v0.7 wire form double-encode the factory.
+	if len(data) >= common.AddressLength &&
+		common.BytesToAddress(data[:common.AddressLength]) == simpleAccountFactory {
+		t.Error("factory data still begins with the factory address")
+	}
+	// A createAccount(address,uint256) call is a 4-byte selector plus two
+	// 32-byte words.
+	if len(data) != 4+32+32 {
+		t.Errorf("factory data is %d bytes, want %d", len(data), 4+32+32)
+	}
+}
+
+// DeriveSenderAddressForFactory and DeriveSenderAddressAuto both need a live
+// client to reach the factory, so the reachable assertion here is that an
+// unknown provider is refused before any dial happens.
+func TestDeriveSenderAddressForFactoryRejectsUnknownProvider(t *testing.T) {
+	owner := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	_, err := DeriveSenderAddressForFactory(nil, owner, simpleAccountFactory, big.NewInt(0), "not_a_provider")
+	if err == nil {
+		t.Error("expected an error for an unrecognised provider")
+	}
+}
+
+// The package-global factory is what GetSenderAddress derives against, and
+// GetSenderAddress infers the account implementation from it. So an unset
+// global must resolve to the DEFAULT provider's factory, not to the v0.6
+// SimpleAccountFactory.
+//
+// This regressed once already: the fallback stayed on
+// config.DefaultFactoryProxyAddressHex after the default provider flipped, so
+// every caller that reached the global before SetFactoryAddressForConfig ran
+// derived a v0.6 address on an MA v2 chain — silently, since both branches
+// return a well-formed address.
+func TestUnsetGlobalFactoryFollowsTheDefaultProvider(t *testing.T) {
+	SetFactoryAddress(common.Address{}) // simulate "never configured"
+
+	got := getFactoryAddress()
+	want, err := FactoryAddressForProvider("", common.HexToAddress(config.DefaultFactoryProxyAddressHex))
+	if err != nil {
+		t.Fatalf("FactoryAddressForProvider: %v", err)
+	}
+	if got != want {
+		t.Errorf("unset global factory = %s, want %s (the default provider's factory)",
+			got.Hex(), want.Hex())
+	}
+	if got == common.HexToAddress(config.DefaultFactoryProxyAddressHex) {
+		t.Error("unset global fell back to the v0.6 SimpleAccountFactory")
+	}
+	if ProviderForFactory(got) != ProviderModularAccountV2 {
+		t.Errorf("unset global resolves to provider %q, want %q",
+			ProviderForFactory(got), ProviderModularAccountV2)
+	}
+}

--- a/core/chainio/aa/derive_test.go
+++ b/core/chainio/aa/derive_test.go
@@ -7,15 +7,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// The default is the single most consequential line in this file. MA v2
-// derives DIFFERENT addresses for the same (owner, salt), so a default of
-// modular_account_v2 would move every existing user's wallet the moment a
-// gateway rolled out — orphaning funds and every task whose runner references
-// the old address. If someone "tidies" this to the newer value, this fails.
-func TestDefaultProviderIsSimpleAccount(t *testing.T) {
-	if got := normaliseProvider(""); got != ProviderSimpleAccount {
-		t.Fatalf("empty provider = %q, want %q — defaulting to MA v2 would move every existing wallet",
-			got, ProviderSimpleAccount)
+// The default is the single most consequential line in this file, and it must
+// track core/config's — see the cross-package guard in core/taskengine. The
+// EntryPoint v0.7 cutover moved it to modular_account_v2 on every chain. MA v2
+// derives DIFFERENT addresses for the same (owner, salt), so reverting this
+// silently moves every wallet back.
+func TestDefaultProviderIsModularAccountV2(t *testing.T) {
+	if got := normaliseProvider(""); got != ProviderModularAccountV2 {
+		t.Fatalf("empty provider = %q, want %q", got, ProviderModularAccountV2)
 	}
 }
 
@@ -32,10 +31,10 @@ func TestFactoryAddressForProvider(t *testing.T) {
 		}
 	})
 
-	t.Run("empty provider behaves as simple account", func(t *testing.T) {
+	t.Run("empty provider behaves as MA v2 and ignores the configured factory", func(t *testing.T) {
 		got, err := FactoryAddressForProvider("", simple)
-		if err != nil || got != simple {
-			t.Errorf("got (%s, %v), want (%s, nil)", got.Hex(), err, simple.Hex())
+		if err != nil || got != MAv2FactoryAddress() {
+			t.Errorf("got (%s, %v), want (%s, nil)", got.Hex(), err, MAv2FactoryAddress().Hex())
 		}
 	})
 
@@ -98,13 +97,13 @@ func TestDeriveSenderAddressRejectsUnknownProvider(t *testing.T) {
 // as an "unknown provider", which reads as a code bug rather than whitespace.
 func TestProviderNormalisationMatchesConfig(t *testing.T) {
 	for _, in := range []AccountProvider{
-		"modular_account_v2", "MODULAR_ACCOUNT_V2", " modular_account_v2 ", "Modular_Account_V2",
+		"", "   ", "modular_account_v2", "MODULAR_ACCOUNT_V2", " modular_account_v2 ", "Modular_Account_V2",
 	} {
 		if got := normaliseProvider(in); got != ProviderModularAccountV2 {
 			t.Errorf("normaliseProvider(%q) = %q, want %q", in, got, ProviderModularAccountV2)
 		}
 	}
-	for _, in := range []AccountProvider{"", "   ", "simple_account", "SIMPLE_ACCOUNT", " Simple_Account "} {
+	for _, in := range []AccountProvider{"simple_account", "SIMPLE_ACCOUNT", " Simple_Account "} {
 		if got := normaliseProvider(in); got != ProviderSimpleAccount {
 			t.Errorf("normaliseProvider(%q) = %q, want %q", in, got, ProviderSimpleAccount)
 		}

--- a/core/chainio/aa/ma_v2_hooks.go
+++ b/core/chainio/aa/ma_v2_hooks.go
@@ -1,0 +1,227 @@
+package aa
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Permission hooks for Modular Account v2 session grants.
+//
+// A SessionGrant's Hooks entries are `bytes25 HookConfig ++ initData`, sliced
+// at exactly those offsets by ModuleManagerInternals. The HookConfig layout
+// mirrors ValidationConfig — module (20) ++ entityId (4) ++ flags (1) — but
+// the flag byte means something different (ERC-6900 HookConfigLib):
+//
+//	bit 0 (1): hook type — 1 validation hook, 0 execution hook
+//	bit 1 (2): execution hook has a post-hook
+//	bit 2 (4): execution hook has a pre-hook
+//
+// Alchemy's stock permission modules divide the §6.3 grant screen between
+// them: AllowlistModule enforces WHERE (targets/selectors, at validation) and
+// HOW MUCH of an ERC-20 (spend limit, at execution); TimeRangeModule enforces
+// HOW LONG (via ERC-4337 validation data, checked by the EntryPoint).
+//
+// The execution-hook half of the allowlist has a structural consequence: an
+// account whose validation carries ANY execution hook refuses operations
+// whose callData is not executeUserOp-wrapped (RequireUserOperationContext),
+// because without user-op context the account cannot tell at execution which
+// hooks should run. WrapExecuteUserOp does the wrapping, and every operation
+// under such a grant needs it — including the one carrying the deferred
+// install, since the hooks are live from the moment the install applies.
+const (
+	HookFlagValidation  byte = 1
+	HookFlagExecHasPost byte = 2
+	HookFlagExecHasPre  byte = 4
+)
+
+// Stock module addresses, deployed at the same address on every chain the MA
+// v2 factory is (modular-account deployments/v2/Deployments.md; code presence
+// verified on Sepolia). AllowlistModule is the v2.0.1 redeploy, matching the
+// v2.0.1 source its encoding here was written against.
+const (
+	AllowlistModuleAddressHex = "0x00000000003e826473a313e600b5b9b791f5a59a"
+	TimeRangeModuleAddressHex = "0x00000000000082B8e2012be914dFA4f62A0573eA"
+)
+
+// AllowlistModuleAddress returns the v2.0.1 AllowlistModule address.
+func AllowlistModuleAddress() common.Address { return common.HexToAddress(AllowlistModuleAddressHex) }
+
+// TimeRangeModuleAddress returns the TimeRangeModule address.
+func TimeRangeModuleAddress() common.Address { return common.HexToAddress(TimeRangeModuleAddressHex) }
+
+// selectorExecuteUserOp is IAccountExecute.executeUserOp(PackedUserOperation,
+// bytes32) — the v0.7 EntryPoint special-cases callData beginning with it and
+// hands the account the full operation as execution context.
+var selectorExecuteUserOp = [4]byte{0x8d, 0xd7, 0x71, 0x2f}
+
+// PackHookConfig builds the bytes25 HookConfig:
+// module (20) ++ entityId (4, big-endian) ++ flags (1).
+func PackHookConfig(module common.Address, entityID uint32, flags byte) [25]byte {
+	// Identical layout to ValidationConfig; only the flag semantics differ.
+	return PackValidationConfig(module, entityID, flags)
+}
+
+// AllowlistInput mirrors AllowlistModule.AllowlistInput. One entry per
+// target; target zero means "any address" for the listed selectors.
+type AllowlistInput struct {
+	Target common.Address
+	// HasSelectorAllowlist scopes the target to Selectors; false allows any
+	// selector on the target.
+	HasSelectorAllowlist bool
+	// HasERC20SpendLimit marks Target as a token whose transfer/approve
+	// amounts are capped by ERC20SpendLimit. Enforced by the module's
+	// EXECUTION hook — installing a grant with a limit requires the exec-hook
+	// entry (AllowlistExecHook) alongside the validation-hook entry, and
+	// executeUserOp wrapping on every operation.
+	HasERC20SpendLimit bool
+	ERC20SpendLimit    *big.Int
+	Selectors          [][4]byte
+}
+
+var (
+	hooksArgsOnce     sync.Once
+	allowlistDataArgs abi.Arguments
+	timeRangeDataArgs abi.Arguments
+	hooksArgsErr      error
+)
+
+func ensureHookABIs() error {
+	hooksArgsOnce.Do(func() {
+		allowlistInputType, err := abi.NewType("tuple[]", "", []abi.ArgumentMarshaling{
+			{Name: "target", Type: "address"},
+			{Name: "hasSelectorAllowlist", Type: "bool"},
+			{Name: "hasERC20SpendLimit", Type: "bool"},
+			{Name: "erc20SpendLimit", Type: "uint256"},
+			{Name: "selectors", Type: "bytes4[]"},
+		})
+		if err != nil {
+			hooksArgsErr = err
+			return
+		}
+		uint32Type, err := abi.NewType("uint32", "", nil)
+		if err != nil {
+			hooksArgsErr = err
+			return
+		}
+		uint48Type, err := abi.NewType("uint48", "", nil)
+		if err != nil {
+			hooksArgsErr = err
+			return
+		}
+		allowlistDataArgs = abi.Arguments{{Type: uint32Type}, {Type: allowlistInputType}}
+		timeRangeDataArgs = abi.Arguments{{Type: uint32Type}, {Type: uint48Type}, {Type: uint48Type}}
+	})
+	return hooksArgsErr
+}
+
+// abiAllowlistInput is the shape go-ethereum's ABI encoder expects for the
+// tuple: field names must match the marshaling above with exported Go names.
+type abiAllowlistInput struct {
+	Target               common.Address `abi:"target"`
+	HasSelectorAllowlist bool           `abi:"hasSelectorAllowlist"`
+	HasERC20SpendLimit   bool           `abi:"hasERC20SpendLimit"`
+	Erc20SpendLimit      *big.Int       `abi:"erc20SpendLimit"`
+	Selectors            [][4]byte      `abi:"selectors"`
+}
+
+// PackAllowlistInstallData encodes AllowlistModule.onInstall's payload:
+// abi.encode(uint32 entityId, AllowlistInput[] inputs).
+func PackAllowlistInstallData(entityID uint32, inputs []AllowlistInput) ([]byte, error) {
+	if err := ensureHookABIs(); err != nil {
+		return nil, err
+	}
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("an empty allowlist install allows nothing and masks a bug")
+	}
+	encoded := make([]abiAllowlistInput, len(inputs))
+	for i, in := range inputs {
+		limit := in.ERC20SpendLimit
+		if limit == nil {
+			limit = big.NewInt(0)
+		}
+		if in.HasERC20SpendLimit && limit.Sign() == 0 {
+			return nil, fmt.Errorf("input %d: a zero ERC20 spend limit with the flag set caps the token at nothing", i)
+		}
+		selectors := in.Selectors
+		if selectors == nil {
+			selectors = [][4]byte{}
+		}
+		encoded[i] = abiAllowlistInput{
+			Target:               in.Target,
+			HasSelectorAllowlist: in.HasSelectorAllowlist,
+			HasERC20SpendLimit:   in.HasERC20SpendLimit,
+			Erc20SpendLimit:      limit,
+			Selectors:            selectors,
+		}
+	}
+	return allowlistDataArgs.Pack(entityID, encoded)
+}
+
+// PackTimeRangeInstallData encodes TimeRangeModule.onInstall's payload:
+// abi.encode(uint32 entityId, uint48 validUntil, uint48 validAfter).
+// validUntil zero means "no expiry" to the module — reject it here instead:
+// every grant this system issues has an explicit expiry (master doc §6.5).
+func PackTimeRangeInstallData(entityID uint32, validUntil, validAfter uint64) ([]byte, error) {
+	if err := ensureHookABIs(); err != nil {
+		return nil, err
+	}
+	const maxUint48 = uint64(1)<<48 - 1
+	if validUntil == 0 {
+		return nil, fmt.Errorf("validUntil 0 would mean no expiry; grants must expire")
+	}
+	if validUntil > maxUint48 || validAfter > maxUint48 {
+		return nil, fmt.Errorf("time range overflows uint48")
+	}
+	if validUntil <= validAfter {
+		return nil, fmt.Errorf("validUntil %d <= validAfter %d", validUntil, validAfter)
+	}
+	return timeRangeDataArgs.Pack(entityID, new(big.Int).SetUint64(validUntil), new(big.Int).SetUint64(validAfter))
+}
+
+// AllowlistValidationHook builds the hook entry enforcing the allowlist at
+// validation, carrying the module's install data (which also seeds any ERC-20
+// limits — state is shared with the exec hook, so it installs once, here).
+func AllowlistValidationHook(entityID uint32, inputs []AllowlistInput) ([]byte, error) {
+	data, err := PackAllowlistInstallData(entityID, inputs)
+	if err != nil {
+		return nil, err
+	}
+	config := PackHookConfig(AllowlistModuleAddress(), entityID, HookFlagValidation)
+	return append(config[:], data...), nil
+}
+
+// AllowlistExecHook builds the pre-execution hook entry that enforces ERC-20
+// spend limits. No install data — the validation-hook entry installed the
+// module state; a second onInstall with the same inputs would just repeat it.
+// (The module's post-hook path reverts NotImplemented, so pre only.)
+func AllowlistExecHook(entityID uint32) []byte {
+	config := PackHookConfig(AllowlistModuleAddress(), entityID, HookFlagExecHasPre)
+	return config[:]
+}
+
+// TimeRangeValidationHook builds the hook entry that bounds the grant in
+// time. Enforcement is by the EntryPoint: the hook returns
+// validUntil/validAfter in its validation data.
+func TimeRangeValidationHook(entityID uint32, validUntil, validAfter uint64) ([]byte, error) {
+	data, err := PackTimeRangeInstallData(entityID, validUntil, validAfter)
+	if err != nil {
+		return nil, err
+	}
+	config := PackHookConfig(TimeRangeModuleAddress(), entityID, HookFlagValidation)
+	return append(config[:], data...), nil
+}
+
+// WrapExecuteUserOp prefixes execution calldata with the executeUserOp
+// selector, opting the operation into user-op context. Required for every
+// operation under a grant that carries execution hooks; harmless overhead
+// (a calldata re-read) otherwise.
+func WrapExecuteUserOp(execCallData []byte) ([]byte, error) {
+	if len(execCallData) < 4 {
+		return nil, fmt.Errorf("execution calldata is %d bytes, shorter than a selector", len(execCallData))
+	}
+	return append(selectorExecuteUserOp[:], execCallData...), nil
+}

--- a/core/chainio/aa/ma_v2_hooks_test.go
+++ b/core/chainio/aa/ma_v2_hooks_test.go
@@ -1,0 +1,137 @@
+package aa
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Golden vector produced by
+//
+//	cast abi-encode "f(uint32,(address,bool,bool,uint256,bytes4[])[])" 1 \
+//	  "[(0x1111…1111,true,true,100000000000000000000,[0xa9059cbb])]"
+//
+// so the Go tuple marshaling is checked against an independent encoder, not
+// against itself.
+const allowlistGolden = "0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000000000000000000040" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000000000000000000020" +
+	"0000000000000000000000001111111111111111111111111111111111111111" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"0000000000000000000000000000000000000000000000056bc75e2d63100000" +
+	"00000000000000000000000000000000000000000000000000000000000000a0" +
+	"0000000000000000000000000000000000000000000000000000000000000001" +
+	"a9059cbb00000000000000000000000000000000000000000000000000000000"
+
+func TestPackAllowlistInstallDataGolden(t *testing.T) {
+	limit, _ := new(big.Int).SetString("100000000000000000000", 10) // 100e18
+	got, err := PackAllowlistInstallData(1, []AllowlistInput{{
+		Target:               common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		HasSelectorAllowlist: true,
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      limit,
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != allowlistGolden {
+		t.Fatalf("allowlist install data does not match the cast golden vector:\ngot  %x", got)
+	}
+}
+
+func TestPackAllowlistInstallDataRejectsFootguns(t *testing.T) {
+	if _, err := PackAllowlistInstallData(1, nil); err == nil {
+		t.Error("expected an empty allowlist to be rejected")
+	}
+	if _, err := PackAllowlistInstallData(1, []AllowlistInput{{
+		Target:             common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		HasERC20SpendLimit: true, // flag set, limit zero
+	}}); err == nil {
+		t.Error("expected a zero limit with the flag set to be rejected")
+	}
+}
+
+func TestPackTimeRangeInstallDataGolden(t *testing.T) {
+	// cast abi-encode "f(uint32,uint48,uint48)" 7 1790000000 12345
+	want := "0000000000000000000000000000000000000000000000000000000000000007" +
+		"000000000000000000000000000000000000000000000000000000006ab13b80" +
+		"0000000000000000000000000000000000000000000000000000000000003039"
+	got, err := PackTimeRangeInstallData(7, 1790000000, 12345)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(got) != want {
+		t.Fatalf("time range install data = %x, want %s", got, want)
+	}
+
+	if _, err := PackTimeRangeInstallData(1, 0, 0); err == nil {
+		t.Error("expected validUntil 0 (no expiry) to be rejected")
+	}
+	if _, err := PackTimeRangeInstallData(1, 100, 100); err == nil {
+		t.Error("expected an empty window to be rejected")
+	}
+}
+
+func TestHookEntryLayout(t *testing.T) {
+	entry, err := TimeRangeValidationHook(3, 1790000000, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// [:25] HookConfig, [25:] initData — the offsets ModuleManagerInternals
+	// slices at.
+	if !bytes.Equal(entry[:20], TimeRangeModuleAddress().Bytes()) {
+		t.Fatalf("module segment = %x", entry[:20])
+	}
+	if entity := uint32(entry[20])<<24 | uint32(entry[21])<<16 | uint32(entry[22])<<8 | uint32(entry[23]); entity != 3 {
+		t.Fatalf("entity segment = %d, want 3", entity)
+	}
+	if entry[24] != HookFlagValidation {
+		t.Fatalf("flags = %x, want validation (%x)", entry[24], HookFlagValidation)
+	}
+	initData, err := PackTimeRangeInstallData(3, 1790000000, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(entry[25:], initData) {
+		t.Fatal("initData segment does not round-trip")
+	}
+}
+
+func TestAllowlistExecHookIsConfigOnly(t *testing.T) {
+	entry := AllowlistExecHook(2)
+	// The exec hook shares module state with the validation hook, which
+	// installed it — a second onInstall would re-run updateAllowlist. Config
+	// only, pre-hook only (the module's post-hook reverts NotImplemented).
+	if len(entry) != 25 {
+		t.Fatalf("exec hook entry is %d bytes, want 25 (config only)", len(entry))
+	}
+	if entry[24] != HookFlagExecHasPre {
+		t.Fatalf("flags = %x, want exec-pre (%x)", entry[24], HookFlagExecHasPre)
+	}
+}
+
+func TestWrapExecuteUserOp(t *testing.T) {
+	inner, err := PackExecute(common.HexToAddress("0x2222222222222222222222222222222222222222"), big.NewInt(0), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapped, err := WrapExecuteUserOp(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(wrapped[:4]) != "8dd7712f" {
+		t.Fatalf("wrapper selector = %x, want 8dd7712f", wrapped[:4])
+	}
+	if !bytes.Equal(wrapped[4:], inner) {
+		t.Fatal("inner calldata does not survive wrapping")
+	}
+	if _, err := WrapExecuteUserOp([]byte{0x01}); err == nil {
+		t.Error("expected sub-selector calldata to be rejected")
+	}
+}

--- a/core/chainio/aa/ma_v2_install.go
+++ b/core/chainio/aa/ma_v2_install.go
@@ -1,0 +1,251 @@
+package aa
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Controller validation install for Modular Account v2.
+//
+// A stock SemiModularAccountBytecode trusts exactly one signer — the owner
+// passed at creation. The controller's authority over a wallet is therefore
+// an explicit, per-account grant: an installValidation self-call naming the
+// controller as an additional validation entity. This file encodes that call.
+//
+// The encoding was established on-chain (Sepolia, avs-infra
+// MA_v2_Authority_Model_And_Spike_Results.md §3.1) rather than from
+// documentation: ValidationConfig is bytes25 = module address (20) ++
+// entityId (uint32, 4) ++ flags (1), and the flag bits follow aa-sdk's
+// serializeValidationConfig, which is NOT the intuitive order.
+
+// SingleSignerValidationModuleAddressHex is Alchemy's audited
+// SingleSignerValidationModule, deployed at the same address on every chain
+// the MA v2 factory is (verified byte-identical across our chains).
+const SingleSignerValidationModuleAddressHex = "0x00000000000099DE0BF6fA90dEB851E2A2df7d83"
+
+// SingleSignerValidationModuleAddress returns the module address.
+func SingleSignerValidationModuleAddress() common.Address {
+	return common.HexToAddress(SingleSignerValidationModuleAddressHex)
+}
+
+// MinSessionEntityID is the lowest entity a session signer may occupy. Entity
+// 0 is the account's fallback signer (the owner) and can never be reused.
+//
+// Entities are allocated PER GRANT, not per gateway — one SessionPolicy, one
+// entity, one signer (avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §6.7). That
+// is not only a product choice. The deferred-action digest commits to the full
+// nonce of the operation that will carry it, and the nonce key is derived from
+// the entity id, so a fresh entity means a fresh key whose sequence is
+// predictably zero — which is the entire reason the owner can sign the grant
+// before the operation exists. Reusing one entity across grants makes the
+// second grant's nonce unpredictable at signing time and the property
+// collapses.
+const MinSessionEntityID uint32 = 1
+
+// ValidationConfig flag bits (aa-sdk serializeValidationConfig order).
+const (
+	// ValidationFlagUserOp lets the entity validate UserOperations.
+	ValidationFlagUserOp byte = 1
+	// ValidationFlagSignature lets the entity answer isValidSignature as the
+	// account. The controller install deliberately EXCLUDES this: the
+	// controller executes, it does not speak as the user.
+	ValidationFlagSignature byte = 2
+	// ValidationFlagGlobal applies the validation to any selector rather than
+	// an enumerated set.
+	ValidationFlagGlobal byte = 4
+)
+
+// PackValidationConfig builds the bytes25 ValidationConfig:
+// module (20) ++ entityId (4, big-endian) ++ flags (1).
+func PackValidationConfig(module common.Address, entityID uint32, flags byte) [25]byte {
+	var out [25]byte
+	copy(out[:20], module.Bytes())
+	out[20] = byte(entityID >> 24)
+	out[21] = byte(entityID >> 16)
+	out[22] = byte(entityID >> 8)
+	out[23] = byte(entityID)
+	out[24] = flags
+	return out
+}
+
+var (
+	installArgsOnce      sync.Once
+	installDataArgs      abi.Arguments
+	installValidationABI abi.ABI
+	installArgsErr       error
+)
+
+func ensureInstallABIs() error {
+	installArgsOnce.Do(func() {
+		uint32Type, err := abi.NewType("uint32", "", nil)
+		if err != nil {
+			installArgsErr = err
+			return
+		}
+		addressType, err := abi.NewType("address", "", nil)
+		if err != nil {
+			installArgsErr = err
+			return
+		}
+		installDataArgs = abi.Arguments{{Type: uint32Type}, {Type: addressType}}
+
+		installValidationABI, installArgsErr = abi.JSON(strings.NewReader(`[
+		  {"type":"function","name":"installValidation","stateMutability":"nonpayable",
+		   "inputs":[{"name":"validationConfig","type":"bytes25"},
+		             {"name":"selectors","type":"bytes4[]"},
+		             {"name":"installData","type":"bytes"},
+		             {"name":"hooks","type":"bytes[]"}]}
+		]`))
+	})
+	return installArgsErr
+}
+
+// PackSingleSignerInstallData encodes the module's onInstall payload:
+// abi.encode(uint32 entityId, address signer).
+func PackSingleSignerInstallData(entityID uint32, signer common.Address) ([]byte, error) {
+	if err := ensureInstallABIs(); err != nil {
+		return nil, err
+	}
+	return installDataArgs.Pack(entityID, signer)
+}
+
+// PackInstallValidation encodes the installValidation self-call
+// (selector 0x1bbf564c, asserted in tests against deployed bytecode).
+func PackInstallValidation(config [25]byte, selectors [][4]byte, installData []byte, hooks [][]byte) ([]byte, error) {
+	if err := ensureInstallABIs(); err != nil {
+		return nil, err
+	}
+	if selectors == nil {
+		selectors = [][4]byte{}
+	}
+	if hooks == nil {
+		hooks = [][]byte{}
+	}
+	return installValidationABI.Pack("installValidation", config, selectors, installData, hooks)
+}
+
+// SessionGrant is one grant of authority on one account: which entity, which
+// signer occupies it, and what that signer is allowed to do.
+//
+// This is the thing an owner authorizes, so every field is committed to by the
+// deferred-action digest. The gateway cannot widen a grant after signing —
+// changing any field here changes the digest and invalidates the signature.
+type SessionGrant struct {
+	// EntityID must be unique per account and >= MinSessionEntityID. It is
+	// allocated by the gateway when a SessionPolicy is created.
+	EntityID uint32
+
+	// Signer is the session key that will sign operations for this grant.
+	Signer common.Address
+
+	// Selectors scopes the grant to specific function selectors. Mutually
+	// exclusive with Global — a global validation never consults the selector
+	// list, so setting both would produce a grant that is wider than it reads.
+	Selectors [][4]byte
+
+	// Global lets the entity validate ANY selector the account exposes,
+	// including the account's own native functions. It must be set
+	// explicitly: it used to be inferred from an empty Selectors, which made
+	// the most dangerous grant the one you got by omission. See
+	// AllowSelfAdministration.
+	Global bool
+
+	// Hooks are the encoded permission hooks (allowlist, spend cap, time
+	// range) installed alongside the validation, each as
+	// hookConfig ++ initData. They ride the SAME installValidation call, so
+	// they are covered by the owner's signature rather than needing one of
+	// their own.
+	Hooks [][]byte
+
+	// AllowSignatureValidation lets this entity answer isValidSignature AS the
+	// account. Default false, and it should stay false for gateway-held
+	// signers: the controller executes, it does not speak as the user. Set it
+	// only for a grant that genuinely represents the owner.
+	AllowSignatureValidation bool
+
+	// AllowSelfAdministration acknowledges that a Global grant carrying no
+	// execution hook can administer its own authority.
+	//
+	// A global validation may call the account's native functions, which is
+	// how one-click self-revoke works (uninstallValidation, proven on Sepolia)
+	// — but the same authority reaches installValidation, so such a grant can
+	// escalate itself: add signature validation, widen its own hooks, or
+	// install a second signer. An execution hook that rejects non-execute
+	// selectors closes this (the allowlist hook does, also proven), which is
+	// why a policied grant cannot touch its own authority.
+	//
+	// Production grants must therefore either be selector-scoped or carry an
+	// execution hook. This flag exists so a spike or a deliberately
+	// self-administering grant can still be built, loudly.
+	AllowSelfAdministration bool
+}
+
+// HasExecutionHook reports whether any hook runs at execution rather than
+// validation. Hook entries are hookConfig(25) ++ initData, and a clear
+// HookFlagValidation bit in the config's flag byte means execution.
+func (g SessionGrant) HasExecutionHook() bool {
+	for _, h := range g.Hooks {
+		if len(h) >= 25 && h[24]&HookFlagValidation == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate reports why a grant cannot be installed, if it cannot.
+func (g SessionGrant) Validate() error {
+	if g.EntityID < MinSessionEntityID {
+		return fmt.Errorf("entity id %d is reserved (entity 0 is the owner's fallback signer)", g.EntityID)
+	}
+	if g.Signer == (common.Address{}) {
+		return fmt.Errorf("session signer is the zero address")
+	}
+	// Scope must be stated. Neither means a grant that validates nothing;
+	// both means a grant whose selector list is silently ignored.
+	if g.Global && len(g.Selectors) > 0 {
+		return fmt.Errorf("grant is Global and also lists %d selectors; a global validation ignores the list, so this is wider than it reads", len(g.Selectors))
+	}
+	if !g.Global && len(g.Selectors) == 0 {
+		return fmt.Errorf("grant has no scope: set Global or list Selectors")
+	}
+	if g.Global && !g.HasExecutionHook() && !g.AllowSelfAdministration {
+		return fmt.Errorf(
+			"refusing a global grant with no execution hook: it can call the account's own installValidation/uninstallValidation and escalate itself. " +
+				"Scope it with Selectors, add an execution hook (e.g. aa.AllowlistExecHook), or set AllowSelfAdministration to accept this deliberately")
+	}
+	return nil
+}
+
+// Flags renders the grant's ValidationConfig flag byte.
+func (g SessionGrant) Flags() byte {
+	flags := ValidationFlagUserOp
+	if g.Global {
+		flags |= ValidationFlagGlobal
+	}
+	if g.AllowSignatureValidation {
+		flags |= ValidationFlagSignature
+	}
+	return flags
+}
+
+// PackSessionSignerInstall encodes the installValidation self-call that grants
+// this session signer its authority — the exact calldata an owner authorizes.
+func PackSessionSignerInstall(grant SessionGrant) ([]byte, error) {
+	if err := grant.Validate(); err != nil {
+		return nil, err
+	}
+	installData, err := PackSingleSignerInstallData(grant.EntityID, grant.Signer)
+	if err != nil {
+		return nil, fmt.Errorf("packing SingleSignerValidationModule install data: %w", err)
+	}
+	config := PackValidationConfig(
+		SingleSignerValidationModuleAddress(),
+		grant.EntityID,
+		grant.Flags(),
+	)
+	return PackInstallValidation(config, grant.Selectors, installData, grant.Hooks)
+}

--- a/core/chainio/aa/ma_v2_install_test.go
+++ b/core/chainio/aa/ma_v2_install_test.go
@@ -1,0 +1,256 @@
+package aa
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestPackValidationConfigLayout(t *testing.T) {
+	module := common.HexToAddress(SingleSignerValidationModuleAddressHex)
+	got := PackValidationConfig(module, 1, ValidationFlagGlobal|ValidationFlagUserOp)
+
+	// module (20) ++ entityId (4, BE) ++ flags (1) — the §3.1 layout that was
+	// verified against deployed bytecode.
+	want := "00000000000099de0bf6fa90deb851e2a2df7d83" + "00000001" + "05"
+	if hex.EncodeToString(got[:]) != want {
+		t.Fatalf("ValidationConfig = %x, want %s", got, want)
+	}
+}
+
+func TestPackSingleSignerInstallData(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	got, err := PackSingleSignerInstallData(1, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// abi.encode(uint32(1), address) = two 32-byte words.
+	if len(got) != 64 {
+		t.Fatalf("install data is %d bytes, want 64", len(got))
+	}
+	if got[31] != 1 {
+		t.Fatalf("entity id word = %x, want …01", got[:32])
+	}
+	if !bytes.Equal(got[44:64], signer.Bytes()) {
+		t.Fatalf("signer word = %x, want …%x", got[32:64], signer.Bytes())
+	}
+}
+
+func TestPackSessionSignerInstallSelectorAndShape(t *testing.T) {
+	controller := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	call, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID, Signer: controller, Global: true, AllowSelfAdministration: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// installValidation(bytes25,bytes4[],bytes,bytes[]) — the selector §0.1 of
+	// the master doc verified against deployed bytecode.
+	if sel := hex.EncodeToString(call[:4]); sel != "1bbf564c" {
+		t.Fatalf("selector = %s, want 1bbf564c", sel)
+	}
+
+	// The config word leads the arguments: bytes25 is right-padded to 32.
+	config := PackValidationConfig(SingleSignerValidationModuleAddress(), MinSessionEntityID,
+		ValidationFlagGlobal|ValidationFlagUserOp)
+	if !bytes.Equal(call[4:4+25], config[:]) {
+		t.Fatalf("leading config = %x, want %x", call[4:4+25], config)
+	}
+
+	// The controller must be granted userOp + global but NEVER signature
+	// validation — the scoping §2.4 of the findings doc presents as the
+	// security improvement.
+	if config[24]&ValidationFlagSignature != 0 {
+		t.Fatal("controller install must not carry isSignatureValidation")
+	}
+}
+
+func TestPackSessionSignerInstallRejectsZeroAddress(t *testing.T) {
+	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: MinSessionEntityID, Global: true, AllowSelfAdministration: true}); err == nil {
+		t.Fatal("expected an error for the zero controller address")
+	}
+}
+
+// Entities are allocated per grant, so the entity id has to reach both the
+// ValidationConfig and the module's install data. If they ever disagree the
+// account installs one entity and the module binds the signer to another —
+// the grant looks applied and every operation under it fails validation.
+func TestSessionGrantEntityReachesBothEncodings(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	const entity = uint32(7)
+
+	call, err := PackSessionSignerInstall(SessionGrant{EntityID: entity, Signer: signer, Global: true, AllowSelfAdministration: true})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	// ValidationConfig sits in the first argument word, right-padded: module
+	// (20) ++ entityId (4) ++ flags (1).
+	cfg := call[4:29]
+	got := uint32(cfg[20])<<24 | uint32(cfg[21])<<16 | uint32(cfg[22])<<8 | uint32(cfg[23])
+	if got != entity {
+		t.Errorf("ValidationConfig entity = %d, want %d", got, entity)
+	}
+	installData, err := PackSingleSignerInstallData(entity, signer)
+	if err != nil {
+		t.Fatalf("PackSingleSignerInstallData: %v", err)
+	}
+	if !bytes.Contains(call, installData) {
+		t.Error("the install call does not carry install data for the same entity")
+	}
+}
+
+func TestSessionGrantFlags(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	t.Run("Global sets the global flag", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true}
+		if g.Flags()&ValidationFlagGlobal == 0 {
+			t.Error("expected the global flag")
+		}
+		if g.Flags()&ValidationFlagUserOp == 0 {
+			t.Error("expected the userOp flag")
+		}
+	})
+
+	t.Run("selector-scoped grants are not global", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Selectors: [][4]byte{{0x09, 0x5e, 0xa7, 0xb3}}}
+		if g.Flags()&ValidationFlagGlobal != 0 {
+			t.Error("an enumerated selector set must not also be global")
+		}
+	})
+
+	// The gateway holds this key. Letting it answer isValidSignature would let
+	// it sign arbitrary messages AS the user, which is not what execution
+	// authority means.
+	t.Run("signature validation is off unless asked for", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true}
+		if g.Flags()&ValidationFlagSignature != 0 {
+			t.Error("signature validation must default off")
+		}
+		g.AllowSignatureValidation = true
+		if g.Flags()&ValidationFlagSignature == 0 {
+			t.Error("signature validation must be settable")
+		}
+	})
+}
+
+func TestSessionGrantRejectsTheOwnerEntity(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	// Entity 0 is the fallback signer. Installing over it would replace the
+	// owner's own validation with a gateway-held key.
+	if _, err := PackSessionSignerInstall(SessionGrant{EntityID: 0, Signer: signer, Global: true, AllowSelfAdministration: true}); err == nil {
+		t.Error("expected entity 0 to be rejected")
+	}
+}
+
+// Hooks ride the same call, which is what puts them under the owner's single
+// signature instead of needing one of their own.
+func TestSessionGrantCarriesHooks(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	hook := append(bytes.Repeat([]byte{0xab}, 26), 0x01, 0x02)
+
+	withHook, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Global: true, Hooks: [][]byte{hook}, AllowSelfAdministration: true})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	if !bytes.Contains(withHook, hook) {
+		t.Error("hook payload is not present in the install call")
+	}
+	without, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Global: true, AllowSelfAdministration: true})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	if len(withHook) <= len(without) {
+		t.Error("hooks did not lengthen the encoded call")
+	}
+}
+
+// A global validation may call the account's own native functions. That is
+// how one-click self-revoke works (uninstallValidation, proven on Sepolia),
+// but the same authority reaches installValidation — so a bare global grant
+// can escalate itself: add signature validation, widen its hooks, install a
+// second signer.
+//
+// This previously WAS the default. Flags() inferred global from an empty
+// Selectors, so the plainest possible grant — entity and signer, nothing else
+// — produced the one shape that must never reach production. The rule lived in
+// a doc sentence while the code made violating it the path of least
+// resistance. It is now a build-time refusal.
+func TestBareGlobalGrantIsRefused(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	// The exact literal that used to be the easy, and wrong, thing to write.
+	_, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer, Global: true})
+	if err == nil {
+		t.Fatal("a global grant with no execution hook must be refused")
+	}
+	if !strings.Contains(err.Error(), "escalate itself") {
+		t.Errorf("the error should say why, got: %v", err)
+	}
+
+	t.Run("an execution hook makes it safe", func(t *testing.T) {
+		// The allowlist exec hook rejects non-execute selectors, which is what
+		// stopped the policied grant from revoking itself in the spike.
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true,
+			Hooks: [][]byte{AllowlistExecHook(1)}}
+		if !g.HasExecutionHook() {
+			t.Fatal("AllowlistExecHook was not recognised as an execution hook")
+		}
+		if _, err := PackSessionSignerInstall(g); err != nil {
+			t.Errorf("a hook-carrying global grant must be allowed: %v", err)
+		}
+	})
+
+	t.Run("a validation-only hook does not make it safe", func(t *testing.T) {
+		// TimeRange runs at validation, so it never sees the selector being
+		// executed and cannot block a self-administering call.
+		timeHook, err := TimeRangeValidationHook(1, 1785541743, 0)
+		if err != nil {
+			t.Fatalf("TimeRangeValidationHook: %v", err)
+		}
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true, Hooks: [][]byte{timeHook}}
+		if g.HasExecutionHook() {
+			t.Fatal("a validation hook must not count as an execution hook")
+		}
+		if _, err := PackSessionSignerInstall(g); err == nil {
+			t.Error("validation-only hooks must not satisfy the guard")
+		}
+	})
+
+	t.Run("selector scoping makes it safe", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer,
+			Selectors: [][4]byte{{0xb6, 0x1d, 0x27, 0xf6}}} // execute
+		if _, err := PackSessionSignerInstall(g); err != nil {
+			t.Errorf("a selector-scoped grant must be allowed: %v", err)
+		}
+	})
+
+	t.Run("the escape hatch is explicit", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true, AllowSelfAdministration: true}
+		if _, err := PackSessionSignerInstall(g); err != nil {
+			t.Errorf("an acknowledged self-administering grant must build: %v", err)
+		}
+	})
+}
+
+// Scope must be stated rather than inferred, in both directions.
+func TestGrantScopeMustBeUnambiguous(t *testing.T) {
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	t.Run("no scope at all", func(t *testing.T) {
+		if _, err := PackSessionSignerInstall(SessionGrant{EntityID: 1, Signer: signer}); err == nil {
+			t.Error("a grant with neither Global nor Selectors must be refused")
+		}
+	})
+
+	t.Run("both is wider than it reads", func(t *testing.T) {
+		g := SessionGrant{EntityID: 1, Signer: signer, Global: true,
+			Selectors:               [][4]byte{{0xb6, 0x1d, 0x27, 0xf6}},
+			AllowSelfAdministration: true}
+		if _, err := PackSessionSignerInstall(g); err == nil {
+			t.Error("Global plus Selectors must be refused; the list is silently ignored on chain")
+		}
+	})
+}

--- a/core/chainio/aa/ma_v2_uninstall.go
+++ b/core/chainio/aa/ma_v2_uninstall.go
@@ -1,0 +1,120 @@
+package aa
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Revocation for Modular Account v2 session grants.
+//
+// uninstallValidation(bytes24 moduleEntity, bytes uninstallData,
+// bytes[] hookUninstallData), selector 0xb6b1ccfe. Like installValidation it
+// is annotated "may be validated by a global validation" in the account
+// source — which is why a BARE global session grant can revoke (or reinstall)
+// itself, and why a policied grant cannot: the allowlist's execution hook
+// reverts SpendingRequestNotAllowed for any selector that is not
+// execute/executeBatch. Both behaviors carry receipts in the results doc
+// §3.5. The owner always can, either as a UserOperation or as a plain
+// transaction straight to the account (fallback direct-call validation).
+//
+// hookUninstallData ordering is the account's, not the install's:
+// **validation hooks in STORED order (reverse of install — the hook set is a
+// prepend-on-add linked list), then execution hooks (same reversal)**, one
+// entry per installed hook or ArrayLengthMismatch. An entry routed to the
+// wrong module does NOT fail the uninstall: onUninstall reverts are caught,
+// flagged only in the ValidationUninstalled event, and the module state is
+// silently stranded. Verify cleanup by reading module state back, not by the
+// transaction succeeding.
+//
+// The uninstall payloads must be reconstructable at revoke time, which is
+// one more reason master §7.4a stores the grant's install_call rather than
+// re-deriving it: the AllowlistModule's uninstall data is the SAME
+// (entityId, inputs) tuple it was installed with — decode it from the stored
+// call, do not rebuild it from current code.
+
+// PackModuleEntity builds the bytes24 ModuleEntity:
+// module (20) ++ entityId (4, big-endian).
+func PackModuleEntity(module common.Address, entityID uint32) [24]byte {
+	var out [24]byte
+	copy(out[:20], module.Bytes())
+	out[20] = byte(entityID >> 24)
+	out[21] = byte(entityID >> 16)
+	out[22] = byte(entityID >> 8)
+	out[23] = byte(entityID)
+	return out
+}
+
+var (
+	uninstallOnce   sync.Once
+	uninstallABI    abi.ABI
+	uninstallABIErr error
+)
+
+func ensureUninstallABI() error {
+	uninstallOnce.Do(func() {
+		uninstallABI, uninstallABIErr = abi.JSON(strings.NewReader(`[
+		  {"type":"function","name":"uninstallValidation","stateMutability":"nonpayable",
+		   "inputs":[{"name":"validationFunction","type":"bytes24"},
+		             {"name":"uninstallData","type":"bytes"},
+		             {"name":"hookUninstallData","type":"bytes[]"}]}
+		]`))
+	})
+	return uninstallABIErr
+}
+
+// PackUninstallValidation encodes the uninstallValidation self-call.
+// hookUninstallData must have exactly one entry per installed hook, in the
+// account's stored order (see the package comment), or be empty to skip all
+// hook cleanup. An empty entry skips that one hook's onUninstall.
+func PackUninstallValidation(module common.Address, entityID uint32, uninstallData []byte, hookUninstallData [][]byte) ([]byte, error) {
+	if err := ensureUninstallABI(); err != nil {
+		return nil, err
+	}
+	if hookUninstallData == nil {
+		hookUninstallData = [][]byte{}
+	}
+	for i, entry := range hookUninstallData {
+		if entry == nil {
+			hookUninstallData[i] = []byte{}
+		}
+	}
+	return uninstallABI.Pack("uninstallValidation", PackModuleEntity(module, entityID), uninstallData, hookUninstallData)
+}
+
+// PackSingleSignerUninstallData encodes SingleSignerValidationModule's
+// onUninstall payload: abi.encode(uint32 entityId). The module zeroes the
+// signer for that entity.
+func PackSingleSignerUninstallData(entityID uint32) ([]byte, error) {
+	if err := ensureHookABIs(); err != nil {
+		return nil, err
+	}
+	// Single uint32 argument — reuse the time-range args' first element.
+	uint32Only := abi.Arguments{timeRangeDataArgs[0]}
+	return uint32Only.Pack(entityID)
+}
+
+// PackTimeRangeUninstallData encodes TimeRangeModule's onUninstall payload:
+// abi.encode(uint32 entityId) — note NOT the install tuple; the module only
+// needs the entity to delete its range.
+func PackTimeRangeUninstallData(entityID uint32) ([]byte, error) {
+	return PackSingleSignerUninstallData(entityID)
+}
+
+// PackSessionSignerUninstall encodes the revocation of a session grant
+// installed by PackSessionSignerInstall: the SingleSignerValidationModule
+// entity plus per-hook cleanup payloads supplied by the caller in the
+// account's stored hook order.
+func PackSessionSignerUninstall(entityID uint32, hookUninstallData [][]byte) ([]byte, error) {
+	if entityID < MinSessionEntityID {
+		return nil, fmt.Errorf("entity id %d is reserved (entity 0 is the owner's fallback signer)", entityID)
+	}
+	uninstallData, err := PackSingleSignerUninstallData(entityID)
+	if err != nil {
+		return nil, err
+	}
+	return PackUninstallValidation(SingleSignerValidationModuleAddress(), entityID, uninstallData, hookUninstallData)
+}

--- a/core/chainio/aa/ma_v2_uninstall_test.go
+++ b/core/chainio/aa/ma_v2_uninstall_test.go
@@ -1,0 +1,91 @@
+package aa
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestPackModuleEntity(t *testing.T) {
+	got := PackModuleEntity(SingleSignerValidationModuleAddress(), 1)
+	want := "00000000000099de0bf6fa90deb851e2a2df7d83" + "00000001"
+	if hex.EncodeToString(got[:]) != want {
+		t.Fatalf("ModuleEntity = %x, want %s", got, want)
+	}
+}
+
+func TestPackSessionSignerUninstallShape(t *testing.T) {
+	timeRangeData, err := PackTimeRangeUninstallData(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := PackSessionSignerUninstall(1, [][]byte{timeRangeData, nil, {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// uninstallValidation(bytes24,bytes,bytes[]) — cast sig 0xb6b1ccfe.
+	if sel := hex.EncodeToString(call[:4]); sel != "b6b1ccfe" {
+		t.Fatalf("selector = %s, want b6b1ccfe", sel)
+	}
+
+	// The ModuleEntity leads the arguments, right-padded to a word.
+	entity := PackModuleEntity(SingleSignerValidationModuleAddress(), 1)
+	if !bytes.Equal(call[4:4+24], entity[:]) {
+		t.Fatalf("leading module entity = %x, want %x", call[4:4+24], entity)
+	}
+
+	// The uninstall data is abi.encode(uint32 1) — a single word ending in 01.
+	uninstallData, err := PackSingleSignerUninstallData(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(uninstallData) != 32 || uninstallData[31] != 1 {
+		t.Fatalf("uninstall data = %x, want a single word of 1", uninstallData)
+	}
+	if !bytes.Contains(call, uninstallData) {
+		t.Fatal("the uninstall call does not carry the module's entity payload")
+	}
+}
+
+func TestPackSessionSignerUninstallRejectsOwnerEntity(t *testing.T) {
+	// Uninstalling entity 0 is not revocation, it is disabling the owner.
+	if _, err := PackSessionSignerUninstall(0, nil); err == nil {
+		t.Fatal("expected entity 0 to be rejected")
+	}
+}
+
+func TestUninstallAndTimeRangePayloadsMatch(t *testing.T) {
+	// Both modules take a bare abi.encode(uint32) on uninstall. If these ever
+	// diverge the shared implementation must split.
+	a, err := PackSingleSignerUninstallData(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := PackTimeRangeUninstallData(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Fatal("SSVM and TimeRange uninstall payloads diverged")
+	}
+}
+
+func TestPackUninstallValidationEmptyHookEntries(t *testing.T) {
+	// Empty entries (skip that hook's onUninstall) must encode as zero-length
+	// bytes, not nil-panic or drop from the array — the account requires one
+	// entry per installed hook.
+	data, err := PackSingleSignerUninstallData(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := PackUninstallValidation(common.HexToAddress("0x1111111111111111111111111111111111111111"), 2, data, [][]byte{nil, nil, nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(call) == 0 {
+		t.Fatal("empty call")
+	}
+}

--- a/core/config/bundler_provider_test.go
+++ b/core/config/bundler_provider_test.go
@@ -85,3 +85,29 @@ func TestBundlerConfigured(t *testing.T) {
 		t.Fatal("self_hosted without url should report not configured")
 	}
 }
+
+// The four chains the expansion targets must resolve to an Alchemy subdomain.
+// A missing entry is a hard error at send time (ActiveBundlerURL refuses to
+// guess), so it would surface as a chain that boots fine and then cannot
+// execute anything.
+func TestExpansionChainsHaveAlchemySubdomains(t *testing.T) {
+	for _, tc := range []struct {
+		chainID int64
+		want    string
+	}{
+		{56, "https://bnb-mainnet.g.alchemy.com/v2/K"},
+		{42161, "https://arb-mainnet.g.alchemy.com/v2/K"},
+		{999, "https://hyperliquid-mainnet.g.alchemy.com/v2/K"},
+		{4663, "https://robinhood-mainnet.g.alchemy.com/v2/K"},
+	} {
+		c := SmartWalletConfig{ChainID: tc.chainID, BundlerProvider: "alchemy", AlchemyAPIKey: "K"}
+		got, err := c.ActiveBundlerURL()
+		if err != nil {
+			t.Errorf("chain %d: %v", tc.chainID, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("chain %d: got %s, want %s", tc.chainID, got, tc.want)
+		}
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -48,7 +48,19 @@ const DefaultFactoryProxyAddressHex = "0xB99BC2E399e06CddCF5E725c0ea341E8f032283
 // DefaultEntrypointAddressHex is the default ERC-4337 EntryPoint address used
 // across supported chains. If the aggregator config omits the
 // smart_wallet.entrypoint_address field, this value will be used.
+//
+// This is the v0.6 EntryPoint, and smart_wallet.entrypoint_address configures
+// only the v0.6 path. Modular Account v2 operations run against
+// EntryPointV07AddressHex regardless of what the YAML says — read
+// SmartWalletConfig.EntryPointAddress() rather than the field, or you will
+// address the wrong contract on an MA v2 chain.
 const DefaultEntrypointAddressHex = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+
+// EntryPointV07AddressHex is the canonical ERC-4337 v0.7 EntryPoint, the same
+// address on every chain that has one. It is deliberately NOT configurable:
+// unlike the v0.6 deployment there is nothing per-chain to point at, and a
+// YAML override could only ever be wrong.
+const EntryPointV07AddressHex = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
 
 // NOTE: there is no DefaultPaymasterAddressHex. The paymaster contract
 // is deployed per network (mainnet and testnet have different addresses),
@@ -237,10 +249,15 @@ type SmartWalletConfig struct {
 	MaxWalletsPerOwner int
 
 	// AccountProvider selects which smart-account implementation this chain
-	// derives and deploys: the v0.6 SimpleAccount fork, or Alchemy Modular
-	// Account v2. See AccountProviderName for why this defaults to the OLD
-	// value, unlike BundlerProvider.
+	// derives and deploys: Alchemy Modular Account v2 (the default), or the
+	// legacy v0.6 SimpleAccount fork. See AccountProviderName.
 	AccountProvider string
+
+	// GasManagerPolicyID is copied down from the top-level config so the v0.7
+	// send path — which is handed only a SmartWalletConfig — can request
+	// sponsorship without reaching back up. Empty means unsponsored: the
+	// operation is priced by estimation and the account pays its own gas.
+	GasManagerPolicyID string
 }
 
 // Bundler provider identifiers for SmartWalletConfig.BundlerProvider.
@@ -256,22 +273,21 @@ const (
 )
 
 // AccountProviderName returns the effective smart-account implementation,
-// defaulting to simple_account when unset.
+// defaulting to modular_account_v2 when unset.
 //
-// This defaults to the OLD value, which is the opposite of BundlerProvider —
-// and the difference is deliberate. Switching bundlers is invisible to users:
-// the same account sends the same operations through a different relay.
-// Switching account providers changes the DERIVED ADDRESS for every
-// (owner, salt), so defaulting to modular_account_v2 would silently move every
-// user's wallet the moment a gateway rolled out, orphaning their funds and
-// every task whose runner references the old address.
+// This default was flipped as part of the EntryPoint v0.7 cutover. Be aware of
+// what it means: the provider changes the DERIVED ADDRESS for every
+// (owner, salt), so a chain that omits account_provider resolves its users to
+// different wallets than it did under simple_account. That is the intended
+// migration, taken deliberately across all chains at once after an audit found
+// no meaningful balances in the v0.6 wallets.
 //
-// The switch is therefore opt-in per chain, so a rollout is a config change
-// that can be made one chain at a time and reverted, rather than a deploy.
+// simple_account remains selectable so a chain can be pinned to the legacy
+// derivation, but it is now the exception rather than the fallback.
 func (c *SmartWalletConfig) AccountProviderName() string {
 	p := strings.ToLower(strings.TrimSpace(c.AccountProvider))
 	if p == "" {
-		return AccountProviderSimpleAccount
+		return AccountProviderModularAccountV2
 	}
 	return p
 }
@@ -279,6 +295,22 @@ func (c *SmartWalletConfig) AccountProviderName() string {
 // UsesModularAccountV2 reports whether this chain derives MA v2 accounts.
 func (c *SmartWalletConfig) UsesModularAccountV2() bool {
 	return c.AccountProviderName() == AccountProviderModularAccountV2
+}
+
+// EntryPointAddress returns the EntryPoint this chain's operations actually
+// run against: the canonical v0.7 contract on an MA v2 chain, otherwise the
+// configured (v0.6) address.
+//
+// Prefer this over reading EntrypointAddress directly. That field is the v0.6
+// EntryPoint, and using it on an MA v2 chain addresses a contract the
+// operation never touches — which does not fail loudly. It produces userOp
+// hashes that match nothing on chain, and receipt polling that waits out its
+// full timeout looking for an event emitted somewhere else.
+func (c *SmartWalletConfig) EntryPointAddress() common.Address {
+	if c.UsesModularAccountV2() {
+		return common.HexToAddress(EntryPointV07AddressHex)
+	}
+	return c.EntrypointAddress
 }
 
 // ValidateAccountProvider rejects an unrecognised value rather than silently
@@ -305,6 +337,14 @@ var alchemyNetworkSubdomain = map[int64]string{
 	8453:     "base-mainnet",
 	84532:    "base-sepolia",
 	56:       "bnb-mainnet",
+	// Chain IDs read from each chain's own eth_chainId rather than from
+	// documentation, and each verified to carry the canonical EntryPoint v0.7
+	// (16,035 bytes) and Modular Account v2 factory (6,661 bytes) at the
+	// standard addresses — byte-identical to Sepolia, where operations have
+	// actually landed.
+	42161: "arb-mainnet",
+	999:   "hyperliquid-mainnet",
+	4663:  "robinhood-mainnet",
 }
 
 // ProviderName returns the effective bundler provider, defaulting to alchemy
@@ -709,6 +749,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			PaymasterAddress:     common.HexToAddress(configRaw.SmartWallet.PaymasterAddress),
 			WhitelistAddresses:   convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
 			MaxWalletsPerOwner:   configRaw.SmartWallet.MaxWalletsPerOwner,
+			GasManagerPolicyID:   firstNonEmpty(configRaw.GasManagerPolicyID, os.Getenv("ALCHEMY_GAS_POLICY_ID")),
 			// PaymasterOwnerAddress will be populated below by calling owner() on the paymaster contract
 		},
 
@@ -824,6 +865,10 @@ func NewConfig(configFilePath string) (*Config, error) {
 				return nil, fmt.Errorf("parsing chain config for %s (chain_id=%d): %w",
 					chainRaw.Name, chainRaw.ChainID, err)
 			}
+			// Sponsorship is configured once for the gateway, not per chain, but
+			// the v0.7 send path is only ever handed a SmartWalletConfig. Push
+			// the policy down so every chain can reach it.
+			chainCfg.SmartWallet.GasManagerPolicyID = config.GasManagerPolicyID
 			config.Chains = append(config.Chains, chainCfg)
 		}
 

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -6,21 +6,21 @@ import "testing"
 // defaults have to agree: config decides what the gateway believes, aa decides
 // what gets derived. If they ever diverge, wallets get recorded under one
 // provider and derived under the other.
-func TestAccountProviderDefaultsToSimpleAccount(t *testing.T) {
+func TestAccountProviderDefaultsToModularAccountV2(t *testing.T) {
 	var c SmartWalletConfig
-	if got := c.AccountProviderName(); got != AccountProviderSimpleAccount {
-		t.Fatalf("default = %q, want %q — defaulting to MA v2 would move every existing wallet",
-			got, AccountProviderSimpleAccount)
+	if got := c.AccountProviderName(); got != AccountProviderModularAccountV2 {
+		t.Fatalf("default = %q, want %q — the v0.7 cutover made MA v2 the default on every chain",
+			got, AccountProviderModularAccountV2)
 	}
-	if c.UsesModularAccountV2() {
-		t.Error("UsesModularAccountV2 is true by default")
+	if !c.UsesModularAccountV2() {
+		t.Error("UsesModularAccountV2 is false by default")
 	}
 }
 
 func TestAccountProviderNormalisation(t *testing.T) {
 	for in, want := range map[string]string{
-		"":                      AccountProviderSimpleAccount,
-		"  ":                    AccountProviderSimpleAccount,
+		"":                      AccountProviderModularAccountV2,
+		"  ":                    AccountProviderModularAccountV2,
 		"simple_account":        AccountProviderSimpleAccount,
 		"MODULAR_ACCOUNT_V2":    AccountProviderModularAccountV2,
 		" modular_account_v2  ": AccountProviderModularAccountV2,
@@ -51,18 +51,23 @@ func TestValidateAccountProvider(t *testing.T) {
 }
 
 // Before this was wired, ValidateAccountProvider existed but was never called
-// during config load: a typo like "mav2" was accepted, AccountProviderName()
-// returned it verbatim, and UsesModularAccountV2() went false — so a chain the
-// operator believed was on MA v2 silently handed users v0.6 addresses. The
-// function existing is not the same as it running.
-func TestTypoWouldSilentlyReadAsSimpleAccount(t *testing.T) {
+// during config load. A typo like "mav2" was accepted and returned verbatim by
+// AccountProviderName(), so UsesModularAccountV2() went false on a chain the
+// operator believed was on MA v2. The function existing is not the same as it
+// running.
+//
+// Since the default flipped, a typo no longer degrades to v0.6 addresses — it
+// reaches aa.DeriveSenderAddress as an unknown provider and errors there. That
+// is a louder failure but a much later one, at the first wallet derivation
+// rather than at boot, which is why validation at load still matters.
+func TestTypoIsRejectedAtLoad(t *testing.T) {
 	c := SmartWalletConfig{AccountProvider: "mav2"}
 
 	if c.UsesModularAccountV2() {
 		t.Fatal("precondition changed")
 	}
-	// This is the trap: it looks harmless. Only validation catches it.
+	// This is the trap: it looks harmless. Only validation catches it early.
 	if err := c.ValidateAccountProvider(); err == nil {
-		t.Fatal("a typo must be rejected; otherwise it degrades silently to simple_account")
+		t.Fatal("a typo must be rejected at config load, not at first derivation")
 	}
 }

--- a/core/config/entrypoint_test.go
+++ b/core/config/entrypoint_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// EntrypointAddress (the YAML field) is the v0.6 EntryPoint. Using it on an
+// MA v2 chain does not fail loudly — it produces userOp hashes that match
+// nothing on chain, and receipt polling that waits out its full timeout
+// watching a contract the operation never touched.
+func TestEntryPointAddressFollowsAccountProvider(t *testing.T) {
+	configured := common.HexToAddress(DefaultEntrypointAddressHex)
+	v07 := common.HexToAddress(EntryPointV07AddressHex)
+
+	if configured == v07 {
+		t.Fatal("the v0.6 and v0.7 EntryPoints must be different addresses")
+	}
+
+	t.Run("MA v2 uses the canonical v0.7 EntryPoint", func(t *testing.T) {
+		c := SmartWalletConfig{
+			EntrypointAddress: configured,
+			AccountProvider:   AccountProviderModularAccountV2,
+		}
+		if got := c.EntryPointAddress(); got != v07 {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), v07.Hex())
+		}
+	})
+
+	t.Run("unset provider is MA v2, so also v0.7", func(t *testing.T) {
+		c := SmartWalletConfig{EntrypointAddress: configured}
+		if got := c.EntryPointAddress(); got != v07 {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), v07.Hex())
+		}
+	})
+
+	t.Run("simple_account keeps the configured address", func(t *testing.T) {
+		c := SmartWalletConfig{
+			EntrypointAddress: configured,
+			AccountProvider:   AccountProviderSimpleAccount,
+		}
+		if got := c.EntryPointAddress(); got != configured {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), configured.Hex())
+		}
+	})
+
+	// A YAML override must still reach the v0.6 path — it is the only
+	// EntryPoint that is per-deployment.
+	t.Run("simple_account honours a YAML override", func(t *testing.T) {
+		custom := common.HexToAddress("0x00000000000000000000000000000000000000ee")
+		c := SmartWalletConfig{
+			EntrypointAddress: custom,
+			AccountProvider:   AccountProviderSimpleAccount,
+		}
+		if got := c.EntryPointAddress(); got != custom {
+			t.Errorf("EntryPointAddress = %s, want %s", got.Hex(), custom.Hex())
+		}
+	})
+}

--- a/core/taskengine/aave_integration_sepolia_test.go
+++ b/core/taskengine/aave_integration_sepolia_test.go
@@ -62,7 +62,7 @@ func TestAAVEHealthFactorContractRead(t *testing.T) {
 		t.Skip("OWNER_EOA or TEST_PRIVATE_KEY not set, skipping AAVE integration test")
 	}
 	smartWalletConfig := config.SmartWallet
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	setGlobalFactory(t, smartWalletConfig)
 	client, err := ethclient.Dial(smartWalletConfig.EthRpcUrl)
 	require.NoError(t, err, "Failed to connect to RPC")
 	defer client.Close()

--- a/core/taskengine/account_provider_consistency_test.go
+++ b/core/taskengine/account_provider_consistency_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // `aa` deliberately redeclares AccountProvider as its own string type instead
@@ -38,7 +39,7 @@ func TestAccountProviderConstantsMatchAcrossPackages(t *testing.T) {
 }
 
 // Both packages must also agree on what an unset value means. If config
-// defaulted to simple_account while aa defaulted to modular_account_v2 (or
+// defaulted to modular_account_v2 while aa defaulted to simple_account (or
 // vice versa), a chain with no account_provider set would be recorded as one
 // and derived as the other.
 func TestAccountProviderDefaultsAgreeAcrossPackages(t *testing.T) {
@@ -46,21 +47,29 @@ func TestAccountProviderDefaultsAgreeAcrossPackages(t *testing.T) {
 	configDefault := swCfg.AccountProviderName()
 
 	// aa's default is observable through the factory it selects for an empty
-	// provider: SimpleAccount uses the supplied factory, MA v2 ignores it.
-	simpleFactory := MAv2WalletFactory() // any non-zero address works as a probe
-	got, err := aa.FactoryAddressForProvider("", simpleFactory)
+	// provider: SimpleAccount echoes back the supplied factory, MA v2 ignores
+	// it and returns its own constant. The probe must therefore be an address
+	// that is NOT the MA v2 factory, or the two branches are indistinguishable.
+	probeFactory := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	if probeFactory == MAv2WalletFactory() {
+		t.Fatal("probe address collides with the MA v2 factory; pick another")
+	}
+	got, err := aa.FactoryAddressForProvider("", probeFactory)
 	if err != nil {
 		t.Fatalf("aa.FactoryAddressForProvider(\"\"): %v", err)
 	}
 
-	aaDefaultIsSimple := got == simpleFactory
+	aaDefaultIsSimple := got == probeFactory
 	configDefaultIsSimple := configDefault == config.AccountProviderSimpleAccount
 
 	if aaDefaultIsSimple != configDefaultIsSimple {
 		t.Fatalf("default mismatch: config says %q, aa resolves an empty provider differently",
 			configDefault)
 	}
-	if !configDefaultIsSimple {
-		t.Fatal("default is no longer simple_account; enabling MA v2 by default moves every existing wallet")
+	// The EntryPoint v0.7 cutover made MA v2 the default on every chain. If
+	// this flips back, an unconfigured chain silently returns to v0.6
+	// derivation and every wallet address moves again.
+	if configDefault != config.AccountProviderModularAccountV2 {
+		t.Fatalf("default is %q, want %q", configDefault, config.AccountProviderModularAccountV2)
 	}
 }

--- a/core/taskengine/chain_state_reader.go
+++ b/core/taskengine/chain_state_reader.go
@@ -66,7 +66,9 @@ type ChainStateReader interface {
 
 	// GetSmartWalletAddress derives the CREATE2 smart-wallet address for
 	// (owner, salt) under the given factory on this chain. Mirrors
-	// aa.GetSenderAddressForFactory.
+	// aa.DeriveSenderAddressAuto — the factory determines which account
+	// implementation (and therefore which derivation ABI) is used, so callers
+	// must pass the factory they actually mean. See aa.EffectiveFactory.
 	GetSmartWalletAddress(ctx context.Context, owner, factory common.Address, salt *big.Int) (common.Address, error)
 
 	// CallContract executes a read-only contract call (eth_call) at the
@@ -219,7 +221,7 @@ func (d *directChainStateReader) GetSmartWalletAddress(_ context.Context, owner,
 	if salt == nil {
 		salt = big.NewInt(0)
 	}
-	addr, err := aa.GetSenderAddressForFactory(d.client, owner, factory, salt)
+	addr, err := aa.DeriveSenderAddressAuto(d.client, owner, factory, salt)
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -283,7 +285,7 @@ func (d *directChainStateReader) FindMatchingWalletSalt(ctx context.Context, own
 		if err := ctx.Err(); err != nil {
 			return false, 0, err
 		}
-		addr, err := aa.GetSenderAddressForFactory(d.client, owner, factory, big.NewInt(salt))
+		addr, err := aa.DeriveSenderAddressAuto(d.client, owner, factory, big.NewInt(salt))
 		if err != nil {
 			lastErr = err
 			errCount++

--- a/core/taskengine/effective_factory_testhelper_test.go
+++ b/core/taskengine/effective_factory_testhelper_test.go
@@ -1,0 +1,49 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// effectiveFactoryHex is the factory a chain actually creates wallets under.
+//
+// Tests used to assert against smart_wallet.factory_address directly. Since
+// the EntryPoint v0.7 cutover that is only the SimpleAccount factory, while an
+// MA v2 chain records wallets under the MA v2 constant — so asserting the
+// configured value tests a wallet the engine no longer creates.
+func effectiveFactoryHex(t *testing.T, swCfg *config.SmartWalletConfig) string {
+	t.Helper()
+	factory, err := aa.EffectiveFactory(swCfg)
+	if err != nil {
+		t.Fatalf("resolving effective factory: %v", err)
+	}
+	return factory.Hex()
+}
+
+// setGlobalFactory points aa's package-global factory at the one this chain
+// actually creates accounts under.
+//
+// Tests used to call setGlobalFactory(t, cfg.SmartWallet)
+// directly. That field is the v0.6 SimpleAccountFactory, and since
+// aa.GetSenderAddress infers the account implementation from the global, those
+// tests forced themselves onto v0.6 derivation while the engine they were
+// exercising derived MA v2 — so the runner never matched any derived address.
+func setGlobalFactory(t *testing.T, swCfg *config.SmartWalletConfig) {
+	t.Helper()
+	if err := aa.SetFactoryAddressForConfig(swCfg); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
+}
+
+// effectiveFactoryAddr is effectiveFactoryHex as an address.
+func effectiveFactoryAddr(t *testing.T, swCfg *config.SmartWalletConfig) common.Address {
+	t.Helper()
+	factory, err := aa.EffectiveFactory(swCfg)
+	if err != nil {
+		t.Fatalf("resolving effective factory: %v", err)
+	}
+	return factory
+}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -389,7 +389,9 @@ func New(db storage.Storage, config *config.Config, queue *apqueue.Queue, logger
 	SetMacroSecrets(config.MacroSecrets)
 
 	SetRpc(config.SmartWallet.EthRpcUrl)
-	aa.SetFactoryAddress(config.SmartWallet.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(config.SmartWallet); err != nil {
+		panic(fmt.Sprintf("smart_wallet: cannot resolve account factory: %v", err))
+	}
 	//SetWsRpc(config.SmartWallet.EthWsUrl)
 
 	// Use global TokenEnrichmentService or initialize if not set
@@ -1096,13 +1098,18 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 	walletsToReturnProto := []*avsproto.SmartWallet{}
 	processedAddresses := make(map[string]bool)
 
-	defaultSystemFactory := n.smartWalletConfig.FactoryAddress
+	// The chain's CURRENT factory, not the raw configured one: on an MA v2
+	// chain those differ, and deriving against the configured SimpleAccount
+	// factory would hand the user their pre-cutover address.
+	defaultSystemFactory, factoryErr := aa.EffectiveFactory(n.smartWalletConfig)
 	var defaultDerivedAddress *common.Address
 	var deriveErr error
 
 	// Only try to derive default address if rpcConn is available
-	if rpcConn != nil {
-		defaultDerivedAddress, deriveErr = aa.GetSenderAddressForFactory(rpcConn, owner, defaultSystemFactory, defaultSalt)
+	if factoryErr != nil {
+		deriveErr = factoryErr
+	} else if rpcConn != nil {
+		defaultDerivedAddress, deriveErr = aa.DeriveSenderAddressAuto(rpcConn, owner, defaultSystemFactory, defaultSalt)
 	} else {
 		// In test environment or when RPC is unavailable, skip default derivation
 		n.logger.Debug("Skipping default wallet derivation due to nil rpcConn (test environment)", "owner", owner.Hex())
@@ -1342,7 +1349,13 @@ func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, pay
 		}
 	}
 
-	factoryAddr := swCfg.FactoryAddress
+	factoryAddr, factoryErr := aa.EffectiveFactory(swCfg)
+	if factoryErr != nil {
+		return nil, status.Errorf(codes.Internal, "GetWallet: resolve factory: %v", factoryErr)
+	}
+	// An explicit factory still wins — that is how a caller reaches a wallet
+	// created under the pre-cutover factory, whose provider is then inferred
+	// from the address itself rather than from this chain's config.
 	if payload.GetFactoryAddress() != "" {
 		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
@@ -1413,7 +1426,7 @@ func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, pay
 				"GetWallet: cannot reach chain %d RPC: %v", chainID, dialErr)
 		}
 		defer chainRPC.Close()
-		derivedSenderAddress, err = aa.GetSenderAddressForFactory(chainRPC, user.Address, factoryAddr, saltBig)
+		derivedSenderAddress, err = aa.DeriveSenderAddressAuto(chainRPC, user.Address, factoryAddr, saltBig)
 		if err != nil {
 			n.logger.Error("GetWallet: factory.getAddress() failed",
 				"chain_id", chainID, "owner", user.Address.Hex(), "factory", factoryAddr.Hex(),
@@ -1527,7 +1540,10 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid salt format: %s", payload.GetSalt())
 	}
 
-	factoryAddr := n.smartWalletConfig.FactoryAddress // Default factory
+	factoryAddr, factoryErr := aa.EffectiveFactory(n.smartWalletConfig) // Default factory
+	if factoryErr != nil {
+		return nil, status.Errorf(codes.Internal, "SetWallet: resolve factory: %v", factoryErr)
+	}
 	if payload.GetFactoryAddress() != "" {
 		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
@@ -1536,7 +1552,7 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, err
 	}
 
-	derivedWalletAddress, err := aa.GetSenderAddressForFactory(rpcConn, owner, factoryAddr, saltBig)
+	derivedWalletAddress, err := aa.DeriveSenderAddressAuto(rpcConn, owner, factoryAddr, saltBig)
 	if err != nil {
 		n.logger.Error("Failed to derive wallet address for SetWallet", "owner", owner.Hex(), "salt", payload.GetSalt(), "factory", payload.GetFactoryAddress(), "error", err)
 		return nil, status.Errorf(codes.Internal, "Failed to derive wallet address: %v", err)

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -392,6 +392,7 @@ func New(db storage.Storage, config *config.Config, queue *apqueue.Queue, logger
 	if err := aa.SetFactoryAddressForConfig(config.SmartWallet); err != nil {
 		panic(fmt.Sprintf("smart_wallet: cannot resolve account factory: %v", err))
 	}
+
 	//SetWsRpc(config.SmartWallet.EthWsUrl)
 
 	// Use global TokenEnrichmentService or initialize if not set

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -1,0 +1,227 @@
+package taskengine
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/oklog/ulid/v2"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// Engine surface for /policies — ownership-gated wrappers over the session
+// grant machinery, one per REST operation. The REST layer maps types and
+// errors; everything that decides anything lives here.
+
+// Sentinel errors the REST layer maps to specific statuses.
+var (
+	// ErrWalletNotOwned: the wallet is not the caller's → 404 (existence is
+	// not confirmed to non-owners).
+	ErrWalletNotOwned = errors.New("wallet is not owned by the caller")
+	// ErrSessionEntityTaken: another grant claimed the entity between prepare
+	// and submit → 409, prepare again.
+	ErrSessionEntityTaken = errors.New("validation entity was taken while the grant was being signed")
+	// ErrSessionPolicyNotFound → 404.
+	ErrSessionPolicyNotFound = errors.New("session policy not found")
+)
+
+// SessionPolicyInput carries one grant's declared shape between prepare and
+// submit. On submit every field is the client's echo of what prepare
+// returned; nothing in it is trusted — the grant is recomputed from it and
+// the signature decides.
+type SessionPolicyInput struct {
+	Wallet        common.Address
+	ChainID       int64
+	AgentLabel    string
+	Justification string
+	Permissions   SessionPermissions
+}
+
+func (in *SessionPolicyInput) validate() error {
+	if in.ChainID <= 0 {
+		return fmt.Errorf("chain id %d is not valid", in.ChainID)
+	}
+	if strings.TrimSpace(in.AgentLabel) == "" {
+		return fmt.Errorf("agent label is required")
+	}
+	return in.Permissions.Validate()
+}
+
+// sessionSignerAddress is the signer the gateway assigns to new grants —
+// today always the controller (see controllerSessionSigner for why that
+// interim holds the model).
+func (n *Engine) sessionSignerAddress() (common.Address, error) {
+	if n.config == nil || n.config.SmartWallet == nil || n.config.SmartWallet.ControllerPrivateKey == nil {
+		return common.Address{}, fmt.Errorf("no controller key configured; cannot assign a session signer")
+	}
+	return crypto.PubkeyToAddress(n.config.SmartWallet.ControllerPrivateKey.PublicKey), nil
+}
+
+// requireOwnedWallet gates every policy operation on wallet ownership. The
+// grant authorizes execution against the wallet, so acting on another
+// owner's wallet — even just listing — is refused as not-found.
+func (n *Engine) requireOwnedWallet(user *model.User, wallet common.Address) error {
+	if user == nil {
+		return fmt.Errorf("no authenticated user")
+	}
+	owned, err := n.userOwnsWalletOnAnyChain(user, wallet)
+	if err != nil {
+		return fmt.Errorf("checking wallet ownership: %w", err)
+	}
+	if !owned {
+		return ErrWalletNotOwned
+	}
+	return nil
+}
+
+// PrepareSessionPolicy allocates a grant and returns what the owner signs.
+// Nothing is stored; an abandoned prepare leaves no state.
+func (n *Engine) PrepareSessionPolicy(user *model.User, in SessionPolicyInput) (*PreparedSessionGrant, error) {
+	if err := in.validate(); err != nil {
+		return nil, err
+	}
+	if err := n.requireOwnedWallet(user, in.Wallet); err != nil {
+		return nil, err
+	}
+	signer, err := n.sessionSignerAddress()
+	if err != nil {
+		return nil, err
+	}
+	prepared, err := PrepareSessionGrant(n.db, in.ChainID, signer, strings.ToLower(ulid.Make().String()), SessionGrantRequest{
+		Owner:         user.Address,
+		Wallet:        in.Wallet,
+		AgentLabel:    in.AgentLabel,
+		Justification: in.Justification,
+		ValidUntil:    in.Permissions.ValidUntilMs,
+		HooksFor:      in.Permissions.HooksFor,
+	})
+	if err != nil {
+		return nil, err
+	}
+	attachDeclaredPermissions(prepared.Policy, in.Permissions)
+	return prepared, nil
+}
+
+// SubmitSessionPolicy verifies the owner's signature over a deterministic
+// re-preparation of the grant and stores it as pending.
+//
+// The client's echo is input, never truth: the install calldata, digest, and
+// carrier nonce are all recomputed here from the declared permissions and the
+// pinned (policyID, entityID, deadline). A tampered echo either fails
+// signature recovery or is a differently-shaped grant that must survive full
+// validation on its own merits — there is no path on which stored bytes
+// diverge from what the owner's wallet displayed and signed.
+func (n *Engine) SubmitSessionPolicy(
+	user *model.User,
+	in SessionPolicyInput,
+	policyID string,
+	entityID uint32,
+	deadline uint64,
+	ownerSignature []byte,
+) (*model.SessionPolicy, error) {
+	if err := in.validate(); err != nil {
+		return nil, err
+	}
+	if err := n.requireOwnedWallet(user, in.Wallet); err != nil {
+		return nil, err
+	}
+	if _, err := ulid.ParseStrict(strings.ToUpper(policyID)); err != nil {
+		return nil, fmt.Errorf("policy id %q is not a ULID", policyID)
+	}
+	if deadline <= uint64(time.Now().Unix()) {
+		return nil, fmt.Errorf("the signing window (deadline %d) has expired; prepare the grant again", deadline)
+	}
+	signer, err := n.sessionSignerAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	prepared, err := PrepareSessionGrant(n.db, in.ChainID, signer, strings.ToLower(policyID), SessionGrantRequest{
+		Owner:         user.Address,
+		Wallet:        in.Wallet,
+		AgentLabel:    in.AgentLabel,
+		Justification: in.Justification,
+		ValidUntil:    in.Permissions.ValidUntilMs,
+		HooksFor:      in.Permissions.HooksFor,
+		Deadline:      deadline,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if prepared.Policy.EntityID != entityID {
+		return nil, fmt.Errorf("%w: prepared entity %d, next free is now %d",
+			ErrSessionEntityTaken, entityID, prepared.Policy.EntityID)
+	}
+	attachDeclaredPermissions(prepared.Policy, in.Permissions)
+	return SubmitSessionGrant(n.db, prepared, ownerSignature)
+}
+
+// ListSessionPoliciesForWallet returns the wallet's policies, newest first.
+func (n *Engine) ListSessionPoliciesForWallet(user *model.User, chainID int64, wallet common.Address) ([]*model.SessionPolicy, error) {
+	if err := n.requireOwnedWallet(user, wallet); err != nil {
+		return nil, err
+	}
+	all, err := ListSessionPolicies(n.db, chainID, user.Address)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*model.SessionPolicy, 0, len(all))
+	for _, p := range all {
+		if p.Runner != nil && *p.Runner == wallet {
+			out = append(out, p)
+		}
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i] // ULID keys scan oldest-first
+	}
+	return out, nil
+}
+
+// GetSessionPolicyByID returns one policy, or ErrSessionPolicyNotFound.
+func (n *Engine) GetSessionPolicyByID(user *model.User, chainID int64, wallet common.Address, policyID string) (*model.SessionPolicy, error) {
+	policies, err := n.ListSessionPoliciesForWallet(user, chainID, wallet)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range policies {
+		if strings.EqualFold(p.ID, policyID) {
+			return p, nil
+		}
+	}
+	return nil, ErrSessionPolicyNotFound
+}
+
+// RevokeSessionPolicyByID revokes one policy. deleted reports the pending
+// case (record removed outright); cleanupRequired reports that the grant's
+// validation is still installed on the account and needs the owner's
+// uninstallValidation.
+func (n *Engine) RevokeSessionPolicyByID(user *model.User, chainID int64, wallet common.Address, policyID string) (deleted, cleanupRequired bool, err error) {
+	policy, err := n.GetSessionPolicyByID(user, chainID, wallet, policyID)
+	if err != nil {
+		return false, false, err
+	}
+	cleanupRequired, err = RevokeSessionGrant(n.db, policy)
+	if err != nil {
+		return false, false, err
+	}
+	return !cleanupRequired, cleanupRequired, nil
+}
+
+// attachDeclaredPermissions records the grant's declared shape on the policy
+// for the manage screen and revocation cleanup. Display data — the signed
+// truth is Grant.InstallCall.
+func attachDeclaredPermissions(policy *model.SessionPolicy, perms SessionPermissions) {
+	if policy == nil {
+		return
+	}
+	policy.AllowedActions = perms.AllowedActions
+	if perms.SpendCap != nil {
+		spendCap := *perms.SpendCap
+		spendCap.GrantedCap = spendCap.Amount
+		policy.ERC20SpendCap = &spendCap
+	}
+}

--- a/core/taskengine/engine_session_policy_test.go
+++ b/core/taskengine/engine_session_policy_test.go
@@ -1,0 +1,243 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// The /policies engine surface, exercised fully offline: prepare, sign,
+// submit, list, get, revoke. Nothing here touches a chain — the grant flow's
+// whole point is that only the FIRST WORKFLOW OPERATION does.
+
+const testPolicyChain = int64(11155111)
+
+var (
+	testTokenAddr  = common.HexToAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238")
+	testRouterAddr = common.HexToAddress("0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E")
+)
+
+func newPolicyTestEngine(t *testing.T) (*Engine, storage.Storage, *ecdsa.PrivateKey, common.Address, common.Address) {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	// The full test config: Engine's constructor dials the configured RPC, so
+	// a hand-built config with no URL panics. Nothing in the policy flow
+	// itself touches the chain. The fixture config carries no controller key
+	// and pins chain 1; both are overridable per its own comments — the key
+	// is only ever used here as an ADDRESS (the assigned session signer).
+	cfg := testutil.GetAggregatorConfig()
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	cfg.SmartWallet.ControllerPrivateKey = controllerKey
+	cfg.SmartWallet.ChainID = testPolicyChain
+	engine := New(db, cfg, nil, testutil.GetLogger())
+
+	ownerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	wallet := common.HexToAddress("0x00000000000000000000000000000000000000a1")
+	factory := common.HexToAddress("0x00000000000017c61b5bEe81050EC8eFc9c6fecd")
+	require.NoError(t, StoreWallet(db, testPolicyChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &wallet, Factory: &factory, Salt: big.NewInt(0),
+	}))
+	return engine, db, ownerKey, owner, wallet
+}
+
+func testPermissions() SessionPermissions {
+	token, router := testTokenAddr, testRouterAddr
+	return SessionPermissions{
+		AllowedActions: []model.AllowedAction{
+			{Target: &router, Selectors: []string{"0x04e45aaf"}}, // exactInputSingle
+			{Target: &token, Selectors: []string{"0x095ea7b3"}},  // approve
+		},
+		SpendCap:     &model.ERC20SpendCap{Token: &token, Amount: "500000000"},
+		ValidUntilMs: time.Now().Add(30 * 24 * time.Hour).UnixMilli(),
+	}
+}
+
+func signDigest(t *testing.T, key *ecdsa.PrivateKey, digest common.Hash) []byte {
+	t.Helper()
+	sig, err := crypto.Sign(digest.Bytes(), key)
+	require.NoError(t, err)
+	sig[64] += 27
+	return sig
+}
+
+func TestSessionPolicyPrepareSubmitRoundTrip(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	perms := testPermissions()
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "swaps you approve",
+		Permissions: perms,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, prepared.Policy.EntityID, "first grant takes entity 1")
+	require.True(t, prepared.Policy.Grant.RequiresExecuteUserOp, "a cap installs an execution hook")
+
+	// Nothing stored by prepare: an abandoned screen leaves no state.
+	policies, err := engine.ListSessionPoliciesForWallet(user, testPolicyChain, wallet)
+	require.NoError(t, err)
+	require.Empty(t, policies)
+
+	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "swaps you approve",
+		Permissions: perms,
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.NoError(t, err)
+	require.Equal(t, model.SessionPolicyPending, stored.Status)
+	require.Len(t, stored.Grant.OwnerSignature, 65)
+	require.Equal(t, "500000000", stored.ERC20SpendCap.GrantedCap)
+	require.Len(t, stored.AllowedActions, 2)
+
+	got, err := engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.Equal(t, stored.ID, got.ID)
+}
+
+// A tampered echo (here: a raised cap) produces different calldata, hence a
+// different digest, hence a signature that recovers to a stranger. The exact
+// property the stateless submit exists for.
+func TestSessionPolicySubmitRejectsTamperedEcho(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	perms := testPermissions()
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: perms,
+	})
+	require.NoError(t, err)
+	sig := signDigest(t, ownerKey, prepared.Digest)
+
+	tampered := testPermissions()
+	tampered.SpendCap.Amount = "500000000000" // 1000x the signed cap
+
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: tampered,
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline, sig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signed by", "the tamper must surface as a signature mismatch")
+}
+
+func TestSessionPolicySubmitRejectsWrongSigner(t *testing.T) {
+	engine, _, _, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+
+	strangerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: testPermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, strangerKey, prepared.Digest))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signed by")
+}
+
+// Two prepares race the same entity; the slower submit must 409, not
+// silently overwrite the faster grant's signer on chain.
+func TestSessionPolicySubmitDetectsEntityRace(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	preparedA, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "A", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	preparedB, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "B", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, preparedA.Policy.EntityID, preparedB.Policy.EntityID, "both prepares saw entity 1")
+
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "A", Permissions: testPermissions(),
+	}, preparedA.Policy.ID, preparedA.Policy.EntityID, preparedA.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, preparedA.Digest))
+	require.NoError(t, err)
+
+	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "B", Permissions: testPermissions(),
+	}, preparedB.Policy.ID, preparedB.Policy.EntityID, preparedB.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, preparedB.Digest))
+	require.ErrorIs(t, err, ErrSessionEntityTaken)
+}
+
+func TestSessionPolicyOwnershipGate(t *testing.T) {
+	engine, _, _, _, wallet := newPolicyTestEngine(t)
+	strangerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	stranger := &model.User{Address: crypto.PubkeyToAddress(strangerKey.PublicKey)}
+
+	_, err = engine.PrepareSessionPolicy(stranger, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "X", Permissions: testPermissions(),
+	})
+	require.ErrorIs(t, err, ErrWalletNotOwned)
+
+	_, err = engine.ListSessionPoliciesForWallet(stranger, testPolicyChain, wallet)
+	require.ErrorIs(t, err, ErrWalletNotOwned)
+}
+
+func TestSessionPolicyRevokePendingDeletesOutright(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.NoError(t, err)
+
+	deleted, cleanupRequired, err := engine.RevokeSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.True(t, deleted, "a pending grant was never on-chain; revoke deletes it")
+	require.False(t, cleanupRequired)
+
+	_, err = engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.True(t, errors.Is(err, ErrSessionPolicyNotFound))
+}
+
+func TestSessionPermissionsValidation(t *testing.T) {
+	token := testTokenAddr
+	base := testPermissions()
+
+	capless := base
+	capless.SpendCap = nil
+	require.Error(t, capless.Validate(), "v1 requires a cap — it installs the exec hook that stops self-administration")
+
+	uncovered := base
+	other := common.HexToAddress("0x00000000000000000000000000000000000000f9")
+	uncovered.SpendCap = &model.ERC20SpendCap{Token: &other, Amount: "1"}
+	require.Error(t, uncovered.Validate(), "the cap token must be an allowed target")
+
+	anyFunction := base
+	anyFunction.AllowedActions = []model.AllowedAction{{Target: &token, Selectors: nil}}
+	require.Error(t, anyFunction.Validate(), "any-function grants are not offered")
+
+	expired := base
+	expired.ValidUntilMs = time.Now().Add(-time.Hour).UnixMilli()
+	require.Error(t, expired.Validate())
+}

--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -67,6 +67,12 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 
 	// Initialize test database and engine
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddr)
+
 	t.Cleanup(func() {
 		storage.Destroy(db.(*storage.BadgerStorage))
 	})
@@ -102,6 +108,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 			TaskType: &avsproto.TaskNode_ContractWrite{
 				ContractWrite: &avsproto.ContractWriteNode{
 					Config: &avsproto.ContractWriteNode_Config{
+						ChainId:         cfg.SmartWallet.ChainID,
 						ContractAddress: SEPOLIA_USDC,
 						ContractAbi: func() []*structpb.Value {
 							abi, _ := structpb.NewValue(map[string]interface{}{
@@ -133,6 +140,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 			TaskType: &avsproto.TaskNode_ContractWrite{
 				ContractWrite: &avsproto.ContractWriteNode{
 					Config: &avsproto.ContractWriteNode_Config{
+						ChainId:         cfg.SmartWallet.ChainID,
 						ContractAddress: SEPOLIA_SWAPROUTER,
 						ContractAbi: func() []*structpb.Value {
 							abi, _ := structpb.NewValue(map[string]interface{}{

--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -43,7 +43,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	t.Logf("   Chain: Sepolia (ID: %d)", cfg.SmartWallet.ChainID)
 
 	// Set factory for AA library
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("   Computing salt:0 smart wallet address...")
 
 	// Connect to Sepolia

--- a/core/taskengine/execute_uniswap_approval_test.go
+++ b/core/taskengine/execute_uniswap_approval_test.go
@@ -34,7 +34,7 @@ func TestExecuteTask_UniswapApprovalAndSwap_DifferentApprovalAmounts_Sepolia(t *
 
 	// Derive smart wallet address from OWNER_EOA + salt:2
 	// Using salt=2 for address 0x5a8A8a79DdF433756D4D97DCCE33334D9E218856 which has proper balance
-	aa.SetFactoryAddress(config.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, config.SmartWallet)
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 	require.NoError(t, err, "Failed to connect to RPC")
 	defer client.Close()

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -1212,7 +1212,11 @@ func (x *WorkflowExecutor) validateWalletOwnership(ctx context.Context, chainID 
 	if swCfg != nil {
 		if reader := GetChainStateReaderForChain(uint64(chainID)); reader != nil {
 			// Gateway mode: derive salt:0 via the chain worker (no gateway dial).
-			if addr, derr := reader.GetSmartWalletAddress(ctx, user.Address, swCfg.FactoryAddress, big.NewInt(0)); derr == nil {
+			defaultFactory, factoryErr := aa.EffectiveFactory(swCfg)
+			if factoryErr != nil {
+				x.logger.Warn("Failed to resolve factory for validation",
+					"chain_id", chainID, "error", factoryErr)
+			} else if addr, derr := reader.GetSmartWalletAddress(ctx, user.Address, defaultFactory, big.NewInt(0)); derr == nil {
 				user.SmartAccountAddress = &addr
 			} else {
 				x.logger.Warn("Failed to load default smart wallet for validation",
@@ -1261,7 +1265,14 @@ func (x *WorkflowExecutor) validateWalletOwnership(ctx context.Context, chainID 
 // passing it in (rather than reading x.smartWalletConfig) is what makes
 // this work in gateway mode where the executor is shared across chains.
 func (x *WorkflowExecutor) validateDerivedWallet(ctx context.Context, chainID int64, swCfg *config.SmartWalletConfig, owner common.Address, smartWalletAddr common.Address) (bool, error) {
-	factoryAddr := swCfg.FactoryAddress
+	// Scans this chain's CURRENT factory only. After the v0.7 cutover that is
+	// the MA v2 factory, so a pre-cutover v0.6 wallet no longer validates by
+	// derivation — it validates through its stored record in step 2 of
+	// validateWalletOwnership, which is where existing wallets are recognised.
+	factoryAddr, factoryErr := aa.EffectiveFactory(swCfg)
+	if factoryErr != nil {
+		return false, factoryErr
+	}
 
 	// Try salt values from 0 to max_wallets_per_owner to see if any produce the target wallet address
 	// This uses the configured limit from aggregator.yaml
@@ -1296,7 +1307,7 @@ func (x *WorkflowExecutor) validateDerivedWallet(ctx context.Context, chainID in
 	defer rpcClient.Close()
 
 	for salt := int64(0); salt < maxWallets; salt++ {
-		derivedAddr, derr := aa.GetSenderAddressForFactory(rpcClient, owner, factoryAddr, big.NewInt(salt))
+		derivedAddr, derr := aa.DeriveSenderAddressAuto(rpcClient, owner, factoryAddr, big.NewInt(salt))
 		if derr != nil {
 			x.logger.Debug("Failed to derive wallet address",
 				"owner", owner.Hex(), "factory", factoryAddr.Hex(), "salt", salt, "error", derr)

--- a/core/taskengine/fee_estimator.go
+++ b/core/taskengine/fee_estimator.go
@@ -352,22 +352,22 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 		gasPrice = big.NewInt(int64(DefaultGasPrice))
 	}
 
-	// Build createAccount calldata using the factory ABI.
-	factoryAddress := fe.smartWalletConfig.FactoryAddress
-	initCodeHex, err := aa.GetInitCodeForFactory(walletAddress.Hex(), factoryAddress, big.NewInt(0))
+	// Build account-creation calldata against the factory this chain actually
+	// deploys with — the method differs between SimpleAccount and MA v2, so
+	// estimating against the configured SimpleAccount factory on an MA v2
+	// chain would price a deployment that never happens.
+	factoryAddress, err := aa.EffectiveFactory(fe.smartWalletConfig)
 	if err != nil {
-		fe.logger.Warn("Failed to build createAccount calldata, using fallback gas estimate",
+		fe.logger.Warn("Failed to resolve account factory, using fallback gas estimate",
 			"error", err, "fallback_gas", fallbackCreationGas)
 		return big.NewInt(fallbackCreationGas), gasPrice, nil
 	}
-
-	// initCode = factoryAddress (20 bytes) + calldata, so strip the factory address prefix
-	initCodeBytes := common.FromHex(initCodeHex)
-	if len(initCodeBytes) <= 20 {
-		fe.logger.Warn("InitCode too short, using fallback gas estimate", "fallback_gas", fallbackCreationGas)
+	factoryAddress, calldata, err := aa.DeriveInitCodeAuto(walletAddress, factoryAddress, big.NewInt(0))
+	if err != nil {
+		fe.logger.Warn("Failed to build account-creation calldata, using fallback gas estimate",
+			"error", err, "fallback_gas", fallbackCreationGas)
 		return big.NewInt(fallbackCreationGas), gasPrice, nil
 	}
-	calldata := initCodeBytes[20:]
 
 	// Estimate gas via eth_estimateGas against the factory contract
 	estimatedGas, err := fe.chain.EstimateGas(ctx, ethereum.CallMsg{

--- a/core/taskengine/list_wallets_storage_test.go
+++ b/core/taskengine/list_wallets_storage_test.go
@@ -34,7 +34,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	// Find the default wallet in the response
 	var defaultWallet *avsproto.SmartWallet
 	for _, w := range listResp.Items {
-		if w.Salt == "0" && w.Factory == config.SmartWallet.FactoryAddress.Hex() {
+		if w.Salt == "0" && w.Factory == effectiveFactoryHex(t, config.SmartWallet) {
 			defaultWallet = w
 			break
 		}
@@ -52,7 +52,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, defaultWallet.Address, storedWallet.Address.Hex(), "Stored wallet address should match")
 	assert.Equal(t, "0", storedWallet.Salt.String(), "Stored wallet salt should be 0")
-	assert.Equal(t, config.SmartWallet.FactoryAddress.Hex(), storedWallet.Factory.Hex(), "Stored wallet factory should match")
+	assert.Equal(t, effectiveFactoryHex(t, config.SmartWallet), storedWallet.Factory.Hex(), "Stored wallet factory should match")
 	assert.False(t, storedWallet.IsHidden, "Default wallet should not be hidden")
 }
 
@@ -194,7 +194,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	// Verify all wallets belong to the same owner
 	for address, wallet := range storedAddresses {
 		assert.Equal(t, user.Address, *wallet.Owner, "Wallet %s should belong to test user", address)
-		assert.Equal(t, config.SmartWallet.FactoryAddress.Hex(), wallet.Factory.Hex(), "Wallet %s should use default factory", address)
+		assert.Equal(t, effectiveFactoryHex(t, config.SmartWallet), wallet.Factory.Hex(), "Wallet %s should use default factory", address)
 	}
 }
 
@@ -327,7 +327,7 @@ func TestListWalletsDatabaseStateVerification(t *testing.T) {
 	for addr, wallet := range wallets1 {
 		salt0Address = addr
 		assert.Equal(t, "0", wallet.Salt.String(), "First wallet should have salt 0")
-		assert.Equal(t, config.SmartWallet.FactoryAddress.Hex(), wallet.Factory.Hex(), "Wallet should use default factory")
+		assert.Equal(t, effectiveFactoryHex(t, config.SmartWallet), wallet.Factory.Hex(), "Wallet should use default factory")
 		assert.Equal(t, user.Address, *wallet.Owner, "Wallet should belong to test user")
 		assert.False(t, wallet.IsHidden, "Wallet should not be hidden")
 		break

--- a/core/taskengine/mav2_grant_integration_test.go
+++ b/core/taskengine/mav2_grant_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+// +build integration
+
+package taskengine
+
+// End-to-end proof of the production MA v2 path: an owner authorizes a session
+// grant with ONE off-chain signature, and the gateway then deploys the
+// account, installs the grant during validation, and executes — all in one
+// operation it signs itself.
+//
+// This is the folded-in form of scripts/spike/deferred_action, promoted from a
+// hand-run harness so the flow is protected by the suite. It exercises the
+// public API (aa.SessionGrant, preset.SessionAuthorization,
+// preset.SendUserOpMAv2) rather than harness internals, so it fails when the
+// contract the gateway depends on changes.
+//
+// Prerequisites are REQUIRED, not skipped: a test that silently skips when a
+// key is missing reports success for a path it never ran. Run with:
+//
+//	make test/integration
+//
+// Env: SPIKE_OWNER_KEY, SPIKE_CONTROLLER_KEY, SPIKE_BUNDLER_URL,
+//      SPIKE_RPC_URL (optional), SPIKE_SALT (optional, default 9).
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// requireKey loads a private key that the test cannot run without.
+func requireKey(t *testing.T, name string) (*ecdsa.PrivateKey, common.Address) {
+	t.Helper()
+	raw := os.Getenv(name)
+	require.NotEmpty(t, raw, "%s must be set — this test executes real operations and cannot be faked", name)
+	key, err := crypto.HexToECDSA(strings.TrimPrefix(raw, "0x"))
+	require.NoError(t, err, "%s is not a valid hex private key", name)
+	return key, crypto.PubkeyToAddress(key.PublicKey)
+}
+
+func TestMAv2SessionGrantEndToEnd(t *testing.T) {
+	ownerKey, owner := requireKey(t, "SPIKE_OWNER_KEY")
+	controllerKey, controller := requireKey(t, "SPIKE_CONTROLLER_KEY")
+
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	require.NotEmpty(t, bundlerURL, "SPIKE_BUNDLER_URL must be set")
+
+	rpcURL := os.Getenv("SPIKE_RPC_URL")
+	if rpcURL == "" {
+		rpcURL = "https://ethereum-sepolia-rpc.publicnode.com"
+	}
+	salt := big.NewInt(9)
+	if s := os.Getenv("SPIKE_SALT"); s != "" {
+		n, err := strconv.ParseInt(s, 10, 64)
+		require.NoError(t, err, "SPIKE_SALT must be a decimal integer")
+		salt = big.NewInt(n)
+	}
+
+	ctx := context.Background()
+	chain, err := ethclient.Dial(rpcURL)
+	require.NoError(t, err, "cannot reach the chain RPC")
+	defer chain.Close()
+
+	chainID, err := chain.ChainID(ctx)
+	require.NoError(t, err)
+
+	swCfg := &config.SmartWalletConfig{
+		EthRpcUrl:            rpcURL,
+		BundlerURL:           bundlerURL,
+		BundlerProvider:      config.BundlerProviderSelfHosted, // BundlerURL is used verbatim
+		AccountProvider:      config.AccountProviderModularAccountV2,
+		ChainID:              chainID.Int64(),
+		ControllerPrivateKey: controllerKey,
+		FactoryAddress:       common.HexToAddress(config.DefaultFactoryProxyAddressHex),
+	}
+
+	factory, err := aa.EffectiveFactory(swCfg)
+	require.NoError(t, err)
+	require.Equal(t, aa.MAv2FactoryAddress(), factory,
+		"an MA v2 chain must resolve to the MA v2 factory")
+
+	account, err := aa.DeriveSenderAddressAuto(chain, owner, factory, salt)
+	require.NoError(t, err, "deriving the account address")
+	t.Logf("owner=%s controller=%s account=%s salt=%s",
+		owner.Hex(), controller.Hex(), account.Hex(), salt)
+
+	code, err := chain.CodeAt(ctx, *account, nil)
+	require.NoError(t, err)
+	require.Empty(t, code,
+		"account %s is already deployed — this test proves the FIRST operation, so use an unused SPIKE_SALT",
+		account.Hex())
+
+	balance, err := chain.BalanceAt(ctx, *account, nil)
+	require.NoError(t, err)
+	require.Positive(t, balance.Sign(),
+		"account %s holds no native balance; fund it before running (it pays its own gas here)",
+		account.Hex())
+
+	// ---- the owner's single, off-chain authorization -------------------------
+	//
+	// Signed before the operation exists: no gas price, no deployment, nothing
+	// on chain. That property is what lets the grant screen collect it.
+
+	const entity = aa.MinSessionEntityID
+	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: entity,
+		Signer:   controller,
+		Global:   true,
+		// No execution hook here, so this grant can administer itself. That is
+		// acceptable for a test fixture and deliberately loud; production
+		// grants carry hooks or selector scoping.
+		AllowSelfAdministration: true,
+	})
+	require.NoError(t, err, "packing the install call")
+
+	deadline := uint64(time.Now().Add(2 * time.Hour).Unix())
+
+	// The digest commits to the FULL nonce of the operation that will carry
+	// the action, which is knowable in advance only because a fresh entity is
+	// a fresh nonce key whose sequence is zero.
+	carrierNonce, err := userop.EncodeNonceMAv2(entity,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction, 0)
+	require.NoError(t, err)
+
+	digest, err := userop.DeferredActionDigest(chainID, *account, carrierNonce, deadline, installCall)
+	require.NoError(t, err, "building the EIP-712 digest")
+
+	ownerSig, err := crypto.Sign(digest.Bytes(), ownerKey) // raw digest — not EIP-191 wrapped
+	require.NoError(t, err)
+	ownerSig[64] += 27
+
+	deferredData, err := userop.EncodeDeferredActionData(userop.FallbackSignerLocator(), deadline, installCall)
+	require.NoError(t, err)
+
+	// ---- the gateway executes, signing as the controller ---------------------
+
+	// The applied-marking callback the resolver installs in production —
+	// captured here to prove the send path invokes it with the carrying
+	// operation's hash once the receipt is in hand.
+	var appliedHash string
+	auth := &preset.SessionAuthorization{
+		EntityID:       entity,
+		SignerKey:      controllerKey,
+		DeferredData:   deferredData,
+		OwnerSignature: ownerSig,
+		OnApplied: func(userOpHash string) error {
+			appliedHash = userOpHash
+			return nil
+		},
+	}
+	require.NoError(t, auth.Validate())
+	require.True(t, auth.Deferred(), "this operation must carry the install")
+
+	callData, err := aa.PackExecute(owner, big.NewInt(0), nil)
+	require.NoError(t, err, "packing the executed call")
+
+	op, receipt, err := preset.SendUserOpMAv2(swCfg, owner, callData, account, salt, auth, logger.NewNoOpLogger())
+	require.NoError(t, err, "the grant-carrying operation must succeed")
+	require.NotNil(t, receipt, "no receipt — the operation did not mine")
+	require.NotNil(t, op)
+	require.NotNil(t, op.Factory, "the first operation must also deploy the account")
+	require.NotEmpty(t, appliedHash,
+		"the send path must report the applied install so the stored grant stops attaching it")
+
+	deployed, err := chain.CodeAt(ctx, *account, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, deployed, "the account should exist after its first operation")
+
+	// ---- the point: the controller now has authority it did not have ---------
+
+	followUp := &preset.SessionAuthorization{EntityID: entity, SignerKey: controllerKey}
+	require.False(t, followUp.Deferred(), "the install must not be replayed")
+
+	op2, receipt2, err := preset.SendUserOpMAv2(swCfg, owner, callData, account, salt, followUp, logger.NewNoOpLogger())
+	require.NoError(t, err,
+		"the controller must be able to sign on its own once the grant is installed")
+	require.NotNil(t, receipt2, "the follow-up operation did not mine")
+	require.Nil(t, op2.Factory, "the account already exists; this must not redeploy")
+}

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2685,7 +2685,10 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 					// runs the scan server-side. Fall back to a direct dial +
 					// local loop when no reader is registered.
 					const runnerSaltScan = int64(5)
-					factoryAddr := n.smartWalletConfig.FactoryAddress
+					factoryAddr, factoryErr := aa.EffectiveFactory(n.smartWalletConfig)
+					if factoryErr != nil {
+						return nil, fmt.Errorf("failed to resolve factory for runner validation: %w", factoryErr)
+					}
 					runnerAddr := common.HexToAddress(runnerStr)
 					if reader := GetChainStateReaderForChain(uint64(n.smartWalletConfig.ChainID)); reader != nil {
 						found, salt, derr := reader.FindMatchingWalletSalt(ctx, vm.TaskOwner, factoryAddr, runnerAddr, runnerSaltScan)
@@ -2702,7 +2705,7 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 							return nil, fmt.Errorf("failed to connect to RPC for address derivation: %w", err)
 						}
 						for salt := int64(0); salt < runnerSaltScan; salt++ {
-							derivedAddr, derr := aa.GetSenderAddress(client, vm.TaskOwner, big.NewInt(salt))
+							derivedAddr, derr := aa.DeriveSenderAddressAuto(client, vm.TaskOwner, factoryAddr, big.NewInt(salt))
 							if derr != nil {
 								if n.logger != nil {
 									n.logger.Debug("Failed to derive address for salt", "salt", salt, "error", derr)

--- a/core/taskengine/run_node_immediately_missing_dependencies_test.go
+++ b/core/taskengine/run_node_immediately_missing_dependencies_test.go
@@ -34,7 +34,7 @@ func TestRunNodeImmediately_ContractWrite_MissingNodeDependency(t *testing.T) {
 	}
 
 	ownerEOA := *ownerAddr
-	factory := config.SmartWallet.FactoryAddress
+	factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 	// Connect to RPC client for GetSenderAddress
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)

--- a/core/taskengine/run_node_immediately_rpc_test.go
+++ b/core/taskengine/run_node_immediately_rpc_test.go
@@ -29,7 +29,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		// Create test user (simulating authenticated user from JWT)
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -271,7 +271,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		// Create test user (simulating authenticated user from JWT)
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -441,7 +441,7 @@ func TestRunNodeImmediatelyRPC(t *testing.T) {
 		// reliably and the balance override is never masked by a real balance.
 		ownerEOA := common.HexToAddress("0xe8a78b476AE1403b7fD39b662545AE608Aced7c7")
 
-		aa.SetFactoryAddress(config.SmartWallet.FactoryAddress)
+		setGlobalFactory(t, config.SmartWallet)
 		client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 		require.NoError(t, err, "Failed to connect to RPC")
 		defer client.Close()

--- a/core/taskengine/run_node_immediately_settings_test.go
+++ b/core/taskengine/run_node_immediately_settings_test.go
@@ -23,7 +23,7 @@ func TestContractWrite_WithSettingsAndUserAuth(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		// Create test user (simulating authenticated user from JWT)
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()

--- a/core/taskengine/run_node_immediately_tuple_test.go
+++ b/core/taskengine/run_node_immediately_tuple_test.go
@@ -33,7 +33,7 @@ func TestRunNodeImmediately_ContractWrite_TupleWithTemplates(t *testing.T) {
 	}
 
 	ownerEOA := *ownerAddr
-	factory := config.SmartWallet.FactoryAddress
+	factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 	// Connect to RPC client for GetSenderAddress
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)

--- a/core/taskengine/run_node_with_inputs_simulation_mode_test.go
+++ b/core/taskengine/run_node_with_inputs_simulation_mode_test.go
@@ -57,7 +57,7 @@ func TestRunNodeWithInputsRespectsIsSimulatedFlag(t *testing.T) {
 			engine := New(db, config, nil, testutil.GetLogger())
 
 			smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-			aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+			setGlobalFactory(t, smartWalletConfig)
 
 			// Create test user (simulating authenticated user from JWT)
 			ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -246,7 +246,7 @@ func TestRunNodeWithInputsDefaultsToSimulation(t *testing.T) {
 	engine := New(db, config, nil, testutil.GetLogger())
 
 	smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	setGlobalFactory(t, smartWalletConfig)
 
 	// Create test user
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()

--- a/core/taskengine/schema.go
+++ b/core/taskengine/schema.go
@@ -415,3 +415,29 @@ func FeeRecordKey(chainID int64, owner common.Address, executionID string) []byt
 func FeeRecordPrefix(chainID int64, owner common.Address) []byte {
 	return []byte(fmt.Sprintf("fr:%d:%s:", chainID, strings.ToLower(owner.Hex())))
 }
+
+// SessionPolicyPrefix scans every session policy an owner holds on a chain.
+// Fresh `sp:` namespace — additive, no migration (avs-infra §7.4a).
+func SessionPolicyPrefix(chainID int64, owner common.Address) []byte {
+	return []byte(fmt.Sprintf(
+		"sp:%d:%s:",
+		chainID,
+		strings.ToLower(owner.Hex()),
+	))
+}
+
+// SessionPolicyKey is the primary key for one grant.
+//
+// Keyed by OWNER, not by wallet, because that is who the grant belongs to and
+// who lists them. The wallet lives in the record's Runner field, so resolving
+// "the grant for this wallet" is a prefix scan plus a filter — see
+// core/taskengine/session_policy.go. Note this means entity-id uniqueness is
+// per account while the key is per owner; allocation has to account for that.
+func SessionPolicyKey(chainID int64, owner common.Address, policyID string) []byte {
+	return []byte(fmt.Sprintf(
+		"sp:%d:%s:%s",
+		chainID,
+		strings.ToLower(owner.Hex()),
+		policyID,
+	))
+}

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -1,0 +1,332 @@
+package taskengine
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Creating a session grant is two calls, not one.
+//
+// The owner signs an EIP-712 payload, and that payload cannot exist until the
+// gateway has allocated an entity, chosen a signer, and computed the nonce the
+// carrying operation will use. So the screen asks for the payload (Prepare),
+// the wallet signs it, and the signature comes back (Submit). avs-infra
+// Smart_Wallet_MA_v2_Spend_Policy.md §7.5.
+//
+// Nothing reaches the chain here. The install rides the workflow's first
+// operation, which is what makes the grant gasless to authorize and free to
+// revoke until it is used.
+
+// SessionGrantRequest is what the grant screen asks for.
+type SessionGrantRequest struct {
+	Owner  common.Address
+	Wallet common.Address // the smart wallet being granted on
+
+	AgentLabel    string
+	Justification string
+
+	// Hooks are the encoded permission modules (allowlist, spend cap, time
+	// range). They ride the same installValidation call, so the owner's one
+	// signature covers them too.
+	Hooks [][]byte
+
+	// HooksFor builds the hooks once the entity is known. Hook install data
+	// embeds the entity id, and the entity is allocated inside
+	// PrepareSessionGrant — so a caller that does not already know its entity
+	// (the REST prepare path) supplies this instead of Hooks. When set it
+	// wins over Hooks.
+	HooksFor func(entityID uint32) ([][]byte, error)
+
+	// Deadline pins the signing-window bound to an absolute uint48 unix-
+	// seconds value instead of now+SigningWindow. The submit path needs this:
+	// the deadline is inside the signed digest, so reproducing the prepared
+	// grant deterministically requires the original value, not a fresh clock
+	// reading. Zero means derive from SigningWindow.
+	Deadline uint64
+
+	// Selectors scopes the grant. Empty means a global grant, which requires
+	// an execution hook — see aa.SessionGrant.
+	Selectors [][4]byte
+
+	// ValidUntil is the grant's own lifetime (unix ms), enforced on chain by
+	// the TimeRangeModule hook when one is installed.
+	ValidUntil int64
+
+	// SigningWindow bounds how long the owner's signature stays usable before
+	// the grant's first operation. Distinct from ValidUntil. Zero picks
+	// defaultSigningWindow.
+	SigningWindow time.Duration
+
+	// AllowSelfAdministration accepts a global grant that carries no execution
+	// hook, which can call the account's own installValidation and escalate
+	// itself. Present so the case is stateable — test fixtures need it — and
+	// deliberately absent from anything the grant screen sends.
+	AllowSelfAdministration bool
+}
+
+// defaultSigningWindow bounds the gap between signing a grant and its first
+// use. Long enough that a workflow scheduled for "tomorrow" still fires, short
+// enough that a forgotten authorization does not sit in storage indefinitely.
+// A dormant workflow whose window lapses needs a re-sign, which is why this is
+// not minutes.
+const defaultSigningWindow = 30 * 24 * time.Hour
+
+// PreparedSessionGrant is what the wallet signs, plus everything the gateway
+// must remember to accept the signature back.
+type PreparedSessionGrant struct {
+	// Digest is the EIP-712 hash the owner signs. Signed RAW — the account's
+	// fallback path skips the replay-safe rewrap during validateUserOp, so
+	// this is exactly what eth_signTypedData_v4 must produce.
+	Digest common.Hash
+
+	// The fields below are echoed back to Submit. They are returned rather
+	// than stashed server-side so a prepare that is never completed leaves no
+	// state behind.
+	Policy *model.SessionPolicy
+
+	// DeferredData is the encoded action the signature authorizes.
+	DeferredData []byte
+}
+
+// PrepareSessionGrant allocates the grant and returns the payload to sign.
+//
+// The entity allocation here is READ-ONLY and provisional. It becomes real in
+// SubmitSessionGrant, which must re-check it inside the write — two prepares
+// racing on one wallet would otherwise both see the same free entity, and the
+// second install would overwrite the first grant's signer.
+func PrepareSessionGrant(
+	db storage.Storage,
+	chainID int64,
+	sessionSigner common.Address,
+	policyID string,
+	req SessionGrantRequest,
+) (*PreparedSessionGrant, error) {
+	if policyID == "" {
+		return nil, fmt.Errorf("policy id is required")
+	}
+	if req.Owner == (common.Address{}) || req.Wallet == (common.Address{}) {
+		return nil, fmt.Errorf("owner and wallet are required")
+	}
+	if sessionSigner == (common.Address{}) {
+		return nil, fmt.Errorf("session signer is required")
+	}
+
+	entity, err := NextSessionEntityID(db, chainID, req.Owner, req.Wallet)
+	if err != nil {
+		return nil, err
+	}
+
+	hooks := req.Hooks
+	if req.HooksFor != nil {
+		if hooks, err = req.HooksFor(entity); err != nil {
+			return nil, fmt.Errorf("building hooks for entity %d: %w", entity, err)
+		}
+	}
+
+	grant := aa.SessionGrant{
+		EntityID:  entity,
+		Signer:    sessionSigner,
+		Selectors: req.Selectors,
+		Hooks:     hooks,
+		Global:    len(req.Selectors) == 0,
+
+		AllowSelfAdministration: req.AllowSelfAdministration,
+	}
+	installCall, err := aa.PackSessionSignerInstall(grant)
+	if err != nil {
+		return nil, fmt.Errorf("building the grant for wallet %s: %w", req.Wallet.Hex(), err)
+	}
+
+	deadline := req.Deadline
+	if deadline == 0 {
+		window := req.SigningWindow
+		if window <= 0 {
+			window = defaultSigningWindow
+		}
+		deadline = uint64(time.Now().Add(window).Unix())
+	}
+
+	// The digest commits to the FULL nonce of the operation that will carry
+	// the action. It is knowable now only because a freshly allocated entity
+	// is a fresh nonce key whose sequence is zero.
+	carrierNonce, err := userop.EncodeNonceMAv2(entity,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction, 0)
+	if err != nil {
+		return nil, fmt.Errorf("encoding the carrier nonce: %w", err)
+	}
+
+	digest, err := userop.DeferredActionDigest(
+		big.NewInt(chainID), req.Wallet, carrierNonce, deadline, installCall)
+	if err != nil {
+		return nil, fmt.Errorf("building the grant digest: %w", err)
+	}
+
+	deferredData, err := userop.EncodeDeferredActionData(
+		userop.FallbackSignerLocator(), deadline, installCall)
+	if err != nil {
+		return nil, fmt.Errorf("encoding the deferred action: %w", err)
+	}
+
+	owner, wallet, signer := req.Owner, req.Wallet, sessionSigner
+	return &PreparedSessionGrant{
+		Digest:       digest,
+		DeferredData: deferredData,
+		Policy: &model.SessionPolicy{
+			ID:            policyID,
+			Owner:         &owner,
+			Runner:        &wallet,
+			ChainID:       chainID,
+			EntityID:      entity,
+			SessionSigner: &signer,
+			AgentLabel:    req.AgentLabel,
+			Justification: req.Justification,
+			ValidUntil:    req.ValidUntil,
+			Status:        model.SessionPolicyPending,
+			CreatedAt:     time.Now().UnixMilli(),
+			Grant: &model.SessionGrantAuthorization{
+				InstallCall:           installCall,
+				CarrierNonce:          carrierNonce,
+				Deadline:              deadline,
+				RequiresExecuteUserOp: grant.HasExecutionHook(),
+			},
+		},
+	}, nil
+}
+
+// SubmitSessionGrant records the owner's signature and stores the policy.
+//
+// The signature is verified against the owner before anything is written. A
+// grant that does not recover to the owner would be accepted, stored, and then
+// fail during the first operation's validation — on chain, with an error that
+// names neither this record nor the mismatch.
+func SubmitSessionGrant(db storage.Storage, prepared *PreparedSessionGrant, ownerSignature []byte) (*model.SessionPolicy, error) {
+	if prepared == nil || prepared.Policy == nil {
+		return nil, fmt.Errorf("nothing prepared to submit")
+	}
+	if len(ownerSignature) != 65 {
+		return nil, fmt.Errorf("owner signature is %d bytes, want 65", len(ownerSignature))
+	}
+	policy := prepared.Policy
+
+	if err := verifyGrantSignature(prepared.Digest, ownerSignature, *policy.Owner); err != nil {
+		return nil, err
+	}
+
+	// Re-check the entity inside the write path. PrepareSessionGrant's
+	// allocation was provisional: another grant on this wallet may have
+	// landed in between, and reusing its entity would overwrite that grant's
+	// signer on chain.
+	entity, err := NextSessionEntityID(db, policy.ChainID, *policy.Owner, *policy.Runner)
+	if err != nil {
+		return nil, err
+	}
+	if entity != policy.EntityID {
+		return nil, fmt.Errorf(
+			"entity %d was taken while this grant was being signed (next free is %d); prepare it again",
+			policy.EntityID, entity)
+	}
+
+	policy.Grant.OwnerSignature = ownerSignature
+	if err := StoreSessionPolicy(db, policy); err != nil {
+		return nil, err
+	}
+	return policy, nil
+}
+
+// MarkSessionGrantApplied records that the deferred install reached the chain,
+// so it is never attached to a second operation.
+func MarkSessionGrantApplied(db storage.Storage, policy *model.SessionPolicy, userOpHash string) error {
+	if policy == nil || policy.Grant == nil {
+		return fmt.Errorf("no policy to mark applied")
+	}
+	if policy.Grant.Applied() {
+		return nil // already recorded; marking twice is not an error
+	}
+	policy.Grant.AppliedAt = time.Now().UnixMilli()
+	policy.Grant.AppliedUserOpHash = userOpHash
+	policy.Status = model.SessionPolicyActive
+	return StoreSessionPolicy(db, policy)
+}
+
+// MarkSessionGrantAppliedByID is MarkSessionGrantApplied for callers that
+// held the policy EARLIER — the resolver's callback fires after an operation
+// confirms, and by then the record may have moved. It re-reads and only
+// transitions pending → active:
+//
+//   - Record gone: the grant was revoked (pending revokes delete outright)
+//     while its install was in flight. Nothing to update — though if the
+//     operation mined, the entity now exists on-chain with no record behind
+//     it, an orphan only the owner's uninstallValidation can clear. Reported
+//     as nil because there is no state left to make consistent.
+//   - Status not pending: never overwrite. Re-storing a stale in-memory
+//     policy here could resurrect a revoked grant as active, which is why
+//     this exists instead of handing the callback the old pointer.
+func MarkSessionGrantAppliedByID(db storage.Storage, chainID int64, owner common.Address, policyID, userOpHash string) error {
+	raw, err := db.GetKey(SessionPolicyKey(chainID, owner, policyID))
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return nil // no record — revoked while in flight; see above
+	}
+	if err != nil {
+		return fmt.Errorf("reading session policy %s: %w", policyID, err)
+	}
+	policy := &model.SessionPolicy{}
+	if err := policy.FromStorageData(raw); err != nil {
+		return fmt.Errorf("session policy %s is unreadable: %w", policyID, err)
+	}
+	if policy.Status != model.SessionPolicyPending || policy.Grant.Applied() {
+		return nil
+	}
+	return MarkSessionGrantApplied(db, policy, userOpHash)
+}
+
+// RevokeSessionGrant removes a grant.
+//
+// Before the install reaches the chain this is complete on its own: nothing
+// was installed, so deleting the record removes the authority. After it has
+// applied, this only stops the gateway from using the grant — the module is
+// still installed on the account, and clearing it needs uninstallValidation.
+// The record is retained in that case so the cleanup payload survives.
+func RevokeSessionGrant(db storage.Storage, policy *model.SessionPolicy) (onChainCleanupRequired bool, err error) {
+	if policy == nil {
+		return false, fmt.Errorf("no policy to revoke")
+	}
+	key := SessionPolicyKey(policy.ChainID, *policy.Owner, policy.ID)
+	if !policy.Grant.Applied() {
+		return false, db.Delete(key)
+	}
+	policy.Status = model.SessionPolicyRevoked
+	return true, StoreSessionPolicy(db, policy)
+}
+
+// verifyGrantSignature checks that the signature recovers to the owner.
+//
+// The digest is signed RAW, not EIP-191 wrapped — the account's fallback 1271
+// path skips the replay-safe rewrap during validateUserOp, so recovery here
+// must match that exactly or a valid grant would be rejected.
+func verifyGrantSignature(digest common.Hash, signature []byte, owner common.Address) error {
+	sig := make([]byte, len(signature))
+	copy(sig, signature)
+	// go-ethereum recovers with v in {0,1}; wallets emit 27/28.
+	if sig[64] >= 27 {
+		sig[64] -= 27
+	}
+	pub, err := crypto.SigToPub(digest.Bytes(), sig)
+	if err != nil {
+		return fmt.Errorf("grant signature is malformed: %w", err)
+	}
+	if got := crypto.PubkeyToAddress(*pub); got != owner {
+		return fmt.Errorf("grant was signed by %s, not the wallet owner %s", got.Hex(), owner.Hex())
+	}
+	return nil
+}

--- a/core/taskengine/session_grant_applied_test.go
+++ b/core/taskengine/session_grant_applied_test.go
@@ -1,0 +1,97 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// The applied-marking loop: the resolver hands the send path a callback, the
+// callback transitions the stored record, and the NEXT resolution stops
+// attaching the deferred action. This is what keeps a grant's install from
+// being replayed onto an entity that already exists.
+
+func storedPendingGrant(t *testing.T) (*Engine, *model.User, common.Address, *model.SessionPolicy) {
+	t.Helper()
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.NoError(t, err)
+	return engine, user, wallet, stored
+}
+
+func testResolverKey(controller *ecdsa.PrivateKey) func(common.Address) (*ecdsa.PrivateKey, error) {
+	return func(common.Address) (*ecdsa.PrivateKey, error) { return controller, nil }
+}
+
+func TestResolverMarksAppliedAndStopsAttachingTheInstall(t *testing.T) {
+	engine, user, wallet, stored := storedPendingGrant(t)
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	resolver := NewSessionResolver(engine.db, testResolverKey(controllerKey))
+
+	// First resolution: pending grant → deferred install attached, with the
+	// callback that will record its landing.
+	auth, err := resolver(testPolicyChain, user.Address, wallet)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	require.True(t, auth.Deferred(), "a pending grant's first operation carries the install")
+	require.NotNil(t, auth.OnApplied, "the send path needs a way to record the landing")
+
+	// The send path saw the receipt.
+	require.NoError(t, auth.OnApplied("0xabc123"))
+
+	updated, err := engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.Equal(t, model.SessionPolicyActive, updated.Status)
+	require.Equal(t, "0xabc123", updated.Grant.AppliedUserOpHash)
+	require.True(t, updated.Grant.Applied())
+
+	// Second resolution: the install is history; the operation runs plain.
+	auth, err = resolver(testPolicyChain, user.Address, wallet)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	require.False(t, auth.Deferred(), "an applied install must never be attached again")
+	require.Nil(t, auth.OnApplied)
+	require.EqualValues(t, stored.EntityID, auth.EntityID)
+}
+
+func TestMarkAppliedByIDIsIdempotentAndRaceSafe(t *testing.T) {
+	engine, user, wallet, stored := storedPendingGrant(t)
+	owner := user.Address
+
+	// Idempotent: marking twice keeps the first record.
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xfirst"))
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xsecond"))
+	updated, err := engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.Equal(t, "0xfirst", updated.Grant.AppliedUserOpHash)
+
+	// Revoked-in-flight: the record moved on; a late mark must not resurrect
+	// it as active.
+	_, cleanup, err := engine.RevokeSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
+	require.NoError(t, err)
+	require.True(t, cleanup, "an applied grant's revoke leaves on-chain state")
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xlate"))
+	after, err := ListSessionPolicies(engine.db, testPolicyChain, owner)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.Equal(t, model.SessionPolicyRevoked, after[0].Status, "a late mark must never resurrect a revoked grant")
+
+	// Deleted-in-flight (a PENDING grant revoked while its op was in the
+	// mempool): no record left; the mark is a no-op, not an error.
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, "01jarbitrarymissingpolicyid", ""))
+}

--- a/core/taskengine/session_grant_test.go
+++ b/core/taskengine/session_grant_test.go
@@ -1,0 +1,223 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// The whole grant flow, without a chain: the gateway prepares a payload, the
+// owner signs it, the gateway stores it, and the send path then resolves an
+// authorization that carries the install exactly once.
+func TestSessionGrantRoundTrip(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	ownerKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	signerKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(signerKey.PublicKey)
+
+	prepared, err := PrepareSessionGrant(db, spChain, signer, "p1", SessionGrantRequest{
+		Owner:      owner,
+		Wallet:     spWallet,
+		AgentLabel: "TradingBot",
+		// A global grant needs an execution hook, so give it one — this also
+		// exercises RequiresExecuteUserOp being derived rather than asserted.
+		Hooks: [][]byte{aa.AllowlistExecHook(1)},
+	})
+	if err != nil {
+		t.Fatalf("PrepareSessionGrant: %v", err)
+	}
+	if prepared.Policy.EntityID != 1 {
+		t.Errorf("first grant should take entity 1, got %d", prepared.Policy.EntityID)
+	}
+	if !prepared.Policy.Grant.RequiresExecuteUserOp {
+		t.Error("a grant carrying an execution hook must require executeUserOp wrapping")
+	}
+	if prepared.Policy.Grant.CarrierNonce == nil {
+		t.Fatal("no carrier nonce — it cannot be recomputed later")
+	}
+
+	// Nothing is stored until the owner signs.
+	if got, _ := ActiveSessionPolicyForWallet(db, spChain, owner, spWallet); got != nil {
+		t.Error("preparing a grant must not persist anything")
+	}
+
+	sig, err := crypto.Sign(prepared.Digest.Bytes(), ownerKey) // raw digest
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig[64] += 27
+
+	policy, err := SubmitSessionGrant(db, prepared, sig)
+	if err != nil {
+		t.Fatalf("SubmitSessionGrant: %v", err)
+	}
+	if policy.Status != model.SessionPolicyPending {
+		t.Errorf("a submitted grant starts pending, got %q", policy.Status)
+	}
+
+	// The send path can now resolve it, and the install rides along exactly
+	// once: attached while pending, dropped after it is marked applied.
+	resolve := NewSessionResolver(db, func(a common.Address) (*ecdsa.PrivateKey, error) {
+		if a != signer {
+			return nil, fmt.Errorf("unexpected signer %s", a.Hex())
+		}
+		return signerKey, nil
+	})
+	auth, err := resolve(spChain, owner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth == nil || !auth.Deferred() {
+		t.Fatal("a pending grant's first operation must carry the install")
+	}
+	if !auth.WrapExecuteUserOp {
+		t.Error("the hook-carrying grant must wrap in user-op context")
+	}
+
+	if err := MarkSessionGrantApplied(db, policy, "0xdeadbeef"); err != nil {
+		t.Fatalf("MarkSessionGrantApplied: %v", err)
+	}
+	auth, err = resolve(spChain, owner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve after apply: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("an applied grant still authorizes execution")
+	}
+	if auth.Deferred() {
+		t.Error("the install must not be attached a second time")
+	}
+}
+
+// A signature from anyone but the owner must be refused before storage. A
+// stored bad grant fails later, on chain, naming neither the record nor the
+// mismatch.
+func TestSubmitSessionGrantRejectsAForeignSignature(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	ownerKey, _ := crypto.GenerateKey()
+	strangerKey, _ := crypto.GenerateKey()
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	signer := crypto.PubkeyToAddress(strangerKey.PublicKey)
+
+	prepared, err := PrepareSessionGrant(db, spChain, signer, "p1", SessionGrantRequest{
+		Owner: owner, Wallet: spWallet, Hooks: [][]byte{aa.AllowlistExecHook(1)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, _ := crypto.Sign(prepared.Digest.Bytes(), strangerKey)
+	sig[64] += 27
+
+	if _, err := SubmitSessionGrant(db, prepared, sig); err == nil {
+		t.Fatal("a grant signed by someone other than the owner must be refused")
+	}
+	if got, _ := ActiveSessionPolicyForWallet(db, spChain, owner, spWallet); got != nil {
+		t.Error("a rejected grant must not be stored")
+	}
+}
+
+// Two grants prepared concurrently on one wallet both see the same free
+// entity. The second submit must lose rather than overwrite the first grant's
+// signer on chain.
+func TestConcurrentPreparesCannotCollideOnAnEntity(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	ownerKey, _ := crypto.GenerateKey()
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	signerKey, _ := crypto.GenerateKey()
+	signer := crypto.PubkeyToAddress(signerKey.PublicKey)
+
+	req := SessionGrantRequest{Owner: owner, Wallet: spWallet, Hooks: [][]byte{aa.AllowlistExecHook(1)}}
+	first, err := PrepareSessionGrant(db, spChain, signer, "p1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := PrepareSessionGrant(db, spChain, signer, "p2", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Policy.EntityID != second.Policy.EntityID {
+		t.Fatal("precondition: both prepares should have seen the same free entity")
+	}
+
+	sign := func(p *PreparedSessionGrant) []byte {
+		s, _ := crypto.Sign(p.Digest.Bytes(), ownerKey)
+		s[64] += 27
+		return s
+	}
+	if _, err := SubmitSessionGrant(db, first, sign(first)); err != nil {
+		t.Fatalf("the first submit should succeed: %v", err)
+	}
+	if _, err := SubmitSessionGrant(db, second, sign(second)); err == nil {
+		t.Error("the second submit must be refused; its entity was taken while it was being signed")
+	}
+}
+
+// Revocation splits on whether the install ever reached the chain.
+func TestRevokeSessionGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	t.Run("before first use it is free and complete", func(t *testing.T) {
+		p := spPolicy("p1", spWallet, 1, model.SessionPolicyPending)
+		if err := StoreSessionPolicy(db, p); err != nil {
+			t.Fatal(err)
+		}
+		onChain, err := RevokeSessionGrant(db, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if onChain {
+			t.Error("an unapplied grant needs no on-chain cleanup")
+		}
+		got, _ := ActiveSessionPolicyForWallet(db, spChain, spOwner, spWallet)
+		if got != nil {
+			t.Error("the record should be gone")
+		}
+	})
+
+	t.Run("after install it needs uninstallValidation", func(t *testing.T) {
+		p := spPolicy("p2", spWallet2, 1, model.SessionPolicyActive)
+		p.Grant.AppliedAt = 1_753_000_000_000
+		if err := StoreSessionPolicy(db, p); err != nil {
+			t.Fatal(err)
+		}
+		onChain, err := RevokeSessionGrant(db, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !onChain {
+			t.Error("an applied grant leaves a module installed on the account")
+		}
+		// Retained, not deleted: the cleanup payload is the same tuple as the
+		// install, so the record has to survive to reproduce it.
+		got, err := ActiveSessionPolicyForWallet(db, spChain, spOwner, spWallet2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Error("a revoked grant must not authorize anything")
+		}
+	})
+}

--- a/core/taskengine/session_grant_testhelper_test.go
+++ b/core/taskengine/session_grant_testhelper_test.go
@@ -1,0 +1,144 @@
+package taskengine
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Live-chain tests execute through the gateway, and the gateway cannot sign as
+// a wallet's owner — a stock MA v2 account trusts only its fallback signer.
+// Every such test therefore needs a session grant in place before it runs, the
+// same one the grant screen will create in production.
+//
+// grantControllerAuthority builds that grant and installs a resolver over the
+// test's own database, so the test exercises the real resolution path rather
+// than injecting an authorization directly.
+//
+// It is idempotent against the CHAIN, which matters because these wallets are
+// long-lived Sepolia fixtures: if the controller is already installed at the
+// entity, the stored grant is marked applied so the deferred install is not
+// replayed onto an entity that already exists. Otherwise it stays pending and
+// rides the test's first operation.
+func grantControllerAuthority(
+	t *testing.T,
+	db storage.Storage,
+	swCfg *config.SmartWalletConfig,
+	owner common.Address,
+	wallet common.Address,
+) {
+	t.Helper()
+
+	ownerKey := requireOwnerKey(t)
+	if got := crypto.PubkeyToAddress(ownerKey.PublicKey); got != owner {
+		t.Fatalf("TEST_PRIVATE_KEY is %s but the test's owner is %s; they must match to authorize a grant",
+			got.Hex(), owner.Hex())
+	}
+	if swCfg.ControllerPrivateKey == nil {
+		t.Fatal("no controller key configured; the gateway cannot be granted anything")
+	}
+	controller := crypto.PubkeyToAddress(swCfg.ControllerPrivateKey.PublicKey)
+
+	prepared, err := PrepareSessionGrant(db, swCfg.ChainID, controller, "test-grant", SessionGrantRequest{
+		Owner:  owner,
+		Wallet: wallet,
+		// Global with no hooks: a fixture grant, and the API makes that
+		// deliberate rather than accidental. Production grants carry hooks.
+		Selectors: nil,
+		Hooks:     nil,
+		// A bare global grant is refused unless acknowledged. Fixtures may be
+		// self-administering; production grants carry hooks or scoping.
+		AllowSelfAdministration: true,
+	})
+	if err != nil {
+		t.Fatalf("preparing the test grant: %v", err)
+	}
+
+	sig, err := crypto.Sign(prepared.Digest.Bytes(), ownerKey) // raw digest
+	if err != nil {
+		t.Fatalf("signing the grant: %v", err)
+	}
+	sig[64] += 27
+
+	policy, err := SubmitSessionGrant(db, prepared, sig)
+	if err != nil {
+		t.Fatalf("submitting the grant: %v", err)
+	}
+
+	// If the entity already holds the controller on chain, the install has
+	// happened in a previous run. Replaying it would re-run installValidation
+	// on an existing entity.
+	if installedOnChain(t, swCfg, wallet, policy.EntityID, controller) {
+		if err := MarkSessionGrantApplied(db, policy, "pre-existing"); err != nil {
+			t.Fatalf("marking the grant applied: %v", err)
+		}
+		t.Logf("grant: entity %d already installed on %s; not replaying the install",
+			policy.EntityID, wallet.Hex())
+	} else {
+		t.Logf("grant: entity %d pending on %s; the install rides the first operation",
+			policy.EntityID, wallet.Hex())
+	}
+
+	preset.SetSessionResolver(NewSessionResolver(db, func(a common.Address) (*ecdsa.PrivateKey, error) {
+		if a != controller {
+			return nil, fmt.Errorf("no key for session signer %s", a.Hex())
+		}
+		return swCfg.ControllerPrivateKey, nil
+	}))
+	t.Cleanup(func() { preset.SetSessionResolver(nil) })
+}
+
+// requireOwnerKey loads the owner key these tests cannot authorize without.
+func requireOwnerKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	raw := os.Getenv("TEST_PRIVATE_KEY")
+	if raw == "" {
+		t.Fatal("TEST_PRIVATE_KEY must be set: the gateway cannot sign for a wallet without a grant, " +
+			"and only the owner can authorize one")
+	}
+	key, err := crypto.HexToECDSA(strings.TrimPrefix(raw, "0x"))
+	if err != nil {
+		t.Fatalf("TEST_PRIVATE_KEY is not a valid hex private key: %v", err)
+	}
+	return key
+}
+
+// installedOnChain reports whether the entity already names this signer.
+func installedOnChain(t *testing.T, swCfg *config.SmartWalletConfig, wallet common.Address, entity uint32, signer common.Address) bool {
+	t.Helper()
+	client, err := ethclient.Dial(swCfg.EthRpcUrl)
+	if err != nil {
+		t.Fatalf("dialing the chain to check the grant: %v", err)
+	}
+	defer client.Close()
+
+	data := append(common.FromHex(selectorSSVMSigners), padWord(entity)...)
+	data = append(data, common.LeftPadBytes(wallet.Bytes(), 32)...)
+	module := aa.SingleSignerValidationModuleAddress()
+	out, err := client.CallContract(context.Background(), ethereum.CallMsg{To: &module, Data: data}, nil)
+	if err != nil || len(out) < 32 {
+		return false
+	}
+	return common.BytesToAddress(out[12:32]) == signer
+}
+
+// selectorSSVMSigners is SingleSignerValidationModule.signers(uint32,address).
+const selectorSSVMSigners = "0x217178fb"
+
+func padWord(v uint32) []byte {
+	return common.LeftPadBytes(big.NewInt(int64(v)).Bytes(), 32)
+}

--- a/core/taskengine/session_permissions.go
+++ b/core/taskengine/session_permissions.go
@@ -1,0 +1,128 @@
+package taskengine
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// SessionPermissions is the declared §7.2 permission set — allowed actions,
+// ERC-20 spend cap, expiry — and its translation into the hook entries a
+// grant installs. This is the only place that translation lives: the REST
+// layer hands over declared permissions, never raw hook bytes, so a client
+// cannot smuggle an encoding the grant screen did not show.
+//
+// v1 requires all three permissions. That is not just product scope: the cap
+// installs the allowlist's EXECUTION hook, and per the revoke spike (results
+// doc §3.5) that hook is what stops a global session validation from
+// self-administering the account. A capless global grant would need
+// selector-scoping instead, which is not yet exercised on-chain.
+type SessionPermissions struct {
+	AllowedActions []model.AllowedAction
+	SpendCap       *model.ERC20SpendCap
+	ValidUntilMs   int64
+}
+
+// Validate rejects a permission set the grant screen could not have produced.
+func (p SessionPermissions) Validate() error {
+	if len(p.AllowedActions) == 0 {
+		return fmt.Errorf("a grant needs at least one allowed action")
+	}
+	for i, action := range p.AllowedActions {
+		if action.Target == nil || *action.Target == (common.Address{}) {
+			return fmt.Errorf("allowed action %d has no target", i)
+		}
+		if len(action.Selectors) == 0 {
+			return fmt.Errorf("allowed action %d on %s has no selectors; an any-function grant is not offered", i, action.Target.Hex())
+		}
+		for _, s := range action.Selectors {
+			if _, err := parseSelector(s); err != nil {
+				return fmt.Errorf("allowed action %d: %w", i, err)
+			}
+		}
+	}
+	if p.SpendCap == nil || p.SpendCap.Token == nil {
+		return fmt.Errorf("a grant needs an ERC-20 spend cap")
+	}
+	if amount, ok := new(big.Int).SetString(p.SpendCap.Amount, 10); !ok || amount.Sign() <= 0 {
+		return fmt.Errorf("spend cap amount %q is not a positive decimal integer", p.SpendCap.Amount)
+	}
+	capCovered := false
+	for _, action := range p.AllowedActions {
+		if action.Target != nil && *action.Target == *p.SpendCap.Token {
+			capCovered = true
+			break
+		}
+	}
+	if !capCovered {
+		return fmt.Errorf("the cap token %s is not an allowed-action target; cap a token the agent may actually call", p.SpendCap.Token.Hex())
+	}
+	if p.ValidUntilMs <= time.Now().UnixMilli() {
+		return fmt.Errorf("validUntil is in the past")
+	}
+	return nil
+}
+
+// HooksFor builds the grant's hook entries for its allocated entity:
+// the allowlist validation hook (targets, selectors, and the cap's limit in
+// one install payload), the allowlist execution hook that enforces the cap,
+// and the time-range hook that expires the grant.
+func (p SessionPermissions) HooksFor(entityID uint32) ([][]byte, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+
+	inputs := make([]aa.AllowlistInput, 0, len(p.AllowedActions))
+	capAmount, _ := new(big.Int).SetString(p.SpendCap.Amount, 10)
+	for _, action := range p.AllowedActions {
+		selectors := make([][4]byte, 0, len(action.Selectors))
+		for _, s := range action.Selectors {
+			sel, err := parseSelector(s)
+			if err != nil {
+				return nil, err
+			}
+			selectors = append(selectors, sel)
+		}
+		input := aa.AllowlistInput{
+			Target:               *action.Target,
+			HasSelectorAllowlist: true,
+			Selectors:            selectors,
+		}
+		if *action.Target == *p.SpendCap.Token {
+			input.HasERC20SpendLimit = true
+			input.ERC20SpendLimit = capAmount
+		}
+		inputs = append(inputs, input)
+	}
+
+	allowlistHook, err := aa.AllowlistValidationHook(entityID, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("building the allowlist hook: %w", err)
+	}
+	timeRangeHook, err := aa.TimeRangeValidationHook(entityID, uint64(p.ValidUntilMs/1000), 0)
+	if err != nil {
+		return nil, fmt.Errorf("building the time-range hook: %w", err)
+	}
+	return [][]byte{allowlistHook, aa.AllowlistExecHook(entityID), timeRangeHook}, nil
+}
+
+func parseSelector(s string) ([4]byte, error) {
+	var out [4]byte
+	raw := strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	if len(raw) != 8 {
+		return out, fmt.Errorf("selector %q is not 4 bytes", s)
+	}
+	b, err := hex.DecodeString(raw)
+	if err != nil {
+		return out, fmt.Errorf("selector %q is not hex: %w", s, err)
+	}
+	copy(out[:], b)
+	return out, nil
+}

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -1,0 +1,206 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Session-policy storage and the resolver that connects it to the send path.
+//
+// A stock Modular Account v2 trusts only its fallback signer — the user's EOA,
+// whose key the gateway does not hold. Everything the gateway executes
+// therefore runs as an installed validation entity, and the grant that
+// installed it lives here.
+
+// ListSessionPolicies returns every policy an owner holds on a chain.
+//
+// Records that fail to deserialize are an error rather than a silent skip: a
+// dropped policy reads downstream as "this wallet has no grant", which sends
+// the operation to the owner's fallback signer and fails on chain with nothing
+// pointing back at the unreadable record.
+func ListSessionPolicies(db storage.Storage, chainID int64, owner common.Address) ([]*model.SessionPolicy, error) {
+	items, err := db.GetByPrefix(SessionPolicyPrefix(chainID, owner))
+	if err != nil {
+		return nil, fmt.Errorf("listing session policies for %s on chain %d: %w", owner.Hex(), chainID, err)
+	}
+	out := make([]*model.SessionPolicy, 0, len(items))
+	for _, item := range items {
+		policy := &model.SessionPolicy{}
+		if err := policy.FromStorageData(item.Value); err != nil {
+			return nil, fmt.Errorf("session policy at %s is unreadable: %w", string(item.Key), err)
+		}
+		out = append(out, policy)
+	}
+	return out, nil
+}
+
+// StoreSessionPolicy persists a grant.
+func StoreSessionPolicy(db storage.Storage, policy *model.SessionPolicy) error {
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	body, err := policy.ToJSON()
+	if err != nil {
+		return fmt.Errorf("serializing session policy %s: %w", policy.ID, err)
+	}
+	return db.Set(SessionPolicyKey(policy.ChainID, *policy.Owner, policy.ID), body)
+}
+
+// ActiveSessionPolicyForWallet returns the usable grant for one wallet.
+//
+// Exactly one usable grant per wallet is expected. More than one is refused
+// rather than resolved by picking: two grants mean two entities, and silently
+// choosing would sign under one while the caller may have provisioned the
+// other — an authority question is not a place for a heuristic.
+func ActiveSessionPolicyForWallet(db storage.Storage, chainID int64, owner, wallet common.Address) (*model.SessionPolicy, error) {
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	if err != nil {
+		return nil, err
+	}
+	var found *model.SessionPolicy
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != wallet || !p.Usable() {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf(
+				"wallet %s has more than one usable session policy (%s, %s); revoke one before executing",
+				wallet.Hex(), found.ID, p.ID)
+		}
+		found = p
+	}
+	return found, nil
+}
+
+// NextSessionEntityID picks an unused validation entity for a wallet.
+//
+// Uniqueness is per ACCOUNT while the storage key is per owner, so this scans
+// the owner's policies and filters by runner. It is deliberately NOT safe to
+// call outside the transaction that writes the resulting policy: two
+// concurrent grants on one wallet would read the same maximum, and the second
+// install would overwrite the first grant's signer at the same entity. See
+// avs-infra §7.4a.
+func NextSessionEntityID(db storage.Storage, chainID int64, owner, wallet common.Address) (uint32, error) {
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	if err != nil {
+		return 0, err
+	}
+	// Revoked policies still count: their entity may hold module state that
+	// was never cleaned up, and reusing it would collide with the leftovers.
+	next := uint32(1)
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != wallet {
+			continue
+		}
+		if p.EntityID >= next {
+			next = p.EntityID + 1
+		}
+	}
+	return next, nil
+}
+
+// InstallSessionResolver wires the send path to this engine's session-policy
+// storage. Without it every MA v2 operation is signed as the account's
+// fallback signer — the user's EOA, whose key the gateway does not hold — so
+// nothing the gateway executes validates.
+//
+// Called once at aggregator startup, deliberately NOT from New: the resolver
+// is process-global (the preset package has no per-engine context), and test
+// suites construct many engines whose constructors would silently overwrite
+// each other's resolver — the last-built engine would then answer authority
+// questions for all of them. The single production engine installs it
+// explicitly; tests that need one install their own scoped to their own
+// database.
+func (n *Engine) InstallSessionResolver() {
+	preset.SetSessionResolver(NewSessionResolver(n.db, controllerSessionSigner(n.config)))
+}
+
+// NewSessionResolver builds the resolver the send path consults, backed by
+// storage and a key lookup.
+//
+// signerKeyFor maps a session-signer ADDRESS to its private key. It is a
+// callback rather than a map so key material stays wherever the gateway keeps
+// it and never has to live on this record.
+func NewSessionResolver(
+	db storage.Storage,
+	signerKeyFor func(signer common.Address) (*ecdsa.PrivateKey, error),
+) preset.SessionResolver {
+	return func(chainID int64, owner, wallet common.Address) (*preset.SessionAuthorization, error) {
+		policy, err := ActiveSessionPolicyForWallet(db, chainID, owner, wallet)
+		if err != nil {
+			return nil, err
+		}
+		if policy == nil {
+			// No grant. The operation stays on the owner's fallback signer,
+			// which the gateway cannot sign — but that failure belongs to the
+			// caller that asked for an operation it has no authority for, and
+			// it reads more clearly than a fabricated authorization.
+			return nil, nil
+		}
+		key, err := signerKeyFor(*policy.SessionSigner)
+		if err != nil {
+			return nil, fmt.Errorf("session policy %s: %w", policy.ID, err)
+		}
+		auth := &preset.SessionAuthorization{
+			EntityID:          policy.EntityID,
+			SignerKey:         key,
+			WrapExecuteUserOp: policy.Grant.RequiresExecuteUserOp,
+		}
+		// The install rides the grant's FIRST operation only. Replaying an
+		// applied action would re-run installValidation on an entity that
+		// already exists. OnApplied is how the send path closes that loop:
+		// it fires when the install is known to be on-chain (receipt in
+		// hand, or the carrier nonce found consumed), and the ByID variant
+		// re-reads the record so a grant revoked mid-flight is never
+		// resurrected by a stale pointer.
+		if !policy.Grant.Applied() {
+			auth.DeferredData = policy.Grant.InstallCall
+			auth.OwnerSignature = policy.Grant.OwnerSignature
+			policyID, policyChain, policyOwner := policy.ID, policy.ChainID, *policy.Owner
+			auth.OnApplied = func(userOpHash string) error {
+				return MarkSessionGrantAppliedByID(db, policyChain, policyOwner, policyID, userOpHash)
+			}
+		}
+		return auth, nil
+	}
+}
+
+// controllerSessionSigner resolves a session signer to its key.
+//
+// Today every policy is signed by the gateway's controller key, so this
+// accepts exactly that address and refuses anything else. That is a deliberate
+// interim: avs-infra §7.4 describes session_signer as gateway-ASSIGNED, one
+// fresh key per policy, which needs key generation and custody this gateway
+// does not have yet.
+//
+// What matters is that the interim does not weaken the model. Authority is
+// still per grant, because each policy occupies its own validation ENTITY —
+// and the entity, not the key, is what carries the hooks, the revocation
+// target, and the nonce space that makes grant-time signing work. Sharing one
+// key across entities means a compromised controller reaches every grant, but
+// that is already true of the controller today.
+//
+// Refusing an unknown signer is the important half: a policy naming a key we
+// cannot produce must fail loudly here, not sign with the wrong one.
+func controllerSessionSigner(cfg *config.Config) func(common.Address) (*ecdsa.PrivateKey, error) {
+	return func(signer common.Address) (*ecdsa.PrivateKey, error) {
+		if cfg == nil || cfg.SmartWallet == nil || cfg.SmartWallet.ControllerPrivateKey == nil {
+			return nil, fmt.Errorf("no controller key configured; cannot sign as session signer %s", signer.Hex())
+		}
+		controller := crypto.PubkeyToAddress(cfg.SmartWallet.ControllerPrivateKey.PublicKey)
+		if signer != controller {
+			return nil, fmt.Errorf(
+				"session signer %s is not the gateway controller %s; per-policy signer keys are not implemented",
+				signer.Hex(), controller.Hex())
+		}
+		return cfg.SmartWallet.ControllerPrivateKey, nil
+	}
+}

--- a/core/taskengine/session_policy_test.go
+++ b/core/taskengine/session_policy_test.go
@@ -1,0 +1,239 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+const spChain = int64(11155111)
+
+var (
+	spOwner   = common.HexToAddress("0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557")
+	spWallet  = common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	spWallet2 = common.HexToAddress("0xD683400781b73a432b2602dA73a5117F4F445744")
+	spSigner  = common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+)
+
+func spPolicy(id string, wallet common.Address, entity uint32, status model.SessionPolicyStatus) *model.SessionPolicy {
+	owner, w, signer := spOwner, wallet, spSigner
+	return &model.SessionPolicy{
+		ID: id, Owner: &owner, Runner: &w, ChainID: spChain,
+		EntityID: entity, SessionSigner: &signer, Status: status,
+		Grant: &model.SessionGrantAuthorization{
+			InstallCall:    []byte{0x1b, 0xbf, 0x56, 0x4c, 0x01},
+			CarrierNonce:   big.NewInt(1),
+			Deadline:       1785541743,
+			OwnerSignature: make([]byte, 65),
+		},
+	}
+}
+
+func spKeyFor(t *testing.T) (func(common.Address) (*ecdsa.PrivateKey, error), *ecdsa.PrivateKey) {
+	t.Helper()
+	k, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(a common.Address) (*ecdsa.PrivateKey, error) {
+		if a != spSigner {
+			return nil, fmt.Errorf("no key for %s", a.Hex())
+		}
+		return k, nil
+	}, k
+}
+
+func TestSessionResolverReturnsTheWalletsGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, key := spKeyFor(t)
+
+	if err := StoreSessionPolicy(db, spPolicy("p1", spWallet, 1, model.SessionPolicyPending)); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+	// A grant on a DIFFERENT wallet the same owner holds must not leak across.
+	if err := StoreSessionPolicy(db, spPolicy("p2", spWallet2, 1, model.SessionPolicyActive)); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+
+	resolve := NewSessionResolver(db, keyFor)
+	auth, err := resolve(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("expected an authorization for a wallet that has a grant")
+	}
+	if auth.EntityID != 1 || auth.SignerKey != key {
+		t.Errorf("wrong entity/key: %d %v", auth.EntityID, auth.SignerKey == key)
+	}
+	// Pending means the install has not been applied, so it must ride along.
+	if !auth.Deferred() {
+		t.Error("a pending grant's first operation must carry the install")
+	}
+}
+
+// The install is a bearer authorization for exactly its calldata. Replaying it
+// would re-run installValidation on an entity that already exists.
+func TestSessionResolverDoesNotReplayAnAppliedGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+
+	p := spPolicy("p1", spWallet, 1, model.SessionPolicyActive)
+	p.Grant.AppliedAt = 1_753_000_000_000
+	p.Grant.AppliedUserOpHash = "0xdeadbeef"
+	if err := StoreSessionPolicy(db, p); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+
+	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth == nil {
+		t.Fatal("an applied grant still authorizes execution")
+	}
+	if auth.Deferred() {
+		t.Error("an applied grant must not re-attach its install")
+	}
+}
+
+func TestSessionResolverNoGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth != nil {
+		t.Error("a wallet with no grant must resolve to nil, leaving the owner's signer")
+	}
+}
+
+// Revoked grants authorize nothing, but their entity is not reusable: module
+// state may survive an incomplete cleanup.
+func TestRevokedGrantIsNotUsableButStillConsumesItsEntity(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+	if err := StoreSessionPolicy(db, spPolicy("p1", spWallet, 1, model.SessionPolicyRevoked)); err != nil {
+		t.Fatalf("StoreSessionPolicy: %v", err)
+	}
+
+	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if auth != nil {
+		t.Error("a revoked grant must not authorize anything")
+	}
+	next, err := NextSessionEntityID(db, spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatalf("NextSessionEntityID: %v", err)
+	}
+	if next != 2 {
+		t.Errorf("next entity = %d, want 2 — a revoked entity may hold stranded module state", next)
+	}
+}
+
+// Two usable grants on one wallet is an authority question, and picking one
+// would sign under an entity the caller may not have provisioned.
+func TestTwoUsableGrantsOnOneWalletIsRefused(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+	for _, p := range []*model.SessionPolicy{
+		spPolicy("p1", spWallet, 1, model.SessionPolicyActive),
+		spPolicy("p2", spWallet, 2, model.SessionPolicyPending),
+	} {
+		if err := StoreSessionPolicy(db, p); err != nil {
+			t.Fatalf("StoreSessionPolicy: %v", err)
+		}
+	}
+	if _, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet); err == nil {
+		t.Error("expected a refusal when a wallet has two usable grants")
+	}
+}
+
+// Entity ids are unique per ACCOUNT while the key is per owner, so allocation
+// must not be confused by the owner's other wallets.
+func TestNextSessionEntityIDIsPerAccount(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	if err := StoreSessionPolicy(db, spPolicy("p1", spWallet, 4, model.SessionPolicyActive)); err != nil {
+		t.Fatal(err)
+	}
+	if err := StoreSessionPolicy(db, spPolicy("p2", spWallet2, 9, model.SessionPolicyActive)); err != nil {
+		t.Fatal(err)
+	}
+	next, err := NextSessionEntityID(db, spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != 5 {
+		t.Errorf("next entity for %s = %d, want 5 (the other wallet's 9 is irrelevant)", spWallet.Hex(), next)
+	}
+	first, err := NextSessionEntityID(db, spChain, spOwner, common.HexToAddress("0x1234"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != 1 {
+		t.Errorf("a fresh wallet's first entity = %d, want 1 (0 is the owner's)", first)
+	}
+}
+
+func TestSessionPolicyValidateRejectsUnusableRecords(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*model.SessionPolicy)
+	}{
+		{"entity 0 is the owner's", func(p *model.SessionPolicy) { p.EntityID = 0 }},
+		{"no install calldata", func(p *model.SessionPolicy) { p.Grant.InstallCall = nil }},
+		{"no owner signature", func(p *model.SessionPolicy) { p.Grant.OwnerSignature = nil }},
+		// The digest commits to it and it cannot be recomputed after the fact.
+		{"no carrier nonce", func(p *model.SessionPolicy) { p.Grant.CarrierNonce = nil }},
+		{"no grant at all", func(p *model.SessionPolicy) { p.Grant = nil }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := spPolicy("p1", spWallet, 1, model.SessionPolicyPending)
+			tt.mutate(p)
+			if err := p.Validate(); err == nil {
+				t.Error("expected Validate to reject this record")
+			}
+		})
+	}
+}
+
+// Round-trip through storage: the grant's bytes and big.Int must survive.
+func TestSessionPolicyRoundTrip(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	p := spPolicy("p1", spWallet, 3, model.SessionPolicyPending)
+	p.Grant.CarrierNonce, _ = new(big.Int).SetString("18446744073709551617", 10) // > uint64
+	if err := StoreSessionPolicy(db, p); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ActiveSessionPolicyForWallet(db, spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("policy not found after storing")
+	}
+	if got.Grant.CarrierNonce.Cmp(p.Grant.CarrierNonce) != 0 {
+		t.Errorf("carrier nonce round-tripped as %s, want %s", got.Grant.CarrierNonce, p.Grant.CarrierNonce)
+	}
+	if string(got.Grant.InstallCall) != string(p.Grant.InstallCall) {
+		t.Error("install calldata did not round-trip")
+	}
+}

--- a/core/taskengine/simulate_sequential_contract_writes_test.go
+++ b/core/taskengine/simulate_sequential_contract_writes_test.go
@@ -43,7 +43,7 @@ func TestSimulateTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	t.Logf("   Chain: Sepolia (ID: %d)", cfg.SmartWallet.ChainID)
 
 	// Set factory for AA library
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("   Computing salt:0 smart wallet address...")
 
 	// Connect to Sepolia

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -51,7 +51,7 @@ func TestSimulateTask_StopLossWorkflow_Sepolia(t *testing.T) {
 	cfg, err := config.NewConfig(testutil.GetConfigPath(testutil.DefaultConfigPath))
 	require.NoError(t, err, "load aggregator config")
 
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 
 	client, err := ethclient.Dial(cfg.SmartWallet.EthRpcUrl)
 	require.NoError(t, err, "connect to Sepolia RPC")

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -69,6 +69,12 @@ func TestSimulateTask_StopLossWorkflow_Sepolia(t *testing.T) {
 		"wallet must hold at least 2 USDC; fund %s", smartWalletAddr.Hex())
 
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddr)
+
 	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
 
 	engine := New(db, cfg, nil, testutil.GetLogger())
@@ -164,6 +170,7 @@ return { inputBalance, hasEnoughBalance, swapAmount };
 		TaskType: &avsproto.TaskNode_ContractWrite{
 			ContractWrite: &avsproto.ContractWriteNode{
 				Config: &avsproto.ContractWriteNode_Config{
+					ChainId:         cfg.SmartWallet.ChainID,
 					ContractAddress: SEPOLIA_USDC,
 					ContractAbi: []*structpb.Value{sv(t, map[string]interface{}{
 						"type": "function", "name": "approve", "stateMutability": "nonpayable",
@@ -190,6 +197,7 @@ return { inputBalance, hasEnoughBalance, swapAmount };
 		TaskType: &avsproto.TaskNode_ContractRead{
 			ContractRead: &avsproto.ContractReadNode{
 				Config: &avsproto.ContractReadNode_Config{
+					ChainId:         cfg.SmartWallet.ChainID,
 					ContractAddress: SEPOLIA_QUOTER_V2,
 					ContractAbi: []*structpb.Value{sv(t, map[string]interface{}{
 						"type": "function", "name": "quoteExactInputSingle", "stateMutability": "nonpayable",
@@ -252,6 +260,7 @@ return { amountOutMinimum: amountOutMinimum.toString() };
 		TaskType: &avsproto.TaskNode_ContractWrite{
 			ContractWrite: &avsproto.ContractWriteNode{
 				Config: &avsproto.ContractWriteNode_Config{
+					ChainId:         cfg.SmartWallet.ChainID,
 					ContractAddress: SEPOLIA_SWAPROUTER,
 					ContractAbi: []*structpb.Value{sv(t, map[string]interface{}{
 						"type": "function", "name": "exactInputSingle", "stateMutability": "payable",

--- a/core/taskengine/userops_batch_swap_test.go
+++ b/core/taskengine/userops_batch_swap_test.go
@@ -149,6 +149,12 @@ func TestUserOpAtomicBatch_Sepolia(t *testing.T) {
 	inputVars := map[string]interface{}{"settings": settings}
 
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddress)
+
 	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
 	engine := New(db, cfg, nil, testutil.GetLogger())
 	t.Cleanup(func() { engine.Stop() })

--- a/core/taskengine/userops_batch_swap_test.go
+++ b/core/taskengine/userops_batch_swap_test.go
@@ -68,7 +68,7 @@ func TestUserOpAtomicBatch_Sepolia(t *testing.T) {
 	require.NoError(t, err, "Failed to connect to RPC")
 	t.Cleanup(func() { client.Close() })
 
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 
 	smartWalletAddress, err := aa.GetSenderAddress(client, ownerAddress, big.NewInt(0))
 	require.NoError(t, err, "Failed to derive smart wallet address")

--- a/core/taskengine/userops_withdraw_all_test.go
+++ b/core/taskengine/userops_withdraw_all_test.go
@@ -85,7 +85,7 @@ func TestWithdrawAllETH_Sepolia(t *testing.T) {
 	t.Cleanup(func() { client.Close() })
 
 	// Set factory address for smart wallet derivation
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("🔧 Set factory address: %s", cfg.SmartWallet.FactoryAddress.Hex())
 
 	// Always derive smart wallet address from owner + salt:0 using GetSenderAddress

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -60,7 +60,7 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 	t.Cleanup(func() { client.Close() })
 
 	// Set factory address for smart wallet derivation
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 
 	// Always derive smart wallet address from owner + salt:0
 	// This ensures consistency and tests the auto-creation flow
@@ -489,7 +489,7 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 	t.Cleanup(func() { client.Close() })
 
 	// Set factory address for smart wallet derivation
-	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	setGlobalFactory(t, cfg.SmartWallet)
 	t.Logf("🔧 Set factory address: %s", cfg.SmartWallet.FactoryAddress.Hex())
 
 	// Always derive smart wallet address from owner + salt:0

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -73,6 +73,12 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 
 	// Create engine for RunNodeImmediately execution
 	db := testutil.TestMustDB()
+
+	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
+	// trusts only its fallback signer — so it needs a session grant, the same
+	// one the grant screen creates in production.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddress)
+
 	t.Cleanup(func() {
 		storage.Destroy(db.(*storage.BadgerStorage))
 	})
@@ -535,6 +541,10 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 
 	// Create engine for RunNodeImmediately execution
 	db := testutil.TestMustDB()
+
+	// Same as above: without a grant the gateway would sign as the wallet's
+	// owner, whose key it does not hold.
+	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddress)
 	t.Cleanup(func() {
 		storage.Destroy(db.(*storage.BadgerStorage))
 	})

--- a/core/taskengine/utils_calldata_test.go
+++ b/core/taskengine/utils_calldata_test.go
@@ -559,7 +559,7 @@ func TestContractWrite_InvalidNumericValue_ResponseStructure(t *testing.T) {
 
 	// Get smart wallet address for settings
 	smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	setGlobalFactory(t, smartWalletConfig)
 
 	client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 	require.NoError(t, err, "Failed to connect to RPC")

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1671,7 +1671,7 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 		v.logger.Info("🔍 VM DEBUG - Smart wallet config details",
 			"bundler_url", swConfig.BundlerURL,
 			"factory_address", swConfig.FactoryAddress,
-			"entrypoint_address", swConfig.EntrypointAddress,
+			"entrypoint_address", swConfig.EntryPointAddress(),
 			"eth_rpc_url", swConfig.EthRpcUrl)
 	} else {
 		v.logger.Warn("⚠️ VM DEBUG - Smart wallet config is NIL in VM!")

--- a/core/taskengine/vm_contract_write_waiting.go
+++ b/core/taskengine/vm_contract_write_waiting.go
@@ -121,7 +121,9 @@ func (v *VM) waitForUserOpConfirmation(userOpHash string) (*waitForUserOpConfirm
 		return nil, fmt.Errorf("failed to create bundler client: %w", err)
 	}
 
-	entrypoint := v.smartWalletConfig.EntrypointAddress
+	// The EntryPoint the operation actually ran against, not the configured
+	// v0.6 address — polling the wrong one just waits out the full timeout.
+	entrypoint := v.smartWalletConfig.EntryPointAddress()
 
 	v.logger.Info("⏳ Waiting for UserOp confirmation",
 		"userOpHash", userOpHash,

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -23,7 +23,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/byte4"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/bundler"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -38,7 +37,7 @@ type SendUserOpFunc func(
 	saltOverride *big.Int,
 	executionFeeWei *big.Int,
 	lgr logger.Logger,
-) (*userop.UserOperation, *types.Receipt, error)
+) (*preset.SentUserOp, *types.Receipt, error)
 
 type ContractWriteProcessor struct {
 	*CommonProcessor
@@ -56,7 +55,7 @@ func NewContractWriteProcessor(vm *VM, client ChainStateReader, smartWalletConfi
 		client:            client,
 		smartWalletConfig: smartWalletConfig,
 		owner:             owner,
-		sendUserOpFunc:    preset.SendUserOp, // Default to the real implementation
+		sendUserOpFunc:    preset.SendUserOpAuto, // Default to the real implementation
 		CommonProcessor: &CommonProcessor{
 			vm: vm,
 		},
@@ -400,7 +399,7 @@ func (r *ContractWriteProcessor) executeMethodCall(
 		r.vm.logger.Info("🔍 CONTRACT WRITE DEBUG - Smart Wallet Config Details",
 			"bundler_url", r.smartWalletConfig.BundlerURL,
 			"factory_address", r.smartWalletConfig.FactoryAddress,
-			"entrypoint_address", r.smartWalletConfig.EntrypointAddress)
+			"entrypoint_address", r.smartWalletConfig.EntryPointAddress())
 	} else {
 		r.vm.logger.Warn("⚠️ CONTRACT WRITE DEBUG - Smart wallet config is NIL!")
 	}
@@ -680,9 +679,11 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 	logLabel string,
 	logTarget string,
 	executionLogBuilder *strings.Builder,
-) (*userop.UserOperation, *types.Receipt, string) {
+) (*preset.SentUserOp, *types.Receipt, string) {
 	// Set up factory address for AA operations
-	aa.SetFactoryAddress(r.smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(r.smartWalletConfig); err != nil {
+		return nil, nil, fmt.Sprintf("cannot resolve account factory: %v", err)
+	}
 	aa.SetEntrypointAddress(r.smartWalletConfig.EntrypointAddress)
 
 	// Optional runner validation: if task.SmartWalletAddress is set, ensure it matches
@@ -693,10 +694,17 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 		// Derive sender at salt:0 via the per-chain reader (worker-routed in
 		// gateway mode) instead of a direct dial. Best-effort sanity check;
 		// the authoritative wallet-list validation runs in the run_node path.
-		sender, derr := r.client.GetSmartWalletAddress(ctx, r.owner, r.smartWalletConfig.FactoryAddress, big.NewInt(0))
-		if derr == nil && (sender != common.Address{}) {
-			if !strings.EqualFold(sender.Hex(), runnerStr) {
-				r.vm.logger.Warn("runner does not match derived salt:0; proceeding (wallet list validation applies in run_node)", "expected", sender.Hex(), "runner", runnerStr)
+		// A factory-resolution failure only costs us the sanity check; the
+		// authoritative validation still runs in run_node. Skipping beats
+		// failing the write on a diagnostic.
+		if defaultFactory, factoryErr := aa.EffectiveFactory(r.smartWalletConfig); factoryErr != nil {
+			r.vm.logger.Warn("skipping runner sanity check: cannot resolve factory", "error", factoryErr)
+		} else {
+			sender, derr := r.client.GetSmartWalletAddress(ctx, r.owner, defaultFactory, big.NewInt(0))
+			if derr == nil && (sender != common.Address{}) {
+				if !strings.EqualFold(sender.Hex(), runnerStr) {
+					r.vm.logger.Warn("runner does not match derived salt:0; proceeding (wallet list validation applies in run_node)", "expected", sender.Hex(), "runner", runnerStr)
+				}
 			}
 		}
 	}
@@ -1161,15 +1169,19 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 	// Pack the atomic batch. Prefer executeBatch (no per-call values) when every value is zero — its
 	// selector is bundler-estimatable, unlike executeBatchWithValues (0xc3ff72fc) which the bundler
 	// can't simulate. Only fall back to executeBatchWithValues when a call actually carries value.
-	packKind := "executeBatch"
-	var smartWalletCallData []byte
-	var packErr error
-	if anyValue {
-		packKind = "executeBatchWithValues"
-		smartWalletCallData, packErr = aa.PackExecuteBatchWithValues(targets, values, datas)
-	} else {
-		smartWalletCallData, packErr = aa.PackExecuteBatch(targets, datas)
+	// Routed on the chain's account implementation. Batching is the one call
+	// shape that did NOT carry over to MA v2 — see aa.PackExecuteBatchAuto —
+	// so packing v0.6 batch calldata here reverts in validation as AA23,
+	// naming neither the batch nor the account type.
+	batchFactory, factoryErr := aa.EffectiveFactory(r.smartWalletConfig)
+	if factoryErr != nil {
+		return failAll(fmt.Sprintf("failed to resolve account factory for batch: %v", factoryErr), nil)
 	}
+	packKind := "executeBatch"
+	if anyValue && aa.ProviderForFactory(batchFactory) != aa.ProviderModularAccountV2 {
+		packKind = "executeBatchWithValues"
+	}
+	smartWalletCallData, packErr := aa.PackExecuteBatchAuto(batchFactory, targets, values, datas)
 	if packErr != nil {
 		return failAll(fmt.Sprintf("failed to pack atomic batch calldata: %v", packErr), nil)
 	}
@@ -1200,7 +1212,7 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 }
 
 // createRealTransactionResult creates a result from a real UserOp transaction
-func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contractAddress, callData string, parsedABI *abi.ABI, userOp *userop.UserOperation, receipt *types.Receipt) *avsproto.ContractWriteNode_MethodResult {
+func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contractAddress, callData string, parsedABI *abi.ABI, userOp *preset.SentUserOp, receipt *types.Receipt) *avsproto.ContractWriteNode_MethodResult {
 	r.vm.logger.Info("🔍 DEPLOYED WORKFLOW: Creating real transaction result",
 		"method_name", methodName,
 		"contract_address", contractAddress,
@@ -1273,7 +1285,7 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 	} else if userOp != nil {
 		// UserOp submitted but receipt not available yet
 		receiptMap = map[string]interface{}{
-			"userOpHash":      userOp.GetUserOpHash(r.smartWalletConfig.EntrypointAddress, big.NewInt(r.smartWalletConfig.ChainID)).Hex(),
+			"userOpHash":      userOp.UserOpHash.Hex(),
 			"sender":          userOp.Sender.Hex(),
 			"nonce":           fmt.Sprintf("0x%x", userOp.Nonce.Uint64()),
 			"status":          "pending",
@@ -1374,7 +1386,7 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 	if receiptMap != nil {
 		receiptMap["executionStatus"] = executionStatus
 		if _, hasHash := receiptMap["userOpHash"]; !hasHash && userOp != nil && r.smartWalletConfig != nil {
-			receiptMap["userOpHash"] = userOp.GetUserOpHash(r.smartWalletConfig.EntrypointAddress, big.NewInt(r.smartWalletConfig.ChainID)).Hex()
+			receiptMap["userOpHash"] = userOp.UserOpHash.Hex()
 		}
 		if v, err := structpb.NewValue(receiptMap); err == nil {
 			receiptValue = v
@@ -2017,8 +2029,8 @@ func (r *ContractWriteProcessor) Execute(stepID string, node *avsproto.ContractW
 					}
 				}()
 				if r.smartWalletConfig != nil {
-					if (r.smartWalletConfig.EntrypointAddress != common.Address{}) {
-						log.WriteString(fmt.Sprintf("  EntryPoint: %s\n", r.smartWalletConfig.EntrypointAddress.Hex()))
+					if (r.smartWalletConfig.EntryPointAddress() != common.Address{}) {
+						log.WriteString(fmt.Sprintf("  EntryPoint: %s\n", r.smartWalletConfig.EntryPointAddress().Hex()))
 					}
 					if r.smartWalletConfig.BundlerURL != "" {
 						log.WriteString(fmt.Sprintf("  Bundler: %s\n", r.smartWalletConfig.BundlerURL))
@@ -2034,7 +2046,7 @@ func (r *ContractWriteProcessor) Execute(stepID string, node *avsproto.ContractW
 			// If this is a bundler/AA error, add additional debugging information
 			if strings.Contains(result.Error, "Bundler failed") || strings.Contains(result.Error, "AA21") {
 				log.WriteString("BUNDLER FAILURE DETAILS:\n")
-				log.WriteString(fmt.Sprintf("  Entry Point: %s\n", r.smartWalletConfig.EntrypointAddress.Hex()))
+				log.WriteString(fmt.Sprintf("  Entry Point: %s\n", r.smartWalletConfig.EntryPointAddress().Hex()))
 				log.WriteString(fmt.Sprintf("  Factory: %s\n", r.smartWalletConfig.FactoryAddress.Hex()))
 
 				if strings.Contains(result.Error, "AA21") {

--- a/core/taskengine/vm_runner_contract_write_batch_test.go
+++ b/core/taskengine/vm_runner_contract_write_batch_test.go
@@ -204,7 +204,10 @@ func TestAtomicBatchOnDemand(t *testing.T) {
 		require.Equal(t, 1, callCount, "still one UserOp")
 
 		require.GreaterOrEqual(t, len(captured), 4)
-		assert.Equal(t, "c3ff72fc", common.Bytes2Hex(captured[:4]), "value-bearing batch must use executeBatchWithValues")
+		// MA v2 (the default provider) carries per-call values natively in
+		// its executeBatch tuples — the v0.6 fork's executeBatchWithValues
+		// (0xc3ff72fc) has no successor and needs none.
+		assert.Equal(t, "34fcd5be", common.Bytes2Hex(captured[:4]), "value-bearing batch must use the MA v2 executeBatch")
 		_, values, _, err := aa.UnpackExecuteCalldata(captured)
 		require.NoError(t, err)
 		require.Len(t, values, 2)

--- a/core/taskengine/vm_runner_contract_write_batch_test.go
+++ b/core/taskengine/vm_runner_contract_write_batch_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/ethereum/go-ethereum/common"
@@ -76,7 +75,7 @@ func TestAtomicBatchOnDemand(t *testing.T) {
 	}
 
 	countingSender := func(callCount *int, captured *[]byte, status uint64) SendUserOpFunc {
-		return func(_ *config.SmartWalletConfig, _ common.Address, callData []byte, _ *preset.VerifyingPaymasterRequest, _ *common.Address, _ *big.Int, _ *big.Int, _ logger.Logger) (*userop.UserOperation, *types.Receipt, error) {
+		return func(_ *config.SmartWalletConfig, _ common.Address, callData []byte, _ *preset.VerifyingPaymasterRequest, _ *common.Address, _ *big.Int, _ *big.Int, _ logger.Logger) (*preset.SentUserOp, *types.Receipt, error) {
 			*callCount++
 			if captured != nil {
 				*captured = callData

--- a/core/taskengine/vm_runner_contract_write_data_priority_test.go
+++ b/core/taskengine/vm_runner_contract_write_data_priority_test.go
@@ -33,14 +33,14 @@ func TestContractWriteDataPriority(t *testing.T) {
 		engine := New(db, config, nil, testutil.GetLogger())
 
 		smartWalletConfig := testutil.GetBaseTestSmartWalletConfig()
-		aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+		setGlobalFactory(t, smartWalletConfig)
 
 		ownerAddr, ok := testutil.MustGetTestOwnerAddress()
 		if !ok {
 			t.Skip("Owner EOA address not set, skipping test")
 		}
 		ownerEOA := *ownerAddr
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 		client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
 		require.NoError(t, err, "Failed to connect to RPC")

--- a/core/taskengine/vm_runner_contract_write_ondemand_test.go
+++ b/core/taskengine/vm_runner_contract_write_ondemand_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/ethereum/go-ethereum/common"
@@ -18,19 +17,14 @@ import (
 
 // wellFormedUserOp returns a UserOperation with every big.Int/byte field populated
 // so GetUserOpHash / PackForSignature don't panic in unit tests.
-func wellFormedUserOp(sender common.Address) *userop.UserOperation {
-	return &userop.UserOperation{
+func wellFormedUserOp(sender common.Address) *preset.SentUserOp {
+	return &preset.SentUserOp{
 		Sender:               sender,
 		Nonce:                big.NewInt(0),
-		InitCode:             []byte{},
-		CallData:             []byte{},
 		CallGasLimit:         big.NewInt(0),
 		VerificationGasLimit: big.NewInt(0),
 		PreVerificationGas:   big.NewInt(0),
 		MaxFeePerGas:         big.NewInt(0),
-		MaxPriorityFeePerGas: big.NewInt(0),
-		PaymasterAndData:     []byte{},
-		Signature:            []byte{},
 	}
 }
 
@@ -144,7 +138,7 @@ func TestContractWriteRealPathForwardsNativeValue(t *testing.T) {
 			_ *big.Int,
 			_ *big.Int,
 			_ logger.Logger,
-		) (*userop.UserOperation, *types.Receipt, error) {
+		) (*preset.SentUserOp, *types.Receipt, error) {
 			capturedCallData = callData
 			return wellFormedUserOp(runner), minedReceipt(1), nil
 		}

--- a/core/taskengine/vm_runner_contract_write_simulation_test.go
+++ b/core/taskengine/vm_runner_contract_write_simulation_test.go
@@ -94,7 +94,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		}
 		ownerEOA := *ownerAddr
 		// Factory address is automatically set by engine.New() from config.SmartWallet.FactoryAddress
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 		// Derive actual salt:0 smart wallet address (no mock needed)
 		// Connect to RPC to derive address
@@ -161,7 +161,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 			t.Skip("Owner EOA address not set, skipping simulation test")
 		}
 		ownerEOA := *ownerAddr
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 
 		// Derive actual salt:0 smart wallet address (need ethclient)
 		client, err := ethclient.Dial(config.SmartWallet.EthRpcUrl)
@@ -298,7 +298,7 @@ func TestContractWriteTenderlySimulation(t *testing.T) {
 		}
 		ethc, err := ethclient.Dial(rpcURL)
 		require.NoError(t, err, "Failed to connect RPC for derivation")
-		factory := config.SmartWallet.FactoryAddress
+		factory := effectiveFactoryAddr(t, config.SmartWallet)
 		derivedRunner, derr := aa.GetSenderAddress(ethc, ownerEOA, big.NewInt(0))
 		require.NoError(t, derr, "Failed to derive runner")
 

--- a/core/taskengine/vm_runner_contract_write_transaction_limit_test.go
+++ b/core/taskengine/vm_runner_contract_write_transaction_limit_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
-	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -23,9 +22,9 @@ func mockSendUserOp(
 	saltOverride *big.Int,
 	executionFeeWei *big.Int,
 	lgr logger.Logger,
-) (*userop.UserOperation, *types.Receipt, error) {
+) (*preset.SentUserOp, *types.Receipt, error) {
 	capturedPaymasterRequest = paymasterReq
-	return &userop.UserOperation{}, &types.Receipt{}, nil
+	return &preset.SentUserOp{}, &types.Receipt{}, nil
 }
 
 /*

--- a/core/taskengine/vm_runner_eth_transfer.go
+++ b/core/taskengine/vm_runner_eth_transfer.go
@@ -300,7 +300,9 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 	// Use the aa and preset packages that should already be imported
 
 	// Set up factory address for AA operations
-	aa.SetFactoryAddress(p.smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(p.smartWalletConfig); err != nil {
+		return nil, fmt.Errorf("cannot resolve account factory: %w", err)
+	}
 	aa.SetEntrypointAddress(p.smartWalletConfig.EntrypointAddress)
 
 	// For ETH transfers, we need to create a call to the smart wallet's execute function
@@ -349,7 +351,7 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 	p.vm.mu.Unlock()
 
 	// Send UserOp transaction with overrides
-	userOp, receipt, err := preset.SendUserOp(
+	userOp, receipt, err := preset.SendUserOpAuto(
 		p.smartWalletConfig,
 		*p.taskOwner,
 		smartWalletCallData,
@@ -381,7 +383,7 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 		txHash = receipt.TxHash.Hex()
 	} else if userOp != nil {
 		// Fallback: use a deterministic hash based on UserOp
-		txHash = fmt.Sprintf("0x%064x", userOp.GetUserOpHash(aa.EntrypointAddress, big.NewInt(p.smartWalletConfig.ChainID)))
+		txHash = userOp.UserOpHash.Hex()
 	} else {
 		txHash = fmt.Sprintf("0x%064d", time.Now().UnixNano())
 	}
@@ -403,7 +405,7 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 	// and include the userOpHash so waitForOnChainConfirmationIfNeeded can poll for it.
 	if receipt == nil && userOp != nil {
 		resultObj["receiptStatus"] = "pending"
-		resultObj["userOpHash"] = fmt.Sprintf("0x%064x", userOp.GetUserOpHash(aa.EntrypointAddress, big.NewInt(p.smartWalletConfig.ChainID)))
+		resultObj["userOpHash"] = userOp.UserOpHash.Hex()
 	}
 
 	// Extract gas information from receipt if available

--- a/core/taskengine/wallet_ma_v2.go
+++ b/core/taskengine/wallet_ma_v2.go
@@ -1,20 +1,12 @@
 package taskengine
 
 import (
-	"errors"
-	"fmt"
-	"math/big"
-
-	"github.com/dgraph-io/badger/v4"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
-	"github.com/AvaProtocol/EigenLayer-AVS/model"
-	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
 
-// Modular Account v2 wallet creation.
+// Modular Account v2 wallet registration.
 //
 // MA v2 wallets reuse the existing record and index schema unchanged, because
 // `Factory` is already part of both the stored record and the `wsalt:` index
@@ -31,102 +23,17 @@ import (
 // An MA v2 wallet that is derived but never stored is therefore invisible to
 // sponsorship: every operation from it is denied, with a message about an
 // unknown sender rather than anything pointing at the missing record.
+//
+// There is deliberately no MA v2-specific creation function. There was one,
+// and the v0.7 cutover made it redundant: Engine.GetWallet now derives through
+// aa.EffectiveFactory and stores whatever factory that returns, so on an MA v2
+// chain the ordinary path already registers MA v2 wallets under the MA v2
+// factory. A parallel creation path would have been a second way to do the
+// same thing, differing only in forcing MA v2 on chains pinned to
+// simple_account — where forcing it is wrong. Use aa.ProviderForFactory to ask
+// what a stored record is.
 
 // MAv2WalletFactory returns the factory address MA v2 wallets are recorded
 // under. Distinct from config.DefaultFactoryProxyAddressHex, which is the
 // v0.6 SimpleAccountFactory.
 func MAv2WalletFactory() common.Address { return aa.MAv2FactoryAddress() }
-
-// IsMAv2Wallet reports whether a stored record was created by the MA v2
-// factory, as opposed to the v0.6 SimpleAccountFactory.
-//
-// Records predating the factory field (Factory == nil) are v0.6 by
-// definition — MA v2 records have always carried it.
-func IsMAv2Wallet(wallet *model.SmartWallet) bool {
-	if wallet == nil || wallet.Factory == nil {
-		return false
-	}
-	return *wallet.Factory == MAv2WalletFactory()
-}
-
-// GetOrCreateMAv2Wallet derives the MA v2 account for (owner, salt) on the
-// given chain and persists its record, returning the existing one if it has
-// already been registered.
-//
-// Idempotent by address rather than by "did we just derive it": the address is
-// a pure function of (factory, owner, salt), so a second call for the same
-// tuple must return the same record instead of writing a duplicate or
-// resetting user-set flags like IsHidden.
-//
-// The address comes from the factory on-chain (see aa.GetSenderAddressMAv2)
-// rather than a local CREATE2 computation, so a derivation that drifts from
-// the contract fails loudly here instead of registering an address that will
-// never hold anything.
-func GetOrCreateMAv2Wallet(db storage.Storage, rpcConn *ethclient.Client, chainID int64, owner common.Address, salt *big.Int) (*model.SmartWallet, error) {
-	if db == nil {
-		return nil, fmt.Errorf("nil storage")
-	}
-	if salt == nil {
-		return nil, fmt.Errorf("salt is nil")
-	}
-	if salt.Sign() < 0 {
-		return nil, fmt.Errorf("salt must be non-negative, got %s", salt)
-	}
-	if owner == (common.Address{}) {
-		return nil, fmt.Errorf("owner is the zero address")
-	}
-
-	factory := MAv2WalletFactory()
-
-	// Prefer the (chain, owner, factory, salt) index over deriving again — it
-	// answers "has this been registered?" without an RPC round trip, and it is
-	// the same index StoreWallet maintains.
-	//
-	// Only a genuine "not recorded yet" may fall through to derive-and-store.
-	// Treating any read error as absence would re-register on a transient
-	// storage fault, and re-registration writes IsHidden:false — silently
-	// un-hiding a wallet the user had hidden. Idempotency here is only as good
-	// as the lookup it rests on.
-	existingAddr, err := LookupCanonicalWalletAddress(db, chainID, owner, factory, salt)
-	switch {
-	case err == nil:
-		wallet, getErr := GetWallet(db, chainID, owner, existingAddr.Hex())
-		if getErr == nil {
-			return wallet, nil
-		}
-		if !errors.Is(getErr, badger.ErrKeyNotFound) {
-			return nil, fmt.Errorf("reading registered MA v2 wallet %s for owner %s on chain %d: %w",
-				existingAddr.Hex(), owner.Hex(), chainID, getErr)
-		}
-		// Index points at a record that is gone. Rewrite it rather than
-		// returning a dangling reference.
-	case errors.Is(err, badger.ErrKeyNotFound):
-		// Not registered yet — the expected path for a new wallet.
-	default:
-		return nil, fmt.Errorf("looking up MA v2 wallet index for owner %s salt %s on chain %d: %w",
-			owner.Hex(), salt, chainID, err)
-	}
-
-	derived, err := aa.GetSenderAddressMAv2ForFactory(rpcConn, owner, factory, salt)
-	if err != nil {
-		return nil, fmt.Errorf("deriving MA v2 wallet for owner %s salt %s on chain %d: %w",
-			owner.Hex(), salt, chainID, err)
-	}
-	if derived == nil || *derived == (common.Address{}) {
-		return nil, fmt.Errorf("factory %s returned the zero address for owner %s salt %s",
-			factory.Hex(), owner.Hex(), salt)
-	}
-
-	wallet := &model.SmartWallet{
-		Owner:    &owner,
-		Address:  derived,
-		Factory:  &factory,
-		Salt:     salt,
-		IsHidden: false,
-	}
-	if err := StoreWallet(db, chainID, owner, wallet); err != nil {
-		return nil, fmt.Errorf("storing MA v2 wallet %s for owner %s on chain %d: %w",
-			derived.Hex(), owner.Hex(), chainID, err)
-	}
-	return wallet, nil
-}

--- a/core/taskengine/wallet_ma_v2_test.go
+++ b/core/taskengine/wallet_ma_v2_test.go
@@ -19,30 +19,6 @@ func mav2Owner() common.Address {
 	return common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
 }
 
-func TestIsMAv2Wallet(t *testing.T) {
-	mav2 := MAv2WalletFactory()
-	v06 := common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
-	owner, addr := mav2Owner(), common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
-
-	tests := []struct {
-		name   string
-		wallet *model.SmartWallet
-		want   bool
-	}{
-		{"MA v2 factory", &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &mav2}, true},
-		{"v0.6 factory", &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &v06}, false},
-		{"no factory recorded is v0.6 by definition", &model.SmartWallet{Owner: &owner, Address: &addr}, false},
-		{"nil wallet", nil, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsMAv2Wallet(tt.wallet); got != tt.want {
-				t.Errorf("IsMAv2Wallet = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // The factory address is what keeps MA v2 and v0.6 records from colliding in
 // the wsalt: index. If both used the same factory, registering an MA v2 wallet
 // at salt 0 would overwrite the v0.6 index entry for the same owner and salt,
@@ -59,37 +35,6 @@ func TestMAv2AndV06IndexKeysDoNotCollide(t *testing.T) {
 	if !strings.Contains(strings.ToLower(string(mav2Key)), strings.ToLower(MAv2WalletFactory().Hex()[2:])) {
 		t.Errorf("index key %q does not carry the factory address", mav2Key)
 	}
-}
-
-func TestGetOrCreateMAv2WalletGuards(t *testing.T) {
-	db := testutil.TestMustDB()
-	defer db.Close()
-	owner := mav2Owner()
-
-	tests := []struct {
-		name  string
-		owner common.Address
-		salt  *big.Int
-	}{
-		{"nil salt", owner, nil},
-		{"negative salt", owner, big.NewInt(-1)},
-		{"zero owner", common.Address{}, big.NewInt(0)},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// rpcConn is nil: every case here must fail on validation before
-			// any RPC is attempted, so a nil client can never be dereferenced.
-			if _, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, tt.owner, tt.salt); err == nil {
-				t.Error("expected an error")
-			}
-		})
-	}
-
-	t.Run("nil storage", func(t *testing.T) {
-		if _, err := GetOrCreateMAv2Wallet(nil, nil, mav2TestChain, owner, big.NewInt(0)); err == nil {
-			t.Error("expected an error for nil storage")
-		}
-	})
 }
 
 // The whole point of registration: the sponsorship webhook resolves a sender
@@ -133,36 +78,6 @@ func TestMAv2RecordIsDiscoverableBySenderScan(t *testing.T) {
 	}
 }
 
-// A second call for the same tuple must return the existing record rather than
-// writing a duplicate or resetting user-set flags.
-func TestMAv2RegistrationIsIdempotent(t *testing.T) {
-	db := testutil.TestMustDB()
-	defer db.Close()
-
-	owner := mav2Owner()
-	addr := common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
-	factory := MAv2WalletFactory()
-	salt := big.NewInt(0)
-
-	first := &model.SmartWallet{Owner: &owner, Address: &addr, Factory: &factory, Salt: salt, IsHidden: true}
-	if err := StoreWallet(db, mav2TestChain, owner, first); err != nil {
-		t.Fatalf("StoreWallet: %v", err)
-	}
-
-	// nil RPC: if the lookup path works, no derivation is attempted, so this
-	// returning successfully is itself the assertion that the index was used.
-	got, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, owner, salt)
-	if err != nil {
-		t.Fatalf("GetOrCreateMAv2Wallet on an already-registered wallet: %v", err)
-	}
-	if got.Address == nil || *got.Address != addr {
-		t.Errorf("address = %v, want %s", got.Address, addr.Hex())
-	}
-	if !got.IsHidden {
-		t.Error("IsHidden was reset; re-registration must not clobber user-set flags")
-	}
-}
-
 // Guards the assumption the whole file rests on: the factory constant here is
 // the same one aa derives against. If they drift, wallets get recorded under a
 // factory that did not create them.
@@ -170,38 +85,5 @@ func TestWalletFactoryMatchesDerivationFactory(t *testing.T) {
 	if MAv2WalletFactory() != aa.MAv2FactoryAddress() {
 		t.Errorf("taskengine factory %s != aa factory %s",
 			MAv2WalletFactory().Hex(), aa.MAv2FactoryAddress().Hex())
-	}
-}
-
-// Idempotency is only as strong as the lookup it rests on. If a storage read
-// error were treated as "not registered", the fall-through would re-derive and
-// re-store with IsHidden:false — silently un-hiding a wallet the user hid. A
-// closed database is the cheapest way to make every read fail.
-func TestRegistrationDoesNotFallThroughOnStorageError(t *testing.T) {
-	db := testutil.TestMustDB()
-	owner := mav2Owner()
-	addr := common.HexToAddress("0x61CaF92C082E70F8F780A8f1c04d01A14B63e0B0")
-	factory := MAv2WalletFactory()
-	salt := big.NewInt(0)
-
-	if err := StoreWallet(db, mav2TestChain, owner, &model.SmartWallet{
-		Owner: &owner, Address: &addr, Factory: &factory, Salt: salt, IsHidden: true,
-	}); err != nil {
-		t.Fatalf("StoreWallet: %v", err)
-	}
-	db.Close() // every subsequent read now errors rather than reporting absence
-
-	// nil RPC: if this wrongly falls through to derive-and-store it will panic
-	// or error on the RPC, either way not returning a fresh IsHidden:false
-	// record. What must NOT happen is a silent success that clobbers the flag.
-	got, err := GetOrCreateMAv2Wallet(db, nil, mav2TestChain, owner, salt)
-	if err == nil {
-		if got != nil && !got.IsHidden {
-			t.Fatal("returned a re-registered record with IsHidden reset; the storage error was masked")
-		}
-		t.Fatal("expected an error when storage reads fail, got success")
-	}
-	if !strings.Contains(err.Error(), "looking up") && !strings.Contains(err.Error(), "reading registered") {
-		t.Errorf("error should name the failed lookup, got: %v", err)
 	}
 }

--- a/core/taskengine/wallet_salt_index_test.go
+++ b/core/taskengine/wallet_salt_index_test.go
@@ -244,7 +244,7 @@ func TestListWallets_HardFiltersStaleRows(t *testing.T) {
 	engine := New(db, cfg, nil, testutil.GetLogger())
 
 	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
-	factory := cfg.SmartWallet.FactoryAddress
+	factory := effectiveFactoryAddr(t, cfg.SmartWallet)
 
 	// Two wallets for different salts, then mark one stale and verify
 	// it disappears from the list response entirely.

--- a/core/taskengine/wallet_test.go
+++ b/core/taskengine/wallet_test.go
@@ -15,7 +15,7 @@ func TestSetWalletHiddenStatus(t *testing.T) {
 	config := testutil.GetAggregatorConfig()
 	n := New(db, config, nil, testutil.GetLogger())
 	u := testutil.TestUser1()
-	defaultFactory := n.smartWalletConfig.FactoryAddress.Hex()
+	defaultFactory := effectiveFactoryHex(t, n.smartWalletConfig)
 
 	saltValue := "12345"
 	// Ensure wallet exists
@@ -215,7 +215,7 @@ func TestHideDefaultWallet(t *testing.T) {
 	config := testutil.GetAggregatorConfig()
 	n := New(db, config, nil, testutil.GetLogger())
 	u := testutil.TestUser1()
-	defaultFactory := n.smartWalletConfig.FactoryAddress.Hex()
+	defaultFactory := effectiveFactoryHex(t, n.smartWalletConfig)
 	defaultSalt := "0"
 
 	// Ensure default wallet exists and get its address

--- a/core/testutil/utils.go
+++ b/core/testutil/utils.go
@@ -865,13 +865,18 @@ func CheckBundlerAvailability(bundlerURL string) error {
 // This is useful for integration tests that need wallets to be deployed before testing UserOp execution.
 // It uses GetSenderAddress to compute the wallet address, which is what the system actually uses.
 func EnsureWalletDeployed(client *ethclient.Client, factoryAddress common.Address, ownerAddress common.Address, salt *big.Int, controllerPrivateKey string) error {
-	// Set factory address so GetSenderAddress uses the correct factory
-	aa.SetFactoryAddress(factoryAddress)
-
-	// Get expected wallet address using GetSenderAddress (this is what the system uses)
-	expectedWalletPtr, err := aa.GetSenderAddress(client, ownerAddress, salt)
+	// Derive against the passed factory explicitly rather than parking it in
+	// the package global first. That global is process-wide: setting it here
+	// changed which factory unrelated tests derived against for the rest of
+	// the run, depending only on execution order.
+	//
+	// The provider is pinned to SimpleAccount because that is what this helper
+	// can actually deploy — it goes through NewSimpleFactory below. It is not
+	// a stand-in for the chain's configured provider.
+	expectedWalletPtr, err := aa.DeriveSenderAddressForFactory(
+		client, ownerAddress, factoryAddress, salt, aa.ProviderSimpleAccount)
 	if err != nil {
-		return fmt.Errorf("failed to get address from GetSenderAddress: %w", err)
+		return fmt.Errorf("failed to derive SimpleAccount address: %w", err)
 	}
 	expectedWallet := *expectedWalletPtr
 
@@ -963,7 +968,10 @@ func GetTestSmartWalletAddress(t *testing.T, client *ethclient.Client, factoryAd
 	err := EnsureWalletDeployed(client, factoryAddress, owner, salt, controllerPrivateKey)
 	require.NoError(t, err, "Failed to ensure wallet is deployed for salt %s", salt.String())
 
-	walletAddress, err := aa.GetSenderAddress(client, owner, salt)
+	// Same factory and provider EnsureWalletDeployed just deployed with, rather
+	// than whatever the package global happens to hold.
+	walletAddress, err := aa.DeriveSenderAddressForFactory(
+		client, owner, factoryAddress, salt, aa.ProviderSimpleAccount)
 	require.NoError(t, err, "Failed to get wallet address for salt %s", salt.String())
 
 	return *walletAddress

--- a/model/session_policy.go
+++ b/model/session_policy.go
@@ -1,0 +1,178 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SessionPolicy is one grant of execution authority on one smart wallet: the
+// record behind the grant screen, and the thing the send path resolves before
+// it can sign anything.
+//
+// Shape and rationale: avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §7.4a.
+// Two things about it are easy to get wrong:
+//
+//   - The grant is a BEARER authorization for exactly its committed calldata.
+//     It authorizes execution against the user's wallet, so it gets the same
+//     handling as a secret: not logged, not returned in list responses,
+//     deleted on revoke.
+//
+//   - InstallCall is stored rather than re-derived. Re-building it from the
+//     policy fields at execution time would let a later code change silently
+//     alter what the owner signed — the signature would then fail, but only
+//     on chain, at execution, for a user who already consented.
+type SessionPolicy struct {
+	ID      string          `json:"id"`
+	Owner   *common.Address `json:"owner"`
+	Runner  *common.Address `json:"runner"` // the smart wallet this grants on
+	ChainID int64           `json:"chain_id"`
+
+	// EntityID is the validation entity this grant occupies on the account.
+	// Unique per ACCOUNT, allocated when the policy is created, never 0 —
+	// entity 0 is the owner's fallback signer.
+	EntityID uint32 `json:"entity_id"`
+
+	// SessionSigner is the key the gateway signs with as that entity.
+	SessionSigner *common.Address `json:"session_signer"`
+
+	AgentLabel    string `json:"agent_label,omitempty"`
+	Justification string `json:"justification,omitempty"`
+
+	// AllowedActions and ERC20SpendCap are the grant's declared permissions
+	// (master §7.2 P1/P2), stored for the manage screen and for rebuilding
+	// the module-cleanup payload at revocation. Display/rebuild data only:
+	// what the owner actually authorized is Grant.InstallCall, and these must
+	// never be re-encoded into it after signing.
+	AllowedActions []AllowedAction `json:"allowed_actions,omitempty"`
+	ERC20SpendCap  *ERC20SpendCap  `json:"erc20_spend_cap,omitempty"`
+
+	// Grant is the owner's authorization. Absent once applied is not a valid
+	// state: it is retained so revocation can reproduce the module cleanup
+	// payload, which is the same (entityId, inputs) tuple as the install.
+	Grant *SessionGrantAuthorization `json:"grant,omitempty"`
+
+	// ValidUntil is the grant's own lifetime (the TimeRangeModule hook),
+	// distinct from Grant.Deadline which only bounds the signing→first-use
+	// window. Unix milliseconds.
+	ValidUntil int64 `json:"valid_until,omitempty"`
+
+	Status    SessionPolicyStatus `json:"status"`
+	CreatedAt int64               `json:"created_at"`
+}
+
+// AllowedAction is one contract the grant's agent may call, scoped to
+// function selectors (master §7.2 P1).
+type AllowedAction struct {
+	Target    *common.Address `json:"target"`
+	Selectors []string        `json:"selectors"` // 0x-prefixed 4-byte selectors
+}
+
+// ERC20SpendCap is the grant's cumulative token cap (master §7.2 P2).
+// GrantedCap preserves the original total for "used X of Y" rendering — the
+// on-chain module only exposes the remainder.
+type ERC20SpendCap struct {
+	Token      *common.Address `json:"token"`
+	Amount     string          `json:"amount"`      // smallest unit, decimal string
+	GrantedCap string          `json:"granted_cap"` // == Amount at grant time
+}
+
+// SessionGrantAuthorization is the owner's signed deferred action.
+type SessionGrantAuthorization struct {
+	// InstallCall is the exact installValidation calldata the signature
+	// commits to.
+	InstallCall []byte `json:"install_call"`
+
+	// CarrierNonce is the FULL 256-bit nonce of the operation that will carry
+	// the action. The digest commits to it, so the carrying operation must use
+	// exactly this value. Computable at grant time only because a fresh entity
+	// is a fresh nonce key whose sequence is zero — it cannot be recomputed
+	// later.
+	CarrierNonce *big.Int `json:"carrier_nonce"`
+
+	// Deadline bounds the window between signing and first execution (uint48
+	// unix seconds). Not the grant's lifetime — see SessionPolicy.ValidUntil.
+	Deadline uint64 `json:"deadline"`
+
+	OwnerSignature []byte `json:"owner_signature"`
+
+	// AppliedAt is the replay marker. The payload authorizes exactly its
+	// committed calldata; attaching it twice must be impossible, and a
+	// non-zero AppliedAt is the check. Unix milliseconds.
+	AppliedAt         int64  `json:"applied_at,omitempty"`
+	AppliedUserOpHash string `json:"applied_userop_hash,omitempty"`
+
+	// RequiresExecuteUserOp is true when the grant installs an EXECUTION hook
+	// (an ERC-20 spend cap does; a time range does not). Every operation under
+	// such a grant must be executeUserOp-wrapped, including the one carrying
+	// this install. Recorded at grant time so the send path does not have to
+	// re-parse the install calldata to find out.
+	RequiresExecuteUserOp bool `json:"requires_execute_user_op,omitempty"`
+}
+
+// SessionPolicyStatus tracks how far a grant has got.
+type SessionPolicyStatus string
+
+const (
+	// SessionPolicyPending is signed and stored but not yet on chain.
+	// Revoking is free here: delete the record, nothing was installed.
+	SessionPolicyPending SessionPolicyStatus = "pending"
+	// SessionPolicyActive means the install applied on chain. Revoking now
+	// needs uninstallValidation.
+	SessionPolicyActive SessionPolicyStatus = "active"
+	// SessionPolicyRevoked is retained for audit; it grants nothing.
+	SessionPolicyRevoked SessionPolicyStatus = "revoked"
+)
+
+// Applied reports whether the deferred action has already been consumed.
+func (g *SessionGrantAuthorization) Applied() bool {
+	return g != nil && g.AppliedAt > 0
+}
+
+// Usable reports whether this policy can authorize an operation right now.
+func (p *SessionPolicy) Usable() bool {
+	if p == nil || p.Grant == nil {
+		return false
+	}
+	return p.Status == SessionPolicyPending || p.Status == SessionPolicyActive
+}
+
+// Validate rejects a record that cannot produce a working authorization.
+func (p *SessionPolicy) Validate() error {
+	if p.ID == "" {
+		return fmt.Errorf("session policy has no id")
+	}
+	if p.Owner == nil || *p.Owner == (common.Address{}) {
+		return fmt.Errorf("session policy %s has no owner", p.ID)
+	}
+	if p.Runner == nil || *p.Runner == (common.Address{}) {
+		return fmt.Errorf("session policy %s has no runner", p.ID)
+	}
+	if p.EntityID == 0 {
+		return fmt.Errorf("session policy %s uses entity 0, which is the owner's fallback signer", p.ID)
+	}
+	if p.SessionSigner == nil || *p.SessionSigner == (common.Address{}) {
+		return fmt.Errorf("session policy %s has no session signer", p.ID)
+	}
+	if p.Grant == nil {
+		return fmt.Errorf("session policy %s has no grant", p.ID)
+	}
+	if len(p.Grant.InstallCall) == 0 {
+		return fmt.Errorf("session policy %s has no install calldata", p.ID)
+	}
+	if len(p.Grant.OwnerSignature) == 0 {
+		return fmt.Errorf("session policy %s has no owner signature", p.ID)
+	}
+	if p.Grant.CarrierNonce == nil {
+		return fmt.Errorf("session policy %s has no carrier nonce; it cannot be recomputed", p.ID)
+	}
+	return nil
+}
+
+func (p *SessionPolicy) ToJSON() ([]byte, error) { return json.Marshal(p) }
+
+func (p *SessionPolicy) FromStorageData(body []byte) error {
+	return json.Unmarshal(body, p)
+}

--- a/pkg/erc4337/preset/builder_execution_success_test.go
+++ b/pkg/erc4337/preset/builder_execution_success_test.go
@@ -27,7 +27,9 @@ func TestUserOpWithdrawalSkipsReimbursementWhenBalanceInsufficient(t *testing.T)
 	require.NoError(t, err, "Failed to connect to RPC")
 	defer client.Close()
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()
 	if !ok {
@@ -167,7 +169,9 @@ func TestUserOpExecutionFailureExcessiveTransfer(t *testing.T) {
 		t.Skipf("Skipping TestUserOpExecutionFailureExcessiveTransfer: chain ID %d is not Sepolia (11155111)", chainID.Uint64())
 	}
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	// Get owner EOA from environment variable (OWNER_EOA or TEST_PRIVATE_KEY)
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()
@@ -263,7 +267,9 @@ func TestUserOpExecutionSuccessWithPaymaster(t *testing.T) {
 		t.Skipf("Skipping TestUserOpExecutionSuccessWithPaymaster: chain ID %d is not Sepolia (11155111)", chainID.Uint64())
 	}
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	// Get owner EOA from environment variable (OWNER_EOA or TEST_PRIVATE_KEY)
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()

--- a/pkg/erc4337/preset/builder_test.go
+++ b/pkg/erc4337/preset/builder_test.go
@@ -39,6 +39,16 @@ func mockGetBaseTestSmartWalletConfig() *config.SmartWalletConfig {
 func TestSendUserOp(t *testing.T) {
 	smartWalletConfig := mockGetBaseTestSmartWalletConfig()
 
+	// SendUserOp is the v0.6 path — v0.6 EntryPoint, executeBatchWithValues
+	// calldata — so it must derive a v0.6 SimpleAccount. Pin the provider
+	// explicitly: the default flipped to modular_account_v2 in the cutover
+	// (#694), which would otherwise resolve this owner+salt to an MA v2
+	// account that rejects a v0.6 UserOp at validation (nonce 0 carries no
+	// validation locator → ValidationFunctionMissing → the bundler's AA23).
+	// When the v0.6 path is removed post-cutover, this test goes with it.
+	smartWalletConfig.AccountProvider = config.AccountProviderSimpleAccount
+	smartWalletConfig.FactoryAddress = common.HexToAddress(config.DefaultFactoryProxyAddressHex)
+
 	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
 		t.Fatalf("setting global factory: %v", err)
 	}

--- a/pkg/erc4337/preset/builder_test.go
+++ b/pkg/erc4337/preset/builder_test.go
@@ -39,7 +39,9 @@ func mockGetBaseTestSmartWalletConfig() *config.SmartWalletConfig {
 func TestSendUserOp(t *testing.T) {
 	smartWalletConfig := mockGetBaseTestSmartWalletConfig()
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	ownerAddr, ok := testutil.MustGetTestOwnerAddress()
 	if !ok {
@@ -89,7 +91,9 @@ func TestPaymaster(t *testing.T) {
 
 	smartWalletConfig := mockGetBaseTestSmartWalletConfig()
 
-	aa.SetFactoryAddress(smartWalletConfig.FactoryAddress)
+	if err := aa.SetFactoryAddressForConfig(smartWalletConfig); err != nil {
+		t.Fatalf("setting global factory: %v", err)
+	}
 
 	// Because we used the master key to signed, the address cannot be calculated from that key and need to set explicitly
 	owner := common.HexToAddress("0xe272b72E51a5bF8cB720fc6D6DF164a4D5E321C5")

--- a/pkg/erc4337/preset/builder_v07.go
+++ b/pkg/erc4337/preset/builder_v07.go
@@ -14,11 +14,15 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 )
 
-// EntryPointV07Address is the same on every chain Alchemy supports.
-const EntryPointV07Address = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+// EntryPointV07Address is the same on every chain Alchemy supports. It is an
+// alias for config's constant rather than a second literal: two copies of an
+// address are two things to get out of step, and a mismatch would surface as
+// signatures that verify nowhere.
+const EntryPointV07Address = config.EntryPointV07AddressHex
 
 // EntryPointV07 returns the v0.7 EntryPoint address.
 func EntryPointV07() common.Address { return common.HexToAddress(EntryPointV07Address) }

--- a/pkg/erc4337/preset/builder_v07.go
+++ b/pkg/erc4337/preset/builder_v07.go
@@ -62,8 +62,22 @@ const selectorGetNonce = "0x35567e1a"
 const (
 	seedVerificationGasDeploying = 200_000 // ~160k actual -> ~0.8 efficiency
 	seedVerificationGasDeployed  = 60_000  // ~45k actual  -> ~0.75 efficiency
-	initialCallGasLimit          = 500_000
-	initialPreVerificationGas    = 100_000
+
+	// Session-entity seeds, all measured on Sepolia rather than derived. Each
+	// step up is a specific cost the previous seed did not cover:
+	//
+	//   module entity      60k AA26s — validating through an installed module
+	//                      is an external call, and the entity's first use
+	//                      writes a cold nonce-key slot (~22k)
+	//   deferred install   300k AA26s — the install itself runs inside
+	//                      validation, writing cold module storage
+	//   + permission hooks 300k AA26s again — every allowlist entry is its
+	//                      own cold SSTORE, so cost scales with grant contents
+	seedVerificationGasModuleEntity  = 100_000
+	seedVerificationGasDeferredBare  = 400_000
+	seedVerificationGasDeferredHooks = 700_000
+	initialCallGasLimit              = 500_000
+	initialPreVerificationGas        = 100_000
 
 	// verificationGasEfficiencyFloor is Rundler's published threshold.
 	verificationGasEfficiencyFloor = 0.4

--- a/pkg/erc4337/preset/deferred_v07.go
+++ b/pkg/erc4337/preset/deferred_v07.go
@@ -1,0 +1,69 @@
+package preset
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// Deferred-action variants of the v0.7 signing helpers. The operation's nonce
+// must carry ValidationOptionDeferredAction and the entity id of the
+// validation the deferred call installs — the CONTROLLER's entity, not the
+// owner's. The owner's part (encodedData + ownerSig) was produced at grant
+// time; only the controller signs here.
+
+// DeferredEstimationSignature builds the signature to estimate a deferred
+// operation with. The deferred segments must be REAL: unlike ordinary
+// signature validation, which fails gracefully so estimation can proceed, a
+// bad deferred-action signature REVERTS (DeferredActionSignatureInvalid) —
+// the owner's actual grant has to ride along even for estimation. Only the
+// controller's part is a dummy.
+func DeferredEstimationSignature(encodedData []byte, ownerSig []byte) ([]byte, error) {
+	return userop.WrapSignatureMAv2Deferred(encodedData, ownerSig, dummySignatureV07())
+}
+
+// SignUserOpV07Deferred signs the operation with the controller key and
+// installs the full deferred-action signature: the owner's grant segments
+// followed by the controller's framed signature. Sign last — the controller
+// signature covers every gas and paymaster field. The owner's signature does
+// not, which is the property that lets it be collected before pricing exists.
+func SignUserOpV07Deferred(
+	op *userop.UserOperationV07,
+	entryPoint common.Address,
+	chainID *big.Int,
+	controllerKey *ecdsa.PrivateKey,
+	encodedData []byte,
+	ownerSig []byte,
+) error {
+	if op == nil {
+		return fmt.Errorf("nil user operation")
+	}
+	if controllerKey == nil {
+		return fmt.Errorf("nil controller key")
+	}
+	hash, err := op.GetUserOpHash(entryPoint, chainID)
+	if err != nil {
+		return fmt.Errorf("computing userOpHash: %w", err)
+	}
+	sig, err := crypto.Sign(accounts.TextHash(hash.Bytes()), controllerKey)
+	if err != nil {
+		return fmt.Errorf("signing userOpHash %s: %w", hash.Hex(), err)
+	}
+	sig[64] += 27
+	framed, err := userop.WrapSignatureMAv2(sig)
+	if err != nil {
+		return err
+	}
+	full, err := userop.WrapSignatureMAv2Deferred(encodedData, ownerSig, framed)
+	if err != nil {
+		return err
+	}
+	op.Signature = full
+	return nil
+}

--- a/pkg/erc4337/preset/nonce_v07.go
+++ b/pkg/erc4337/preset/nonce_v07.go
@@ -1,0 +1,169 @@
+package preset
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// v0.7 nonce management.
+//
+// EntryPoint.getNonce reflects MINED state only. A workflow with two
+// sequential contract writes sends the second operation while the first sits
+// in the bundler's mempool — a fresh getNonce returns the same sequence and
+// the send dies AA25 invalid account nonce. The v0.6 path solved this with a
+// per-sender cache (bundler.NonceManager); this is its v0.7 counterpart, with
+// one structural difference that is the whole reason it is a separate type:
+//
+// MA v2 sequences are per NONCE KEY, not per sender. The 192-bit key encodes
+// the validation entity and the option bits, so one account has independent
+// counters for entity 1 plain, entity 1 deferred, entity 2, and so on. A
+// sender-keyed cache would see entity 2's first operation, find entity 1's
+// cached value, and hand out a sequence from the wrong counter. The cache key
+// here is (sender, nonce key).
+//
+// Semantics are v0.6 parity, proven in production there:
+//
+//   - read     → max(on-chain, cached): the chain wins when pending work
+//     mined or was dropped; the cache wins while work is in flight.
+//   - accepted → cache = used+1, recorded when the BUNDLER accepts, not when
+//     the operation mines. That is what lets the next operation overlap the
+//     mempool — and it also covers the subtler failure where the operation
+//     HAS mined but a load-balanced RPC replica serves a pre-mine getNonce.
+//   - failure  → drop the slot; the next read is authoritative chain state.
+//     AA25 covers both a duplicate (cache behind) and a gap (cache ahead
+//     after a drop), so the caller's response to it is invalidate + re-read.
+//
+// Deferred operations NEVER go through the cache. A grant's carrying
+// operation uses the nonce the owner signed over at grant time — sequence
+// zero of a fresh key — and no cache may substitute another value: the
+// digest would no longer match and the account would revert
+// DeferredActionSignatureInvalid with nothing pointing at the nonce. See
+// VerifyDeferredNonceUnused for the check that replaces caching there.
+//
+// Known limit, inherited from v0.6: reads do not RESERVE. Two goroutines
+// racing the same (sender, key) between read and accept can draw the same
+// sequence; the loser gets AA25 and heals through invalidate + retry. Node
+// execution within a workflow is sequential, so this window only matters for
+// concurrent tasks on one wallet.
+type nonceManagerV07 struct {
+	mu   sync.Mutex
+	next map[nonceSlotV07]*big.Int
+}
+
+// nonceSlotV07 identifies one sequence counter: an account and one of its
+// 192-bit nonce keys (entity + options), string-keyed for comparability.
+type nonceSlotV07 struct {
+	sender common.Address
+	key    string
+}
+
+var globalNonceManagerV07 = &nonceManagerV07{next: make(map[nonceSlotV07]*big.Int)}
+
+func slotV07(sender common.Address, entityID uint32, options uint8) (nonceSlotV07, error) {
+	key, err := userop.NonceKeyMAv2(entityID, options)
+	if err != nil {
+		return nonceSlotV07{}, err
+	}
+	return nonceSlotV07{sender: sender, key: key.String()}, nil
+}
+
+// NextNonceV07Managed returns the nonce the next operation should use for
+// this (sender, entity, options): the on-chain value, or the cached
+// next-after-pending value when that is ahead.
+func NextNonceV07Managed(ctx context.Context, client *rpc.Client, entryPoint, sender common.Address, entityID uint32, options uint8) (*big.Int, error) {
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil {
+		return nil, err
+	}
+	onChain, err := NextNonceV07(ctx, client, entryPoint, sender, entityID, options)
+	if err != nil {
+		return nil, err
+	}
+
+	m := globalNonceManagerV07
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if cached, ok := m.next[slot]; ok && cached.Cmp(onChain) > 0 {
+		return new(big.Int).Set(cached), nil
+	}
+	return onChain, nil
+}
+
+// NoteUserOpAccepted records that the bundler accepted an operation at
+// usedNonce, so the next operation on the same key overlaps it in the
+// mempool instead of colliding with it.
+//
+// The successor is built by re-encoding sequence+1 under the slot's own key
+// rather than adding 1 to the full 256-bit nonce: the layout is
+// [192-bit key][64-bit sequence], and a bare +1 at the sequence ceiling
+// would carry into the key half and cache a nonce for a different validation
+// entirely. Unrepresentable states drop the record — a missing cache entry
+// costs a chain read; a corrupt one costs an AA25.
+func NoteUserOpAccepted(sender common.Address, entityID uint32, options uint8, usedNonce *big.Int) {
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil || usedNonce == nil {
+		return // an unencodable slot was never cached; nothing to record
+	}
+	_, _, sequence, err := userop.DecodeNonceMAv2(usedNonce)
+	if err != nil || sequence == ^uint64(0) {
+		return
+	}
+	next, err := userop.EncodeNonceMAv2(entityID, options, sequence+1)
+	if err != nil {
+		return
+	}
+	m := globalNonceManagerV07
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.next[slot] = next
+}
+
+// InvalidateNonce drops the cached counter so the next read is authoritative
+// chain state. Call it when a send fails for any reason — a rejected
+// operation was never pending, and a stale cache is worse than none.
+func InvalidateNonce(sender common.Address, entityID uint32, options uint8) {
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil {
+		return
+	}
+	m := globalNonceManagerV07
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.next, slot)
+}
+
+// isInvalidNonceError recognises the EntryPoint's AA25 in a bundler error.
+// (The v0.6 path also matches Voltaire's mempool-replacement phrasing; the
+// v0.7 path only ever talks to Rundler, which surfaces AA25 verbatim.)
+func isInvalidNonceError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "AA25")
+}
+
+// VerifyDeferredNonceUnused is the deferred path's replacement for nonce
+// management: the owner's signature committed to sequence zero of the
+// grant's key, so the only question is whether that nonce is still available.
+// A consumed sequence means the grant was already applied (or a duplicate
+// send is racing this one), and the answer is a clear error here rather than
+// DeferredActionSignatureInvalid from the account with nothing pointing at
+// the nonce.
+func VerifyDeferredNonceUnused(liveNonce *big.Int) error {
+	if liveNonce == nil {
+		return fmt.Errorf("nil nonce")
+	}
+	_, _, sequence, err := userop.DecodeNonceMAv2(liveNonce)
+	if err != nil {
+		return err
+	}
+	if sequence != 0 {
+		return fmt.Errorf("the grant's nonce key already has sequence %d on-chain — its deferred action was already applied (or a duplicate send is in flight); this grant cannot be replayed", sequence)
+	}
+	return nil
+}

--- a/pkg/erc4337/preset/nonce_v07_test.go
+++ b/pkg/erc4337/preset/nonce_v07_test.go
@@ -1,0 +1,148 @@
+package preset
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// The manager is package state; each test claims distinct senders so they do
+// not interfere.
+
+func mustNonce(t *testing.T, entityID uint32, options uint8, seq uint64) *big.Int {
+	t.Helper()
+	n, err := userop.EncodeNonceMAv2(entityID, options, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// cacheAhead reads the cached value the way NextNonceV07Managed does once the
+// chain read is in hand, without needing a live RPC.
+func cachedNext(t *testing.T, sender common.Address, entityID uint32, options uint8) (*big.Int, bool) {
+	t.Helper()
+	slot, err := slotV07(sender, entityID, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	globalNonceManagerV07.mu.Lock()
+	defer globalNonceManagerV07.mu.Unlock()
+	v, ok := globalNonceManagerV07.next[slot]
+	if !ok {
+		return nil, false
+	}
+	return new(big.Int).Set(v), true
+}
+
+func TestNonceManagerV07AcceptedAdvancesTheSlot(t *testing.T) {
+	sender := common.HexToAddress("0x00000000000000000000000000000000000000A1")
+	used := mustNonce(t, 1, userop.ValidationOptionGlobal, 0)
+
+	NoteUserOpAccepted(sender, 1, userop.ValidationOptionGlobal, used)
+
+	next, ok := cachedNext(t, sender, 1, userop.ValidationOptionGlobal)
+	if !ok {
+		t.Fatal("acceptance did not populate the slot")
+	}
+	want := mustNonce(t, 1, userop.ValidationOptionGlobal, 1)
+	if next.Cmp(want) != 0 {
+		t.Fatalf("cached next = %s, want %s (used+1)", next, want)
+	}
+
+	InvalidateNonce(sender, 1, userop.ValidationOptionGlobal)
+	if _, ok := cachedNext(t, sender, 1, userop.ValidationOptionGlobal); ok {
+		t.Fatal("invalidate did not drop the slot")
+	}
+}
+
+// One account's counters are per (entity, options) — the whole reason this is
+// not the v0.6 sender-keyed manager. Entity 1 plain, entity 1 deferred, and
+// entity 2 must be three independent slots.
+func TestNonceManagerV07SlotsAreIndependent(t *testing.T) {
+	sender := common.HexToAddress("0x00000000000000000000000000000000000000A2")
+	deferredOpts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+
+	NoteUserOpAccepted(sender, 1, userop.ValidationOptionGlobal, mustNonce(t, 1, userop.ValidationOptionGlobal, 4))
+
+	if _, ok := cachedNext(t, sender, 1, deferredOpts); ok {
+		t.Fatal("entity 1's plain acceptance leaked into its deferred slot")
+	}
+	if _, ok := cachedNext(t, sender, 2, userop.ValidationOptionGlobal); ok {
+		t.Fatal("entity 1's acceptance leaked into entity 2's slot")
+	}
+
+	next, ok := cachedNext(t, sender, 1, userop.ValidationOptionGlobal)
+	if !ok || next.Cmp(mustNonce(t, 1, userop.ValidationOptionGlobal, 5)) != 0 {
+		t.Fatalf("entity 1 plain slot = %v, want sequence 5", next)
+	}
+}
+
+func TestNonceManagerV07SendersAreIndependent(t *testing.T) {
+	a := common.HexToAddress("0x00000000000000000000000000000000000000A3")
+	b := common.HexToAddress("0x00000000000000000000000000000000000000A4")
+
+	NoteUserOpAccepted(a, 1, userop.ValidationOptionGlobal, mustNonce(t, 1, userop.ValidationOptionGlobal, 7))
+	if _, ok := cachedNext(t, b, 1, userop.ValidationOptionGlobal); ok {
+		t.Fatal("sender A's acceptance leaked into sender B's slot")
+	}
+}
+
+func TestVerifyDeferredNonceUnused(t *testing.T) {
+	deferredOpts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+
+	if err := VerifyDeferredNonceUnused(mustNonce(t, 1, deferredOpts, 0)); err != nil {
+		t.Fatalf("sequence 0 must be usable: %v", err)
+	}
+	err := VerifyDeferredNonceUnused(mustNonce(t, 1, deferredOpts, 1))
+	if err == nil {
+		t.Fatal("a consumed sequence must be rejected")
+	}
+	if !errorsMentionsReplay(err) {
+		t.Fatalf("the error should say the grant cannot be replayed, got: %v", err)
+	}
+	if err := VerifyDeferredNonceUnused(nil); err == nil {
+		t.Fatal("nil nonce must be rejected")
+	}
+}
+
+func errorsMentionsReplay(err error) bool {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if containsAll(e.Error(), "already", "replay") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestIsInvalidNonceError(t *testing.T) {
+	if !isInvalidNonceError(errors.New("eth_sendUserOperation: validation reverted: [reason]: AA25 invalid account nonce")) {
+		t.Fatal("AA25 not recognised")
+	}
+	if isInvalidNonceError(errors.New("AA23 reverted")) {
+		t.Fatal("AA23 misclassified as a nonce error")
+	}
+	if isInvalidNonceError(nil) {
+		t.Fatal("nil error misclassified")
+	}
+}

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -38,14 +38,15 @@ func SendUserOpMAv2(
 	callData []byte,
 	senderOverride *common.Address,
 	saltOverride *big.Int,
+	auth *SessionAuthorization,
 	lgr logger.Logger,
 ) (*userop.UserOperationV07, *types.Receipt, error) {
 	l := logger.EnsureLogger(lgr)
 	if smartWalletConfig == nil {
 		return nil, nil, fmt.Errorf("nil smart wallet config")
 	}
-	if smartWalletConfig.ControllerPrivateKey == nil {
-		return nil, nil, fmt.Errorf("no controller private key configured")
+	if err := auth.Validate(); err != nil {
+		return nil, nil, err
 	}
 
 	bundlerURL, err := smartWalletConfig.ActiveBundlerURL()
@@ -66,6 +67,12 @@ func SendUserOpMAv2(
 	}
 	defer bundlerRPC.Close()
 
+	// Nonce reads are plain eth_calls and go to the CHAIN rpc. The bundler
+	// endpoint only advertises the ERC-4337 namespace on some providers
+	// (Voltaire answers eth_call with Method-not-found; Alchemy happens to
+	// serve both from one URL, which is how this hid during development).
+	nonceRPC := chainRPC.Client()
+
 	entryPoint := EntryPointV07()
 	chainID := big.NewInt(smartWalletConfig.ChainID)
 
@@ -82,6 +89,38 @@ func SendUserOpMAv2(
 	sender, err := resolveSenderV07(chainRPC, owner, factory, salt, senderOverride)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// A caller that supplies no authorization gets the stored grant for THIS
+	// wallet — looked up only now, because grants are keyed by the smart
+	// wallet's address and the sender is not known until it is resolved.
+	// Resolving earlier against the owner EOA (or a guessed wallet) finds
+	// nothing and signs as the fallback entity the gateway cannot validate
+	// for.
+	if auth == nil {
+		if auth, err = resolveSession(smartWalletConfig.ChainID, owner, sender); err != nil {
+			return nil, nil, fmt.Errorf("resolving session authorization for %s: %w", sender.Hex(), err)
+		}
+		if err = auth.Validate(); err != nil {
+			return nil, nil, err
+		}
+	}
+	// Without a session authorization the operation runs as the account's
+	// fallback signer, which only the OWNER's key can do. The gateway does not
+	// hold it, so this path exists for callers that supply their own signer.
+	if auth == nil && smartWalletConfig.ControllerPrivateKey == nil {
+		return nil, nil, fmt.Errorf("no controller private key configured")
+	}
+
+	// A grant carrying execution hooks requires user-op context on EVERY
+	// operation under it — including the one that installs the grant, since
+	// the hooks are live from the moment the install applies mid-validation.
+	if auth != nil && auth.WrapExecuteUserOp {
+		wrapped, wrapErr := aa.WrapExecuteUserOp(callData)
+		if wrapErr != nil {
+			return nil, nil, fmt.Errorf("wrapping calldata for user-op context: %w", wrapErr)
+		}
+		callData = wrapped
 	}
 
 	op := &userop.UserOperationV07{
@@ -108,17 +147,67 @@ func SendUserOpMAv2(
 		op.Factory = &deployFactory
 		op.FactoryData = factoryData
 	}
-	op.VerificationGasLimit = seedVerificationGas(op)
+	op.VerificationGasLimit = seedVerificationGasFor(op, auth)
 
 	// MA v2 selects its validation function from the NONCE, not the signature.
 	// A zero nonce reverts with ValidationFunctionMissing rather than as a
 	// nonce error, which is the single most misleading failure on this path.
-	nonce, err := NextNonceV07(ctx, bundlerRPC, entryPoint, sender,
-		userop.FallbackSignerEntityID, userop.ValidationOptionGlobal)
+	//
+	// Plain operations read through the nonce manager so a second write can
+	// overlap the first in the mempool (getNonce alone reads mined state and
+	// AA25s any sequential pair). Deferred operations bypass it: the owner's
+	// signature committed to sequence zero at grant time, so no cached value
+	// may substitute.
+	nonceEntity, nonceOptions := auth.nonceEntity()
+	var nonce *big.Int
+	if auth.Deferred() {
+		nonce, err = NextNonceV07(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
+		if err == nil {
+			var sequence uint64
+			if _, _, sequence, err = userop.DecodeNonceMAv2(nonce); err == nil && sequence != 0 {
+				// The carrier sequence is consumed, and the only operation
+				// that ever uses a grant's deferred key is its install: the
+				// install MINED without this process seeing the receipt (a
+				// confirmation timeout, or a crash between send and record).
+				// Not an error — record the fact and run this operation as
+				// an ordinary one under the now-installed entity.
+				l.Info("grant install found already applied on-chain; recording and continuing plain",
+					"sender", sender.Hex(), "entity", auth.EntityID, "sequence", sequence)
+				if auth.OnApplied != nil {
+					if markErr := auth.OnApplied(""); markErr != nil {
+						l.Error("grant is applied on-chain but could not be recorded; the next operation will retry",
+							"sender", sender.Hex(), "error", markErr)
+					}
+				}
+				auth.DeferredData, auth.OwnerSignature = nil, nil
+				nonceEntity, nonceOptions = auth.nonceEntity()
+				op.Signature = nil
+				op.VerificationGasLimit = seedVerificationGasFor(op, auth)
+				nonce, err = NextNonceV07Managed(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
+			}
+		}
+	} else {
+		nonce, err = NextNonceV07Managed(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading nonce: %w", err)
 	}
 	op.Nonce = nonce
+
+	// Estimation of a deferred operation must carry the REAL owner grant.
+	// Ordinary signature validation fails gracefully so estimation can
+	// proceed, but a bad deferred-action signature REVERTS
+	// (DeferredActionSignatureInvalid) — so estimating with the plain dummy
+	// gets AA23 with nothing pointing at the missing grant. Only the
+	// controller's half may be a dummy here; the real one is installed below,
+	// after pricing, because the signature covers the gas fields.
+	if auth.Deferred() {
+		estSig, estErr := DeferredEstimationSignature(auth.DeferredData, auth.OwnerSignature)
+		if estErr != nil {
+			return nil, nil, fmt.Errorf("building the estimation signature: %w", estErr)
+		}
+		op.Signature = estSig
+	}
 
 	if err := priceOperationV07(ctx, chainRPC, bundlerRPC, op, entryPoint, smartWalletConfig, l); err != nil {
 		return nil, nil, err
@@ -128,18 +217,51 @@ func SendUserOpMAv2(
 	// to come after pricing. SendUserOpV07WithRetry only RE-signs, and only
 	// when it tightens the verification gas limit — it will not sign an
 	// unsigned operation, it rejects one.
-	if err := SignUserOpV07(op, entryPoint, chainID, smartWalletConfig.ControllerPrivateKey); err != nil {
+	signingKey := smartWalletConfig.ControllerPrivateKey
+	if auth != nil {
+		signingKey = auth.SignerKey
+	}
+	if auth.Deferred() {
+		if err := SignUserOpV07Deferred(op, entryPoint, chainID, signingKey,
+			auth.DeferredData, auth.OwnerSignature); err != nil {
+			return op, nil, fmt.Errorf("signing user operation with deferred action: %w", err)
+		}
+	} else if err := SignUserOpV07(op, entryPoint, chainID, signingKey); err != nil {
 		return op, nil, fmt.Errorf("signing user operation: %w", err)
 	}
 
-	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID,
-		smartWalletConfig.ControllerPrivateKey)
+	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID, signingKey)
+	if err != nil && !auth.Deferred() && isInvalidNonceError(err) {
+		// AA25 covers both directions of cache drift — a duplicate (another
+		// operation took this sequence) and a gap (a cached pending operation
+		// was dropped). Either way the cache is wrong: drop it, take the
+		// chain's answer, re-sign (the nonce is in the userOpHash), retry
+		// once. Deferred operations are excluded — their nonce is committed
+		// by the owner's signature and cannot be substituted.
+		InvalidateNonce(sender, nonceEntity, nonceOptions)
+		freshNonce, nonceErr := NextNonceV07Managed(ctx, nonceRPC, entryPoint, sender, nonceEntity, nonceOptions)
+		if nonceErr == nil && freshNonce.Cmp(op.Nonce) != 0 {
+			l.Info("retrying after AA25 with the chain's nonce",
+				"sender", sender.Hex(), "stale", op.Nonce.String(), "fresh", freshNonce.String())
+			op.Nonce = freshNonce
+			if signErr := SignUserOpV07(op, entryPoint, chainID, signingKey); signErr == nil {
+				opHash, err = SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID, signingKey)
+			}
+		}
+	}
 	if err != nil {
+		InvalidateNonce(sender, nonceEntity, nonceOptions)
 		return op, nil, fmt.Errorf("sending user operation: %w", err)
 	}
+	// Record acceptance NOW — the bundler holds the operation, so the next
+	// one on this key must use the following sequence even though nothing has
+	// mined yet. This is the line that lets sequential contract writes
+	// overlap the mempool instead of dying AA25.
+	NoteUserOpAccepted(sender, nonceEntity, nonceOptions, op.Nonce)
 	l.Info("v0.7 user operation sent",
 		"sender", sender.Hex(), "userop_hash", opHash.Hex(),
-		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil)
+		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil,
+		"entity", nonceEntity, "installs_grant", auth.Deferred())
 
 	// Reuses the v0.6 confirmation watcher: UserOperationEvent is unchanged
 	// between EntryPoint versions, so only the EntryPoint address differs.
@@ -152,9 +274,34 @@ func SendUserOpMAv2(
 			l.Warn("websocket dial failed, polling for the receipt instead", "error", wsErr)
 		}
 	}
+	installsGrant := auth.Deferred()
 	receipt, err := waitForUserOpConfirmation(chainRPC, wsClient, entryPoint, opHash.Hex(), l)
 	if err != nil {
+		// Includes the mined-but-execution-reverted case — in which the
+		// install DID apply (it runs in the validation frame, which an
+		// execution revert does not roll back, results doc §3.4). Not marked
+		// here because this path cannot distinguish that from a true
+		// validation-level failure; the next operation heals it through the
+		// consumed-carrier-nonce path above.
 		return op, nil, err
+	}
+	if installsGrant {
+		if receipt == nil {
+			// Confirmation timed out with the operation still pending. The
+			// grant stays recorded as pending; if the install mines later,
+			// the next operation discovers the consumed carrier nonce and
+			// records it then.
+			l.Info("grant install sent but unconfirmed; recording deferred to the next operation",
+				"sender", sender.Hex(), "userop_hash", opHash.Hex())
+		} else if auth.OnApplied != nil {
+			// The install is on-chain. Record it so the stored grant stops
+			// attaching the deferred action — attaching a consumed one would
+			// fail every subsequent operation on this wallet.
+			if markErr := auth.OnApplied(opHash.Hex()); markErr != nil {
+				l.Error("grant applied on-chain but could not be recorded; the next operation will retry",
+					"sender", sender.Hex(), "userop_hash", opHash.Hex(), "error", markErr)
+			}
+		}
 	}
 	return op, receipt, nil
 }

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -1,0 +1,274 @@
+package preset
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// SendUserOpMAv2 is the v0.7 counterpart to SendUserOp: it takes the same
+// inputs, builds a Modular Account v2 operation, and returns once the
+// operation is mined. (SendUserOpV07 is the raw one-shot send this sits on
+// top of; this is the orchestrator that builds, prices, and signs first.)
+//
+// callData is the account's execute() calldata, the SAME bytes the v0.6 path
+// builds. execute(address,uint256,bytes) kept selector 0xb61d27f6 in MA v2, so
+// aa.PackExecute output is byte-identical to aa.PackExecuteMAv2 and callers
+// need no repacking. That is NOT true of batching:
+// executeBatchWithValues has no MA v2 successor, so a batched operation must
+// be packed with aa.PackExecuteBatchMAv2 before it gets here.
+//
+// Sponsorship is all-or-nothing on purpose. When a Gas Manager policy is
+// configured, an operation the policy declines fails rather than falling back
+// to self-funded — silently paying out of the account's own balance is how a
+// declined sponsorship turns into a drained wallet.
+func SendUserOpMAv2(
+	smartWalletConfig *config.SmartWalletConfig,
+	owner common.Address,
+	callData []byte,
+	senderOverride *common.Address,
+	saltOverride *big.Int,
+	lgr logger.Logger,
+) (*userop.UserOperationV07, *types.Receipt, error) {
+	l := logger.EnsureLogger(lgr)
+	if smartWalletConfig == nil {
+		return nil, nil, fmt.Errorf("nil smart wallet config")
+	}
+	if smartWalletConfig.ControllerPrivateKey == nil {
+		return nil, nil, fmt.Errorf("no controller private key configured")
+	}
+
+	bundlerURL, err := smartWalletConfig.ActiveBundlerURL()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving bundler url: %w", err)
+	}
+
+	ctx := context.Background()
+	chainRPC, err := ethclient.Dial(smartWalletConfig.EthRpcUrl)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dialing chain rpc: %w", err)
+	}
+	defer chainRPC.Close()
+
+	bundlerRPC, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dialing bundler: %w", err)
+	}
+	defer bundlerRPC.Close()
+
+	entryPoint := EntryPointV07()
+	chainID := big.NewInt(smartWalletConfig.ChainID)
+
+	salt := saltOverride
+	if salt == nil {
+		salt = big.NewInt(0)
+	}
+
+	factory, err := aa.EffectiveFactory(smartWalletConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving account factory: %w", err)
+	}
+
+	sender, err := resolveSenderV07(chainRPC, owner, factory, salt, senderOverride)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	op := &userop.UserOperationV07{
+		Sender:               sender,
+		CallData:             callData,
+		CallGasLimit:         big.NewInt(initialCallGasLimit),
+		PreVerificationGas:   big.NewInt(initialPreVerificationGas),
+		MaxFeePerGas:         big.NewInt(0),
+		MaxPriorityFeePerGas: big.NewInt(0),
+	}
+
+	// An account with no code yet must carry its own deployment. Reading the
+	// code is the authoritative check — a wallet record can exist for an
+	// address that was never deployed, and vice versa.
+	deployed, err := isDeployed(ctx, chainRPC, sender)
+	if err != nil {
+		return nil, nil, fmt.Errorf("checking whether %s is deployed: %w", sender.Hex(), err)
+	}
+	if !deployed {
+		deployFactory, factoryData, initErr := aa.DeriveInitCodeAuto(owner, factory, salt)
+		if initErr != nil {
+			return nil, nil, fmt.Errorf("building init code: %w", initErr)
+		}
+		op.Factory = &deployFactory
+		op.FactoryData = factoryData
+	}
+	op.VerificationGasLimit = seedVerificationGas(op)
+
+	// MA v2 selects its validation function from the NONCE, not the signature.
+	// A zero nonce reverts with ValidationFunctionMissing rather than as a
+	// nonce error, which is the single most misleading failure on this path.
+	nonce, err := NextNonceV07(ctx, bundlerRPC, entryPoint, sender,
+		userop.FallbackSignerEntityID, userop.ValidationOptionGlobal)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading nonce: %w", err)
+	}
+	op.Nonce = nonce
+
+	if err := priceOperationV07(ctx, chainRPC, bundlerRPC, op, entryPoint, smartWalletConfig, l); err != nil {
+		return nil, nil, err
+	}
+
+	// Sign last: the signature covers every gas and paymaster field, so it has
+	// to come after pricing. SendUserOpV07WithRetry only RE-signs, and only
+	// when it tightens the verification gas limit — it will not sign an
+	// unsigned operation, it rejects one.
+	if err := SignUserOpV07(op, entryPoint, chainID, smartWalletConfig.ControllerPrivateKey); err != nil {
+		return op, nil, fmt.Errorf("signing user operation: %w", err)
+	}
+
+	opHash, err := SendUserOpV07WithRetry(ctx, bundlerRPC, op, entryPoint, chainID,
+		smartWalletConfig.ControllerPrivateKey)
+	if err != nil {
+		return op, nil, fmt.Errorf("sending user operation: %w", err)
+	}
+	l.Info("v0.7 user operation sent",
+		"sender", sender.Hex(), "userop_hash", opHash.Hex(),
+		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil)
+
+	// Reuses the v0.6 confirmation watcher: UserOperationEvent is unchanged
+	// between EntryPoint versions, so only the EntryPoint address differs.
+	var wsClient *ethclient.Client
+	if smartWalletConfig.EthWsUrl != "" {
+		if ws, wsErr := ethclient.Dial(smartWalletConfig.EthWsUrl); wsErr == nil {
+			wsClient = ws
+			defer ws.Close()
+		} else {
+			l.Warn("websocket dial failed, polling for the receipt instead", "error", wsErr)
+		}
+	}
+	receipt, err := waitForUserOpConfirmation(chainRPC, wsClient, entryPoint, opHash.Hex(), l)
+	if err != nil {
+		return op, nil, err
+	}
+	return op, receipt, nil
+}
+
+// resolveSenderV07 picks the account the operation runs as. An explicit
+// override is trusted (the caller has already resolved which of the owner's
+// wallets to use); otherwise the address is derived from the factory.
+func resolveSenderV07(
+	chainRPC *ethclient.Client,
+	owner, factory common.Address,
+	salt *big.Int,
+	senderOverride *common.Address,
+) (common.Address, error) {
+	if senderOverride != nil && *senderOverride != (common.Address{}) {
+		return *senderOverride, nil
+	}
+	derived, err := aa.DeriveSenderAddressAuto(chainRPC, owner, factory, salt)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("deriving sender for owner %s salt %s: %w",
+			owner.Hex(), salt.String(), err)
+	}
+	if derived == nil || *derived == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("derived a zero sender for owner %s salt %s",
+			owner.Hex(), salt.String())
+	}
+	return *derived, nil
+}
+
+// priceOperationV07 fills the gas and paymaster fields, either from a Gas
+// Manager policy (which prices the operation as part of sponsoring it) or from
+// the bundler's own estimate.
+func priceOperationV07(
+	ctx context.Context,
+	chainRPC *ethclient.Client,
+	bundlerRPC *rpc.Client,
+	op *userop.UserOperationV07,
+	entryPoint common.Address,
+	smartWalletConfig *config.SmartWalletConfig,
+	l logger.Logger,
+) error {
+	if policyID := smartWalletConfig.GasManagerPolicyID; policyID != "" {
+		if err := RequestSponsorshipV07(ctx, bundlerRPC, op, entryPoint,
+			SponsorshipRequestV07{PolicyID: policyID}); err != nil {
+			// Deliberately fatal. See SendUserOpV07's contract: falling through
+			// to an unsponsored send would spend the account's own balance on
+			// an operation the policy just refused to fund.
+			return fmt.Errorf("gas manager declined to sponsor: %w", err)
+		}
+		l.Debug("operation sponsored", "paymaster", op.Paymaster.Hex())
+		return nil
+	}
+
+	// Unsponsored: the account pays, so the fee fields have to be real. A
+	// zero maxFeePerGas is accepted by estimation and then silently never
+	// mined, which reads as a hung operation rather than a pricing bug.
+	tip, err := chainRPC.SuggestGasTipCap(ctx)
+	if err != nil {
+		return fmt.Errorf("suggesting gas tip: %w", err)
+	}
+	head, err := chainRPC.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("reading latest header: %w", err)
+	}
+
+	// The bundler enforces its own priority-fee floor, independent of what the
+	// chain suggests, and rejects anything under it in precheck:
+	//
+	//	maxPriorityFeePerGas is 1500000 but must be at least 100000000
+	//
+	// On a quiet testnet the chain's suggestion is well below that floor, so
+	// the chain value alone is not enough. Ask the bundler and take whichever
+	// is higher — it is the party that decides whether to accept the operation.
+	if bundlerTip, tipErr := bundlerMaxPriorityFee(ctx, bundlerRPC); tipErr != nil {
+		l.Debug("bundler did not report a priority fee, using the chain's", "error", tipErr)
+	} else if bundlerTip.Cmp(tip) > 0 {
+		l.Debug("raising priority fee to the bundler's floor",
+			"chain_tip", tip.String(), "bundler_tip", bundlerTip.String())
+		tip = bundlerTip
+	}
+
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+
+	estimate, err := EstimateUserOpGasV07(ctx, bundlerRPC, op, entryPoint)
+	if err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	op.CallGasLimit = estimate.CallGasLimit
+	op.VerificationGasLimit = estimate.VerificationGasLimit
+	op.PreVerificationGas = estimate.PreVerificationGas
+	return nil
+}
+
+// isDeployed reports whether an account already has code.
+func isDeployed(ctx context.Context, client *ethclient.Client, addr common.Address) (bool, error) {
+	code, err := client.CodeAt(ctx, addr, nil)
+	if err != nil {
+		return false, err
+	}
+	return len(code) > 0, nil
+}
+
+// bundlerMaxPriorityFee asks the bundler what priority fee it currently wants.
+//
+// Rundler exposes this as rundler_maxPriorityFeePerGas. It is not part of
+// ERC-4337, so a bundler that does not implement it returns a method error —
+// which is why the caller treats failure as "no opinion" rather than fatal.
+func bundlerMaxPriorityFee(ctx context.Context, client *rpc.Client) (*big.Int, error) {
+	if client == nil {
+		return nil, fmt.Errorf("nil bundler client")
+	}
+	var out string
+	if err := client.CallContext(ctx, &out, "rundler_maxPriorityFeePerGas"); err != nil {
+		return nil, err
+	}
+	return parseHexBig(out, "rundler_maxPriorityFeePerGas")
+}

--- a/pkg/erc4337/preset/sent_userop.go
+++ b/pkg/erc4337/preset/sent_userop.go
@@ -72,7 +72,12 @@ func SendUserOpAuto(
 	}
 
 	if smartWalletConfig.UsesModularAccountV2() {
-		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, lgr)
+		// nil auth: SendUserOpMAv2 resolves the session grant itself, AFTER
+		// it has resolved the actual sender. Grants are stored per
+		// smart-wallet address, and callers do not always pass an override —
+		// resolving here against the owner EOA used to find nothing and sign
+		// as the fallback entity the gateway cannot validate for.
+		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, nil, lgr)
 		sent, convErr := sentFromV07(op, big.NewInt(smartWalletConfig.ChainID))
 		if err != nil {
 			// Report the send failure, not the conversion: the send is why

--- a/pkg/erc4337/preset/sent_userop.go
+++ b/pkg/erc4337/preset/sent_userop.go
@@ -1,0 +1,173 @@
+package preset
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// SentUserOp is what an execution path reports about an operation it sent,
+// independent of EntryPoint version.
+//
+// Callers only ever read this handful of fields off the operation — sender,
+// nonce, the gas limits, and the hash — so carrying the version-specific
+// struct out to them bought nothing and forced every consumer to know which
+// UserOperation shape it had.
+//
+// UserOpHash is computed here rather than left for the caller. That is not
+// just convenience: the hash binds to an EntryPoint address, and consumers
+// were computing it against smart_wallet.entrypoint_address, which is the
+// v0.6 EntryPoint. Doing that to a v0.7 operation yields a plausible-looking
+// hash that matches nothing on chain — it would have been reported in
+// execution logs and receipts as if it were real.
+type SentUserOp struct {
+	Sender     common.Address
+	Nonce      *big.Int
+	EntryPoint common.Address
+	UserOpHash common.Hash
+
+	CallGasLimit         *big.Int
+	VerificationGasLimit *big.Int
+	PreVerificationGas   *big.Int
+	MaxFeePerGas         *big.Int
+
+	// Sponsored reports whether a paymaster covered this operation, whichever
+	// mechanism did it — the v0.6 verifying paymaster or a v0.7 Gas Manager
+	// policy.
+	Sponsored bool
+}
+
+// SendUserOpAuto sends an operation using whichever account implementation the
+// chain is configured for, and reports the result in version-neutral terms.
+//
+// Dispatch is per CHAIN, not per wallet. That is a deliberate consequence of
+// cutting every chain over at once: a wallet created before the cutover is a
+// v0.6 SimpleAccount, and on a chain now configured for MA v2 it will no
+// longer execute. Those wallets were audited to hold no meaningful balances
+// before this was chosen. If that assumption ever stops holding, this is the
+// function that has to learn to look at the wallet's factory instead.
+//
+// paymasterReq and executionFeeWei apply only to the v0.6 path. MA v2
+// sponsorship comes from the Gas Manager policy on the chain's config, so
+// those arguments are ignored there rather than quietly changing meaning.
+func SendUserOpAuto(
+	smartWalletConfig *config.SmartWalletConfig,
+	owner common.Address,
+	callData []byte,
+	paymasterReq *VerifyingPaymasterRequest,
+	senderOverride *common.Address,
+	saltOverride *big.Int,
+	executionFeeWei *big.Int,
+	lgr logger.Logger,
+) (*SentUserOp, *types.Receipt, error) {
+	if smartWalletConfig == nil {
+		return nil, nil, fmt.Errorf("nil smart wallet config")
+	}
+
+	if smartWalletConfig.UsesModularAccountV2() {
+		op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, lgr)
+		sent, convErr := sentFromV07(op, big.NewInt(smartWalletConfig.ChainID))
+		if err != nil {
+			// Report the send failure, not the conversion: the send is why
+			// this failed, and `sent` is best-effort context for the caller.
+			return sent, receipt, err
+		}
+		if convErr != nil {
+			return nil, receipt, convErr
+		}
+		return sent, receipt, nil
+	}
+
+	op, receipt, err := SendUserOp(smartWalletConfig, owner, callData, paymasterReq,
+		senderOverride, saltOverride, executionFeeWei, lgr)
+	sent := sentFromV06(op, smartWalletConfig.EntrypointAddress, big.NewInt(smartWalletConfig.ChainID))
+	if err != nil {
+		return sent, receipt, err
+	}
+	return sent, receipt, nil
+}
+
+// SendUserOpAutoWithWsClient is SendUserOpAuto reusing a caller-owned
+// WebSocket client for receipt monitoring.
+//
+// The MA v2 path ignores wsClient and opens its own from the chain config.
+// Sharing the aggregator's long-lived socket saved a dial on the v0.6 path;
+// threading it through the v0.7 builder is not worth a second signature for
+// what is only a receipt watcher.
+func SendUserOpAutoWithWsClient(
+	smartWalletConfig *config.SmartWalletConfig,
+	owner common.Address,
+	callData []byte,
+	paymasterReq *VerifyingPaymasterRequest,
+	senderOverride *common.Address,
+	saltOverride *big.Int,
+	wsClient *ethclient.Client,
+	executionFeeWei *big.Int,
+	lgr logger.Logger,
+) (*SentUserOp, *types.Receipt, error) {
+	if smartWalletConfig == nil {
+		return nil, nil, fmt.Errorf("nil smart wallet config")
+	}
+	if smartWalletConfig.UsesModularAccountV2() {
+		return SendUserOpAuto(smartWalletConfig, owner, callData, paymasterReq,
+			senderOverride, saltOverride, executionFeeWei, lgr)
+	}
+	op, receipt, err := SendUserOpWithWsClient(smartWalletConfig, owner, callData, paymasterReq,
+		senderOverride, saltOverride, wsClient, executionFeeWei, lgr)
+	sent := sentFromV06(op, smartWalletConfig.EntrypointAddress, big.NewInt(smartWalletConfig.ChainID))
+	if err != nil {
+		return sent, receipt, err
+	}
+	return sent, receipt, nil
+}
+
+// sentFromV07 converts a v0.7 operation. It returns (nil, nil) for a nil
+// operation so a failed send that never built one is not an error here.
+func sentFromV07(op *userop.UserOperationV07, chainID *big.Int) (*SentUserOp, error) {
+	if op == nil {
+		return nil, nil
+	}
+	entryPoint := EntryPointV07()
+	sent := &SentUserOp{
+		Sender:               op.Sender,
+		Nonce:                op.Nonce,
+		EntryPoint:           entryPoint,
+		CallGasLimit:         op.CallGasLimit,
+		VerificationGasLimit: op.VerificationGasLimit,
+		PreVerificationGas:   op.PreVerificationGas,
+		MaxFeePerGas:         op.MaxFeePerGas,
+		Sponsored:            op.Paymaster != nil,
+	}
+	// An operation that never got priced cannot be hashed — every gas field
+	// participates. Leaving the hash zero is honest; inventing one is not.
+	hash, err := op.GetUserOpHash(entryPoint, chainID)
+	if err != nil {
+		return sent, nil
+	}
+	sent.UserOpHash = hash
+	return sent, nil
+}
+
+func sentFromV06(op *userop.UserOperation, entryPoint common.Address, chainID *big.Int) *SentUserOp {
+	if op == nil {
+		return nil
+	}
+	return &SentUserOp{
+		Sender:               op.Sender,
+		Nonce:                op.Nonce,
+		EntryPoint:           entryPoint,
+		UserOpHash:           op.GetUserOpHash(entryPoint, chainID),
+		CallGasLimit:         op.CallGasLimit,
+		VerificationGasLimit: op.VerificationGasLimit,
+		PreVerificationGas:   op.PreVerificationGas,
+		MaxFeePerGas:         op.MaxFeePerGas,
+		Sponsored:            len(op.PaymasterAndData) > 0,
+	}
+}

--- a/pkg/erc4337/preset/session_auth.go
+++ b/pkg/erc4337/preset/session_auth.go
@@ -1,0 +1,173 @@
+package preset
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// SessionAuthorization is how an operation runs under a session grant rather
+// than as the account's owner.
+//
+// A stock Modular Account v2 trusts its fallback signer — the user's EOA — and
+// the gateway does not hold that key. Everything the gateway executes
+// therefore runs as an installed validation entity, and this carries what that
+// requires: which entity, which key signs, and (on the grant's first
+// operation) the owner's deferred authorization that installs it.
+//
+// This is deliberately a plain struct rather than a storage lookup. The
+// gateway reads a SessionPolicy and builds one of these; the send path never
+// touches BadgerDB. See avs-infra Smart_Wallet_MA_v2_Spend_Policy.md §7.4a for
+// the record these fields come from.
+type SessionAuthorization struct {
+	// EntityID is the validation entity the grant installed. It keys the
+	// nonce, so it must match the entity the deferred action installs.
+	EntityID uint32
+
+	// SignerKey signs the operation as that entity.
+	SignerKey *ecdsa.PrivateKey
+
+	// DeferredData and OwnerSignature carry the grant itself. Set on a
+	// grant's FIRST operation only: the account applies the install during
+	// validation, then validates this same operation against the entity it
+	// just installed. Once applied they must never be replayed — the stored
+	// record's applied_at is the marker.
+	DeferredData   []byte
+	OwnerSignature []byte
+
+	// WrapExecuteUserOp opts the operation into user-op context, which every
+	// operation under a grant carrying EXECUTION hooks must do. It is derived
+	// from the stored grant's contents, not guessed: an ERC-20 spend cap
+	// installs an execution hook, a time range does not.
+	WrapExecuteUserOp bool
+
+	// OnApplied is how the send path reports that the grant's install reached
+	// the chain, so the stored record stops attaching the deferred action.
+	// Set by the resolver alongside DeferredData; carried as a callback
+	// because the record lives above this package (BadgerDB, taskengine) and
+	// the send path must not reach into storage.
+	//
+	// Invoked with the carrying operation's userOpHash once its receipt is
+	// seen — or with "" when the install is discovered indirectly, by finding
+	// the carrier nonce already consumed (the only operation that ever uses a
+	// grant's deferred key is its install, so a consumed sequence IS the
+	// receipt). An error is logged by the caller, never fatal: the install
+	// succeeded on-chain, and an unrecorded one heals on the next operation
+	// through that same consumed-nonce path.
+	OnApplied func(userOpHash string) error
+}
+
+// Deferred reports whether this operation carries the grant's install.
+func (s *SessionAuthorization) Deferred() bool {
+	return s != nil && len(s.DeferredData) > 0 && len(s.OwnerSignature) > 0
+}
+
+// Validate rejects an authorization that cannot produce a valid operation.
+func (s *SessionAuthorization) Validate() error {
+	if s == nil {
+		return nil
+	}
+	if s.EntityID < aa.MinSessionEntityID {
+		return fmt.Errorf("session entity %d is reserved (0 is the owner's fallback signer)", s.EntityID)
+	}
+	if s.SignerKey == nil {
+		return fmt.Errorf("session authorization has no signing key")
+	}
+	// Half a deferred action is worse than none: the operation would be signed
+	// as an entity that does not exist yet and fail validation on chain, with
+	// nothing pointing at the missing half.
+	if len(s.DeferredData) > 0 && len(s.OwnerSignature) == 0 {
+		return fmt.Errorf("deferred action has no owner signature")
+	}
+	if len(s.OwnerSignature) > 0 && len(s.DeferredData) == 0 {
+		return fmt.Errorf("owner signature has no deferred action to authorize")
+	}
+	return nil
+}
+
+// nonceEntity returns the entity whose nonce key this operation uses, and the
+// nonce options. Without an authorization the owner's fallback signer runs the
+// operation, which is the path used to sign a grant directly.
+func (s *SessionAuthorization) nonceEntity() (entityID uint32, options uint8) {
+	options = userop.ValidationOptionGlobal
+	if s == nil {
+		return userop.FallbackSignerEntityID, options
+	}
+	if s.Deferred() {
+		options |= userop.ValidationOptionDeferredAction
+	}
+	return s.EntityID, options
+}
+
+// seedVerificationGasFor sizes the verification limit for what this operation
+// actually does during validation.
+//
+// The numbers come from Sepolia, not from theory (avs-infra
+// MA_v2_Authority_Model_And_Spike_Results.md §3.2–§3.4). Validation cost grows
+// with what the operation installs: a bare deferred install AA26s at 300k
+// because module storage is cold, and a hook-carrying install AA26s at 300k
+// again because every allowlist entry is its own cold SSTORE. Seeding must
+// therefore scale with the grant's contents rather than with a single
+// deploying/deployed flag.
+//
+// Over-seeding is not free either — Rundler refuses an operation whose
+// verification efficiency falls under 0.4 — so these are sized to land inside
+// that window, and SendUserOpV07WithRetry tightens from the bundler's own
+// ratio when they miss.
+func seedVerificationGasFor(op *userop.UserOperationV07, auth *SessionAuthorization) *big.Int {
+	if auth.Deferred() {
+		if auth.WrapExecuteUserOp {
+			// Hook-carrying grant: allowlist entries plus the exec hook.
+			return big.NewInt(seedVerificationGasDeferredHooks)
+		}
+		return big.NewInt(seedVerificationGasDeferredBare)
+	}
+	if auth != nil {
+		// Validating as an installed module entity rather than the bytecode
+		// fallback signer: an external call plus, on the entity's first use, a
+		// cold nonce-key slot.
+		return big.NewInt(seedVerificationGasModuleEntity)
+	}
+	return seedVerificationGas(op)
+}
+
+// SessionResolver answers "under what authority may the gateway execute for
+// this wallet?" — returning nil when there is no grant, which leaves the
+// operation on the owner's fallback signer.
+//
+// This exists so the send path never reaches into storage. The gateway
+// installs one resolver at boot that reads SessionPolicy records; tests and
+// the v0.6 path leave it unset and nothing changes.
+type SessionResolver func(chainID int64, owner, wallet common.Address) (*SessionAuthorization, error)
+
+var (
+	sessionResolverMu sync.RWMutex
+	sessionResolver   SessionResolver
+)
+
+// SetSessionResolver installs the resolver. Call once at gateway startup.
+func SetSessionResolver(r SessionResolver) {
+	sessionResolverMu.Lock()
+	defer sessionResolverMu.Unlock()
+	sessionResolver = r
+}
+
+// resolveSession looks up the authorization for a wallet. A resolver error is
+// returned rather than swallowed: falling back to the fallback signer would
+// mean signing with a key the gateway does not have, and the operation would
+// fail on chain with nothing pointing at the storage read that failed.
+func resolveSession(chainID int64, owner, wallet common.Address) (*SessionAuthorization, error) {
+	sessionResolverMu.RLock()
+	r := sessionResolver
+	sessionResolverMu.RUnlock()
+	if r == nil {
+		return nil, nil
+	}
+	return r(chainID, owner, wallet)
+}

--- a/pkg/erc4337/preset/session_auth_test.go
+++ b/pkg/erc4337/preset/session_auth_test.go
@@ -1,0 +1,170 @@
+package preset
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func testKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return k
+}
+
+// The nonce selects the validation entity on MA v2 — not the signature. Get
+// this wrong and the account validates against a different entity than the one
+// that signed, which surfaces as an opaque signature failure.
+func TestSessionAuthNonceEntity(t *testing.T) {
+	t.Run("no authorization runs as the owner's fallback signer", func(t *testing.T) {
+		var auth *SessionAuthorization
+		entity, opts := auth.nonceEntity()
+		if entity != userop.FallbackSignerEntityID {
+			t.Errorf("entity = %d, want the fallback signer %d", entity, userop.FallbackSignerEntityID)
+		}
+		if opts&userop.ValidationOptionDeferredAction != 0 {
+			t.Error("no authorization must not set the deferred bit")
+		}
+	})
+
+	t.Run("a grant runs as its own entity", func(t *testing.T) {
+		auth := &SessionAuthorization{EntityID: 7, SignerKey: testKey(t)}
+		entity, opts := auth.nonceEntity()
+		if entity != 7 {
+			t.Errorf("entity = %d, want 7", entity)
+		}
+		if opts&userop.ValidationOptionDeferredAction != 0 {
+			t.Error("a grant with no deferred action must not set the deferred bit")
+		}
+	})
+
+	// The bit is what tells the account to apply the install during
+	// validation. Without it the deferred payload is ignored and the operation
+	// validates against an entity that does not exist yet.
+	t.Run("the grant's first operation sets the deferred bit", func(t *testing.T) {
+		auth := &SessionAuthorization{
+			EntityID: 7, SignerKey: testKey(t),
+			DeferredData: []byte{0x01}, OwnerSignature: bytes.Repeat([]byte{0x02}, 65),
+		}
+		if !auth.Deferred() {
+			t.Fatal("Deferred() should be true when both halves are present")
+		}
+		_, opts := auth.nonceEntity()
+		if opts&userop.ValidationOptionDeferredAction == 0 {
+			t.Error("the deferred bit must be set on the install-carrying operation")
+		}
+	})
+}
+
+func TestSessionAuthValidate(t *testing.T) {
+	sig := bytes.Repeat([]byte{0x02}, 65)
+	for _, tt := range []struct {
+		name    string
+		auth    *SessionAuthorization
+		wantErr bool
+	}{
+		{"nil is fine — the owner signs", nil, false},
+		{"valid", &SessionAuthorization{EntityID: 1, SignerKey: testKey(t)}, false},
+		{"entity 0 is the owner's", &SessionAuthorization{EntityID: 0, SignerKey: testKey(t)}, true},
+		{"no key", &SessionAuthorization{EntityID: 1}, true},
+		// Half a deferred action signs as an entity that does not exist yet.
+		{"deferred data without a signature", &SessionAuthorization{EntityID: 1, SignerKey: testKey(t), DeferredData: []byte{0x01}}, true},
+		{"signature without deferred data", &SessionAuthorization{EntityID: 1, SignerKey: testKey(t), OwnerSignature: sig}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.auth.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Seeds are measured, and each tier covers a cost the one below it does not.
+// A seed that is too low AA26s; too high and Rundler refuses the operation for
+// falling under its 0.4 verification-efficiency floor.
+func TestSeedVerificationGasScalesWithGrantContents(t *testing.T) {
+	op := &userop.UserOperationV07{}
+	sig := bytes.Repeat([]byte{0x02}, 65)
+
+	none := seedVerificationGasFor(op, nil)
+	entity := seedVerificationGasFor(op, &SessionAuthorization{EntityID: 1, SignerKey: testKey(t)})
+	bare := seedVerificationGasFor(op, &SessionAuthorization{
+		EntityID: 1, SignerKey: testKey(t), DeferredData: []byte{0x01}, OwnerSignature: sig})
+	hooks := seedVerificationGasFor(op, &SessionAuthorization{
+		EntityID: 1, SignerKey: testKey(t), DeferredData: []byte{0x01}, OwnerSignature: sig,
+		WrapExecuteUserOp: true})
+
+	if !(none.Cmp(entity) < 0 && entity.Cmp(bare) < 0 && bare.Cmp(hooks) < 0) {
+		t.Errorf("seeds must increase with validation work: none=%s entity=%s deferred=%s hooks=%s",
+			none, entity, bare, hooks)
+	}
+	// §3.4 measured the hook-carrying install AA26-ing at 300k.
+	if hooks.Cmp(big.NewInt(300_000)) <= 0 {
+		t.Errorf("hook-carrying seed %s is at or below the measured AA26 threshold", hooks)
+	}
+}
+
+// The resolver is the only way storage reaches the send path. An unset
+// resolver must leave every existing caller untouched.
+func TestSessionResolver(t *testing.T) {
+	t.Cleanup(func() { SetSessionResolver(nil) })
+
+	SetSessionResolver(nil)
+	got, err := resolveSession(11155111, common.Address{}, common.Address{})
+	if err != nil || got != nil {
+		t.Errorf("an unset resolver must return (nil, nil), got (%v, %v)", got, err)
+	}
+
+	want := &SessionAuthorization{EntityID: 3, SignerKey: testKey(t)}
+	var sawChain int64
+	var sawWallet common.Address
+	SetSessionResolver(func(chainID int64, owner, wallet common.Address) (*SessionAuthorization, error) {
+		sawChain, sawWallet = chainID, wallet
+		return want, nil
+	})
+	wallet := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	got, err = resolveSession(11155111, common.Address{}, wallet)
+	if err != nil {
+		t.Fatalf("resolveSession: %v", err)
+	}
+	if got != want {
+		t.Error("resolver result was not returned")
+	}
+	// The grant is per (wallet, chain) — resolving by owner alone would hand a
+	// user's grant on one wallet to a different wallet they also own.
+	if sawChain != 11155111 || sawWallet != wallet {
+		t.Errorf("resolver saw chain=%d wallet=%s; both must identify the grant", sawChain, sawWallet)
+	}
+}
+
+func TestSessionAuthEntityMatchesInstallEntity(t *testing.T) {
+	// The authorization's entity keys the nonce; the grant's entity is what
+	// the install writes. If they disagree the account installs one entity and
+	// validates against another.
+	const entity = uint32(5)
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	call, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: entity, Signer: signer, Global: true, AllowSelfAdministration: true,
+	})
+	if err != nil {
+		t.Fatalf("PackSessionSignerInstall: %v", err)
+	}
+	auth := &SessionAuthorization{EntityID: entity, SignerKey: testKey(t)}
+	gotEntity, _ := auth.nonceEntity()
+
+	cfg := call[4:29]
+	installEntity := uint32(cfg[20])<<24 | uint32(cfg[21])<<16 | uint32(cfg[22])<<8 | uint32(cfg[23])
+	if gotEntity != installEntity {
+		t.Errorf("nonce entity %d != installed entity %d", gotEntity, installEntity)
+	}
+}

--- a/pkg/erc4337/userop/deferred_action.go
+++ b/pkg/erc4337/userop/deferred_action.go
@@ -1,0 +1,174 @@
+package userop
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Deferred actions — the mechanism that lets the owner authorize the
+// controller install as an off-chain EIP-712 signature, executed later during
+// validation of the first controller-signed operation. The owner never signs
+// a UserOperation; the grant is collected at the Studio grant screen and the
+// install rides the first real op (avs-infra
+// MA_v2_Authority_Model_And_Spike_Results.md §5.1).
+//
+// Everything here mirrors ModularAccountBase.sol v2.0.1 (the deployed
+// implementation), not aa-sdk. Three facts worth stating because each was
+// established by reading that source and cost nothing to get wrong silently:
+//
+//  1. The typed data commits to the FULL 256-bit nonce of the operation that
+//     will carry the action — locator bits and sequence included. The digest
+//     can therefore be produced at grant time only because a fresh account's
+//     first sequence under a fresh key is predictably zero, and because the
+//     gas fields are NOT part of it.
+//  2. The digest is signed RAW. During validateUserOp the fallback signer's
+//     1271 path skips the usual replay-safe rewrap ("the hash is already
+//     replay-safe" — SemiModularAccountBase._exec1271Validation), so the
+//     bytes a wallet returns from eth_signTypedData_v4 are exactly what the
+//     account verifies. No EIP-191 prefix anywhere.
+//  3. The account's EIP-712 domain is minimal:
+//     EIP712Domain(uint256 chainId,address verifyingContract) — no name, no
+//     version. The verifyingContract is the counterfactual account address.
+var (
+	// keccak256("DeferredAction(uint256 nonce,uint48 deadline,bytes call)")
+	deferredActionTypeHash = crypto.Keccak256Hash(
+		[]byte("DeferredAction(uint256 nonce,uint48 deadline,bytes call)"))
+	// keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
+	deferredDomainTypeHash = crypto.Keccak256Hash(
+		[]byte("EIP712Domain(uint256 chainId,address verifyingContract)"))
+)
+
+// maxDeadline is the uint48 ceiling; the contract truncates anything wider,
+// which would make the signed digest and the encoded data disagree.
+const maxDeadline = uint64(1)<<48 - 1
+
+// PackValidationLocator builds the bytes21 ValidationLocator the account
+// reads out of a deferred action's encoded data: uint168 big-endian,
+// entityId<<8 | options. For the owner's fallback validation this is entity 0
+// with only the global bit — which the lookup masks back to the fallback key.
+func PackValidationLocator(entityID uint32, options uint8) ([21]byte, error) {
+	var out [21]byte
+	if options&ValidationOptionDirectCall != 0 {
+		return out, fmt.Errorf("direct-call locators carry a 20-byte address, not an entity id")
+	}
+	out[16] = byte(entityID >> 24)
+	out[17] = byte(entityID >> 16)
+	out[18] = byte(entityID >> 8)
+	out[19] = byte(entityID)
+	out[20] = options
+	return out, nil
+}
+
+// FallbackSignerLocator is the locator naming the account's own fallback
+// signer (the owner) as the validation for the deferred action's signature.
+// The global bit must be set: installValidation is checked against the
+// deferred validation's applicability, and the fallback signer is a global
+// validation.
+func FallbackSignerLocator() [21]byte {
+	loc, _ := PackValidationLocator(FallbackSignerEntityID, ValidationOptionGlobal)
+	return loc
+}
+
+// EncodeDeferredActionData assembles the encodedData segment of a deferred
+// signature: locator (21) ++ deadline (uint48 big-endian, 6) ++ the self-call
+// the account will execute during validation. A zero deadline means no
+// deadline.
+func EncodeDeferredActionData(locator [21]byte, deadline uint64, call []byte) ([]byte, error) {
+	if deadline > maxDeadline {
+		return nil, fmt.Errorf("deadline %d overflows uint48", deadline)
+	}
+	if len(call) < 4 {
+		return nil, fmt.Errorf("deferred call is %d bytes, shorter than a selector", len(call))
+	}
+	out := make([]byte, 0, 21+6+len(call))
+	out = append(out, locator[:]...)
+	var d [8]byte
+	binary.BigEndian.PutUint64(d[:], deadline)
+	out = append(out, d[2:8]...)
+	return append(out, call...), nil
+}
+
+// DeferredActionDigest computes the EIP-712 digest the OWNER signs:
+//
+//	keccak256(0x1901 ++ domainSeparator ++ structHash)
+//	domainSeparator = keccak256(abi.encode(domainTypeHash, chainId, account))
+//	structHash      = keccak256(abi.encode(typeHash, nonce, deadline, keccak256(call)))
+//
+// nonce is the full nonce of the operation that will carry the action —
+// build it with EncodeNonceMAv2 using the SAME entity id and options
+// (including ValidationOptionDeferredAction) the operation will use, or the
+// signature verifies against a digest the account never computes.
+func DeferredActionDigest(chainID *big.Int, account common.Address, nonce *big.Int, deadline uint64, call []byte) (common.Hash, error) {
+	if chainID == nil || chainID.Sign() <= 0 {
+		return common.Hash{}, fmt.Errorf("chain id is nil or non-positive")
+	}
+	if nonce == nil || nonce.Sign() < 0 || nonce.BitLen() > 256 {
+		return common.Hash{}, fmt.Errorf("nonce is nil, negative, or overflows uint256")
+	}
+	if deadline > maxDeadline {
+		return common.Hash{}, fmt.Errorf("deadline %d overflows uint48", deadline)
+	}
+
+	var word [32]byte
+	domain := make([]byte, 0, 96)
+	domain = append(domain, deferredDomainTypeHash.Bytes()...)
+	chainID.FillBytes(word[:])
+	domain = append(domain, word[:]...)
+	domain = append(domain, common.LeftPadBytes(account.Bytes(), 32)...)
+	domainSeparator := crypto.Keccak256(domain)
+
+	structData := make([]byte, 0, 128)
+	structData = append(structData, deferredActionTypeHash.Bytes()...)
+	nonce.FillBytes(word[:])
+	structData = append(structData, word[:]...)
+	new(big.Int).SetUint64(deadline).FillBytes(word[:])
+	structData = append(structData, word[:]...)
+	structData = append(structData, crypto.Keccak256(call)...)
+	structHash := crypto.Keccak256(structData)
+
+	return crypto.Keccak256Hash([]byte{0x19, 0x01}, domainSeparator, structHash), nil
+}
+
+// WrapSignatureMAv2Deferred assembles the full UserOperation signature for an
+// operation whose nonce carries ValidationOptionDeferredAction. Layout, per
+// ModularAccountBase._validateUserOp:
+//
+//	[0:4]   uint32 len(encodedData)
+//	[4:..]  encodedData             (EncodeDeferredActionData output)
+//	[..]    uint32 len(deferredSig)
+//	[..]    deferredSig = 0x00 (SignatureType.EOA) ++ owner's 65-byte ECDSA
+//	        over DeferredActionDigest — raw, no segment marker
+//	[..]    framedUserOpSig         (WrapSignatureMAv2 output: 0xFF 0x00 ++
+//	        the controller's signature over the EIP-191 hash of userOpHash)
+func WrapSignatureMAv2Deferred(encodedData []byte, ownerSig []byte, framedUserOpSig []byte) ([]byte, error) {
+	if len(encodedData) < 21+6+4 {
+		return nil, fmt.Errorf("encoded deferred data is %d bytes, shorter than locator+deadline+selector", len(encodedData))
+	}
+	if len(ownerSig) != 65 {
+		return nil, fmt.Errorf("expected a 65-byte owner signature, got %d bytes", len(ownerSig))
+	}
+	if v := ownerSig[64]; v != 27 && v != 28 {
+		return nil, fmt.Errorf("owner signature v is %d, want 27 or 28 — go-ethereum's crypto.Sign returns 0/1 and needs +27", v)
+	}
+	if len(framedUserOpSig) < 2 || framedUserOpSig[0] != SigSegmentValidationData {
+		return nil, fmt.Errorf("user-op signature is not framed (missing 0xFF segment marker); wrap it first")
+	}
+
+	deferredSig := make([]byte, 0, 1+len(ownerSig))
+	deferredSig = append(deferredSig, byte(0x00)) // SignatureType.EOA
+	deferredSig = append(deferredSig, ownerSig...)
+
+	out := make([]byte, 0, 4+len(encodedData)+4+len(deferredSig)+len(framedUserOpSig))
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(encodedData)))
+	out = append(out, l[:]...)
+	out = append(out, encodedData...)
+	binary.BigEndian.PutUint32(l[:], uint32(len(deferredSig)))
+	out = append(out, l[:]...)
+	out = append(out, deferredSig...)
+	return append(out, framedUserOpSig...), nil
+}

--- a/pkg/erc4337/userop/deferred_action.go
+++ b/pkg/erc4337/userop/deferred_action.go
@@ -6,7 +6,10 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
 // Deferred actions — the mechanism that lets the owner authorize the
@@ -131,6 +134,37 @@ func DeferredActionDigest(chainID *big.Int, account common.Address, nonce *big.I
 	structHash := crypto.Keccak256(structData)
 
 	return crypto.Keccak256Hash([]byte{0x19, 0x01}, domainSeparator, structHash), nil
+}
+
+// DeferredActionTypedData builds the eth_signTypedData_v4 payload whose hash
+// is DeferredActionDigest — the exact JSON a wallet needs to produce the
+// owner's grant signature. Digest parity between this construction and the
+// manual assembly is pinned by TestDeferredActionDigestMatchesTypedData; a
+// drift between them would produce signatures the account rejects.
+func DeferredActionTypedData(chainID *big.Int, account common.Address, nonce *big.Int, deadline uint64, call []byte) apitypes.TypedData {
+	return apitypes.TypedData{
+		Types: apitypes.Types{
+			"EIP712Domain": []apitypes.Type{
+				{Name: "chainId", Type: "uint256"},
+				{Name: "verifyingContract", Type: "address"},
+			},
+			"DeferredAction": []apitypes.Type{
+				{Name: "nonce", Type: "uint256"},
+				{Name: "deadline", Type: "uint48"},
+				{Name: "call", Type: "bytes"},
+			},
+		},
+		PrimaryType: "DeferredAction",
+		Domain: apitypes.TypedDataDomain{
+			ChainId:           (*math.HexOrDecimal256)(chainID),
+			VerifyingContract: account.Hex(),
+		},
+		Message: apitypes.TypedDataMessage{
+			"nonce":    (*math.HexOrDecimal256)(nonce),
+			"deadline": (*math.HexOrDecimal256)(new(big.Int).SetUint64(deadline)),
+			"call":     hexutil.Bytes(call),
+		},
+	}
 }
 
 // WrapSignatureMAv2Deferred assembles the full UserOperation signature for an

--- a/pkg/erc4337/userop/deferred_action_test.go
+++ b/pkg/erc4337/userop/deferred_action_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
@@ -89,29 +88,9 @@ func TestDeferredActionDigestMatchesTypedData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	typed := apitypes.TypedData{
-		Types: apitypes.Types{
-			"EIP712Domain": []apitypes.Type{
-				{Name: "chainId", Type: "uint256"},
-				{Name: "verifyingContract", Type: "address"},
-			},
-			"DeferredAction": []apitypes.Type{
-				{Name: "nonce", Type: "uint256"},
-				{Name: "deadline", Type: "uint48"},
-				{Name: "call", Type: "bytes"},
-			},
-		},
-		PrimaryType: "DeferredAction",
-		Domain: apitypes.TypedDataDomain{
-			ChainId:           (*math.HexOrDecimal256)(chainID),
-			VerifyingContract: account.Hex(),
-		},
-		Message: apitypes.TypedDataMessage{
-			"nonce":    (*math.HexOrDecimal256)(nonce),
-			"deadline": (*math.HexOrDecimal256)(new(big.Int).SetUint64(deadline)),
-			"call":     hexutil.Bytes(call),
-		},
-	}
+	// The PRODUCTION helper builds the payload — this pins wallet parity for
+	// what the /policies prepare response actually returns, not a test copy.
+	typed := DeferredActionTypedData(chainID, account, nonce, deadline, call)
 	walletDigest, _, err := apitypes.TypedDataAndHash(typed)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/erc4337/userop/deferred_action_test.go
+++ b/pkg/erc4337/userop/deferred_action_test.go
@@ -1,0 +1,165 @@
+package userop
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+)
+
+func TestPackValidationLocator(t *testing.T) {
+	loc, err := PackValidationLocator(1, ValidationOptionGlobal|ValidationOptionDeferredAction)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// uint168 big-endian: entityId<<8 | options in the low 5 bytes.
+	want := "000000000000000000000000000000000000000103"
+	if hex.EncodeToString(loc[:]) != want {
+		t.Fatalf("locator = %x, want %s", loc, want)
+	}
+
+	if _, err := PackValidationLocator(1, ValidationOptionDirectCall); err == nil {
+		t.Fatal("expected the direct-call option to be rejected")
+	}
+}
+
+func TestFallbackSignerLocator(t *testing.T) {
+	loc := FallbackSignerLocator()
+	// Entity 0 with only the global bit. The account masks the global bit off
+	// when deriving the lookup key, landing on FALLBACK_VALIDATION_LOOKUP_KEY
+	// (zero) — but without the bit the applicability check would consult the
+	// fallback's (empty) selector set and revert.
+	want := "000000000000000000000000000000000000000001"
+	if hex.EncodeToString(loc[:]) != want {
+		t.Fatalf("fallback locator = %x, want %s", loc, want)
+	}
+}
+
+func TestEncodeDeferredActionDataLayout(t *testing.T) {
+	loc := FallbackSignerLocator()
+	call := common.FromHex("0x1bbf564cdeadbeef")
+	data, err := EncodeDeferredActionData(loc, 1234567, call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// [:21] locator, [21:27] uint48 deadline, [27:] call — the fixed offsets
+	// ModularAccountBase._handleDeferredAction slices at.
+	if !bytes.Equal(data[:21], loc[:]) {
+		t.Fatalf("locator segment = %x", data[:21])
+	}
+	deadline := binary.BigEndian.Uint64(append(make([]byte, 2), data[21:27]...))
+	if deadline != 1234567 {
+		t.Fatalf("deadline segment = %d, want 1234567", deadline)
+	}
+	if !bytes.Equal(data[27:], call) {
+		t.Fatalf("call segment = %x", data[27:])
+	}
+
+	if _, err := EncodeDeferredActionData(loc, uint64(1)<<48, call); err == nil {
+		t.Fatal("expected a uint48 deadline overflow to be rejected")
+	}
+	if _, err := EncodeDeferredActionData(loc, 0, []byte{0x1b}); err == nil {
+		t.Fatal("expected a sub-selector call to be rejected")
+	}
+}
+
+// TestDeferredActionDigestMatchesTypedData proves the manual digest assembly
+// equals what a wallet computes from the equivalent eth_signTypedData_v4
+// payload. This is the property §5.1 of the findings doc depends on: the
+// grant screen hands the wallet structured typed data, and the bytes the
+// wallet returns must verify against the digest the account computes.
+func TestDeferredActionDigestMatchesTypedData(t *testing.T) {
+	chainID := big.NewInt(11155111)
+	account := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	nonce, err := EncodeNonceMAv2(1, ValidationOptionGlobal|ValidationOptionDeferredAction, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := uint64(1790000000)
+	call := common.FromHex("0x1bbf564c00112233445566778899aabbccddeeff")
+
+	manual, err := DeferredActionDigest(chainID, account, nonce, deadline, call)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typed := apitypes.TypedData{
+		Types: apitypes.Types{
+			"EIP712Domain": []apitypes.Type{
+				{Name: "chainId", Type: "uint256"},
+				{Name: "verifyingContract", Type: "address"},
+			},
+			"DeferredAction": []apitypes.Type{
+				{Name: "nonce", Type: "uint256"},
+				{Name: "deadline", Type: "uint48"},
+				{Name: "call", Type: "bytes"},
+			},
+		},
+		PrimaryType: "DeferredAction",
+		Domain: apitypes.TypedDataDomain{
+			ChainId:           (*math.HexOrDecimal256)(chainID),
+			VerifyingContract: account.Hex(),
+		},
+		Message: apitypes.TypedDataMessage{
+			"nonce":    (*math.HexOrDecimal256)(nonce),
+			"deadline": (*math.HexOrDecimal256)(new(big.Int).SetUint64(deadline)),
+			"call":     hexutil.Bytes(call),
+		},
+	}
+	walletDigest, _, err := apitypes.TypedDataAndHash(typed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(manual.Bytes(), walletDigest) {
+		t.Fatalf("manual digest %s != typed-data digest %s", manual.Hex(), hexutil.Encode(walletDigest))
+	}
+}
+
+func TestWrapSignatureMAv2Deferred(t *testing.T) {
+	loc := FallbackSignerLocator()
+	call := common.FromHex("0x1bbf564cdeadbeef")
+	encoded, err := EncodeDeferredActionData(loc, 0, call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerSig := bytes.Repeat([]byte{0x11}, 65)
+	ownerSig[64] = 27
+	inner := bytes.Repeat([]byte{0x22}, 65)
+	framedInner, err := WrapSignatureMAv2(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	full, err := WrapSignatureMAv2Deferred(encoded, ownerSig, framedInner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-slice exactly as ModularAccountBase._validateUserOp does.
+	encLen := int(binary.BigEndian.Uint32(full[:4]))
+	if !bytes.Equal(full[4:4+encLen], encoded) {
+		t.Fatal("encodedData segment does not round-trip")
+	}
+	sigLen := int(binary.BigEndian.Uint32(full[4+encLen : 8+encLen]))
+	deferredSig := full[8+encLen : 8+encLen+sigLen]
+	if deferredSig[0] != 0x00 || !bytes.Equal(deferredSig[1:], ownerSig) {
+		t.Fatal("deferred signature segment is not SignatureType.EOA ++ ownerSig")
+	}
+	if !bytes.Equal(full[8+encLen+sigLen:], framedInner) {
+		t.Fatal("trailing user-op signature segment does not round-trip")
+	}
+
+	badV := bytes.Repeat([]byte{0x11}, 65) // v = 0x11: crypto.Sign output not normalised
+	if _, err := WrapSignatureMAv2Deferred(encoded, badV, framedInner); err == nil {
+		t.Fatal("expected an un-normalised v to be rejected")
+	}
+	if _, err := WrapSignatureMAv2Deferred(encoded, ownerSig, inner); err == nil {
+		t.Fatal("expected an unframed user-op signature to be rejected")
+	}
+}

--- a/scripts/spike/deferred_action/main.go
+++ b/scripts/spike/deferred_action/main.go
@@ -1,0 +1,439 @@
+// Deferred-action spike — proves the §5.1 onboarding flow end to end on a
+// live chain (avs-infra MA_v2_Authority_Model_And_Spike_Results.md):
+//
+//  1. The OWNER signs one EIP-712 deferred-action payload, off-chain, at
+//     "grant time" — before any gas price or operation exists.
+//  2. The CONTROLLER signs the first real UserOperation, which deploys the
+//     account (initCode), applies the controller install during validation
+//     (the deferred action), and executes — one operation, no owner UserOp
+//     signature, ever.
+//  3. A second, plain controller-signed operation proves the install
+//     persists.
+//
+// Environment:
+//
+//	SPIKE_OWNER_KEY       hex private key of the owner EOA (signs the grant,
+//	                      prefunds the account)
+//	SPIKE_CONTROLLER_KEY  hex private key of the controller
+//	SPIKE_BUNDLER_URL     v0.7-capable bundler (Alchemy Rundler)
+//	SPIKE_RPC_URL         chain RPC (default: Sepolia publicnode)
+//	SPIKE_SALT            account salt (default 2 — salts 0/1 were consumed
+//	                      by the §3 spike)
+//	SPIKE_DEADLINE_HOURS  grant deadline horizon (default 24)
+//
+// Run: go run ./scripts/spike/deferred_action
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+const defaultRPC = "https://ethereum-sepolia-rpc.publicnode.com"
+
+// prefundWei covers both operations at Sepolia fee levels with headroom;
+// the unspent remainder stays in the account.
+var prefundWei = big.NewInt(2_000_000_000_000_000) // 0.002 ETH
+
+// spikeEntityID is the entity this harness grants. Real grants allocate one
+// per SessionPolicy; the spike only ever creates one.
+const spikeEntityID = aa.MinSessionEntityID
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "spike failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, common.Address{}, fmt.Errorf("%s is not set", name)
+	}
+	key, err := crypto.HexToECDSA(trim0x(raw))
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func trim0x(s string) string {
+	if len(s) >= 2 && s[:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}
+
+func run() error {
+	ctx := context.Background()
+
+	ownerKey, ownerAddr, err := requireKey("SPIKE_OWNER_KEY")
+	if err != nil {
+		return err
+	}
+	controllerKey, controllerAddr, err := requireKey("SPIKE_CONTROLLER_KEY")
+	if err != nil {
+		return err
+	}
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	if bundlerURL == "" {
+		return fmt.Errorf("SPIKE_BUNDLER_URL is not set")
+	}
+
+	salt := big.NewInt(2)
+	if s := os.Getenv("SPIKE_SALT"); s != "" {
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			return fmt.Errorf("SPIKE_SALT %q is not a decimal integer", s)
+		}
+		salt = v
+	}
+	deadlineHours, err := strconv.Atoi(env("SPIKE_DEADLINE_HOURS", "24"))
+	if err != nil {
+		return fmt.Errorf("SPIKE_DEADLINE_HOURS: %w", err)
+	}
+
+	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return fmt.Errorf("dialing chain rpc: %w", err)
+	}
+	defer chain.Close()
+	chainRPC := chain.Client()
+
+	bundler, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return fmt.Errorf("dialing bundler: %w", err)
+	}
+	defer bundler.Close()
+
+	chainID, err := chain.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("reading chain id: %w", err)
+	}
+	entryPoint := preset.EntryPointV07()
+
+	fmt.Printf("chain %s, entrypoint %s\n", chainID, entryPoint)
+	fmt.Printf("owner      %s\ncontroller %s\nsalt       %s\n", ownerAddr, controllerAddr, salt)
+
+	// ── The account ────────────────────────────────────────────────────────
+	accountPtr, err := aa.GetSenderAddressMAv2(chain, ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	account := *accountPtr
+	code, err := chain.CodeAt(ctx, account, nil)
+	if err != nil {
+		return err
+	}
+	alreadyDeployed := len(code) > 0
+	if alreadyDeployed {
+		fmt.Printf("account    %s already deployed — skipping grant + op A, proving persistence only\n\n", account)
+	} else {
+		fmt.Printf("account    %s (counterfactual, salt %s)\n\n", account, salt)
+	}
+
+	// ── Grant time: the owner's one off-chain signature ───────────────────
+	// Everything the owner commits to is knowable before any operation or
+	// gas price exists: the install call, the deadline, and the full nonce —
+	// a fresh account's first sequence under the deferred key is zero.
+	if alreadyDeployed {
+		if err := ensurePrefund(ctx, chain, chainID, ownerKey, ownerAddr, account); err != nil {
+			return err
+		}
+		return proveInstallPersists(ctx, chain, chainRPC, bundler, entryPoint, chainID,
+			account, ownerAddr, controllerKey)
+	}
+	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: spikeEntityID,
+		Signer:   controllerAddr,
+		Global:   true,
+		// This harness proves the deferred-action mechanism in isolation, so
+		// it grants bare global authority on purpose. A grant of this shape
+		// can administer itself (see SessionGrant.AllowSelfAdministration);
+		// production grants are selector-scoped or carry an execution hook.
+		AllowSelfAdministration: true,
+	})
+	if err != nil {
+		return err
+	}
+	opts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+	nonce, err := userop.EncodeNonceMAv2(spikeEntityID, opts, 0)
+	if err != nil {
+		return err
+	}
+	// Cross-check the assumption rather than trusting it: the on-chain
+	// sequence for this key must still be zero.
+	liveNonce, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, spikeEntityID, opts)
+	if err != nil {
+		return err
+	}
+	if liveNonce.Cmp(nonce) != 0 {
+		return fmt.Errorf("live nonce %s != grant-time nonce %s — key already used", liveNonce, nonce)
+	}
+
+	deadline := uint64(time.Now().Add(time.Duration(deadlineHours) * time.Hour).Unix())
+	digest, err := userop.DeferredActionDigest(chainID, account, nonce, deadline, installCall)
+	if err != nil {
+		return err
+	}
+	ownerSig, err := crypto.Sign(digest.Bytes(), ownerKey) // raw digest — no EIP-191 wrap
+	if err != nil {
+		return err
+	}
+	ownerSig[64] += 27
+	encodedData, err := userop.EncodeDeferredActionData(userop.FallbackSignerLocator(), deadline, installCall)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("grant signed (owner, off-chain, gasless)\n  712 digest %s\n  deadline   %s\n  nonce      0x%x\n\n",
+		digest, time.Unix(int64(deadline), 0).UTC().Format(time.RFC3339), nonce)
+
+	// ── Prefund the counterfactual account (it pays its own gas) ─────────
+	if err := ensurePrefund(ctx, chain, chainID, ownerKey, ownerAddr, account); err != nil {
+		return err
+	}
+
+	// ── First use: controller builds, signs, sends — deploy + install + execute ──
+	callData, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	factory, factoryData, err := aa.GetInitCodeMAv2(ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	opA := &userop.UserOperationV07{
+		Sender:      account,
+		Nonce:       nonce,
+		Factory:     &factory,
+		FactoryData: factoryData,
+		CallData:    callData,
+		// Deploy (~160k) + deferred install (~45k) + 1271 check must fit under
+		// the seed, and Rundler echoes seeds rather than computing them.
+		VerificationGasLimit: big.NewInt(300_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opA, entryPoint, encodedData, ownerSig); err != nil {
+		return err
+	}
+	if err := preset.SignUserOpV07Deferred(opA, entryPoint, chainID, controllerKey, encodedData, ownerSig); err != nil {
+		return err
+	}
+	hashA, err := preset.SendUserOpV07(ctx, bundler, opA, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op A (deploy + deferred install + execute): %w", err)
+	}
+	fmt.Printf("op A sent: deploy + deferred install + execute, controller-signed\n  userOpHash %s\n", hashA)
+	receiptA, err := waitReceipt(ctx, bundler, hashA)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s costWei=%s tx=%s\n\n",
+		receiptA.Success, receiptA.ActualGasUsed, receiptA.ActualGasCost, receiptA.TxHash)
+	if !receiptA.Success {
+		return fmt.Errorf("op A mined but reverted")
+	}
+
+	// ── Persistence: a plain controller-signed op, no deferred action ─────
+	return proveInstallPersists(ctx, chain, chainRPC, bundler, entryPoint, chainID,
+		account, ownerAddr, controllerKey)
+}
+
+// proveInstallPersists sends an ordinary controller-signed operation with no
+// deferred action attached. It can only succeed if the entity-1 validation
+// the deferred action installed is durable account state.
+func proveInstallPersists(ctx context.Context, chain *ethclient.Client, chainRPC *rpc.Client,
+	bundler *rpc.Client, entryPoint common.Address, chainID *big.Int,
+	account, ownerAddr common.Address, controllerKey *ecdsa.PrivateKey) error {
+
+	callData, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	nonceB, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, spikeEntityID,
+		userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	opB := &userop.UserOperationV07{
+		Sender:   account,
+		Nonce:    nonceB,
+		CallData: callData,
+		// The deployed-account default seed (60k) is too tight here: module
+		// validation at entity 1 plus the first write to a fresh nonce-key
+		// slot (~22k cold SSTORE) lands actual verification just above it,
+		// which AA26s at send. Measured on this spike; see the results doc.
+		VerificationGasLimit: big.NewInt(100_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opB, entryPoint, nil, nil); err != nil {
+		return err
+	}
+	if err := preset.SignUserOpV07(opB, entryPoint, chainID, controllerKey); err != nil {
+		return err
+	}
+	hashB, err := preset.SendUserOpV07(ctx, bundler, opB, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op B (plain controller op): %w", err)
+	}
+	fmt.Printf("op B sent: ordinary op, controller-signed, no deferred action\n  userOpHash %s\n", hashB)
+	receiptB, err := waitReceipt(ctx, bundler, hashB)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s costWei=%s tx=%s\n\n",
+		receiptB.Success, receiptB.ActualGasUsed, receiptB.ActualGasCost, receiptB.TxHash)
+	if !receiptB.Success {
+		return fmt.Errorf("op B mined but reverted")
+	}
+
+	fmt.Println("PROVEN: owner signed once, off-chain, before gas existed; the controller")
+	fmt.Println("deployed, installed itself, and executed in one operation, and kept")
+	fmt.Println("authority afterwards. The owner never signed a UserOperation.")
+	return nil
+}
+
+// priceOp fills fee fields from chain + bundler and sizes gas via estimation.
+// For the deferred op, estimation must carry the REAL owner grant — a fake
+// deferred signature reverts instead of failing gracefully.
+func priceOp(ctx context.Context, chain *ethclient.Client, bundler *rpc.Client,
+	op *userop.UserOperationV07, entryPoint common.Address, encodedData, ownerSig []byte) error {
+
+	tip, err := chain.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	var bundlerTipHex string
+	if err := bundler.CallContext(ctx, &bundlerTipHex, "rundler_maxPriorityFeePerGas"); err == nil {
+		if bundlerTip, ok := new(big.Int).SetString(trim0x(bundlerTipHex), 16); ok && bundlerTip.Cmp(tip) > 0 {
+			tip = bundlerTip
+		}
+	}
+	head, err := chain.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+
+	if encodedData != nil {
+		sig, err := preset.DeferredEstimationSignature(encodedData, ownerSig)
+		if err != nil {
+			return err
+		}
+		op.Signature = sig
+		defer func() { op.Signature = nil }()
+	}
+	if _, err := preset.EstimateUserOpGasV07(ctx, bundler, op, entryPoint); err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	return nil
+}
+
+func ensurePrefund(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, account common.Address) error {
+
+	balance, err := chain.BalanceAt(ctx, account, nil)
+	if err != nil {
+		return err
+	}
+	if balance.Cmp(prefundWei) >= 0 {
+		fmt.Printf("account already holds %s wei, skipping prefund\n\n", balance)
+		return nil
+	}
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+	// A deployed MA v2 account's receive() costs more than a bare transfer's
+	// 21k; a hardcoded 21k limit makes the top-up revert out-of-gas. Ask.
+	gasLimit, err := chain.EstimateGas(ctx, ethereum.CallMsg{
+		From: ownerAddr, To: &account, Value: prefundWei,
+	})
+	if err != nil {
+		return fmt.Errorf("estimating prefund transfer gas: %w", err)
+	}
+	tx := types.NewTransaction(nonce, account, prefundWei, gasLimit+10_000, gasPrice, nil)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return fmt.Errorf("prefunding %s: %w", account, err)
+	}
+	fmt.Printf("prefunding %s wei from owner, tx %s ", prefundWei, signed.Hash())
+	for range 60 {
+		receipt, err := chain.TransactionReceipt(ctx, signed.Hash())
+		if err == nil && receipt.Status == types.ReceiptStatusSuccessful {
+			fmt.Printf("— mined\n\n")
+			return nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return fmt.Errorf("prefund tx %s not mined after 3 minutes", signed.Hash())
+}
+
+type userOpReceipt struct {
+	Success       bool
+	ActualGasUsed *big.Int
+	ActualGasCost *big.Int
+	TxHash        string
+}
+
+func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (*userOpReceipt, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var raw json.RawMessage
+		if err := bundler.CallContext(ctx, &raw, "eth_getUserOperationReceipt", opHash.Hex()); err == nil &&
+			len(raw) > 0 && string(raw) != "null" {
+			var parsed struct {
+				Success       bool   `json:"success"`
+				ActualGasUsed string `json:"actualGasUsed"`
+				ActualGasCost string `json:"actualGasCost"`
+				Receipt       struct {
+					TransactionHash string `json:"transactionHash"`
+				} `json:"receipt"`
+			}
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return nil, fmt.Errorf("decoding userop receipt: %w", err)
+			}
+			gasUsed, _ := new(big.Int).SetString(trim0x(parsed.ActualGasUsed), 16)
+			gasCost, _ := new(big.Int).SetString(trim0x(parsed.ActualGasCost), 16)
+			return &userOpReceipt{
+				Success:       parsed.Success,
+				ActualGasUsed: gasUsed,
+				ActualGasCost: gasCost,
+				TxHash:        parsed.Receipt.TransactionHash,
+			}, nil
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return nil, fmt.Errorf("no receipt for %s after 3 minutes", opHash)
+}

--- a/scripts/spike/permission_hooks/main.go
+++ b/scripts/spike/permission_hooks/main.go
@@ -1,0 +1,623 @@
+// Permission-hooks spike — master doc §5 step 2, the last unproven claim:
+// that the policy hooks a SessionGrant carries actually ENFORCE, not merely
+// install. One owner signature grants a session signer bounded by all three
+// §6.3 dimensions, then four operations probe the bounds:
+//
+//	C  in-policy ERC-20 transfer            → mines, cap 100 → 60
+//	D  call to a non-allowlisted target     → refused at validation
+//	E  transfer over the remaining cap      → mines success=false, cap rolls back
+//	F  in-policy again, after expiry        → refused as expired
+//
+// Where each bound enforces is part of the finding: the allowlist enforces at
+// VALIDATION (nothing mines), the ERC-20 cap at EXECUTION (the op mines and
+// reverts, gas is spent), the expiry at the ENTRYPOINT via validation data.
+//
+// The grant carries an execution hook (the cap), which obligates EVERY
+// operation under it to be executeUserOp-wrapped — including the one carrying
+// the deferred install. That wrapping is exercised here for the first time.
+//
+// Environment: as scripts/spike/deferred_action, plus
+//
+//	SPIKE_SALT           default 3
+//	SPIKE_TOKEN          existing SpikeToken address; deployed fresh if unset
+//	SPIKE_VALID_MINUTES  time-range window (default 8) — the harness waits it
+//	                     out to prove expiry, so total runtime exceeds it
+//
+// Run: go run ./scripts/spike/permission_hooks
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+const defaultRPC = "https://ethereum-sepolia-rpc.publicnode.com"
+
+var (
+	prefundWei = big.NewInt(3_000_000_000_000_000) // 0.003 ETH
+	oneToken   = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+	capTokens      = tokens(100) // the grant's ERC-20 spend limit
+	inPolicyAmount = tokens(40)  // op C — leaves 60 under the cap
+	overCapAmount  = tokens(100) // op E — exceeds the remaining 60
+	expiryAmount   = tokens(10)  // op F — in policy except for time
+)
+
+func tokens(n int64) *big.Int { return new(big.Int).Mul(big.NewInt(n), oneToken) }
+
+// spikeTokenCreationHex is the compiled SpikeToken (solc 0.8.26 via forge), a
+// minimal ERC-20 that mints 1,000,000e18 to its deployer and exposes exactly
+// transfer(address,uint256) — the selector the allowlist scopes to. Source in
+// the doc; re-compile with `forge build` on the snippet there to reproduce.
+const spikeTokenCreationHex = "0x60a060405234801561000f575f80fd5b5069d3c21bcecceda10000006080818152505069d3c21bcecceda10000005f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20819055503373ffffffffffffffffffffffffffffffffffffffff165f73ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef69d3c21bcecceda10000006040516100d4919061012c565b60405180910390a3610145565b5f819050919050565b5f819050919050565b5f819050919050565b5f61011661011161010c846100e1565b6100f3565b6100ea565b9050919050565b610126816100fc565b82525050565b5f60208201905061013f5f83018461011d565b92915050565b60805161062261015d5f395f61017701526106225ff3fe608060405234801561000f575f80fd5b5060043610610060575f3560e01c806306fdde031461006457806318160ddd14610082578063313ce567146100a057806370a08231146100be57806395d89b41146100ee578063a9059cbb1461010c575b5f80fd5b61006c61013c565b60405161007991906103db565b60405180910390f35b61008a610175565b6040516100979190610413565b60405180910390f35b6100a8610199565b6040516100b59190610447565b60405180910390f35b6100d860048036038101906100d391906104be565b61019e565b6040516100e59190610413565b60405180910390f35b6100f66101b2565b60405161010391906103db565b60405180910390f35b61012660048036038101906101219190610513565b6101eb565b604051610133919061056b565b60405180910390f35b6040518060400160405280601081526020017f4d417632205370696b6520546f6b656e0000000000000000000000000000000081525081565b7f000000000000000000000000000000000000000000000000000000000000000081565b601281565b5f602052805f5260405f205f915090505481565b6040518060400160405280600581526020017f5350494b4500000000000000000000000000000000000000000000000000000081525081565b5f805f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205490508281101561026f576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610266906105ce565b60405180910390fd5b8281035f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f2081905550825f808673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825401925050819055508373ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef856040516103589190610413565b60405180910390a3600191505092915050565b5f81519050919050565b5f82825260208201905092915050565b8281835e5f83830152505050565b5f601f19601f8301169050919050565b5f6103ad8261036b565b6103b78185610375565b93506103c7818560208601610385565b6103d081610393565b840191505092915050565b5f6020820190508181035f8301526103f381846103a3565b905092915050565b5f819050919050565b61040d816103fb565b82525050565b5f6020820190506104265f830184610404565b92915050565b5f60ff82169050919050565b6104418161042c565b82525050565b5f60208201905061045a5f830184610438565b92915050565b5f80fd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f61048d82610464565b9050919050565b61049d81610483565b81146104a7575f80fd5b50565b5f813590506104b881610494565b92915050565b5f602082840312156104d3576104d2610460565b5b5f6104e0848285016104aa565b91505092915050565b6104f2816103fb565b81146104fc575f80fd5b50565b5f8135905061050d816104e9565b92915050565b5f806040838503121561052957610528610460565b5b5f610536858286016104aa565b9250506020610547858286016104ff565b9150509250929050565b5f8115159050919050565b61056581610551565b82525050565b5f60208201905061057e5f83018461055c565b92915050565b7f5370696b65546f6b656e3a2062616c616e6365000000000000000000000000005f82015250565b5f6105b8601383610375565b91506105c382610584565b602082019050919050565b5f6020820190508181035f8301526105e5816105ac565b905091905056fea2646970667358221220def2f328ce26f0b8b67e18e56a58766dc05a67ea41c0396f3686c267aace530264736f6c634300081a0033"
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "spike failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, common.Address{}, fmt.Errorf("%s is not set", name)
+	}
+	key, err := crypto.HexToECDSA(trim0x(raw))
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func trim0x(s string) string {
+	if len(s) >= 2 && s[:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}
+
+func packTransfer(to common.Address, amount *big.Int) []byte {
+	out := make([]byte, 0, 4+64)
+	out = append(out, 0xa9, 0x05, 0x9c, 0xbb)
+	out = append(out, common.LeftPadBytes(to.Bytes(), 32)...)
+	return append(out, common.LeftPadBytes(amount.Bytes(), 32)...)
+}
+
+func run() error {
+	ctx := context.Background()
+
+	ownerKey, ownerAddr, err := requireKey("SPIKE_OWNER_KEY")
+	if err != nil {
+		return err
+	}
+	controllerKey, controllerAddr, err := requireKey("SPIKE_CONTROLLER_KEY")
+	if err != nil {
+		return err
+	}
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	if bundlerURL == "" {
+		return fmt.Errorf("SPIKE_BUNDLER_URL is not set")
+	}
+	salt := big.NewInt(3)
+	if s := os.Getenv("SPIKE_SALT"); s != "" {
+		v, ok := new(big.Int).SetString(s, 10)
+		if !ok {
+			return fmt.Errorf("SPIKE_SALT %q is not a decimal integer", s)
+		}
+		salt = v
+	}
+	validMinutes, err := strconv.Atoi(env("SPIKE_VALID_MINUTES", "8"))
+	if err != nil {
+		return fmt.Errorf("SPIKE_VALID_MINUTES: %w", err)
+	}
+
+	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return err
+	}
+	defer chain.Close()
+	chainRPC := chain.Client()
+	bundler, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return err
+	}
+	defer bundler.Close()
+	chainID, err := chain.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+	entryPoint := preset.EntryPointV07()
+
+	fmt.Printf("chain %s, owner %s, controller %s, salt %s\n", chainID, ownerAddr, controllerAddr, salt)
+
+	// ── Test token ─────────────────────────────────────────────────────────
+	var token common.Address
+	if t := os.Getenv("SPIKE_TOKEN"); t != "" {
+		token = common.HexToAddress(t)
+	} else {
+		token, err = deployToken(ctx, chain, chainID, ownerKey, ownerAddr)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("token      %s\n", token)
+
+	// ── The account ────────────────────────────────────────────────────────
+	accountPtr, err := aa.GetSenderAddressMAv2(chain, ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	account := *accountPtr
+	if code, cErr := chain.CodeAt(ctx, account, nil); cErr != nil {
+		return cErr
+	} else if len(code) > 0 {
+		return fmt.Errorf("account %s already has code — bump SPIKE_SALT for a fresh grant", account)
+	}
+	fmt.Printf("account    %s (counterfactual)\n\n", account)
+
+	// Seed it: SPIKE for the transfers, ETH for gas. Both idempotent so a
+	// failed run can be retried without doubling the account's stake.
+	if held, hErr := readTokenBalance(ctx, chain, token, account); hErr != nil {
+		return hErr
+	} else if held.Cmp(tokens(1000)) < 0 {
+		if err := transferToken(ctx, chain, chainID, ownerKey, ownerAddr, token, account, tokens(1000)); err != nil {
+			return err
+		}
+	}
+	if bal, bErr := chain.BalanceAt(ctx, account, nil); bErr != nil {
+		return bErr
+	} else if bal.Cmp(prefundWei) < 0 {
+		if err := sendETH(ctx, chain, chainID, ownerKey, ownerAddr, account, prefundWei); err != nil {
+			return err
+		}
+	}
+
+	// ── The grant: signer + all three §6.3 bounds, one owner signature ─────
+	entity := aa.MinSessionEntityID
+	validUntil := uint64(time.Now().Add(time.Duration(validMinutes) * time.Minute).Unix())
+	allowHook, err := aa.AllowlistValidationHook(entity, []aa.AllowlistInput{{
+		Target:               token,
+		HasSelectorAllowlist: true,
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      capTokens,
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}}, // transfer
+	}})
+	if err != nil {
+		return err
+	}
+	timeHook, err := aa.TimeRangeValidationHook(entity, validUntil, 0)
+	if err != nil {
+		return err
+	}
+	installCall, err := aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: entity,
+		Signer:   controllerAddr,
+		Global:   true,
+		// Global is safe here BECAUSE of the allowlist execution hook: it
+		// rejects any non-execute selector, so this grant cannot reach the
+		// account's own installValidation/uninstallValidation. Probe D proved
+		// exactly that.
+		Hooks: [][]byte{allowHook, aa.AllowlistExecHook(entity), timeHook},
+	})
+	if err != nil {
+		return err
+	}
+
+	opts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+	carrierNonce, err := userop.EncodeNonceMAv2(entity, opts, 0)
+	if err != nil {
+		return err
+	}
+	deadline := uint64(time.Now().Add(time.Hour).Unix())
+	digest, err := userop.DeferredActionDigest(chainID, account, carrierNonce, deadline, installCall)
+	if err != nil {
+		return err
+	}
+	ownerSig, err := crypto.Sign(digest.Bytes(), ownerKey)
+	if err != nil {
+		return err
+	}
+	ownerSig[64] += 27
+	encodedData, err := userop.EncodeDeferredActionData(userop.FallbackSignerLocator(), deadline, installCall)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("grant signed: allowlist(token, transfer) + cap 100 SPIKE + expires %s\n  712 digest %s\n\n",
+		time.Unix(int64(validUntil), 0).UTC().Format(time.RFC3339), digest)
+
+	// ── Op C: in-policy transfer, carries the deferred install ────────────
+	execC, err := aa.PackExecute(token, big.NewInt(0), packTransfer(controllerAddr, inPolicyAmount))
+	if err != nil {
+		return err
+	}
+	callC, err := aa.WrapExecuteUserOp(execC)
+	if err != nil {
+		return err
+	}
+	factory, factoryData, err := aa.GetInitCodeMAv2(ownerAddr, salt)
+	if err != nil {
+		return err
+	}
+	opC := &userop.UserOperationV07{
+		Sender:      account,
+		Nonce:       carrierNonce,
+		Factory:     &factory,
+		FactoryData: factoryData,
+		CallData:    callC,
+		// Deploy + install (validation + 3 hooks + allowlist state) + hook
+		// validation runtime. Rundler echoes seeds; the floor is 0.4. The
+		// hook-carrying install is far heavier than the bare one (§3.2's
+		// 300k seed AA26'd here): every allowlist entry is cold SSTOREs.
+		VerificationGasLimit: big.NewInt(700_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opC, entryPoint, encodedData, ownerSig); err != nil {
+		return fmt.Errorf("pricing op C: %w", err)
+	}
+	if err := preset.SignUserOpV07Deferred(opC, entryPoint, chainID, controllerKey, encodedData, ownerSig); err != nil {
+		return err
+	}
+	hashC, err := preset.SendUserOpV07(ctx, bundler, opC, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op C: %w", err)
+	}
+	fmt.Printf("op C sent: deploy + deferred install(signer+3 hooks) + transfer 40 SPIKE\n  userOpHash %s\n", hashC)
+	rC, err := waitReceipt(ctx, bundler, hashC)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s tx=%s\n", rC.Success, rC.ActualGasUsed, rC.TxHash)
+	if !rC.Success {
+		return fmt.Errorf("op C reverted — the in-policy operation must succeed")
+	}
+	limitAfterC, err := readSpendLimit(ctx, chain, entity, token, account)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  on-chain cap after C: %s SPIKE (want 60)\n\n", inTokens(limitAfterC))
+	if limitAfterC.Cmp(tokens(60)) != 0 {
+		return fmt.Errorf("cap after C is %s, want 60e18", limitAfterC)
+	}
+
+	// ── Op D: off-allowlist target — must die at validation ───────────────
+	execD, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	callD, err := aa.WrapExecuteUserOp(execD)
+	if err != nil {
+		return err
+	}
+	nonceD, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	opD := &userop.UserOperationV07{
+		Sender: account, Nonce: nonceD, CallData: callD,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	errD := priceOp(ctx, chain, bundler, opD, entryPoint, nil, nil)
+	if errD == nil {
+		return fmt.Errorf("op D (non-allowlisted target) was NOT refused — the allowlist does not enforce")
+	}
+	fmt.Printf("op D refused at validation, as required (target not on allowlist)\n  %s\n\n", firstLine(errD.Error()))
+
+	// ── Op E: over the remaining cap — mines, reverts at execution ────────
+	execE, err := aa.PackExecute(token, big.NewInt(0), packTransfer(controllerAddr, overCapAmount))
+	if err != nil {
+		return err
+	}
+	callE, err := aa.WrapExecuteUserOp(execE)
+	if err != nil {
+		return err
+	}
+	opE := &userop.UserOperationV07{
+		Sender: account, Nonce: nonceD, CallData: callE,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	if err := priceOp(ctx, chain, bundler, opE, entryPoint, nil, nil); err != nil {
+		// The cap enforces at execution: some estimators refuse the reverting
+		// call outright. Fall back to op C's numbers — validation is cheaper
+		// here than there, so they are safe over-estimates for sending.
+		fmt.Printf("op E estimation refused (%s) — sending with op C's gas numbers\n", firstLine(err.Error()))
+		opE.CallGasLimit = opC.CallGasLimit
+		opE.PreVerificationGas = opC.PreVerificationGas
+		opE.MaxFeePerGas = opC.MaxFeePerGas
+		opE.MaxPriorityFeePerGas = opC.MaxPriorityFeePerGas
+	}
+	if err := preset.SignUserOpV07(opE, entryPoint, chainID, controllerKey); err != nil {
+		return err
+	}
+	hashE, err := preset.SendUserOpV07(ctx, bundler, opE, entryPoint)
+	if err != nil {
+		return fmt.Errorf("sending op E: %w", err)
+	}
+	fmt.Printf("op E sent: transfer 100 SPIKE against a remaining cap of 60\n  userOpHash %s\n", hashE)
+	rE, err := waitReceipt(ctx, bundler, hashE)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s tx=%s\n", rE.Success, rE.ActualGasUsed, rE.TxHash)
+	if rE.Success {
+		return fmt.Errorf("op E SUCCEEDED over the cap — the spend limit does not enforce")
+	}
+	limitAfterE, err := readSpendLimit(ctx, chain, entity, token, account)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  on-chain cap after E: %s SPIKE (rollback intact, want 60)\n\n", inTokens(limitAfterE))
+	if limitAfterE.Cmp(tokens(60)) != 0 {
+		return fmt.Errorf("cap after E is %s, want 60e18 — the failed execution leaked accounting", limitAfterE)
+	}
+
+	// ── Op F: in policy except for time ───────────────────────────────────
+	wait := time.Until(time.Unix(int64(validUntil), 0).Add(30 * time.Second))
+	if wait > 0 {
+		fmt.Printf("waiting %s for the grant to expire…\n", wait.Round(time.Second))
+		time.Sleep(wait)
+	}
+	execF, err := aa.PackExecute(token, big.NewInt(0), packTransfer(controllerAddr, expiryAmount))
+	if err != nil {
+		return err
+	}
+	callF, err := aa.WrapExecuteUserOp(execF)
+	if err != nil {
+		return err
+	}
+	nonceF, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	opF := &userop.UserOperationV07{
+		Sender: account, Nonce: nonceF, CallData: callF,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	errF := priceOp(ctx, chain, bundler, opF, entryPoint, nil, nil)
+	if errF == nil {
+		if err := preset.SignUserOpV07(opF, entryPoint, chainID, controllerKey); err != nil {
+			return err
+		}
+		_, errF = preset.SendUserOpV07(ctx, bundler, opF, entryPoint)
+		if errF == nil {
+			return fmt.Errorf("op F was accepted AFTER expiry — the time range does not enforce")
+		}
+	}
+	fmt.Printf("op F refused after expiry, as required\n  %s\n\n", firstLine(errF.Error()))
+
+	fmt.Println("PROVEN: one owner signature installed signer + allowlist + cap + expiry;")
+	fmt.Println("in-policy ran, off-list died at validation, over-cap reverted at execution")
+	fmt.Println("with clean rollback, and the whole grant went dark on schedule.")
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func priceOp(ctx context.Context, chain *ethclient.Client, bundler *rpc.Client,
+	op *userop.UserOperationV07, entryPoint common.Address, encodedData, ownerSig []byte) error {
+
+	tip, err := chain.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	var bundlerTipHex string
+	if err := bundler.CallContext(ctx, &bundlerTipHex, "rundler_maxPriorityFeePerGas"); err == nil {
+		if bundlerTip, ok := new(big.Int).SetString(trim0x(bundlerTipHex), 16); ok && bundlerTip.Cmp(tip) > 0 {
+			tip = bundlerTip
+		}
+	}
+	head, err := chain.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+
+	if encodedData != nil {
+		sig, err := preset.DeferredEstimationSignature(encodedData, ownerSig)
+		if err != nil {
+			return err
+		}
+		op.Signature = sig
+		defer func() { op.Signature = nil }()
+	}
+	if _, err := preset.EstimateUserOpGasV07(ctx, bundler, op, entryPoint); err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	return nil
+}
+
+func deployToken(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr common.Address) (common.Address, error) {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return common.Address{}, err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return common.Address{}, err
+	}
+	data := common.FromHex(spikeTokenCreationHex)
+	tx := types.NewContractCreation(nonce, big.NewInt(0), 600_000, gasPrice, data)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return common.Address{}, fmt.Errorf("deploying SpikeToken: %w", err)
+	}
+	receipt, err := waitMined(ctx, chain, signed.Hash())
+	if err != nil {
+		return common.Address{}, err
+	}
+	fmt.Printf("SpikeToken deployed at %s (tx %s)\n", receipt.ContractAddress, signed.Hash())
+	return receipt.ContractAddress, nil
+}
+
+func transferToken(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, token, to common.Address, amount *big.Int) error {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+	tx := types.NewTransaction(nonce, token, big.NewInt(0), 80_000, gasPrice, packTransfer(to, amount))
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return fmt.Errorf("seeding SPIKE: %w", err)
+	}
+	if _, err := waitMined(ctx, chain, signed.Hash()); err != nil {
+		return err
+	}
+	fmt.Printf("seeded %s SPIKE to the account\n", inTokens(amount))
+	return nil
+}
+
+func sendETH(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, to common.Address, amount *big.Int) error {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+	gasLimit, err := chain.EstimateGas(ctx, ethereum.CallMsg{From: ownerAddr, To: &to, Value: amount})
+	if err != nil {
+		return err
+	}
+	tx := types.NewTransaction(nonce, to, amount, gasLimit+10_000, gasPrice, nil)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return fmt.Errorf("prefunding: %w", err)
+	}
+	if _, err := waitMined(ctx, chain, signed.Hash()); err != nil {
+		return err
+	}
+	fmt.Printf("prefunded %s wei\n\n", amount)
+	return nil
+}
+
+func waitMined(ctx context.Context, chain *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
+	for range 60 {
+		receipt, err := chain.TransactionReceipt(ctx, hash)
+		if err == nil {
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return nil, fmt.Errorf("tx %s mined but failed", hash)
+			}
+			return receipt, nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return nil, fmt.Errorf("tx %s not mined after 3 minutes", hash)
+}
+
+// readTokenBalance reads SpikeToken.balanceOf(holder).
+func readTokenBalance(ctx context.Context, chain *ethclient.Client, token, holder common.Address) (*big.Int, error) {
+	selector := crypto.Keccak256([]byte("balanceOf(address)"))[:4]
+	data := append(selector, common.LeftPadBytes(holder.Bytes(), 32)...)
+	out, err := chain.CallContract(ctx, ethereum.CallMsg{To: &token, Data: data}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading balanceOf: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+// readSpendLimit reads AllowlistModule.erc20SpendLimits(entity, token, account)
+// — the live on-chain cap accounting.
+func readSpendLimit(ctx context.Context, chain *ethclient.Client, entity uint32, token, account common.Address) (*big.Int, error) {
+	selector := crypto.Keccak256([]byte("erc20SpendLimits(uint32,address,address)"))[:4]
+	data := make([]byte, 0, 4+96)
+	data = append(data, selector...)
+	data = append(data, common.LeftPadBytes(big.NewInt(int64(entity)).Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(token.Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(account.Bytes(), 32)...)
+	module := aa.AllowlistModuleAddress()
+	out, err := chain.CallContract(ctx, ethereum.CallMsg{To: &module, Data: data}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading erc20SpendLimits: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+func inTokens(wei *big.Int) string {
+	return new(big.Int).Div(wei, oneToken).String()
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+type userOpReceipt struct {
+	Success       bool
+	ActualGasUsed *big.Int
+	TxHash        string
+}
+
+func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (*userOpReceipt, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var raw json.RawMessage
+		if err := bundler.CallContext(ctx, &raw, "eth_getUserOperationReceipt", opHash.Hex()); err == nil &&
+			len(raw) > 0 && string(raw) != "null" {
+			var parsed struct {
+				Success       bool   `json:"success"`
+				ActualGasUsed string `json:"actualGasUsed"`
+				Receipt       struct {
+					TransactionHash string `json:"transactionHash"`
+				} `json:"receipt"`
+			}
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return nil, err
+			}
+			gasUsed, _ := new(big.Int).SetString(trim0x(parsed.ActualGasUsed), 16)
+			return &userOpReceipt{
+				Success:       parsed.Success,
+				ActualGasUsed: gasUsed,
+				TxHash:        parsed.Receipt.TransactionHash,
+			}, nil
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return nil, fmt.Errorf("no receipt for %s after 3 minutes", opHash)
+}

--- a/scripts/spike/revoke/main.go
+++ b/scripts/spike/revoke/main.go
@@ -1,0 +1,451 @@
+// Revoke spike — the last unproven line of master §5: uninstallValidation,
+// which §6.4's revoke screen depends on. Four probes across the two accounts
+// the earlier spikes left behind, answering WHO can revoke, not just whether
+// the call works:
+//
+//	R1  bare grant (salt 2): the CONTROLLER uninstalls itself — one
+//	    controller-signed op, no owner involvement. This is §6.4's
+//	    "backend uninstalls" one-click revoke. It works because
+//	    uninstallValidation "may be validated by a global validation"
+//	    (account source) — which cuts both ways: a bare global grant could
+//	    equally call installValidation. Bare grants are self-modifiable
+//	    BY DESIGN; the receipt here is the evidence.
+//	R2  bare grant, after R1: a controller op is refused — authority is gone.
+//	R4  policied grant (salt 3): the controller CANNOT self-revoke — the
+//	    allowlist's execution hook reverts any selector that is not
+//	    execute/executeBatch. Policied grants are not self-modifiable.
+//	R3  policied grant: the OWNER revokes with a PLAIN transaction straight
+//	    to the account (fallback direct-call validation) — no UserOp, no
+//	    bundler. This is the backstop against a gateway that refuses to
+//	    revoke. Hook cleanup data rides along in the account's STORED hook
+//	    order (validation hooks in reverse install order, then exec hooks);
+//	    module state is then read back to prove the cleanup landed, because
+//	    a misrouted entry does not fail the transaction — it strands state
+//	    silently.
+//
+// Environment: as the earlier spikes; SPIKE_BARE_SALT (default 2),
+// SPIKE_POLICIED_SALT (default 3), SPIKE_TOKEN (default the §3.4 SpikeToken).
+// The policied grant's uninstall payload must reproduce the §3.4 install
+// inputs exactly — in production this comes from the stored install_call
+// (master §7.4a), never re-derived.
+//
+// Run: go run ./scripts/spike/revoke
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+const (
+	defaultRPC   = "https://ethereum-sepolia-rpc.publicnode.com"
+	defaultToken = "0xaA4D01B75fdEB5fbbD98276EC7755eF71801c2E7"
+)
+
+var oneToken = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "spike failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return nil, common.Address{}, fmt.Errorf("%s is not set", name)
+	}
+	key, err := crypto.HexToECDSA(trim0x(raw))
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func trim0x(s string) string {
+	if len(s) >= 2 && s[:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}
+
+func run() error {
+	ctx := context.Background()
+
+	ownerKey, ownerAddr, err := requireKey("SPIKE_OWNER_KEY")
+	if err != nil {
+		return err
+	}
+	controllerKey, controllerAddr, err := requireKey("SPIKE_CONTROLLER_KEY")
+	if err != nil {
+		return err
+	}
+	bundlerURL := os.Getenv("SPIKE_BUNDLER_URL")
+	if bundlerURL == "" {
+		return fmt.Errorf("SPIKE_BUNDLER_URL is not set")
+	}
+	bareSalt, ok := new(big.Int).SetString(env("SPIKE_BARE_SALT", "2"), 10)
+	if !ok {
+		return fmt.Errorf("SPIKE_BARE_SALT is not a decimal integer")
+	}
+	policiedSalt, ok := new(big.Int).SetString(env("SPIKE_POLICIED_SALT", "3"), 10)
+	if !ok {
+		return fmt.Errorf("SPIKE_POLICIED_SALT is not a decimal integer")
+	}
+	token := common.HexToAddress(env("SPIKE_TOKEN", defaultToken))
+
+	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return err
+	}
+	defer chain.Close()
+	chainRPC := chain.Client()
+	bundler, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return err
+	}
+	defer bundler.Close()
+	chainID, err := chain.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+	entryPoint := preset.EntryPointV07()
+	entity := aa.MinSessionEntityID
+
+	bare, err := aa.GetSenderAddressMAv2(chain, ownerAddr, bareSalt)
+	if err != nil {
+		return err
+	}
+	policied, err := aa.GetSenderAddressMAv2(chain, ownerAddr, policiedSalt)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("chain %s\nowner      %s\ncontroller %s\nbare       %s (salt %s)\npolicied   %s (salt %s)\n\n",
+		chainID, ownerAddr, controllerAddr, bare.Hex(), bareSalt, policied.Hex(), policiedSalt)
+
+	// Preconditions: both grants must still be live.
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *bare); sErr != nil {
+		return sErr
+	} else if signer != controllerAddr {
+		return fmt.Errorf("bare account's entity-%d signer is %s, want the controller — §3.2 state gone?", entity, signer)
+	}
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *policied); sErr != nil {
+		return sErr
+	} else if signer != controllerAddr {
+		return fmt.Errorf("policied account's entity-%d signer is %s, want the controller — §3.4 state gone?", entity, signer)
+	}
+
+	// ── R1: controller revokes itself on the bare grant ───────────────────
+	uninstallBare, err := aa.PackSessionSignerUninstall(entity, nil) // no hooks installed, no cleanup entries
+	if err != nil {
+		return err
+	}
+	nonce1, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *bare, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op1 := &userop.UserOperationV07{
+		Sender: *bare, Nonce: nonce1, CallData: uninstallBare,
+		VerificationGasLimit: big.NewInt(150_000),
+	}
+	if err := priceOp(ctx, chain, bundler, op1, entryPoint); err != nil {
+		return fmt.Errorf("pricing R1: %w", err)
+	}
+	if err := preset.SignUserOpV07(op1, entryPoint, chainID, controllerKey); err != nil {
+		return err
+	}
+	// The retry variant handles Rundler's efficiency floor: an uninstall's
+	// verification is light (~50k) and a comfortable seed lands under the
+	// 0.4 actual/limit ratio, so the send must tighten and re-sign.
+	hash1, err := preset.SendUserOpV07WithRetry(ctx, bundler, op1, entryPoint, chainID, controllerKey)
+	if err != nil {
+		return fmt.Errorf("sending R1: %w", err)
+	}
+	fmt.Printf("R1 sent: controller-signed uninstallValidation on the bare grant\n  userOpHash %s\n", hash1)
+	r1, err := waitReceipt(ctx, bundler, hash1)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  mined: success=%v gasUsed=%s tx=%s\n", r1.Success, r1.ActualGasUsed, r1.TxHash)
+	if !r1.Success {
+		return fmt.Errorf("R1 reverted — controller self-revoke on a bare grant should succeed")
+	}
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *bare); sErr != nil {
+		return sErr
+	} else if signer != (common.Address{}) {
+		return fmt.Errorf("SSVM still names %s after R1", signer)
+	}
+	fmt.Printf("  module signer cleared: signers(%d, bare) = 0x0\n\n", entity)
+
+	// ── R2: the controller's authority is gone ────────────────────────────
+	probe, err := aa.PackExecute(ownerAddr, big.NewInt(0), nil)
+	if err != nil {
+		return err
+	}
+	nonce2, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *bare, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op2 := &userop.UserOperationV07{Sender: *bare, Nonce: nonce2, CallData: probe,
+		VerificationGasLimit: big.NewInt(150_000)}
+	if err := priceOp(ctx, chain, bundler, op2, entryPoint); err == nil {
+		return fmt.Errorf("R2: a controller op was accepted AFTER revocation")
+	} else {
+		fmt.Printf("R2: controller op refused after revoke, as required\n  %s\n\n", firstLine(err.Error()))
+	}
+
+	// ── R4: the policied grant cannot self-revoke ─────────────────────────
+	// Three hook entries exist; content is irrelevant because the allowlist
+	// exec hook rejects the selector before the uninstall would run.
+	uninstallPolicied, err := aa.PackSessionSignerUninstall(entity, [][]byte{nil, nil, nil})
+	if err != nil {
+		return err
+	}
+	wrapped, err := aa.WrapExecuteUserOp(uninstallPolicied)
+	if err != nil {
+		return err
+	}
+	nonce4, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *policied, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op4 := &userop.UserOperationV07{Sender: *policied, Nonce: nonce4, CallData: wrapped,
+		VerificationGasLimit: big.NewInt(200_000)}
+	if err := priceOp(ctx, chain, bundler, op4, entryPoint); err == nil {
+		return fmt.Errorf("R4: the policied controller's self-revoke was NOT blocked")
+	} else {
+		fmt.Printf("R4: policied controller self-revoke blocked by the execution hook, as required\n  %s\n\n", firstLine(err.Error()))
+	}
+
+	// ── R3: the owner revokes the policied grant with a plain transaction ──
+	// Hook cleanup in STORED order: validation hooks reversed from install
+	// ([allowlist, timerange] installed → [timerange, allowlist] stored),
+	// then the exec hook (empty: same module as the allowlist entry, state
+	// already deleted there).
+	timeRangeCleanup, err := aa.PackTimeRangeUninstallData(entity)
+	if err != nil {
+		return err
+	}
+	allowlistCleanup, err := aa.PackAllowlistInstallData(entity, []aa.AllowlistInput{{
+		Target:               token,
+		HasSelectorAllowlist: true,
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      new(big.Int).Mul(big.NewInt(100), oneToken),
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}},
+	}})
+	if err != nil {
+		return err
+	}
+	uninstallR3, err := aa.PackSessionSignerUninstall(entity, [][]byte{timeRangeCleanup, allowlistCleanup, nil})
+	if err != nil {
+		return err
+	}
+	txHash, gasUsed, err := sendOwnerTx(ctx, chain, chainID, ownerKey, ownerAddr, *policied, uninstallR3)
+	if err != nil {
+		return fmt.Errorf("R3: %w", err)
+	}
+	fmt.Printf("R3: owner revoked the policied grant with a PLAIN transaction (no UserOp, no bundler)\n  tx %s gasUsed=%d\n", txHash, gasUsed)
+
+	// Cleanup verification — reads, not vibes.
+	if signer, sErr := readSessionSigner(ctx, chain, entity, *policied); sErr != nil {
+		return sErr
+	} else if signer != (common.Address{}) {
+		return fmt.Errorf("SSVM still names %s after R3", signer)
+	}
+	limit, err := readSpendLimit(ctx, chain, entity, token, *policied)
+	if err != nil {
+		return err
+	}
+	until, after, err := readTimeRange(ctx, chain, entity, *policied)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  module state cleared: signer=0x0, erc20SpendLimit=%s, timeRange=(%d,%d)\n\n", limit, until, after)
+	if limit.Sign() != 0 || until != 0 || after != 0 {
+		return fmt.Errorf("hook module state survived the uninstall — cleanup order wrong or onUninstall failed")
+	}
+
+	// ── Post-R3: the policied controller is dead too ──────────────────────
+	probeWrapped, err := aa.WrapExecuteUserOp(probe)
+	if err != nil {
+		return err
+	}
+	nonce5, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, *policied, entity, userop.ValidationOptionGlobal)
+	if err != nil {
+		return err
+	}
+	op5 := &userop.UserOperationV07{Sender: *policied, Nonce: nonce5, CallData: probeWrapped,
+		VerificationGasLimit: big.NewInt(150_000)}
+	if err := priceOp(ctx, chain, bundler, op5, entryPoint); err == nil {
+		return fmt.Errorf("post-R3: a controller op was accepted AFTER the owner's revoke")
+	} else {
+		fmt.Printf("post-R3: controller op refused, as required\n  %s\n\n", firstLine(err.Error()))
+	}
+
+	fmt.Println("PROVEN: a bare grant one-click revokes itself (and is therefore")
+	fmt.Println("self-modifiable — by design); a policied grant cannot touch its own")
+	fmt.Println("authority; the owner revokes either kind with a plain transaction and")
+	fmt.Println("the hook state provably clears. Revocation has receipts.")
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func priceOp(ctx context.Context, chain *ethclient.Client, bundler *rpc.Client,
+	op *userop.UserOperationV07, entryPoint common.Address) error {
+
+	tip, err := chain.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	var bundlerTipHex string
+	if err := bundler.CallContext(ctx, &bundlerTipHex, "rundler_maxPriorityFeePerGas"); err == nil {
+		if bundlerTip, ok := new(big.Int).SetString(trim0x(bundlerTipHex), 16); ok && bundlerTip.Cmp(tip) > 0 {
+			tip = bundlerTip
+		}
+	}
+	head, err := chain.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+	if _, err := preset.EstimateUserOpGasV07(ctx, bundler, op, entryPoint); err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	return nil
+}
+
+func sendOwnerTx(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, ownerAddr, to common.Address, data []byte) (common.Hash, uint64, error) {
+
+	nonce, err := chain.PendingNonceAt(ctx, ownerAddr)
+	if err != nil {
+		return common.Hash{}, 0, err
+	}
+	gasPrice, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return common.Hash{}, 0, err
+	}
+	gasLimit, err := chain.EstimateGas(ctx, ethereum.CallMsg{From: ownerAddr, To: &to, Data: data})
+	if err != nil {
+		return common.Hash{}, 0, fmt.Errorf("estimating the owner's revoke tx: %w", err)
+	}
+	tx := types.NewTransaction(nonce, to, big.NewInt(0), gasLimit+20_000, gasPrice, data)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return common.Hash{}, 0, err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return common.Hash{}, 0, err
+	}
+	for range 60 {
+		receipt, rErr := chain.TransactionReceipt(ctx, signed.Hash())
+		if rErr == nil {
+			if receipt.Status != types.ReceiptStatusSuccessful {
+				return signed.Hash(), receipt.GasUsed, fmt.Errorf("owner revoke tx mined but failed")
+			}
+			return signed.Hash(), receipt.GasUsed, nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return signed.Hash(), 0, fmt.Errorf("owner revoke tx not mined after 3 minutes")
+}
+
+func callWords(ctx context.Context, chain *ethclient.Client, to common.Address, sig string, args ...[]byte) ([]byte, error) {
+	data := crypto.Keccak256([]byte(sig))[:4]
+	for _, a := range args {
+		data = append(data, common.LeftPadBytes(a, 32)...)
+	}
+	return chain.CallContract(ctx, ethereum.CallMsg{To: &to, Data: data}, nil)
+}
+
+func readSessionSigner(ctx context.Context, chain *ethclient.Client, entity uint32, account common.Address) (common.Address, error) {
+	out, err := callWords(ctx, chain, aa.SingleSignerValidationModuleAddress(),
+		"signers(uint32,address)", big.NewInt(int64(entity)).Bytes(), account.Bytes())
+	if err != nil || len(out) < 32 {
+		return common.Address{}, fmt.Errorf("reading SSVM signer: %w", err)
+	}
+	return common.BytesToAddress(out[12:32]), nil
+}
+
+func readSpendLimit(ctx context.Context, chain *ethclient.Client, entity uint32, token, account common.Address) (*big.Int, error) {
+	out, err := callWords(ctx, chain, aa.AllowlistModuleAddress(),
+		"erc20SpendLimits(uint32,address,address)", big.NewInt(int64(entity)).Bytes(), token.Bytes(), account.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("reading erc20SpendLimits: %w", err)
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+func readTimeRange(ctx context.Context, chain *ethclient.Client, entity uint32, account common.Address) (uint64, uint64, error) {
+	out, err := callWords(ctx, chain, aa.TimeRangeModuleAddress(),
+		"timeRanges(uint32,address)", big.NewInt(int64(entity)).Bytes(), account.Bytes())
+	if err != nil || len(out) < 64 {
+		return 0, 0, fmt.Errorf("reading timeRanges: %w", err)
+	}
+	return new(big.Int).SetBytes(out[:32]).Uint64(), new(big.Int).SetBytes(out[32:64]).Uint64(), nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+type userOpReceipt struct {
+	Success       bool
+	ActualGasUsed *big.Int
+	TxHash        string
+}
+
+func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (*userOpReceipt, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var raw json.RawMessage
+		if err := bundler.CallContext(ctx, &raw, "eth_getUserOperationReceipt", opHash.Hex()); err == nil &&
+			len(raw) > 0 && string(raw) != "null" {
+			var parsed struct {
+				Success       bool   `json:"success"`
+				ActualGasUsed string `json:"actualGasUsed"`
+				Receipt       struct {
+					TransactionHash string `json:"transactionHash"`
+				} `json:"receipt"`
+			}
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				return nil, err
+			}
+			gasUsed, _ := new(big.Int).SetString(trim0x(parsed.ActualGasUsed), 16)
+			return &userOpReceipt{Success: parsed.Success, ActualGasUsed: gasUsed,
+				TxHash: parsed.Receipt.TransactionHash}, nil
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return nil, fmt.Errorf("no receipt for %s after 3 minutes", opHash)
+}

--- a/worker/server.go
+++ b/worker/server.go
@@ -93,7 +93,7 @@ func (s *Server) ExecuteUserOp(ctx context.Context, req *avsproto.ExecuteUserOpR
 		)
 	}
 
-	userOp, receipt, err := preset.SendUserOp(
+	userOp, receipt, err := preset.SendUserOpAuto(
 		s.worker.smartWalletCfg,
 		ownerAddr,
 		req.CallData,
@@ -115,11 +115,7 @@ func (s *Server) ExecuteUserOp(ctx context.Context, req *avsproto.ExecuteUserOpR
 	}
 
 	if userOp != nil {
-		opHash := userOp.GetUserOpHash(
-			s.worker.smartWalletCfg.EntrypointAddress,
-			big.NewInt(s.worker.config.ChainID),
-		)
-		resp.UserOpHash = opHash.Hex()
+		resp.UserOpHash = userOp.UserOpHash.Hex()
 	}
 
 	if receipt != nil {
@@ -182,7 +178,10 @@ func (s *Server) GetSmartWalletAddress(ctx context.Context, req *avsproto.Worker
 	// worker's configured factory. The gateway passes its per-chain /
 	// per-request factory so worker-derived addresses match the gateway's
 	// direct-RPC derivation exactly.
-	factory := s.worker.smartWalletCfg.FactoryAddress
+	factory, factoryErr := aa.EffectiveFactory(s.worker.smartWalletCfg)
+	if factoryErr != nil {
+		return nil, factoryErr
+	}
 	if req.FactoryAddress != "" {
 		if !common.IsHexAddress(req.FactoryAddress) {
 			return nil, fmt.Errorf("invalid factory address %q", req.FactoryAddress)
@@ -190,7 +189,7 @@ func (s *Server) GetSmartWalletAddress(ctx context.Context, req *avsproto.Worker
 		factory = common.HexToAddress(req.FactoryAddress)
 	}
 
-	addr, err := aa.GetSenderAddressForFactory(
+	addr, err := aa.DeriveSenderAddressAuto(
 		s.worker.rpcClient,
 		ownerAddr,
 		factory,
@@ -460,7 +459,10 @@ func (s *Server) FindMatchingWalletSalt(ctx context.Context, req *avsproto.Worke
 		return nil, fmt.Errorf("max_salts %d exceeds cap %d", req.MaxSalts, maxWalletSaltScan)
 	}
 
-	factory := s.worker.smartWalletCfg.FactoryAddress
+	factory, factoryErr := aa.EffectiveFactory(s.worker.smartWalletCfg)
+	if factoryErr != nil {
+		return nil, factoryErr
+	}
 	if req.FactoryAddress != "" {
 		if !common.IsHexAddress(req.FactoryAddress) {
 			return nil, fmt.Errorf("invalid factory address %q", req.FactoryAddress)
@@ -475,7 +477,7 @@ func (s *Server) FindMatchingWalletSalt(ctx context.Context, req *avsproto.Worke
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		addr, err := aa.GetSenderAddressForFactory(s.worker.rpcClient, owner, factory, big.NewInt(salt))
+		addr, err := aa.DeriveSenderAddressAuto(s.worker.rpcClient, owner, factory, big.NewInt(salt))
 		if err != nil {
 			// A single failed derivation shouldn't abort the whole scan.
 			continue


### PR DESCRIPTION
Promotes the MA v2 + EntryPoint v0.7 migration to `main`. Two squashed changes since the last release:

- **feat: MA v2 + EntryPoint v0.7 cutover (#694)** — every chain derives Alchemy Modular Account v2 accounts through the v0.7 EntryPoint; execution dispatches to v0.7; the default `account_provider` is `modular_account_v2` (with `simple_account` still selectable per-chain).
- **feat: session-grant execution, /policies REST surface, v0.7 nonce manager (#695)** — the gateway executes only under an owner-granted validation entity; the `/policies` prepare→sign→submit surface backs the grant screen; a v0.7 nonce manager keyed by (sender, nonce key) fixes sequential-write AA25.

## Audit (this diff vs `main`)

- **Storage**: `make storage-check` green — additive only (new `sp:` policy namespace; no persisted model struct reshaped).
- **Wire/API**: no `.proto` changes; REST is additive only (new `/policies` paths + schemas, no field renames/removals).
- **Dual-stack preserved**: the v0.6 `SendUserOp` path and `simple_account` provider remain, so the address flip is config-gated (avs-infra), not forced by this merge.

## ⚠️ Deploy prerequisites (merge cuts a pre-release; it does NOT deploy)

The deploy (avs-infra `release.sh`) must stay gated until:

- [ ] **`/policies` SDK (ava-sdk-js) + Studio grant screen shipped** — the hard blocker. Post-flip the gateway holds no authority until each owner signs a grant; without the client surface, MA v2 users cannot onboard.
- [ ] **`alchemy_api_key` set** in avs-infra prod (or `bundler_provider: self_hosted`). Note: this is **not** a boot-time fail-fast — `NewConfig`'s probe treats a missing key as a connectivity-only rollout (`BundlerConfigured()` discards the error), so a misconfigured chain boots clean and fails on the **first contract-write** instead. Verify config before release rather than relying on startup to reject it.
- [ ] **Re-onboarding plan + comms** — MA v2 changes every wallet address; deployed tasks on old runners stop executing.
- [ ] **Gas Manager sponsorship webhook** (FeeLedger credit gate) shipped — else sponsored spend is uncapped.
- [ ] Session-signer strategy revisited (currently the shared controller key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

