### PR TITLE
fix: EIP-712 domain serialization, factory override + wallet-creation gas, version default

### DIFF
--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"github.com/labstack/echo/v4"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
@@ -296,7 +297,32 @@ func typedDataJSON(policy *model.SessionPolicy) (map[string]interface{}, error) 
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, err
 	}
+
+	// go-ethereum's TypedDataDomain has no `omitempty`, so marshalling it
+	// emits name, version and salt as empty strings even though this domain
+	// declares neither. EIP-712 says a verifier reads the domain through its
+	// TYPE, so the digest is unaffected — but strict clients validate the
+	// object, and ethers v6 rejects the payload outright ("invalid BytesLike
+	// value" for salt: ""). Emit only what EIP712Domain declares.
+	out["domain"] = filterToDeclaredFields(out["domain"], typed.Types["EIP712Domain"])
 	return out, nil
+}
+
+// filterToDeclaredFields drops domain keys the EIP712Domain type does not
+// declare. Keyed off the type rather than a hardcoded list so a future domain
+// that does carry a name or version keeps it without another fix here.
+func filterToDeclaredFields(domain interface{}, declared []apitypes.Type) interface{} {
+	fields, ok := domain.(map[string]interface{})
+	if !ok {
+		return domain
+	}
+	kept := make(map[string]interface{}, len(declared))
+	for _, f := range declared {
+		if v, present := fields[f.Name]; present {
+			kept[f.Name] = v
+		}
+	}
+	return kept
 }
 
 // mapPolicyError translates engine sentinels into REST problems.

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -267,3 +267,30 @@ func TestPoliciesSubmitRejectsTamperedCapOverHTTP(t *testing.T) {
 	require.True(t, strings.Contains(rec.Body.String(), "POLICIES_BAD_SIGNATURE"),
 		"a tampered echo must surface as a signature mismatch, got: %s", rec.Body.String())
 }
+
+// go-ethereum's TypedDataDomain has no `omitempty`, so a naive marshal emits
+// name, version and salt as empty strings. EIP-712 verifiers read the domain
+// through its TYPE, so the digest is unaffected and this looks harmless — but
+// ethers v6 validates the object and rejects `salt: ""` outright with
+// "invalid BytesLike value", which fails the grant before it is ever signed.
+// Found by running the SDK's grant flow against a live gateway.
+func TestTypedDataDomainCarriesOnlyDeclaredFields(t *testing.T) {
+	rig := newPolicyRig(t)
+	rec := rig.call(t, prepareBody(policyTestChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, generated.EthereumAddress(rig.wallet.Hex()))
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+	domain, ok := prepared.TypedData["domain"].(map[string]interface{})
+	require.True(t, ok, "domain should be an object")
+
+	for _, undeclared := range []string{"name", "version", "salt"} {
+		require.NotContains(t, domain, undeclared,
+			"domain carries %q, which EIP712Domain does not declare; strict clients reject it", undeclared)
+	}
+	for _, declared := range []string{"chainId", "verifyingContract"} {
+		require.Contains(t, domain, declared)
+	}
+}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1302,6 +1302,23 @@ func (n *Engine) resolveUserChainID(user *model.User) int64 {
 	return n.defaultChainID()
 }
 
+// resolveFactoryOverride picks the factory a wallet operation should use.
+//
+// An explicit override always wins: it is how a caller reaches a wallet
+// created under the pre-cutover factory (its provider is inferred from the
+// address rather than this chain's config), and it lets a chain with no
+// configured default factory still serve a caller who supplies one. Only when
+// there is no override does the chain default (EffectiveFactory) apply — whose
+// error is fatal solely in that case. The override's format must already be
+// validated by the caller. Shared by GetWallet and SetWallet so the "override
+// wins" rule lives in one place.
+func resolveFactoryOverride(swCfg *config.SmartWalletConfig, overrideHex string) (common.Address, error) {
+	if overrideHex != "" {
+		return common.HexToAddress(overrideHex), nil
+	}
+	return aa.EffectiveFactory(swCfg)
+}
+
 // GetWallet is the gRPC handler for the GetWallet RPC.
 // It uses the owner (from auth context), salt, and factory_address from payload to derive the wallet address.
 //
@@ -1350,15 +1367,9 @@ func (n *Engine) GetWalletWithContext(ctx context.Context, user *model.User, pay
 		}
 	}
 
