### PR TITLE
fix: emit only the EIP-712 domain fields the type declares

### DIFF
--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -8,9 +8,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/labstack/echo/v4"
-
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/labstack/echo/v4"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/labstack/echo/v4"
 
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
@@ -296,7 +298,32 @@ func typedDataJSON(policy *model.SessionPolicy) (map[string]interface{}, error) 
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, err
 	}
+
+	// go-ethereum's TypedDataDomain has no `omitempty`, so marshalling it
+	// emits name, version and salt as empty strings even though this domain
+	// declares neither. EIP-712 says a verifier reads the domain through its
+	// TYPE, so the digest is unaffected — but strict clients validate the
+	// object, and ethers v6 rejects the payload outright ("invalid BytesLike
+	// value" for salt: ""). Emit only what EIP712Domain declares.
+	out["domain"] = filterToDeclaredFields(out["domain"], typed.Types["EIP712Domain"])
 	return out, nil
+}
+
+// filterToDeclaredFields drops domain keys the EIP712Domain type does not
+// declare. Keyed off the type rather than a hardcoded list so a future domain
+// that does carry a name or version keeps it without another fix here.
+func filterToDeclaredFields(domain interface{}, declared []apitypes.Type) interface{} {
+	fields, ok := domain.(map[string]interface{})
+	if !ok {
+		return domain
+	}
+	kept := make(map[string]interface{}, len(declared))
+	for _, f := range declared {
+		if v, present := fields[f.Name]; present {
+			kept[f.Name] = v
+		}
+	}
+	return kept
 }
 
 // mapPolicyError translates engine sentinels into REST problems.

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -286,12 +286,6 @@ func TestTypedDataDomainCarriesOnlyDeclaredFields(t *testing.T) {
 	domain, ok := prepared.TypedData["domain"].(map[string]interface{})
 	require.True(t, ok, "domain should be an object")
 
-	// go-ethereum's TypedDataDomain has no `omitempty`, so a naive marshal
-	// emits name, version and salt as empty strings. EIP-712 verifiers read
-	// the domain through its TYPE, so the digest is unaffected and this looks
-	// harmless — but ethers v6 validates the object and rejects `salt: ""`
-	// with "invalid BytesLike value", failing the grant before it is signed.
-	// Found by running the SDK grant flow against a live gateway.
 	for _, undeclared := range []string{"name", "version", "salt"} {
 		require.NotContains(t, domain, undeclared,
 			"domain carries %q, which EIP712Domain does not declare; strict clients reject it", undeclared)

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -267,3 +267,36 @@ func TestPoliciesSubmitRejectsTamperedCapOverHTTP(t *testing.T) {
 	require.True(t, strings.Contains(rec.Body.String(), "POLICIES_BAD_SIGNATURE"),
 		"a tampered echo must surface as a signature mismatch, got: %s", rec.Body.String())
 }
+
+// go-ethereum's TypedDataDomain has no `omitempty`, so a naive marshal emits
+// name, version and salt as empty strings. EIP-712 verifiers read the domain
+// through its TYPE, so the digest is unaffected and this looks harmless — but
+// ethers v6 validates the object and rejects `salt: ""` outright with
+// "invalid BytesLike value", which fails the grant before it is ever signed.
+// Found by running the SDK's grant flow against a live gateway.
+func TestTypedDataDomainCarriesOnlyDeclaredFields(t *testing.T) {
+	rig := newPolicyRig(t)
+	rec := rig.call(t, prepareBody(policyTestChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, generated.EthereumAddress(rig.wallet.Hex()))
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+	domain, ok := prepared.TypedData["domain"].(map[string]interface{})
+	require.True(t, ok, "domain should be an object")
+
+	// go-ethereum's TypedDataDomain has no `omitempty`, so a naive marshal
+	// emits name, version and salt as empty strings. EIP-712 verifiers read
+	// the domain through its TYPE, so the digest is unaffected and this looks
+	// harmless — but ethers v6 validates the object and rejects `salt: ""`
+	// with "invalid BytesLike value", failing the grant before it is signed.
+	// Found by running the SDK grant flow against a live gateway.
+	for _, undeclared := range []string{"name", "version", "salt"} {
+		require.NotContains(t, domain, undeclared,
+			"domain carries %q, which EIP712Domain does not declare; strict clients reject it", undeclared)
+	}
+	for _, declared := range []string{"chainId", "verifyingContract"} {
+		require.Contains(t, domain, declared)
+	}
+}


### PR DESCRIPTION
The prepare response's typed data carried `name`, `version` and `salt` as empty strings, although its `EIP712Domain` declares only `chainId` and `verifyingContract`:

```json
"types":  { "EIP712Domain": [ {"name":"chainId",...}, {"name":"verifyingContract",...} ] }
"domain": { "chainId":"0xaa36a7", "name":"", "salt":"", "verifyingContract":"0x209e…", "version":"" }
```

go-ethereum's `TypedDataDomain` has no `omitempty`, so marshalling it emits every field whether the domain uses one or not.

## Why nothing caught this

**The digest was never wrong.** EIP-712 verifiers read the domain through its *type*, so undeclared keys are ignored and the hash is unaffected. The existing round-trip test passes because it re-parses the payload with the same library that produced it — go-ethereum agrees with itself.

Strict clients do not. ethers v6 validates the domain object and rejects `salt: ""`:

```
TypeError: invalid BytesLike value (argument="value", value="", code=INVALID_ARGUMENT)
```

That fails a grant **before the owner is ever asked to sign** — the wallet never opens. Found by running the ava-sdk-js grant flow against a live local gateway, not by any test in this repo.

## The fix

Filter the serialized domain to the fields `EIP712Domain` declares. Keyed off the declared type rather than a hardcoded deny-list, so a domain that legitimately carries a `name` or `version` later keeps it without another fix here.

The builder (`userop.DeferredActionTypedData`) was already correct — it only ever set `ChainId` and `VerifyingContract`. The bug lived entirely in serialization, which is why the regression test asserts on the **HTTP response** rather than on the builder. I verified it fails without the fix:

```
domain carries "name", which EIP712Domain does not declare; strict clients reject it
```

## Verification

With this branch built and running locally, the full SDK grant flow passes end to end — prepare → `eth_signTypedData_v4` → submit → signature verifies → stored `pending` → revoked. Before it, that test died at the signing step.

Worth merging ahead of the SDK work: anything building against staging still has the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
