### PR TITLE
fix: factory override wins over unresolvable default; stop pricing wallet creation as self-owned

### DIFF
--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1302,6 +1302,23 @@ func (n *Engine) resolveUserChainID(user *model.User) int64 {
 	return n.defaultChainID()
 }
 
+// resolveFactoryOverride picks the factory a wallet operation should use.
+//
+// An explicit override always wins: it is how a caller reaches a wallet
+// created under the pre-cutover factory (its provider is inferred from the
+// address rather than this chain's config), and it lets a chain with no
+// configured default factory still serve a caller who supplies one. Only when
+// there is no override does the chain default (EffectiveFactory) apply — whose
+// error is fatal solely in that case. The override's format must already be
+// validated by the caller. Shared by GetWallet and SetWallet so the "override
+// wins" rule lives in one place.
+func resolveFactoryOverride(swCfg *config.SmartWalletConfig, overrideHex string) (common.Address, error) {
+	if overrideHex != "" {
+		return common.HexToAddress(overrideHex), nil
+	}
+	return aa.EffectiveFactory(swCfg)
+}
+
 // GetWallet is the gRPC handler for the GetWallet RPC.
 // It uses the owner (from auth context), salt, and factory_address from payload to derive the wallet address.
 //
@@ -1350,15 +1367,9 @@ func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, pay
 		}
 	}
 