-	factoryAddr, factoryErr := aa.EffectiveFactory(swCfg)
+	factoryAddr, factoryErr := resolveFactoryOverride(swCfg, payload.GetFactoryAddress())
 	if factoryErr != nil {
 		return nil, status.Errorf(codes.Internal, "GetWallet: resolve factory: %v", factoryErr)
-	}
-	// An explicit factory still wins — that is how a caller reaches a wallet
-	// created under the pre-cutover factory, whose provider is then inferred
-	// from the address itself rather than from this chain's config.
-	if payload.GetFactoryAddress() != "" {
-		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
 
 	if err := n.validateNonZeroAddress(factoryAddr, "GetWallet", user.Address.Hex(), saltBig.String()); err != nil {
@@ -1541,12 +1552,9 @@ func (n *Engine) SetWallet(owner common.Address, payload *avsproto.SetWalletReq)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid salt format: %s", payload.GetSalt())
 	}
 
-	factoryAddr, factoryErr := aa.EffectiveFactory(n.smartWalletConfig) // Default factory
+	factoryAddr, factoryErr := resolveFactoryOverride(n.smartWalletConfig, payload.GetFactoryAddress())
 	if factoryErr != nil {
 		return nil, status.Errorf(codes.Internal, "SetWallet: resolve factory: %v", factoryErr)
-	}
-	if payload.GetFactoryAddress() != "" {
-		factoryAddr = common.HexToAddress(payload.GetFactoryAddress())
 	}
 
 	if err := n.validateNonZeroAddress(factoryAddr, "SetWallet", owner.Hex(), payload.GetSalt()); err != nil {

--- a/core/taskengine/factory_override_test.go
+++ b/core/taskengine/factory_override_test.go
@@ -1,0 +1,53 @@
+package taskengine
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+// resolveFactoryOverride is the one place the "explicit factory wins" rule
+// lives for GetWallet/SetWallet. The bug it fixes: the override used to be
+// applied AFTER EffectiveFactory, so a chain that could not resolve a default
+// factory returned 500 even when the caller supplied a working override.
+
+func TestResolveFactoryOverride_OverrideWinsEvenWhenDefaultUnresolvable(t *testing.T) {
+	// simple_account with no configured factory: EffectiveFactory fails here.
+	cfg := &config.SmartWalletConfig{
+		AccountProvider: config.AccountProviderSimpleAccount,
+		FactoryAddress:  common.Address{}, // unset — EffectiveFactory would error
+	}
+	require.Error(t, mustFactoryErr(cfg), "precondition: this config must fail EffectiveFactory")
+
+	override := "0x00000000000017c61b5bEe81050EC8eFc9c6fecd"
+	got, err := resolveFactoryOverride(cfg, override)
+	require.NoError(t, err, "a supplied override must succeed even when the chain default cannot resolve")
+	require.Equal(t, common.HexToAddress(override), got)
+}
+
+func TestResolveFactoryOverride_FallsBackToChainDefault(t *testing.T) {
+	// No override, MA v2 chain: resolves to the MA v2 factory.
+	cfg := &config.SmartWalletConfig{AccountProvider: config.AccountProviderModularAccountV2}
+	got, err := resolveFactoryOverride(cfg, "")
+	require.NoError(t, err)
+	require.Equal(t, aa.MAv2FactoryAddress(), got)
+}
+
+func TestResolveFactoryOverride_NoOverrideAndUnresolvableDefaultErrors(t *testing.T) {
+	// No override AND an unresolvable default is the one case that must error.
+	cfg := &config.SmartWalletConfig{
+		AccountProvider: config.AccountProviderSimpleAccount,
+		FactoryAddress:  common.Address{},
+	}
+	_, err := resolveFactoryOverride(cfg, "")
+	require.Error(t, err)
+}
+
+func mustFactoryErr(cfg *config.SmartWalletConfig) error {
+	_, err := aa.EffectiveFactory(cfg)
+	return err
+}

--- a/core/taskengine/fee_estimator.go
+++ b/core/taskengine/fee_estimator.go
@@ -342,6 +342,12 @@ func (fe *FeeEstimator) resolveRunnerAndWalletCreation(ctx context.Context, req 
 
 // estimateWalletCreationGas estimates gas needed for smart wallet creation
 // by calling eth_estimateGas against the factory's createAccount method.
+// feeEstimationDummyOwner is a placeholder owner used only to build
+// representative account-creation init code for gas estimation. The deploy
+// cost does not depend on the owner value, and the real owner is not available
+// on the fee-estimation path — so a fixed non-zero address stands in.
+var feeEstimationDummyOwner = common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+
 func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAddress common.Address) (*big.Int, *big.Int, error) {
 	const fallbackCreationGas = int64(500000) // Conservative fallback for ERC-6900 wallet deployment
 
@@ -362,7 +368,13 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 			"error", err, "fallback_gas", fallbackCreationGas)
 		return big.NewInt(fallbackCreationGas), gasPrice, nil
 	}
-	factoryAddress, calldata, err := aa.DeriveInitCodeAuto(walletAddress, factoryAddress, big.NewInt(0))
+	// Deploy gas is independent of the owner baked into the CREATE2 init code,
+	// and the real owner is not in scope on this estimation path — so use a
+	// fixed placeholder rather than walletAddress. Passing the wallet as its
+	// own owner prices creation of a *different*, wallet-owned account; the gas
+	// happens to match, which is why this was latent, but it is misleading and
+	// should not be relied on.
+	factoryAddress, calldata, err := aa.DeriveInitCodeAuto(feeEstimationDummyOwner, factoryAddress, big.NewInt(0))
 	if err != nil {
 		fe.logger.Warn("Failed to build account-creation calldata, using fallback gas estimate",
 			"error", err, "fallback_gas", fallbackCreationGas)
@@ -386,7 +398,7 @@ func (fe *FeeEstimator) estimateWalletCreationGas(ctx context.Context, walletAdd
 	bufferedGas.Add(bufferedGas, buffer)
 
 	fe.logger.Info("Estimated wallet creation gas via eth_estimateGas",
-		"raw_gas", estimatedGas, "buffered_gas", bufferedGas, "factory", factoryAddress.Hex())
+		"wallet", walletAddress.Hex(), "raw_gas", estimatedGas, "buffered_gas", bufferedGas, "factory", factoryAddress.Hex())
 
 	return bufferedGas, gasPrice, nil
 }

--- a/core/taskengine/fee_estimator_creation_test.go
+++ b/core/taskengine/fee_estimator_creation_test.go
@@ -1,0 +1,69 @@
+package taskengine
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+// stubCreationChainReader satisfies ChainStateReader by embedding the interface
+// (nil) and overriding only the two methods estimateWalletCreationGas calls —
+// so the test needs no live RPC. EstimateGas records the CallMsg it was handed,
+// which is where the init code the estimate prices lands.
+type stubCreationChainReader struct {
+	ChainStateReader
+	gasPrice    *big.Int
+	estimateGas uint64
+	captured    ethereum.CallMsg
+}
+
+func (s *stubCreationChainReader) SuggestGasPrice(context.Context) (*big.Int, error) {
+	return s.gasPrice, nil
+}
+
+func (s *stubCreationChainReader) EstimateGas(_ context.Context, msg ethereum.CallMsg) (uint64, error) {
+	s.captured = msg
+	return s.estimateGas, nil
+}
+
+// The estimate must build init code from a placeholder owner, not from the
+// wallet address. Passing the wallet as its own owner (the fixed bug) prices
+// creation of a different, wallet-owned account; the gas happens to match,
+// which is why it was latent, so only the calldata reveals it.
+func TestEstimateWalletCreationGas_BuildsInitCodeFromDummyOwnerNotWallet(t *testing.T) {
+	logger, err := sdklogging.NewZapLogger(sdklogging.Development)
+	require.NoError(t, err)
+
+	stub := &stubCreationChainReader{gasPrice: big.NewInt(1_000_000_000), estimateGas: 300_000}
+	fe := &FeeEstimator{
+		logger: logger,
+		chain:  stub,
+		// MA v2 so EffectiveFactory resolves from config alone (no RPC).
+		smartWalletConfig: &config.SmartWalletConfig{AccountProvider: config.AccountProviderModularAccountV2},
+	}
+	wallet := common.HexToAddress("0x00000000000000000000000000000000000000a1")
+
+	_, _, err = fe.estimateWalletCreationGas(context.Background(), wallet)
+	require.NoError(t, err)
+
+	factory := aa.MAv2FactoryAddress()
+	_, dummyOwnerData, err := aa.DeriveInitCodeAuto(feeEstimationDummyOwner, factory, big.NewInt(0))
+	require.NoError(t, err)
+	_, walletOwnedData, err := aa.DeriveInitCodeAuto(wallet, factory, big.NewInt(0))
+	require.NoError(t, err)
+
+	require.NotNil(t, stub.captured.To)
+	require.Equal(t, factory, *stub.captured.To, "estimate must target the effective factory")
+	require.Equal(t, dummyOwnerData, stub.captured.Data,
+		"init code must be built from feeEstimationDummyOwner")
+	require.NotEqual(t, walletOwnedData, stub.captured.Data,
+		"must not price an account owned by the wallet itself — the bug this fix removes")
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,16 +1,28 @@
 package version
 
 var (
-	// Default values stamped into the binary when -ldflags doesn't
-	// override them. Both Makefile targets (`make build`, `make build-prod`)
-	// and the Dockerfile now derive these from `git describe` / `git rev-parse`
-	// at compile time, so these defaults only fire when the build path
-	// bypasses both (e.g. a one-off `go build ./...` without ldflags).
+	// Defaults for builds that bypass -ldflags. Every real build path stamps
+	// these instead:
 	//
-	// Keep `semver` here roughly in sync with the latest release tag as a
-	// safety net — if a build slips through without ldflags, /health will
-	// still report something plausible rather than ancient history.
-	semver   = "4.7.1"
+	//	make build / build-prod   SEMVER from `git describe --tags`
+	//	Dockerfile               ARG SEMVER, falling back to the git tag
+	//	publish-prod-docker.yml  SEMVER from the published release tag
+	//
+	// so these values only surface on a bare `go build ./...`, a `go run`, or
+	// a test binary.
+	//
+	// semver is deliberately "dev" rather than the latest release number. A
+	// stale release number here is worse than no number: an unstamped binary
+	// reporting "4.7.1" on /health and in Sentry's release tag is
+	// indistinguishable from a real 4.7.1, so a locally-built binary running
+	// somewhere it shouldn't looks like a legitimate deploy. "dev" says
+	// exactly what it is.
+	//
+	// This also removes a manual chore. Keeping the literal in step with the
+	// tag meant a `chore: bump version.go` commit on main after every release,
+	// which then had to be synced back to staging — upkeep for a value nothing
+	// reads in production.
+	semver   = "dev"
 	revision = "unknown"
 )
 


### PR DESCRIPTION
Promotes three fixes accumulated on `staging` since v4.9.0.

- **fix: emit only the EIP-712 domain fields the type declares (#699)** — the `/policies` prepare response no longer serializes empty `name`/`version`/`salt`, which strict clients (ethers v6) reject before the owner is asked to sign.
- **fix: factory override wins over an unresolvable default; stop pricing wallet creation as self-owned (#700)** — an explicit `factory_address` override now works on a chain whose default factory can't resolve (was a 500); wallet-creation gas no longer builds init code from the wallet as its own owner.
- **chore(version): default semver to dev (#693)** — an unstamped binary reports `dev` (concretely `dev@unknown`, since `revision` also defaults) instead of masquerading as a real release number in Sentry. Real builds stamp both `semver` and `revision` via ldflags, so this only affects bare `go build`/test binaries. Drops the manual post-release bump.

## Audit
- **Storage:** no `model/` or `schema.go` changes → additive/none (no migration).
- **Wire/API:** no proto changes; the #699 edit is response serialization only.
- **Effective diff:** +229/−22 across 7 files.
- Merge cuts a pre-release (~v4.9.1, `fix:`); it does **not** deploy — the /policies deploy is still gated on the avs-infra prerequisites tracked in #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

