### PR TITLE
chore(session-auth): PR #696 review follow-ups — sentinel error, race test, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ tmp/rehearsal-gateway-backup/
 # spike harness build outputs
 /deferred_action
 /permission_hooks
+/revoke

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"math/big"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -310,7 +309,7 @@ func mapPolicyError(err error) error {
 	case errors.Is(err, taskengine.ErrSessionEntityTaken):
 		return &restmw.HTTPError{Status: http.StatusConflict, Code: "POLICIES_ENTITY_TAKEN",
 			Title: "Grant allocation superseded", Detail: err.Error() + " Prepare the grant again."}
-	case strings.Contains(err.Error(), "signed by"):
+	case errors.Is(err, taskengine.ErrGrantSignerMismatch):
 		return badRequest("POLICIES_BAD_SIGNATURE", "Signature does not match", err.Error())
 	default:
 		return badRequest("POLICIES_REJECTED", "Policy request rejected", err.Error())

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -326,7 +326,12 @@ func verifyGrantSignature(digest common.Hash, signature []byte, owner common.Add
 		return fmt.Errorf("grant signature is malformed: %w", err)
 	}
 	if got := crypto.PubkeyToAddress(*pub); got != owner {
-		return fmt.Errorf("grant was signed by %s, not the wallet owner %s", got.Hex(), owner.Hex())
+		return fmt.Errorf("%w: signed by %s, not the wallet owner %s", ErrGrantSignerMismatch, got.Hex(), owner.Hex())
 	}
 	return nil
 }
+
+// ErrGrantSignerMismatch is returned when a grant's signature recovers to an
+// address other than the wallet owner. Exposed as a sentinel so the REST
+// layer can map it to a 400 with errors.Is rather than matching error text.
+var ErrGrantSignerMismatch = errors.New("grant was signed by the wrong key")

--- a/pkg/erc4337/preset/nonce_v07_test.go
+++ b/pkg/erc4337/preset/nonce_v07_test.go
@@ -3,6 +3,7 @@ package preset
 import (
 	"errors"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -133,6 +134,41 @@ func containsAll(s string, subs ...string) bool {
 		}
 	}
 	return true
+}
+
+// The manager exists because the *previous* nonce bug was a concurrency bug,
+// so it must be race-clean under concurrent access. Run with -race. This
+// asserts no data race and that every concurrent accept lands a
+// well-formed successor — not a sequential ordering (concurrent callers may
+// interleave; the send path heals interleavings via AA25-invalidate-retry).
+func TestNonceManagerV07ConcurrentAccessIsRaceFree(t *testing.T) {
+	sender := common.HexToAddress("0x00000000000000000000000000000000000000A5")
+	const goroutines, iterations = 8, 200
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(entityID uint32) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				used := mustNonce(t, entityID, userop.ValidationOptionGlobal, uint64(i))
+				NoteUserOpAccepted(sender, entityID, userop.ValidationOptionGlobal, used)
+				_, _ = cachedNext(t, sender, entityID, userop.ValidationOptionGlobal)
+				if i%3 == 0 {
+					InvalidateNonce(sender, entityID, userop.ValidationOptionGlobal)
+				}
+			}
+		}(uint32(g + 1)) // distinct entity per goroutine: distinct slots, same map
+	}
+	wg.Wait()
+
+	// After the storm, a fresh accept must still produce the exact successor —
+	// the map is intact, not corrupted by the concurrent writers.
+	NoteUserOpAccepted(sender, 1, userop.ValidationOptionGlobal, mustNonce(t, 1, userop.ValidationOptionGlobal, 41))
+	next, ok := cachedNext(t, sender, 1, userop.ValidationOptionGlobal)
+	if !ok || next.Cmp(mustNonce(t, 1, userop.ValidationOptionGlobal, 42)) != 0 {
+		t.Fatalf("post-concurrency slot = %v, want sequence 42", next)
+	}
 }
 
 func TestIsInvalidNonceError(t *testing.T) {


### PR DESCRIPTION
Low-risk cleanups from the #696 (staging→main) release review, split out of the release PR rather than pushed onto it.

**Applied here**
- `mapPolicyError` matches `ErrGrantSignerMismatch` via `errors.Is` instead of `strings.Contains(err, "signed by")` — decouples REST error codes from `verifyGrantSignature`'s wording.
- Concurrent `-race` test for the v0.7 nonce manager (the bug it fixes was a concurrency bug; prior tests were sequential only).
- `.gitignore` gains `/revoke` (the third spike binary, missed alongside `/deferred_action` + `/permission_hooks`).

**Deliberately deferred (tracked, not blocking the release)**
- Off-chain grant-expiry in `SessionPolicy.Usable()` — the on-chain `TimeRangeValidationHook` already rejects expired grants (spike §3.4); a naive `Usable()` change degrades the failure mode (resolver returns nil → signs as fallback entity → more confusing on-chain revert). Needs a distinct "grant expired" error path.
- Global `aa.factoryAddress` / `SetEntrypointAddress` mutation hardening under dual-stack — pre-existing architecture; its own PR.
- Bundled `WorkflowStatus` codegen rename — already merged via `make rest-gen`; verified harmless.
- Zero-`UserOpHash` → `"0x000…"` guards — pre-existing edge-case pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