-	factoryAddr, factoryErr := aa.EffectiveFactory(swCfg)
+	factoryAddr, factoryErr := resolveFactoryOverride(swCfg, payload.GetFactoryAddress())
 	if factoryErr != nil {
 		return nil, status.Errorf(codes.Internal, "GetWallet: resolve factory: %v", factoryErr)
-	}
-	// An explicit factory still wins — that is how a caller reaches a wallet
-	// created under the pre-cutover factory, whose provider is then inferred
-	// from the address itself rather than from this chain's config.
-	if payload.GetFactoryAddress() != "" {
-		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
 
 	if err := n.validateNonZeroAddress(factoryAddr, "GetWallet", user.Address.Hex(), saltBig.String()); err != nil {
@@ -1541,12 +1552,9 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid salt format: %s", payload.GetSalt())
 	}
 
-	factoryAddr, factoryErr := aa.EffectiveFactory(n.smartWalletConfig) // Default factory
+	factoryAddr, factoryErr := resolveFactoryOverride(n.smartWalletConfig, payload.GetFactoryAddress())
 	if factoryErr != nil {
 		return nil, status.Errorf(codes.Internal, "SetWallet: resolve factory: %v", factoryErr)
-	}
-	if payload.GetFactoryAddress() != "" {
-		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
 
 	if err := n.validateNonZeroAddress(factoryAddr, "SetWallet", owner.Hex(), payload.GetSalt()); err != nil {

--- a/core/taskengine/factory_override_test.go
+++ b/core/taskengine/factory_override_test.go
@@ -1,0 +1,53 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+// resolveFactoryOverride is the one place the "explicit factory wins" rule
+// lives for GetWallet/SetWallet. The bug it fixes: the override used to be
+// applied AFTER EffectiveFactory, so a chain that could not resolve a default
+// factory returned 500 even when the caller supplied a working override.
+
+func TestResolveFactoryOverride_OverrideWinsEvenWhenDefaultUnresolvable(t *testing.T) {
+	// simple_account with no configured factory: EffectiveFactory fails here.
+	cfg := &config.SmartWalletConfig{
+		AccountProvider: config.AccountProviderSimpleAccount,
+		FactoryAddress:  common.Address{}, // unset — EffectiveFactory would error
+	}
+	require.Error(t, mustFactoryErr(cfg), "precondition: this config must fail EffectiveFactory")
+
+	override := "0x00000000000017c61b5bEe81050EC8eFc9c6fecd"
+	got, err := resolveFactoryOverride(cfg, override)
+	require.NoError(t, err, "a supplied override must succeed even when the chain default cannot resolve")
+	require.Equal(t, common.HexToAddress(override), got)
+}
+
+func TestResolveFactoryOverride_FallsBackToChainDefault(t *testing.T) {
+	// No override, MA v2 chain: resolves to the MA v2 factory.
+	cfg := &config.SmartWalletConfig{AccountProvider: config.AccountProviderModularAccountV2}
+	got, err := resolveFactoryOverride(cfg, "")
+	require.NoError(t, err)
+	require.Equal(t, aa.MAv2FactoryAddress(), got)
+}
+
+func TestResolveFactoryOverride_NoOverrideAndUnresolvableDefaultErrors(t *testing.T) {
+	// No override AND an unresolvable default is the one case that must error.
+	cfg := &config.SmartWalletConfig{
+		AccountProvider: config.AccountProviderSimpleAccount,
+		FactoryAddress:  common.Address{},
+	}
+	_, err := resolveFactoryOverride(cfg, "")
+	require.Error(t, err)
+}
+
+func mustFactoryErr(cfg *config.SmartWalletConfig) error {
+	_, err := aa.EffectiveFactory(cfg)
+	return err
+}

--- a/core/taskengine/fee_estimator.go
+++ b/core/taskengine/fee_estimator.go
@@ -342,6 +342,12 @@ func (fe *FeeEstimator) resolveRunnerAndWalletCreation(ctx context.Context, req 
 
 // estimateWalletCreationGas estimates gas needed for smart wallet creation
 // by calling eth_estimateGas against the factory's createAccount method.
+// feeEstimationDummyOwner is a placeholder owner used only to build
+// representative account-creation init code for gas estimation. The deploy
+// cost does not depend on the owner value, and the real owner is not available
+// on the fee-estimation path — so a fixed non-zero address stands in.
+var feeEstimationDummyOwner = common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+
 func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAddress common.Address) (*big.Int, *big.Int, error) {
 	const fallbackCreationGas = int64(500000) // Conservative fallback for ERC-6900 wallet deployment
 
@@ -362,7 +368,13 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 			"error", err, "fallback_gas", fallbackCreationGas)
 		return big.NewInt(fallbackCreationGas), gasPrice, nil
 	}
-	factoryAddress, calldata, err := aa.DeriveInitCodeAuto(walletAddress, factoryAddress, big.NewInt(0))
+	// Deploy gas is independent of the owner baked into the CREATE2 init code,
+	// and the real owner is not in scope on this estimation path — so use a
+	// fixed placeholder rather than walletAddress. Passing the wallet as its
+	// own owner prices creation of a *different*, wallet-owned account; the gas
+	// happens to match, which is why this was latent, but it is misleading and
+	// should not be relied on.
+	factoryAddress, calldata, err := aa.DeriveInitCodeAuto(feeEstimationDummyOwner, factoryAddress, big.NewInt(0))
 	if err != nil {
 		fe.logger.Warn("Failed to build account-creation calldata, using fallback gas estimate",
 			"error", err, "fallback_gas", fallbackCreationGas)
@@ -386,7 +398,7 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 	bufferedGas.Add(bufferedGas, buffer)
 
 	fe.logger.Info("Estimated wallet creation gas via eth_estimateGas",
-		"raw_gas", estimatedGas, "buffered_gas", bufferedGas, "factory", factoryAddress.Hex())
+		"wallet", walletAddress.Hex(), "raw_gas", estimatedGas, "buffered_gas", bufferedGas, "factory", factoryAddress.Hex())
 
 	return bufferedGas, gasPrice, nil
 }

--- a/core/taskengine/fee_estimator_creation_test.go
+++ b/core/taskengine/fee_estimator_creation_test.go
@@ -1,0 +1,69 @@
+package taskengine
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+// stubCreationChainReader satisfies ChainStateReader by embedding the interface
+// (nil) and overriding only the two methods estimateWalletCreationGas calls —
+// so the test needs no live RPC. EstimateGas records the CallMsg it was handed,
+// which is where the init code the estimate prices lands.
+type stubCreationChainReader struct {
+	ChainStateReader
+	gasPrice    *big.Int
+	estimateGas uint64
+	captured    ethereum.CallMsg
+}
+
+func (s *stubCreationChainReader) SuggestGasPrice(context.Context) (*big.Int, error) {
+	return s.gasPrice, nil
+}
+
+func (s *stubCreationChainReader) EstimateGas(_ context.Context, msg ethereum.CallMsg) (uint64, error) {
+	s.captured = msg
+	return s.estimateGas, nil
+}
+
+// The estimate must build init code from a placeholder owner, not from the
+// wallet address. Passing the wallet as its own owner (the fixed bug) prices
+// creation of a different, wallet-owned account; the gas happens to match,
+// which is why it was latent, so only the calldata reveals it.
+func TestEstimateWalletCreationGas_BuildsInitCodeFromDummyOwnerNotWallet(t *testing.T) {
+	logger, err := sdklogging.NewZapLogger(sdklogging.Development)
+	require.NoError(t, err)
+
+	stub := &stubCreationChainReader{gasPrice: big.NewInt(1_000_000_000), estimateGas: 300_000}
+	fe := &FeeEstimator{
+		logger: logger,
+		chain:  stub,
+		// MA v2 so EffectiveFactory resolves from config alone (no RPC).
+		smartWalletConfig: &config.SmartWalletConfig{AccountProvider: config.AccountProviderModularAccountV2},
+	}
+	wallet := common.HexToAddress("0x00000000000000000000000000000000000000a1")
+
+	_, _, err = fe.estimateWalletCreationGas(context.Background(), wallet)
+	require.NoError(t, err)
+
+	factory := aa.MAv2FactoryAddress()
+	_, dummyOwnerData, err := aa.DeriveInitCodeAuto(feeEstimationDummyOwner, factory, big.NewInt(0))
+	require.NoError(t, err)
+	_, walletOwnedData, err := aa.DeriveInitCodeAuto(wallet, factory, big.NewInt(0))
+	require.NoError(t, err)
+
+	require.NotNil(t, stub.captured.To)
+	require.Equal(t, factory, *stub.captured.To, "estimate must target the effective factory")
+	require.Equal(t, dummyOwnerData, stub.captured.Data,
+		"init code must be built from feeEstimationDummyOwner")
+	require.NotEqual(t, walletOwnedData, stub.captured.Data,
+		"must not price an account owned by the wallet itself — the bug this fix removes")
+}


### PR DESCRIPTION
Clears the two bugs left on `staging` from the #696/#699 reviews — both confirmed still present. Unrelated to each other, small, and the only outstanding *bugs* on the migration list (everything else there is scoped work or a deploy).

## 1. Factory override ignored when the chain default can't resolve — `engine.go` (GetWallet + SetWallet)

The explicit `factory_address` override was applied **after** `aa.EffectiveFactory`, so a `simple_account` chain with no configured default factory returned **500** even when the caller supplied a working override — contradicting the "an explicit factory still wins" comment sitting right there.

Extracted the rule into one shared `resolveFactoryOverride` helper (both sites duplicated it): the override wins outright; `EffectiveFactory`'s error is fatal only when there is no override. Unit-tested without RPC, including the exact 500 case (`TestResolveFactoryOverride_OverrideWinsEvenWhenDefaultUnresolvable`).

## 2. Wallet-creation gas priced as self-owned — `fee_estimator.go`

`estimateWalletCreationGas` passed `walletAddress` as the **owner** to `DeriveInitCodeAuto`, pricing creation of a *different* account owned by the wallet itself. Deploy gas is owner-independent, so the number was never wrong — which is why it stayed latent — but it's misleading, and the real owner isn't in scope on this path. Now uses an explicit `feeEstimationDummyOwner` placeholder rather than misusing the wallet address.

## Notes
- `make storage-check`: no model/key changes.
- New unit tests pass; `go build ./...` clean.
- `TestFeeEstimator_ChainIDDetection` flakes locally (it resolves chain ID over live Sepolia RPC) — pre-existing and environmental, unrelated to this change (passes 3/3 in isolation).

## Not in this PR (deliberately, from the same review)
Per-policy signer keys, the deferred-action uninstall composition, and selector-scoped grants are scoped follow-ups, not bugs. The ava-sdk-js `policiesLive` 404 needs staging *deployed*, not a code change. #693 (version.go → dev) is a separate stale PR to merge or close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
