### PR TITLE
fix(taskengine): preserve methodCalls contractAddress (Auto swap AA23)

### DIFF
--- a/FINDINGS_AA23_FACTORY_MISMATCH.md
+++ b/FINDINGS_AA23_FACTORY_MISMATCH.md
@@ -1,0 +1,285 @@
+# Findings — AA23 on Auto swap: factory mismatch was a red herring
+
+**Date:** 2026-08-05  
+**Follow-up to:** deferred-action AA23 fix on staging; initial hand-off titled
+“factory_address / account_provider mismatch”.  
+**Found during:** Studio live test of Auto-mode Uniswap swap, owner EOA
+`0xc60e71bd…c788`, Sepolia.  
+**Status:** **Resolved for case B (first-use MA v2)** — end-to-end UserOp mined
+on Sepolia under Gas Manager. Earlier Studio AA23 at Gas Manager was not a
+durable send-path bug (see “Resolution” below).
+
+---
+
+## TL;DR (current)
+
+| # | Issue | Verdict |
+|---|--------|---------|
+| 1 | Factory mismatch (`0xB99BC2` vs MA v2) | **Red herring** — raw config field; send path uses `EffectiveFactory` → `0x0000…17c6…` |
+| 2 | Studio Auto runner / picker | **Fixed (Studio)** — Auto on `0x46aD…`; v0.6 chip filtered |
+| 3 | Missing Alchemy paymaster policy | **Fixed (config)** — `alchemy_paymaster_policy_id` / `ALCHEMY_PAYMASTER_POLICY_ID` |
+| 4 | Zero balance without sponsorship | **Fixed as guard** — fail-fast + clear error; sponsorship is the product path |
+| 5 | Misleading boot logs / v0.6 paymaster probe | **Fixed (code)** — effective factory/EP/policy logged; MA v2 skips v0.6 probe |
+| 6 | Moralis “no API key” WARN | **Fixed (config)** — top-level `moralis_api_key` (fee USD only; not UserOps) |
+| 7 | AA23 on first-use MA v2 under Gas Manager | **Resolved** — full path verified; wallet deployed + swap mined |
+
+---
+
+## Resolution (2026-08-05 evening)
+
+### What failed in Studio (19:31 PDT)
+
+```
+v0.7 user operation prepared { sender: 0x46aD…, deferred: true, deploying: true,
+  wrap_execute_user_op: true, verification_gas_seed: 900000, paymaster_policy_set: true }
+→ gas manager declined to sponsor: alchemy_requestGasAndPaymasterAndData … AA23 reverted
+```
+
+Prepare log was correct. Failure was only at Alchemy’s sponsorship simulation.
+
+### What the investigation showed
+
+Replayed the **same grant + same approve/swap batch** against live Alchemy Sepolia
+with the real app key and policy `bf905871-…`:
+
+| Probe | Result |
+|-------|--------|
+| `eth_estimateUserOperationGas` (prod-like: 900k vgas, zero fees, deferred est sig) | **OK** |
+| `alchemy_requestGasAndPaymasterAndData` (same shape) | **OK** → paymaster `0x2cc0…B633` |
+| Fee seeding / higher vgas / body-sig cleared | All **OK** (not required) |
+| Off-allowlist simple `execute` | **AA23** (expected under hooks grant) |
+| Single on-allowlist `approve` | **OK** |
+
+Then ran the **real** gateway path `preset.SendUserOpMAv2` with the live
+controller key, MA v2 factory, deferred install + hooks, atomic batch, and
+Gas Manager policy:
+
+| Step | Result |
+|------|--------|
+| First-use send (deploy + deferred install + approve + swap) | **Mined** `status=1` |
+| Tx | [`0xb24e3a73…2755`](https://sepolia.etherscan.io/tx/0xb24e3a73a2d7ad7a243fcfdea167b8d7503d0823a1992cd090d90c261b4d2755) |
+| Account | [`0x46aD59…7BDd`](https://sepolia.etherscan.io/address/0x46aD59AFc8a21F0dfa3FE74C53A998b7550c7BDd) (81-byte proxy) |
+| Paymaster | `0x2cc0c7981D846b9F2a16276556f6e8cb52BfB633` |
+| Follow-up plain entity op (no deferred, still sponsored) | **Mined** `0xc51061a2…6a74` |
+
+On-chain logs for the first tx include factory create, session install / hooks,
+USDC `Approval`, USDC/`WETH` transfers, and EntryPoint `UserOperationEvent`
+success — i.e. the full Auto swap frame, not just deploy.
+
+### Why Studio still showed AA23 at 19:31
+
+The send path + grant + sponsorship request shape are **not** the durable
+bug. That single Studio failure did not reproduce under the same inputs once
+the live Alchemy key/policy were used in a direct probe. Most likely causes
+for the one-off AA23:
+
+1. **Transient Gas Manager / bundler simulation flake** (or brief rate-limit
+   surface as AA23).
+2. **Earlier misconfiguration windows** (policy unset, wrong runner) already
+   fixed before 19:31, leaving a residual flaky attempt in the same session.
+
+**Not** root causes for case B (ruled out by the successful replay):
+
+- Factory mismatch / wrong initCode  
+- Missing / mis-encoded deferred grant  
+- Allowlist mismatch on the production batch  
+- Zero `maxFeePerGas` before sponsorship (Gas Manager fills fees)  
+- Verification seed 900k under-seed for this install size  
+
+### Local Badger note after the probe
+
+The diagnostic `SendUserOpMAv2` **did not** call `OnApplied`, so the live
+gateway DB may still show policy `01kz8ebk…` as `pending` even though the
+install is on-chain. The send path already heals this: on the next op it sees
+the deferred carrier sequence consumed, records the grant applied, and
+continues as a plain entity operation. **No manual DB edit required** — retry
+Studio Auto on `0x46aD…`.
+
+---
+
+## Case split (historical, still useful)
+
+| # | Runner | Type | On-chain | Outcome |
+|---|--------|------|----------|---------|
+| A | `0x5d814Cc9…434f` | v0.6 SimpleAccount (salt 0) | **deployed** | Always AA23 under MA v2 path. Studio no longer offers this in Auto. Gateway **fails fast** with derive mismatch before bundler. |
+| B | `0x46aD59…7BDd` | MA v2 (salt 0) | **deployed (after probe)** | Correct factory/runner/grant. First-use + sponsorship **works**. |
+
+---
+
+## Evidence timeline (local Sepolia, PDT)
+
+### Early runs (15:36–15:41) — factory red herring + no Gas Manager
+
+- Debug logs printed raw `factory_address: 0xB99BC2…` while `entrypoint` was already v0.7.
+- Case A used v0.6 runner `0x5d81…` → AA23 (account-type mismatch).
+- Case B used MA v2 `0x46aD…` → AA23 at `eth_estimateUserOperationGas` with
+  `paymaster_policy_set: false` and zero wallet balance.
+
+### Live re-probe (same grant + production batch)
+
+| Step | Result |
+|------|--------|
+| Factory / derive / deferred / hooks | OK |
+| `eth_estimateUserOperationGas` (unsponsored) | **Succeeded** for approve+swap batch |
+| `eth_sendUserOperation` | Prefund fail (balance+deposit = 0) |
+
+So the durable pre-policy blocker was **sponsorship / prefund**, not factory
+mismatch.
+
+### After gateway fix + paymaster policy (19:05–19:31 PDT)
+
+| | Before | After policy |
+|---|--------|--------------|
+| Path | `eth_estimateUserOperationGas` | `alchemy_requestGasAndPaymasterAndData` |
+| Studio 19:31 | — | One AA23 at Gas Manager (did not reproduce) |
+
+### End-to-end success (post-19:31 investigation)
+
+| | Result |
+|---|--------|
+| Direct `RequestSponsorshipV07` / estimate matrix | All on-allowlist variants OK |
+| `SendUserOpMAv2` first-use | Tx `0xb24e3a73…` status 1 |
+| `SendUserOpMAv2` follow-up (installed entity) | Tx `0xc51061a2…` status 1 |
+
+---
+
+## Why “factory mismatch” is wrong
+
+1. **Config** fills `SmartWalletConfig.FactoryAddress` with the v0.6 default when
+   YAML omits it (`0xB99BC2…`).
+2. **Send path** uses `aa.EffectiveFactory` → MA v2 constant under
+   `modular_account_v2`.
+3. **Deploy-safety** refuses `sender ≠ derive(owner, factory, salt)` before the
+   bundler (covers case A and wrong salt).
+4. Wallet DB records already store the correct factory per runner
+   (`w:` / `wsalt:`).
+
+---
+
+## Session grant dig (case B is not “missing auth”)
+
+| Field | Value (MA v2 runner) |
+|-------|----------------------|
+| id | `01kz8ebkzgv2th9r32w9qrcw79` |
+| status | was `pending`; install applied on-chain by probe |
+| entity_id | 1 |
+| session_signer | gateway controller `0x82F2…` |
+| carrier_nonce | entity 1 + deferred + seq 0 (now consumed) |
+| requires_execute_user_op | true |
+| install | `installValidation` (`0x1bbf564c`) |
+| allowlist | router `exactInputSingle` + USDC `approve` |
+| spend cap | 500 USDC |
+
+Owner signature recovers as **raw EIP-712** to `0xc60e…` (correct for MA v2).
+
+Off-allowlist calldata (e.g. bare `execute` to the owner) **does** AA23 under a
+hooks grant; the Auto swap batch targets are on-allowlist.
+
+---
+
+## Implemented fixes (gateway / config)
+
+### Send-path guards & logging
+
+| Fix | Status |
+|-----|--------|
+| Log effective factory / provider / deferred / entity / policy / seed | ✅ |
+| Fail-fast derive mismatch (v0.6 runner, wrong salt) | ✅ |
+| Fail-fast missing session grant on MA v2 | ✅ |
+| Assert deferred `CarrierNonce == op.Nonce` | ✅ |
+| Fail-fast zero balance + no paymaster policy | ✅ |
+| Prefund error annotation → `ALCHEMY_PAYMASTER_POLICY_ID` | ✅ |
+| MA v2 does not claim v0.6 verifying paymaster is “in use” | ✅ |
+| Deferred est signature on sponsorship request | ✅ (required; plain dummy → AA23) |
+| Heal consumed carrier nonce → mark grant applied | ✅ |
+
+### Config / naming
+
+| Item | Canonical name |
+|------|----------------|
+| YAML | `alchemy_paymaster_policy_id` |
+| Env | `ALCHEMY_PAYMASTER_POLICY_ID` |
+| Go | `AlchemyPaymasterPolicyID` |
+
+Legacy names removed. Local + avs-infra use the canonical names; production
+Railway env: `ALCHEMY_PAYMASTER_POLICY_ID=bf905871-55d7-4197-a020-605302f4bc87`.
+
+### Boot / observability
+
+| Fix | Status |
+|-----|--------|
+| Effective factory / v0.7 EP / provider / policy on engine start | ✅ |
+| Skip v0.6 verifying-paymaster probe on MA v2 | ✅ |
+| Top-level `moralis_api_key` for fee USD | ✅ |
+
+### E2E / unit tests
+
+```bash
+go test -tags=integration -count=1 -v \
+  -run 'TestMAv2SendRejects|TestMAv2EffectiveFactoryOnSepolia' \
+  ./core/taskengine/
+```
+
+| Test | Proves |
+|------|--------|
+| `TestMAv2SendRejectsMissingSessionGrant_Sepolia` | No grant → hard error, not AA23 |
+| `TestMAv2SendRejectsSimpleAccountRunner_Sepolia` | Live v0.6 runner refused (derive) |
+| `TestMAv2SendRejectsUndeployedWrongSalt_Sepolia` | Wrong salt refused |
+| `TestMAv2SendRejectsZeroBalanceWithoutGasManager_Sepolia` | Zero balance + no policy → clear prefund error |
+| `TestMAv2EffectiveFactoryOnSepoliaConfig_IgnoresRawV06Factory` | Raw v0.6 factory ignored under MA v2 |
+
+Unit: `pkg/erc4337/preset/send_v07_guards_test.go`.  
+Full happy-path (keys + funded salt): `TestMAv2SessionGrantEndToEnd`.
+
+---
+
+## Studio (cross-repo)
+
+- Auto routes to MA v2 `0x46aD…`; consent / grant active (e.g. 500 USDC).  
+- Picker filter: v0.6 salt-0 chip removed/filtered.  
+- **Retry Auto** on this wallet — account is deployed, grant installed on-chain,
+  sponsorship works. Gateway will mark the stored grant applied on the next op
+  if DB still says `pending`.
+
+---
+
+## Reproduction / verify checklist
+
+1. Runner `0x46aD…` (not `0x5d81…`).
+2. Gateway boot: `paymaster_policy_set: true`, MA v2 skip of v0.6 paymaster probe.
+3. Prepare log: `effective_factory` MA v2, `deferred: true|false`, `paymaster_policy_set: true`.
+4. Expect success at Gas Manager + mined UserOp (sponsored by `0x2cc0…`).
+5. Explorer: first-use tx `0xb24e3a73…`, follow-up `0xc51061a2…`.
+
+---
+
+## Appendix — key addresses (Sepolia)
+
+| Role | Address |
+|------|---------|
+| Owner EOA | `0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788` |
+| Gateway controller / session signer | `0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB` |
+| MA v2 AccountFactory | `0x00000000000017c61b5bEe81050EC8eFc9c6fecd` |
+| v0.6 SimpleAccount factory (legacy default) | `0xB99BC2E399e06CddCF5E725c0ea341E8f0322834` |
+| EntryPoint v0.7 | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` |
+| MA v2 runner (Auto) | `0x46aD59AFc8a21F0dfa3FE74C53A998b7550c7BDd` |
+| v0.6 runner (do not use in Auto) | `0x5d814Cc9E94B2656f59Ee439D44AA1b6ca21434f` |
+| Uniswap router | `0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E` |
+| USDC | `0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` |
+| Alchemy paymaster | `0x2cc0c7981D846b9F2a16276556f6e8cb52BfB633` |
+| Alchemy paymaster policy | `bf905871-55d7-4197-a020-605302f4bc87` |
+| First-use success tx | `0xb24e3a73a2d7ad7a243fcfdea167b8d7503d0823a1992cd090d90c261b4d2755` |
+| Follow-up success tx | `0xc51061a22bfb73015cc13e049cdf867127b108c49dc1fb8e6d105f70d6486a74` |
+
+---
+
+## Supersedes
+
+1. Claim that AA23 on `0x46aD` was caused by building initCode with the v0.6
+   `factory_address` — **false** (misleading raw config logs).  
+2. Claim that the only remaining issue after deferred-action fix is factory
+   config — **false** (paymaster policy was required; first-use now proven).  
+3. Claim that unsponsored estimate always AA23s for this batch — **false**
+   (estimate can succeed; prefund blocks send without policy).  
+4. Claim that first-use under Gas Manager is a durable AA23 bug — **false**
+   (full path mined; Studio 19:31 did not reproduce).

--- a/aggregator/gas_manager_webhook.go
+++ b/aggregator/gas_manager_webhook.go
@@ -60,8 +60,9 @@ type gasManagerWebhookResponse struct {
 }
 
 // gasManagerWebhookConfig carries the deployment-supplied settings. Both come
-// from the gateway config (`gas_manager_policy_id`, `gas_manager_webhook_secret`),
-// which resolves them from YAML with an environment fallback — the same path
+// from the gateway config (`alchemy_paymaster_policy_id` /
+// ALCHEMY_PAYMASTER_POLICY_ID, `gas_manager_webhook_secret`), which resolves
+// them from YAML with an environment fallback — the same path
 // `moralis_api_key` and `alchemy_api_key` take, so a deployment configures
 // them in one place rather than two.
 type gasManagerWebhookConfig struct {
@@ -82,7 +83,7 @@ func (agg *Aggregator) gasManagerWebhookConfig() gasManagerWebhookConfig {
 		return gasManagerWebhookConfig{}
 	}
 	return gasManagerWebhookConfig{
-		PolicyID: strings.TrimSpace(agg.config.GasManagerPolicyID),
+		PolicyID: strings.TrimSpace(agg.config.AlchemyPaymasterPolicyID),
 		Secret:   strings.TrimSpace(agg.config.GasManagerWebhookSecret),
 	}
 }
@@ -136,7 +137,7 @@ func (agg *Aggregator) registerGasManagerWebhook(e *echo.Echo) {
 		// Without a policy id every request would be refused, which is worse
 		// than not serving the route: an operator who set the URL in the
 		// dashboard would see all sponsorship denied with no clue why.
-		agg.logger.Warn("gas manager webhook not mounted: gas_manager_policy_id is unset (env ALCHEMY_GAS_POLICY_ID)",
+		agg.logger.Warn("paymaster / gas manager webhook not mounted: alchemy_paymaster_policy_id is unset (env ALCHEMY_PAYMASTER_POLICY_ID)",
 			"path", gasManagerWebhookPath)
 		return
 	}

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -1,7 +1,9 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -27,15 +29,30 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		return err
 	}
 
+	// AA23 debug: capture the raw HTTP body BEFORE Bind consumes it, so we can
+	// prove whether Studio's JSON carried methodCalls[].contractAddress on the wire.
+	// Grep gateway.log for "AA23_DEBUG". Temporary — remove once root cause is closed.
+	rawBody, rawErr := io.ReadAll(ctx.Request().Body)
+	if rawErr == nil {
+		ctx.Request().Body = io.NopCloser(bytes.NewReader(rawBody))
+		s.logAA23RawBodyMethodCalls(rawBody)
+	} else if s.logger != nil {
+		s.logger.Warn("AA23_DEBUG RunNode: failed to read raw body", "error", rawErr.Error())
+	}
+
 	var body generated.RunNodeRequest
 	if err := ctx.Bind(&body); err != nil {
 		return badRequest("NODES_BAD_REQUEST", "Invalid request body", err.Error())
 	}
 
+	s.logAA23OpenAPIMethodCalls("post-bind", body.Node)
+
 	node, err := mapping.OpenAPIToProtoNode(body.Node)
 	if err != nil {
 		return badRequest("NODES_BAD_NODE", "Invalid node payload", err.Error())
 	}
+
+	s.logAA23ProtoMethodCalls("post-map", node)
 
 	req := &avsproto.RunNodeWithInputsReq{Node: node}
 	if body.ChainId != nil {
@@ -68,6 +85,165 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		return err
 	}
 	return ctx.JSON(http.StatusOK, runNodeRespToOpenAPI(resp))
+}
+
+// logAA23RawBodyMethodCalls extracts methodCalls[].contractAddress from the raw
+// HTTP JSON body before any struct Bind. Proves what Studio put on the wire.
+// Temporary AA23 instrumentation — remove when closed.
+func (s *Server) logAA23RawBodyMethodCalls(raw []byte) {
+	if s.logger == nil {
+		return
+	}
+	var probe struct {
+		Node *struct {
+			ID     string `json:"id"`
+			Type   string `json:"type"`
+			Config *struct {
+				ContractAddress string `json:"contractAddress"`
+				ChainID         int64  `json:"chainId"`
+				IsSimulated     *bool  `json:"isSimulated"`
+				MethodCalls     []struct {
+					MethodName      string   `json:"methodName"`
+					ContractAddress *string  `json:"contractAddress"`
+					MethodParams    []string `json:"methodParams"`
+				} `json:"methodCalls"`
+			} `json:"config"`
+		} `json:"node"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		s.logger.Warn("AA23_DEBUG RunNode.raw-body: JSON parse failed",
+			"error", err.Error(), "body_bytes", len(raw))
+		return
+	}
+	if probe.Node == nil || probe.Node.Config == nil {
+		s.logger.Info("AA23_DEBUG RunNode.raw-body: no contractWrite config",
+			"body_bytes", len(raw))
+		return
+	}
+	cfg := probe.Node.Config
+	type callSnap struct {
+		Index              int    `json:"index"`
+		MethodName         string `json:"methodName"`
+		HasContractAddress bool   `json:"hasContractAddress"`
+		ContractAddress    string `json:"contractAddress"`
+		MethodParamsCount  int    `json:"methodParamsCount"`
+	}
+	calls := make([]callSnap, 0, len(cfg.MethodCalls))
+	for i, mc := range cfg.MethodCalls {
+		snap := callSnap{
+			Index:             i,
+			MethodName:        mc.MethodName,
+			MethodParamsCount: len(mc.MethodParams),
+		}
+		if mc.ContractAddress != nil {
+			snap.HasContractAddress = true
+			snap.ContractAddress = *mc.ContractAddress
+		}
+		calls = append(calls, snap)
+	}
+	isSim := interface{}(nil)
+	if cfg.IsSimulated != nil {
+		isSim = *cfg.IsSimulated
+	}
+	s.logger.Info("AA23_DEBUG RunNode.raw-body",
+		"body_bytes", len(raw),
+		"node_id", probe.Node.ID,
+		"node_type", probe.Node.Type,
+		"node_contract", cfg.ContractAddress,
+		"chain_id", cfg.ChainID,
+		"is_simulated", isSim,
+		"method_call_count", len(calls),
+		"method_calls", calls,
+	)
+}
+
+// logAA23OpenAPIMethodCalls logs methodCalls after Echo Bind + AsContractWriteNode.
+// Temporary AA23 instrumentation.
+func (s *Server) logAA23OpenAPIMethodCalls(stage string, n generated.Node) {
+	if s.logger == nil {
+		return
+	}
+	if n.Type != generated.NodeTypeContractWrite {
+		s.logger.Info("AA23_DEBUG RunNode."+stage+": not contractWrite",
+			"node_id", n.Id, "node_type", string(n.Type))
+		return
+	}
+	cw, err := n.AsContractWriteNode()
+	if err != nil || cw.Config == nil {
+		s.logger.Warn("AA23_DEBUG RunNode."+stage+": AsContractWriteNode failed",
+			"node_id", n.Id, "error", errString(err))
+		return
+	}
+	cfg := cw.Config
+	type callSnap struct {
+		Index              int    `json:"index"`
+		MethodName         string `json:"methodName"`
+		HasContractAddress bool   `json:"hasContractAddress"`
+		ContractAddress    string `json:"contractAddress"`
+	}
+	var calls []callSnap
+	if cfg.MethodCalls != nil {
+		for i, mc := range *cfg.MethodCalls {
+			snap := callSnap{Index: i, MethodName: mc.MethodName}
+			if mc.ContractAddress != nil {
+				snap.HasContractAddress = true
+				snap.ContractAddress = string(*mc.ContractAddress)
+			}
+			calls = append(calls, snap)
+		}
+	}
+	s.logger.Info("AA23_DEBUG RunNode."+stage,
+		"node_id", n.Id,
+		"node_contract", string(cfg.ContractAddress),
+		"chain_id", cfg.ChainId,
+		"method_call_count", len(calls),
+		"method_calls", calls,
+	)
+}
+
+// logAA23ProtoMethodCalls logs methodCalls after OpenAPI→proto mapping.
+// Temporary AA23 instrumentation.
+func (s *Server) logAA23ProtoMethodCalls(stage string, node *avsproto.TaskNode) {
+	if s.logger == nil || node == nil {
+		return
+	}
+	cw := node.GetContractWrite()
+	if cw == nil || cw.GetConfig() == nil {
+		s.logger.Info("AA23_DEBUG RunNode."+stage+": no ContractWrite config",
+			"node_id", node.GetId(), "type", node.GetType().String())
+		return
+	}
+	cfg := cw.GetConfig()
+	type callSnap struct {
+		Index              int    `json:"index"`
+		MethodName         string `json:"methodName"`
+		HasContractAddress bool   `json:"hasContractAddress"`
+		ContractAddress    string `json:"contractAddress"`
+	}
+	calls := make([]callSnap, 0, len(cfg.GetMethodCalls()))
+	for i, mc := range cfg.GetMethodCalls() {
+		addr := mc.GetContractAddress()
+		calls = append(calls, callSnap{
+			Index:              i,
+			MethodName:         mc.GetMethodName(),
+			HasContractAddress: mc.ContractAddress != nil && addr != "",
+			ContractAddress:    addr,
+		})
+	}
+	s.logger.Info("AA23_DEBUG RunNode."+stage,
+		"node_id", node.GetId(),
+		"node_contract", cfg.GetContractAddress(),
+		"chain_id", cfg.GetChainId(),
+		"method_call_count", len(calls),
+		"method_calls", calls,
+	)
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // openAPIERC20OverridesToProto maps the REST ERC20StateOverride list onto the

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -32,12 +32,15 @@ func (s *Server) RunNode(ctx echo.Context) error {
 	// AA23 debug: capture the raw HTTP body BEFORE Bind consumes it, so we can
 	// prove whether Studio's JSON carried methodCalls[].contractAddress on the wire.
 	// Grep gateway.log for "AA23_DEBUG". Temporary — remove once root cause is closed.
+	// Always restore Body so Bind still works even when ReadAll fails mid-stream.
 	rawBody, rawErr := io.ReadAll(ctx.Request().Body)
-	if rawErr == nil {
-		ctx.Request().Body = io.NopCloser(bytes.NewReader(rawBody))
+	ctx.Request().Body = io.NopCloser(bytes.NewReader(rawBody))
+	if rawErr != nil {
+		if s.logger != nil {
+			s.logger.Warn("AA23_DEBUG RunNode: failed to read raw body", "error", rawErr.Error(), "bytes_read", len(rawBody))
+		}
+	} else {
 		s.logAA23RawBodyMethodCalls(rawBody)
-	} else if s.logger != nil {
-		s.logger.Warn("AA23_DEBUG RunNode: failed to read raw body", "error", rawErr.Error())
 	}
 
 	var body generated.RunNodeRequest
@@ -116,7 +119,7 @@ func (s *Server) logAA23RawBodyMethodCalls(raw []byte) {
 		return
 	}
 	if probe.Node == nil || probe.Node.Config == nil {
-		s.logger.Info("AA23_DEBUG RunNode.raw-body: no contractWrite config",
+		s.logger.Debug("AA23_DEBUG RunNode.raw-body: no contractWrite config",
 			"body_bytes", len(raw))
 		return
 	}
@@ -145,7 +148,7 @@ func (s *Server) logAA23RawBodyMethodCalls(raw []byte) {
 	if cfg.IsSimulated != nil {
 		isSim = *cfg.IsSimulated
 	}
-	s.logger.Info("AA23_DEBUG RunNode.raw-body",
+	s.logger.Debug("AA23_DEBUG RunNode.raw-body",
 		"body_bytes", len(raw),
 		"node_id", probe.Node.ID,
 		"node_type", probe.Node.Type,
@@ -164,7 +167,7 @@ func (s *Server) logAA23OpenAPIMethodCalls(stage string, n generated.Node) {
 		return
 	}
 	if n.Type != generated.NodeTypeContractWrite {
-		s.logger.Info("AA23_DEBUG RunNode."+stage+": not contractWrite",
+		s.logger.Debug("AA23_DEBUG RunNode."+stage+": not contractWrite",
 			"node_id", n.Id, "node_type", string(n.Type))
 		return
 	}
@@ -192,7 +195,7 @@ func (s *Server) logAA23OpenAPIMethodCalls(stage string, n generated.Node) {
 			calls = append(calls, snap)
 		}
 	}
-	s.logger.Info("AA23_DEBUG RunNode."+stage,
+	s.logger.Debug("AA23_DEBUG RunNode."+stage,
 		"node_id", n.Id,
 		"node_contract", string(cfg.ContractAddress),
 		"chain_id", cfg.ChainId,
@@ -209,7 +212,7 @@ func (s *Server) logAA23ProtoMethodCalls(stage string, node *avsproto.TaskNode) 
 	}
 	cw := node.GetContractWrite()
 	if cw == nil || cw.GetConfig() == nil {
-		s.logger.Info("AA23_DEBUG RunNode."+stage+": no ContractWrite config",
+		s.logger.Debug("AA23_DEBUG RunNode."+stage+": no ContractWrite config",
 			"node_id", node.GetId(), "type", node.GetType().String())
 		return
 	}
@@ -230,7 +233,7 @@ func (s *Server) logAA23ProtoMethodCalls(stage string, node *avsproto.TaskNode) 
 			ContractAddress:    addr,
 		})
 	}
-	s.logger.Info("AA23_DEBUG RunNode."+stage,
+	s.logger.Debug("AA23_DEBUG RunNode."+stage,
 		"node_id", node.GetId(),
 		"node_contract", cfg.GetContractAddress(),
 		"chain_id", cfg.GetChainId(),

--- a/aggregator/task_engine.go
+++ b/aggregator/task_engine.go
@@ -45,10 +45,12 @@ import (
 	"time"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/apqueue"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/services"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine/macros"
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
@@ -58,12 +60,25 @@ func (agg *Aggregator) stopTaskEngine() {
 }
 
 func (agg *Aggregator) startTaskEngine(ctx context.Context) {
-	agg.logger.Info("Start execution engine",
-		"bundler", agg.config.SmartWallet.BundlerURL,
-		"factory", agg.config.SmartWallet.FactoryAddress,
-		"entrypoint", agg.config.SmartWallet.EntrypointAddress,
-		"paymaster", agg.config.SmartWallet.PaymasterAddress,
-	)
+	sw := agg.config.SmartWallet
+	if sw == nil {
+		agg.logger.Info("Start execution engine", "smart_wallet", "nil")
+	} else {
+		effectiveFactory := common.Address{}
+		if f, err := aa.EffectiveFactory(sw); err == nil {
+			effectiveFactory = f
+		}
+		// Prefer effective (provider-aware) values over raw yaml fields so boot
+		// logs do not look like a v0.6 SimpleAccount stack when MA v2 is on.
+		agg.logger.Info("Start execution engine",
+			"account_provider", sw.AccountProviderName(),
+			"effective_factory", effectiveFactory.Hex(),
+			"config_factory_address", sw.FactoryAddress.Hex(),
+			"entry_point", sw.EntryPointAddress().Hex(),
+			"paymaster_policy_set", sw.AlchemyPaymasterPolicyID != "",
+			"legacy_v06_paymaster", sw.PaymasterAddress.Hex(),
+		)
+	}
 
 	// ChainIDs lets the cleanup loop locate tasks across every chain bucket
 	// in chain-scoped storage. Single-chain aggregator: just its own chain.

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -47,14 +47,13 @@ tenderly_account: ""
 tenderly_project: ""
 tenderly_access_key: ""
 
-# Optional: Alchemy Gas Manager sponsorship webhook.
+# Optional: Alchemy paymaster policy sponsorship (Gas Manager dashboard).
 #
-# gas_manager_policy_id is the policy this gateway answers sponsorship
-# questions for. The webhook at POST /webhooks/gas-manager is mounted ONLY
-# when this is set — leaving it empty is the normal local-dev state, and the
-# route then 404s rather than silently refusing every sponsorship.
+# alchemy_paymaster_policy_id — Policy UUID from Alchemy (Gas Manager → policy).
+# Used for MA v2 UserOp sponsorship. Env override: ALCHEMY_PAYMASTER_POLICY_ID.
+# The webhook at POST /webhooks/gas-manager is mounted ONLY when this is set.
 #
-# Two things to know before pointing a real Gas Manager policy at a gateway:
+# Two things to know before pointing a real policy at a gateway:
 #   - the policy's "Sponsor on error or timeout" must stay OFF, so an
 #     unreachable gateway denies sponsorship instead of handing out unlimited
 #     gas; which also means
@@ -68,16 +67,21 @@ tenderly_access_key: ""
 # READ ONLY: a read/write key can delete the policy that funds sponsorship.
 alchemy_api_secret: ""
 
-gas_manager_policy_id: ""
+alchemy_paymaster_policy_id: ""
 # Echoed back as the request's webhookData. The webhook cannot sit behind the
 # REST JWT (Alchemy has no token), so this is its only caller authentication.
 # Empty disables the check.
 gas_manager_webhook_secret: ""
 
+# Token price service for fee USD lines / estimateFees. Env: MORALIS_API_KEY.
+# Distinct from macros.secrets.moralis_api_key (workflow templates only).
+moralis_api_key: ${MORALIS_API_KEY}
+
 # Top-level smart_wallet — required by the aa package globals (factory +
-# entrypoint), the startup paymaster probe, and any cmd tool that takes
-# the aggregator's default chain context. Points at Sepolia to match the
-# AVS chain above. Per-workflow execution still routes via chains[].
+# entrypoint). On modular_account_v2 chains the v0.6 verifying-paymaster
+# probe is skipped; Alchemy paymaster policy sponsors MA v2 UserOps.
+# Points at Sepolia to match the AVS chain above. Per-workflow execution
+# still routes via chains[].
 smart_wallet:
   eth_rpc_url:            ${ETH_RPC_URL}
   # bundler_provider selects the bundler; 'alchemy' is both the code default and

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -151,12 +151,13 @@ type Config struct {
 	// READ; a read/write key can delete the policy that funds sponsorship.
 	AlchemyAPISecret string `yaml:"alchemy_api_secret"`
 
-	// GasManagerPolicyID is the Alchemy Gas Manager policy this gateway
-	// answers sponsorship questions for. The Gas Manager "custom rules"
-	// webhook is only mounted when this is set — a mounted route that
-	// refuses everything is indistinguishable from a broken chain in the
-	// dashboard, whereas an unmounted route 404s loudly.
-	GasManagerPolicyID string `yaml:"gas_manager_policy_id"`
+	// AlchemyPaymasterPolicyID is the Alchemy Gas Manager / paymaster policy
+	// UUID used for ERC-4337 sponsorship (yaml alchemy_paymaster_policy_id,
+	// env ALCHEMY_PAYMASTER_POLICY_ID). The Gas Manager "custom rules" webhook
+	// is only mounted when this is set — a mounted route that refuses
+	// everything is indistinguishable from a broken chain in the dashboard,
+	// whereas an unmounted route 404s loudly.
+	AlchemyPaymasterPolicyID string
 
 	// GasManagerWebhookSecret, when set, must be echoed as the webhook
 	// request's webhookData. The webhook cannot sit behind the REST JWT
@@ -253,11 +254,11 @@ type SmartWalletConfig struct {
 	// legacy v0.6 SimpleAccount fork. See AccountProviderName.
 	AccountProvider string
 
-	// GasManagerPolicyID is copied down from the top-level config so the v0.7
-	// send path — which is handed only a SmartWalletConfig — can request
+	// AlchemyPaymasterPolicyID is copied down from the top-level config so the
+	// v0.7 send path — which is handed only a SmartWalletConfig — can request
 	// sponsorship without reaching back up. Empty means unsponsored: the
 	// operation is priced by estimation and the account pays its own gas.
-	GasManagerPolicyID string
+	AlchemyPaymasterPolicyID string
 }
 
 // Bundler provider identifiers for SmartWalletConfig.BundlerProvider.
@@ -489,10 +490,10 @@ type ConfigRaw struct {
 	// Moralis Web3 Data API key for token price lookup (optional)
 	MoralisApiKey string `yaml:"moralis_api_key"`
 
-	// Alchemy Gas Manager sponsorship webhook + admin API (optional; see Config)
-	AlchemyAPISecret        string `yaml:"alchemy_api_secret"`
-	GasManagerPolicyID      string `yaml:"gas_manager_policy_id"`
-	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
+	// Alchemy paymaster policy (Gas Manager) + admin API (optional; see Config)
+	AlchemyAPISecret         string `yaml:"alchemy_api_secret"`
+	AlchemyPaymasterPolicyID string `yaml:"alchemy_paymaster_policy_id"`
+	GasManagerWebhookSecret  string `yaml:"gas_manager_webhook_secret"`
 
 	// Fee structure: execution_fee + COGS + value tiers
 	// Pointer fields: nil = use default, explicit 0.0 = free tier
@@ -736,20 +737,20 @@ func NewConfig(configFilePath string) (*Config, error) {
 		PartnerAssertionAudience: configRaw.PartnerAssertionAudience,
 
 		SmartWallet: &SmartWalletConfig{
-			EthRpcUrl:            configRaw.SmartWallet.EthRpcUrl,
-			EthWsUrl:             configRaw.SmartWallet.EthWsUrl,
-			BundlerURL:           configRaw.SmartWallet.BundlerURL,
-			BundlerProvider:      configRaw.SmartWallet.BundlerProvider,
-			AccountProvider:      configRaw.SmartWallet.AccountProvider,
-			AlchemyAPIKey:        configRaw.SmartWallet.AlchemyAPIKey,
-			FactoryAddress:       common.HexToAddress(firstNonEmpty(configRaw.SmartWallet.FactoryAddress, DefaultFactoryProxyAddressHex)),
-			EntrypointAddress:    common.HexToAddress(firstNonEmpty(configRaw.SmartWallet.EntrypointAddress, DefaultEntrypointAddressHex)),
-			ChainID:              smartWalletChainId.Int64(), // Use smart wallet chain ID, not EigenLayer chain ID (prevents cross-chain configuration errors for Base aggregator)
-			ControllerPrivateKey: controllerPrivateKey,
-			PaymasterAddress:     common.HexToAddress(configRaw.SmartWallet.PaymasterAddress),
-			WhitelistAddresses:   convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
-			MaxWalletsPerOwner:   configRaw.SmartWallet.MaxWalletsPerOwner,
-			GasManagerPolicyID:   firstNonEmpty(configRaw.GasManagerPolicyID, os.Getenv("ALCHEMY_GAS_POLICY_ID")),
+			EthRpcUrl:                configRaw.SmartWallet.EthRpcUrl,
+			EthWsUrl:                 configRaw.SmartWallet.EthWsUrl,
+			BundlerURL:               configRaw.SmartWallet.BundlerURL,
+			BundlerProvider:          configRaw.SmartWallet.BundlerProvider,
+			AccountProvider:          configRaw.SmartWallet.AccountProvider,
+			AlchemyAPIKey:            configRaw.SmartWallet.AlchemyAPIKey,
+			FactoryAddress:           common.HexToAddress(firstNonEmpty(configRaw.SmartWallet.FactoryAddress, DefaultFactoryProxyAddressHex)),
+			EntrypointAddress:        common.HexToAddress(firstNonEmpty(configRaw.SmartWallet.EntrypointAddress, DefaultEntrypointAddressHex)),
+			ChainID:                  smartWalletChainId.Int64(), // Use smart wallet chain ID, not EigenLayer chain ID (prevents cross-chain configuration errors for Base aggregator)
+			ControllerPrivateKey:     controllerPrivateKey,
+			PaymasterAddress:         common.HexToAddress(configRaw.SmartWallet.PaymasterAddress),
+			WhitelistAddresses:       convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
+			MaxWalletsPerOwner:       configRaw.SmartWallet.MaxWalletsPerOwner,
+			AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
 			// PaymasterOwnerAddress will be populated below by calling owner() on the paymaster contract
 		},
 
@@ -767,10 +768,10 @@ func NewConfig(configFilePath string) (*Config, error) {
 		// Pass through Moralis API key (from YAML or environment variable)
 		MoralisApiKey: firstNonEmpty(configRaw.MoralisApiKey, os.Getenv("MORALIS_API_KEY")),
 
-		// Gas Manager sponsorship webhook + admin API (from YAML or environment)
-		AlchemyAPISecret:        firstNonEmpty(configRaw.AlchemyAPISecret, os.Getenv("ALCHEMY_API_SECRET")),
-		GasManagerPolicyID:      firstNonEmpty(configRaw.GasManagerPolicyID, os.Getenv("ALCHEMY_GAS_POLICY_ID")),
-		GasManagerWebhookSecret: firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
+		// Alchemy paymaster policy (Gas Manager) + admin API
+		AlchemyAPISecret:         firstNonEmpty(configRaw.AlchemyAPISecret, os.Getenv("ALCHEMY_API_SECRET")),
+		AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
+		GasManagerWebhookSecret:  firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
 
 		// Initialize fee rates - use defaults if no YAML config provided
 		FeeRates: loadFeeRatesFromConfig(configRaw.FeeRates),
@@ -814,44 +815,20 @@ func NewConfig(configFilePath string) (*Config, error) {
 		}
 	}
 
+	// The v0.6 verifying-paymaster probe (owner + verifyingSigner) only applies
+	// to SimpleAccount chains. MA v2 sponsors via AlchemyPaymasterPolicyID and
+	// ignores smart_wallet.paymaster_address on the send path — probing the
+	// legacy contract at boot only produced misleading "paymaster loaded"
+	// logs and forced a live RPC dependency for an unused address.
 	if config.SmartWallet != nil && config.SmartWallet.PaymasterAddress != (common.Address{}) {
-		paymasterOwner, err := fetchPaymasterOwner(smartWalletRpcClient, config.SmartWallet.PaymasterAddress)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"paymaster %s is unreachable on RPC %s (owner() call failed: %w) — "+
-					"verify the paymaster address is deployed on this chain, and that the "+
-					"smart_wallet.eth_rpc_url points at the chain where the paymaster lives",
-				config.SmartWallet.PaymasterAddress.Hex(),
-				configRaw.SmartWallet.EthRpcUrl,
-				err,
+		if config.SmartWallet.UsesModularAccountV2() {
+			logger.Info("Skipping v0.6 verifying-paymaster probe on modular_account_v2; sponsorship uses alchemy_paymaster_policy_id",
+				"paymaster_address_ignored", config.SmartWallet.PaymasterAddress.Hex(),
+				"paymaster_policy_set", config.AlchemyPaymasterPolicyID != "",
 			)
+		} else if err := probeVerifyingPaymaster(logger, smartWalletRpcClient, config.SmartWallet, configRaw.SmartWallet.EthRpcUrl); err != nil {
+			return nil, err
 		}
-		config.SmartWallet.PaymasterOwnerAddress = paymasterOwner
-		logger.Info("Paymaster owner address loaded", "paymaster", config.SmartWallet.PaymasterAddress, "owner", paymasterOwner.Hex())
-
-		// The aggregator signs the paymaster hash with the controller key, so the
-		// paymaster's verifyingSigner must equal the controller address or every
-		// sponsored UserOp fails at signing time. Probe it at startup (alongside
-		// owner()) so a key/paymaster-tier mismatch is fatal here, not silent until
-		// the first user transfer (Sentry EIGENLAYER-AVS-1W).
-		verifyingSigner, err := fetchPaymasterVerifyingSigner(smartWalletRpcClient, config.SmartWallet.PaymasterAddress)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"paymaster %s verifyingSigner() call failed on RPC %s: %w",
-				config.SmartWallet.PaymasterAddress.Hex(), configRaw.SmartWallet.EthRpcUrl, err,
-			)
-		}
-		if verifyingSigner != config.SmartWallet.ControllerAddress {
-			return nil, fmt.Errorf(
-				"paymaster %s verifyingSigner (%s) does not match controller address (%s) — "+
-					"the controller_private_key and paymaster_address belong to different "+
-					"network tiers (e.g. testnet controller paired with the mainnet paymaster); "+
-					"set the controller key whose address equals the paymaster's verifyingSigner",
-				config.SmartWallet.PaymasterAddress.Hex(),
-				verifyingSigner.Hex(), config.SmartWallet.ControllerAddress.Hex(),
-			)
-		}
-		logger.Info("Paymaster verifyingSigner verified", "paymaster", config.SmartWallet.PaymasterAddress, "verifyingSigner", verifyingSigner.Hex())
 	}
 
 	// Gateway mode: parse per-chain configs
@@ -868,7 +845,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			// Sponsorship is configured once for the gateway, not per chain, but
 			// the v0.7 send path is only ever handed a SmartWalletConfig. Push
 			// the policy down so every chain can reach it.
-			chainCfg.SmartWallet.GasManagerPolicyID = config.GasManagerPolicyID
+			chainCfg.SmartWallet.AlchemyPaymasterPolicyID = config.AlchemyPaymasterPolicyID
 			config.Chains = append(config.Chains, chainCfg)
 		}
 
@@ -954,6 +931,12 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// resolveAlchemyPaymasterPolicyID returns the Alchemy paymaster policy UUID
+// from yaml alchemy_paymaster_policy_id or env ALCHEMY_PAYMASTER_POLICY_ID.
+func resolveAlchemyPaymasterPolicyID(raw ConfigRaw) string {
+	return firstNonEmpty(raw.AlchemyPaymasterPolicyID, os.Getenv("ALCHEMY_PAYMASTER_POLICY_ID"))
 }
 
 func ReadYamlConfig(path string, o interface{}) error {
@@ -1106,6 +1089,52 @@ func fetchPaymasterVerifyingSigner(client paymasterCaller, paymasterAddress comm
 	return callPaymasterAddressGetter(client, paymasterAddress, paymasterVerifyingSignerABI, "verifyingSigner")
 }
 
+// probeVerifyingPaymaster loads owner() and verifyingSigner() on a v0.6
+// VerifyingPaymaster and ensures verifyingSigner equals the controller.
+// Only call this for simple_account chains — MA v2 does not use this contract.
+func probeVerifyingPaymaster(
+	logger sdklogging.Logger,
+	client paymasterCaller,
+	sw *SmartWalletConfig,
+	rpcURL string,
+) error {
+	if sw == nil || sw.PaymasterAddress == (common.Address{}) {
+		return nil
+	}
+	paymasterOwner, err := fetchPaymasterOwner(client, sw.PaymasterAddress)
+	if err != nil {
+		return fmt.Errorf(
+			"paymaster %s is unreachable on RPC %s (owner() call failed: %w) — "+
+				"verify the paymaster address is deployed on this chain, and that the "+
+				"eth_rpc_url points at the chain where the paymaster lives",
+			sw.PaymasterAddress.Hex(), rpcURL, err,
+		)
+	}
+	sw.PaymasterOwnerAddress = paymasterOwner
+	logger.Info("Paymaster owner address loaded",
+		"paymaster", sw.PaymasterAddress.Hex(), "owner", paymasterOwner.Hex())
+
+	verifyingSigner, err := fetchPaymasterVerifyingSigner(client, sw.PaymasterAddress)
+	if err != nil {
+		return fmt.Errorf(
+			"paymaster %s verifyingSigner() call failed on RPC %s: %w",
+			sw.PaymasterAddress.Hex(), rpcURL, err,
+		)
+	}
+	if verifyingSigner != sw.ControllerAddress {
+		return fmt.Errorf(
+			"paymaster %s verifyingSigner (%s) does not match controller address (%s) — "+
+				"the controller_private_key and paymaster_address belong to different "+
+				"network tiers (e.g. testnet controller paired with the mainnet paymaster); "+
+				"set the controller key whose address equals the paymaster's verifyingSigner",
+			sw.PaymasterAddress.Hex(), verifyingSigner.Hex(), sw.ControllerAddress.Hex(),
+		)
+	}
+	logger.Info("Paymaster verifyingSigner verified",
+		"paymaster", sw.PaymasterAddress.Hex(), "verifyingSigner", verifyingSigner.Hex())
+	return nil
+}
+
 // parseChainConfig converts a raw YAML chain config into a runtime ChainConfig.
 // Unlike the top-level SmartWalletConfig, we don't connect to the chain RPC here —
 // that's the worker's responsibility. We just parse and validate the config fields.
@@ -1191,51 +1220,22 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 	// BundlerConfigured() was false and the probe was skipped by accident.
 	hasPaymaster := chainCfg.SmartWallet.PaymasterAddress != (common.Address{})
 	if hasPaymaster && chainCfg.SmartWallet.BundlerConfigured() && chainCfg.SmartWallet.EthRpcUrl != "" {
-		rpcClient, err := ethclient.Dial(chainCfg.SmartWallet.EthRpcUrl)
-		if err != nil {
-			return nil, fmt.Errorf("dial RPC %s for chain %s (chain_id=%d): %w",
-				chainCfg.SmartWallet.EthRpcUrl, raw.Name, raw.ChainID, err)
-		}
-		defer rpcClient.Close()
-
-		paymasterOwner, err := fetchPaymasterOwner(rpcClient, chainCfg.SmartWallet.PaymasterAddress)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"chain %s (chain_id=%d): paymaster %s is unreachable on RPC %s "+
-					"(owner() call failed: %w) — verify the paymaster address is deployed "+
-					"on this chain, and that the chain's eth_rpc_url points at the same chain "+
-					"as the paymaster",
-				raw.Name, raw.ChainID,
-				chainCfg.SmartWallet.PaymasterAddress.Hex(),
-				chainCfg.SmartWallet.EthRpcUrl,
-				err,
+		if chainCfg.SmartWallet.UsesModularAccountV2() {
+			logger.Info("Skipping v0.6 verifying-paymaster probe on modular_account_v2 chain",
+				"chain_id", chainCfg.ChainID,
+				"name", chainCfg.Name,
+				"paymaster_address_ignored", chainCfg.SmartWallet.PaymasterAddress.Hex(),
 			)
-		}
-		chainCfg.SmartWallet.PaymasterOwnerAddress = paymasterOwner
-
-		// The controller key must match this paymaster's verifyingSigner, or
-		// sponsored UserOps on this chain fail at signing time. This is the
-		// per-chain analogue of the top-level probe — it catches a controller
-		// key from the wrong network tier (Sentry EIGENLAYER-AVS-1W: the
-		// gateway's testnet controller paired with the mainnet paymaster on
-		// Ethereum + Base).
-		verifyingSigner, err := fetchPaymasterVerifyingSigner(rpcClient, chainCfg.SmartWallet.PaymasterAddress)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"chain %s (chain_id=%d): paymaster %s verifyingSigner() call failed on RPC %s: %w",
-				raw.Name, raw.ChainID, chainCfg.SmartWallet.PaymasterAddress.Hex(),
-				chainCfg.SmartWallet.EthRpcUrl, err,
-			)
-		}
-		if verifyingSigner != chainCfg.SmartWallet.ControllerAddress {
-			return nil, fmt.Errorf(
-				"chain %s (chain_id=%d): paymaster %s verifyingSigner (%s) does not match "+
-					"controller address (%s) — the controller_private_key and paymaster_address "+
-					"belong to different network tiers; set the controller key whose address "+
-					"equals the paymaster's verifyingSigner",
-				raw.Name, raw.ChainID, chainCfg.SmartWallet.PaymasterAddress.Hex(),
-				verifyingSigner.Hex(), chainCfg.SmartWallet.ControllerAddress.Hex(),
-			)
+		} else {
+			rpcClient, err := ethclient.Dial(chainCfg.SmartWallet.EthRpcUrl)
+			if err != nil {
+				return nil, fmt.Errorf("dial RPC %s for chain %s (chain_id=%d): %w",
+					chainCfg.SmartWallet.EthRpcUrl, raw.Name, raw.ChainID, err)
+			}
+			defer rpcClient.Close()
+			if err := probeVerifyingPaymaster(logger, rpcClient, chainCfg.SmartWallet, chainCfg.SmartWallet.EthRpcUrl); err != nil {
+				return nil, fmt.Errorf("chain %s (chain_id=%d): %w", raw.Name, raw.ChainID, err)
+			}
 		}
 	}
 
@@ -1243,6 +1243,7 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 		"chain_id", chainCfg.ChainID,
 		"name", chainCfg.Name,
 		"worker_addr", chainCfg.WorkerAddr,
+		"account_provider", chainCfg.SmartWallet.AccountProviderName(),
 		"bundler_provider", chainCfg.SmartWallet.ProviderName(),
 		"controller", chainCfg.SmartWallet.ControllerAddress.Hex(),
 		"paymaster_owner", chainCfg.SmartWallet.PaymasterOwnerAddress.Hex())

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -493,7 +493,10 @@ type ConfigRaw struct {
 	// Alchemy paymaster policy (Gas Manager) + admin API (optional; see Config)
 	AlchemyAPISecret         string `yaml:"alchemy_api_secret"`
 	AlchemyPaymasterPolicyID string `yaml:"alchemy_paymaster_policy_id"`
-	GasManagerWebhookSecret  string `yaml:"gas_manager_webhook_secret"`
+	// GasManagerPolicyID is a legacy yaml alias for alchemy_paymaster_policy_id.
+	// Still resolved as a fallback so existing configs keep sponsorship.
+	GasManagerPolicyID      string `yaml:"gas_manager_policy_id"`
+	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
 
 	// Fee structure: execution_fee + COGS + value tiers
 	// Pointer fields: nil = use default, explicit 0.0 = free tier
@@ -933,10 +936,17 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-// resolveAlchemyPaymasterPolicyID returns the Alchemy paymaster policy UUID
-// from yaml alchemy_paymaster_policy_id or env ALCHEMY_PAYMASTER_POLICY_ID.
+// resolveAlchemyPaymasterPolicyID returns the Alchemy paymaster policy UUID.
+// Canonical: yaml alchemy_paymaster_policy_id / env ALCHEMY_PAYMASTER_POLICY_ID.
+// Legacy aliases still accepted so existing deployments do not silently lose
+// sponsorship: yaml gas_manager_policy_id / env ALCHEMY_GAS_POLICY_ID.
 func resolveAlchemyPaymasterPolicyID(raw ConfigRaw) string {
-	return firstNonEmpty(raw.AlchemyPaymasterPolicyID, os.Getenv("ALCHEMY_PAYMASTER_POLICY_ID"))
+	return firstNonEmpty(
+		raw.AlchemyPaymasterPolicyID,
+		os.Getenv("ALCHEMY_PAYMASTER_POLICY_ID"),
+		raw.GasManagerPolicyID,
+		os.Getenv("ALCHEMY_GAS_POLICY_ID"),
+	)
 }
 
 func ReadYamlConfig(path string, o interface{}) error {

--- a/core/taskengine/loop_helpers.go
+++ b/core/taskengine/loop_helpers.go
@@ -93,6 +93,13 @@ func processContractWriteTemplates(vm *VM, contractWrite *avsproto.ContractWrite
 			CallData:   processedCallData,
 			MethodName: substituteTemplateVariables(methodCall.MethodName, iterInputs),
 		}
+		// Preserve per-call target override (G4 heterogeneous batch). Without
+		// this, loop-hosted approve+swap falls back to the node-level router
+		// and session hooks AA23.
+		if methodCall.ContractAddress != nil && *methodCall.ContractAddress != "" {
+			addr := substituteTemplateVariables(*methodCall.ContractAddress, iterInputs)
+			processedMethodCall.ContractAddress = &addr
+		}
 
 		// Process methodParams with advanced template variable preprocessing
 		// This supports dot notation like {{value.address}} in addition to simple {{value}} substitution

--- a/core/taskengine/mav2_grant_integration_test.go
+++ b/core/taskengine/mav2_grant_integration_test.go
@@ -159,6 +159,7 @@ func TestMAv2SessionGrantEndToEnd(t *testing.T) {
 		SignerKey:      controllerKey,
 		DeferredData:   deferredData,
 		OwnerSignature: ownerSig,
+		CarrierNonce:   carrierNonce, // send path asserts op.Nonce == this
 		OnApplied: func(userOpHash string) error {
 			appliedHash = userOpHash
 			return nil

--- a/core/taskengine/mav2_send_guards_integration_test.go
+++ b/core/taskengine/mav2_send_guards_integration_test.go
@@ -1,0 +1,207 @@
+//go:build integration
+// +build integration
+
+package taskengine
+
+// Sepolia live checks for the MA v2 send-path guards introduced after the
+// AA23 factory-mismatch hand-off. These prove the gateway refuses doomed
+// UserOps BEFORE the bundler returns opaque AA23.
+//
+// They dial a public Sepolia RPC only — no bundler, no private keys, no
+// balance. Failures here mean the guard regressed, not that Sepolia is flaky.
+//
+//	make test/integration
+//
+// Optional env:
+//
+//	SPIKE_RPC_URL  — defaults to https://ethereum-sepolia-rpc.publicnode.com
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
+)
+
+// Live Sepolia fixtures from the 2026-08-05 Auto-mode AA23 investigation
+// (owner 0xc60e… holds both a v0.6 SimpleAccount and an MA v2 runner at salt 0).
+const (
+	sepoliaOwnerEOA         = "0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788"
+	sepoliaMAv2Runner       = "0x46aD59AFc8a21F0dfa3FE74C53A998b7550c7BDd"
+	sepoliaSimpleAccountV06 = "0x5d814Cc9E94B2656f59Ee439D44AA1b6ca21434f"
+)
+
+func sepoliaRPC(t *testing.T) string {
+	t.Helper()
+	if u := os.Getenv("SPIKE_RPC_URL"); u != "" {
+		return u
+	}
+	return "https://ethereum-sepolia-rpc.publicnode.com"
+}
+
+func sepoliaMAv2Config(t *testing.T) *config.SmartWalletConfig {
+	t.Helper()
+	return &config.SmartWalletConfig{
+		EthRpcUrl:       sepoliaRPC(t),
+		AccountProvider: config.AccountProviderModularAccountV2,
+		// Deliberately leave the raw v0.6 default factory — EffectiveFactory
+		// must still resolve to the MA v2 constant (the findings red herring).
+		FactoryAddress:  common.HexToAddress(config.DefaultFactoryProxyAddressHex),
+		ChainID:         11155111,
+		BundlerProvider: config.BundlerProviderSelfHosted,
+		// No bundler URL: guards must fail before dialing the bundler.
+	}
+}
+
+func TestMAv2SendRejectsMissingSessionGrant_Sepolia(t *testing.T) {
+	swCfg := sepoliaMAv2Config(t)
+	owner := common.HexToAddress(sepoliaOwnerEOA)
+	salt := big.NewInt(0)
+	runner := common.HexToAddress(sepoliaMAv2Runner)
+
+	// Empty calldata is fine — we never reach execution.
+	callData, err := aa.PackExecute(owner, big.NewInt(0), nil)
+	require.NoError(t, err)
+
+	// No session resolver installed → resolveSession returns nil → hard fail.
+	preset.SetSessionResolver(nil)
+	t.Cleanup(func() { preset.SetSessionResolver(nil) })
+
+	_, _, err = preset.SendUserOpMAv2(swCfg, owner, callData, &runner, salt, nil, logger.NewNoOpLogger())
+	require.Error(t, err, "MA v2 send without a session grant must fail before the bundler")
+	require.Contains(t, err.Error(), "no session authorization",
+		"error must name the missing grant, not AA23: %v", err)
+	require.NotContains(t, strings.ToLower(err.Error()), "aa23",
+		"must not reach bundler estimation: %v", err)
+	require.Contains(t, err.Error(), runner.Hex())
+}
+
+func TestMAv2SendRejectsSimpleAccountRunner_Sepolia(t *testing.T) {
+	swCfg := sepoliaMAv2Config(t)
+	owner := common.HexToAddress(sepoliaOwnerEOA)
+	salt := big.NewInt(0)
+	v06Runner := common.HexToAddress(sepoliaSimpleAccountV06)
+
+	// Prove on-chain that salt-0 under the MA v2 factory is the OTHER address.
+	chain, err := ethclient.Dial(swCfg.EthRpcUrl)
+	require.NoError(t, err)
+	defer chain.Close()
+
+	factory, err := aa.EffectiveFactory(swCfg)
+	require.NoError(t, err)
+	require.Equal(t, aa.MAv2FactoryAddress(), factory)
+
+	derived, err := aa.DeriveSenderAddressAuto(chain, owner, factory, salt)
+	require.NoError(t, err)
+	require.NotNil(t, derived)
+	require.Equal(t, strings.ToLower(sepoliaMAv2Runner), strings.ToLower(derived.Hex()),
+		"fixture drift: owner salt-0 under MA v2 factory should be the known MA v2 runner")
+	require.NotEqual(t, *derived, v06Runner,
+		"fixture drift: v0.6 runner must not equal the MA v2 derivation")
+
+	// Confirm the v0.6 runner still has code (fixture has not been self-destructed).
+	code, err := chain.CodeAt(context.Background(), v06Runner, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, code, "fixture drift: v0.6 SimpleAccount %s should be deployed", v06Runner.Hex())
+
+	// Explicit session auth so the missing-grant guard does not fire first —
+	// we want the account-type / derive mismatch.
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	auth := &preset.SessionAuthorization{EntityID: 1, SignerKey: controllerKey}
+
+	callData, err := aa.PackExecute(owner, big.NewInt(0), nil)
+	require.NoError(t, err)
+
+	_, _, err = preset.SendUserOpMAv2(swCfg, owner, callData, &v06Runner, salt, auth, logger.NewNoOpLogger())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match the address derived",
+		"v0.6 SimpleAccount runner must be refused with a derive mismatch: %v", err)
+	require.Contains(t, err.Error(), v06Runner.Hex())
+	require.Contains(t, err.Error(), derived.Hex())
+	require.NotContains(t, strings.ToLower(err.Error()), "aa23",
+		"must not reach bundler estimation: %v", err)
+}
+
+func TestMAv2SendRejectsUndeployedWrongSalt_Sepolia(t *testing.T) {
+	swCfg := sepoliaMAv2Config(t)
+	owner := common.HexToAddress(sepoliaOwnerEOA)
+	// Claim the salt-0 MA v2 address while deriving initCode for salt 99.
+	runner := common.HexToAddress(sepoliaMAv2Runner)
+	wrongSalt := big.NewInt(99)
+
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	auth := &preset.SessionAuthorization{EntityID: 1, SignerKey: controllerKey}
+
+	callData, err := aa.PackExecute(owner, big.NewInt(0), nil)
+	require.NoError(t, err)
+
+	_, _, err = preset.SendUserOpMAv2(swCfg, owner, callData, &runner, wrongSalt, auth, logger.NewNoOpLogger())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match the address derived",
+		"salt mismatch must refuse before initCode attach: %v", err)
+	require.NotContains(t, strings.ToLower(err.Error()), "aa23")
+}
+
+func TestMAv2EffectiveFactoryOnSepoliaConfig_IgnoresRawV06Factory(t *testing.T) {
+	swCfg := sepoliaMAv2Config(t)
+	factory, err := aa.EffectiveFactory(swCfg)
+	require.NoError(t, err)
+	require.Equal(t, aa.MAv2FactoryAddress(), factory)
+	require.NotEqual(t, swCfg.FactoryAddress, factory,
+		"raw config factory is the v0.6 default; effective must be MA v2")
+}
+
+// The 16:31 Auto swap failure was diagnosed as AA23, but a live re-probe of
+// the same grant + atomicBatch shape estimates successfully and only fails
+// later on prefund. This test locks the early fail-fast: zero balance + no
+// Gas Manager must refuse BEFORE the bundler, with a sponsorship hint.
+func TestMAv2SendRejectsZeroBalanceWithoutGasManager_Sepolia(t *testing.T) {
+	swCfg := sepoliaMAv2Config(t)
+	// No AlchemyPaymasterPolicyID — matches the local gateway log
+	// "paymaster_policy_set: false".
+	owner := common.HexToAddress(sepoliaOwnerEOA)
+	runner := common.HexToAddress(sepoliaMAv2Runner)
+	salt := big.NewInt(0)
+
+	// Confirm fixture is still unfunded / counterfactual.
+	chain, err := ethclient.Dial(swCfg.EthRpcUrl)
+	require.NoError(t, err)
+	defer chain.Close()
+	bal, err := chain.BalanceAt(context.Background(), runner, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, bal.Sign(), "fixture drift: MA v2 runner should be unfunded for this guard test")
+	code, err := chain.CodeAt(context.Background(), runner, nil)
+	require.NoError(t, err)
+	require.Empty(t, code, "fixture drift: MA v2 runner should still be counterfactual")
+
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	// Minimal auth so we pass the session-grant guard and reach prefund.
+	// (A real deferred grant is not required to exercise the balance check.)
+	auth := &preset.SessionAuthorization{EntityID: 1, SignerKey: controllerKey}
+
+	callData, err := aa.PackExecute(owner, big.NewInt(0), nil)
+	require.NoError(t, err)
+
+	_, _, err = preset.SendUserOpMAv2(swCfg, owner, callData, &runner, salt, auth, logger.NewNoOpLogger())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot pay gas",
+		"zero-balance unsponsored MA v2 ops must fail with a prefund message: %v", err)
+	require.Contains(t, err.Error(), "ALCHEMY_PAYMASTER_POLICY_ID",
+		"error must point at Alchemy paymaster policy sponsorship: %v", err)
+	require.NotContains(t, strings.ToLower(err.Error()), "aa23",
+		"must not reach bundler estimate: %v", err)
+}

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -3,6 +3,7 @@ package taskengine
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -109,9 +110,9 @@ func NextSessionEntityID(db storage.Storage, chainID int64, owner, wallet common
 }
 
 // InstallSessionResolver wires the send path to this engine's session-policy
-// storage. Without it every MA v2 operation is signed as the account's
-// fallback signer — the user's EOA, whose key the gateway does not hold — so
-// nothing the gateway executes validates.
+// storage. Without it every MA v2 operation fails fast with "no session
+// authorization" — the gateway cannot sign as the owner fallback, and
+// estimating a doomed UserOp only produces opaque AA23.
 //
 // Called once at aggregator startup, deliberately NOT from New: the resolver
 // is process-global (the preset package has no per-engine context), and test
@@ -140,10 +141,8 @@ func NewSessionResolver(
 			return nil, err
 		}
 		if policy == nil {
-			// No grant. The operation stays on the owner's fallback signer,
-			// which the gateway cannot sign — but that failure belongs to the
-			// caller that asked for an operation it has no authority for, and
-			// it reads more clearly than a fabricated authorization.
+			// No grant. SendUserOpMAv2 fails fast on nil rather than estimating
+			// a controller-as-fallback UserOp that always AA23s.
 			return nil, nil
 		}
 		key, err := signerKeyFor(*policy.SessionSigner)
@@ -153,6 +152,7 @@ func NewSessionResolver(
 		auth := &preset.SessionAuthorization{
 			EntityID:          policy.EntityID,
 			SignerKey:         key,
+			PolicyID:          policy.ID,
 			WrapExecuteUserOp: policy.Grant.RequiresExecuteUserOp,
 		}
 		// The install rides the grant's FIRST operation only. Replaying an
@@ -180,6 +180,9 @@ func NewSessionResolver(
 			}
 			auth.DeferredData = encoded
 			auth.OwnerSignature = policy.Grant.OwnerSignature
+			if policy.Grant.CarrierNonce != nil {
+				auth.CarrierNonce = new(big.Int).Set(policy.Grant.CarrierNonce)
+			}
 			policyID, policyChain, policyOwner := policy.ID, policy.ChainID, *policy.Owner
 			auth.OnApplied = func(userOpHash string) error {
 				return MarkSessionGrantAppliedByID(db, policyChain, policyOwner, policyID, userOpHash)

--- a/core/taskengine/session_policy_test.go
+++ b/core/taskengine/session_policy_test.go
@@ -76,6 +76,13 @@ func TestSessionResolverReturnsTheWalletsGrant(t *testing.T) {
 	if auth.EntityID != 1 || auth.SignerKey != key {
 		t.Errorf("wrong entity/key: %d %v", auth.EntityID, auth.SignerKey == key)
 	}
+	if auth.PolicyID != "p1" {
+		t.Errorf("PolicyID = %q, want p1 (for send-path logging)", auth.PolicyID)
+	}
+	if auth.CarrierNonce == nil || auth.CarrierNonce.Cmp(pending.Grant.CarrierNonce) != 0 {
+		t.Errorf("CarrierNonce = %v, want %v (send path asserts it against op.Nonce)",
+			auth.CarrierNonce, pending.Grant.CarrierNonce)
+	}
 	// Pending means the install has not been applied, so it must ride along.
 	if !auth.Deferred() {
 		t.Error("a pending grant's first operation must carry the install")

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine/macros"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
@@ -1668,10 +1669,17 @@ func (v *VM) runContractWrite(taskNode *avsproto.TaskNode) (*avsproto.Execution_
 		"task_owner", v.TaskOwner.Hex())
 
 	if swConfig != nil {
+		effectiveFactory, factoryErr := aa.EffectiveFactory(swConfig)
+		effectiveFactoryHex := ""
+		if factoryErr == nil {
+			effectiveFactoryHex = effectiveFactory.Hex()
+		}
 		v.logger.Info("🔍 VM DEBUG - Smart wallet config details",
 			"bundler_url", swConfig.BundlerURL,
-			"factory_address", swConfig.FactoryAddress,
-			"entrypoint_address", swConfig.EntryPointAddress(),
+			"account_provider", swConfig.AccountProviderName(),
+			"effective_factory", effectiveFactoryHex,
+			"config_factory_address", swConfig.FactoryAddress.Hex(),
+			"entrypoint_address", swConfig.EntryPointAddress().Hex(),
 			"eth_rpc_url", swConfig.EthRpcUrl)
 	} else {
 		v.logger.Warn("⚠️ VM DEBUG - Smart wallet config is NIL in VM!")
@@ -3879,6 +3887,15 @@ func ExtractNodeConfiguration(taskNode *avsproto.TaskNode) map[string]interface{
 						methodCallMap["callData"] = ""
 					}
 
+					// Per-call target (G4 atomic approve+swap). MUST survive the
+					// proto→map→proto round-trip in GetNodeDataForExecution /
+					// CreateNodeFromType. Dropping it forces every sub-call onto
+					// the node-level router → hooks allowlist rejects approve →
+					// opaque AA23 at Gas Manager (live 2026-08-05).
+					if methodCall.ContractAddress != nil && *methodCall.ContractAddress != "" {
+						methodCallMap["contractAddress"] = *methodCall.ContractAddress
+					}
+
 					// Include methodParams if present
 					if len(methodCall.MethodParams) > 0 {
 						methodCallMap["methodParams"] = methodCall.MethodParams
@@ -4164,6 +4181,11 @@ func extractLoopRunnerConfig(loop *avsproto.LoopNode) map[string]interface{} {
 				// Include callData only if it's set (it's optional)
 				if methodCall.CallData != nil {
 					methodCallMap["callData"] = *methodCall.CallData
+				}
+
+				// Per-call target — same G4 field as non-loop contractWrite extract.
+				if methodCall.ContractAddress != nil && *methodCall.ContractAddress != "" {
+					methodCallMap["contractAddress"] = *methodCall.ContractAddress
 				}
 
 				// Include methodParams if present

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -1945,9 +1945,10 @@ func (r *ContractWriteProcessor) Execute(stepID string, node *avsproto.ContractW
 		aa23Snaps = append(aa23Snaps, snap)
 	}
 	// AA23 debug: single summary of how every sub-call target was resolved.
+	// Debug level — temporary instrumentation (avoid Info noise on every multi-call write).
 	// Grep gateway.log for "AA23_DEBUG contractWrite.per-call-targets".
 	if r.vm != nil && r.vm.logger != nil {
-		r.vm.logger.Info("AA23_DEBUG contractWrite.per-call-targets",
+		r.vm.logger.Debug("AA23_DEBUG contractWrite.per-call-targets",
 			"node_contract", contractAddr.Hex(),
 			"method_call_count", len(methodCalls),
 			"calls", aa23Snaps,

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -396,10 +396,17 @@ func (r *ContractWriteProcessor) executeMethodCall(
 		"contract_address", contractAddress.Hex())
 
 	if r.smartWalletConfig != nil {
+		effectiveFactory, factoryErr := aa.EffectiveFactory(r.smartWalletConfig)
+		effectiveFactoryHex := ""
+		if factoryErr == nil {
+			effectiveFactoryHex = effectiveFactory.Hex()
+		}
 		r.vm.logger.Info("🔍 CONTRACT WRITE DEBUG - Smart Wallet Config Details",
 			"bundler_url", r.smartWalletConfig.BundlerURL,
-			"factory_address", r.smartWalletConfig.FactoryAddress,
-			"entrypoint_address", r.smartWalletConfig.EntryPointAddress())
+			"account_provider", r.smartWalletConfig.AccountProviderName(),
+			"effective_factory", effectiveFactoryHex,
+			"config_factory_address", r.smartWalletConfig.FactoryAddress.Hex(),
+			"entrypoint_address", r.smartWalletConfig.EntryPointAddress().Hex())
 	} else {
 		r.vm.logger.Warn("⚠️ CONTRACT WRITE DEBUG - Smart wallet config is NIL!")
 	}
@@ -1171,6 +1178,29 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 		values[i] = value
 		datas[i] = callDataBytes
 		log.WriteString(fmt.Sprintf("Batch call %d: %s on %s (value %s wei, %d bytes)\n", i+1, methodName, perCallTargets[i].Hex(), value.String(), len(callDataBytes)))
+		// Structured so AA23 under session hooks can be diagnosed from the
+		// gateway log alone: a hooks grant allowlists (token, approve) +
+		// (router, exactInputSingle). If both sub-calls land on the node-level
+		// router (missing methodCalls[].contractAddress), the allowlist
+		// refuses and Gas Manager surfaces opaque AA23.
+		if r.vm != nil && r.vm.logger != nil {
+			override := ""
+			if mc != nil {
+				override = strings.TrimSpace(mc.GetContractAddress())
+			}
+			nodeContract := ""
+			if node != nil && node.Config != nil {
+				nodeContract = node.Config.ContractAddress
+			}
+			r.vm.logger.Info("atomic batch sub-call target",
+				"index", i,
+				"method", methodName,
+				"target", perCallTargets[i].Hex(),
+				"per_call_contract_address", override,
+				"node_contract", nodeContract,
+				"used_node_fallback", override == "",
+			)
+		}
 	}
 
 	// Pack the atomic batch. Prefer executeBatch (no per-call values) when every value is zero — its
@@ -1197,6 +1227,14 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 	// The batch spans heterogeneous targets; join the unique ones so bundler/AA error logs don't
 	// misleadingly point at just the first sub-call's contract.
 	logTarget := strings.Join(uniqueTargetHexes(targets), ",")
+	if r.vm != nil && r.vm.logger != nil {
+		r.vm.logger.Info("submitting atomic batch UserOp",
+			"methods", logLabel,
+			"targets", logTarget,
+			"pack_kind", packKind,
+			"num_calls", n,
+		)
+	}
 	log.WriteString(fmt.Sprintf("Submitting atomic batch of %d calls as one UserOp (%s)\n", n, packKind))
 
 	var executionLogBuilder strings.Builder
@@ -1442,25 +1480,44 @@ func convertLogsToInterface(logs []*types.Log) []interface{} {
 	return result
 }
 
-// shouldUsePaymaster determines if paymaster should be used for gas sponsorship
+// shouldUsePaymaster determines if the v0.6 verifying paymaster should be
+// attached to a UserOp.
 //
-// - ALWAYS use paymaster if configured (no more EntryPoint deposit checking or override flags)
-// - Paymaster sponsors gas upfront, wallet reimburses via executeBatchWithValues
-// - If reimbursement fails (insufficient wallet balance), UserOp still completes without reimbursement
+// MA v2 never uses that path: SendUserOpAuto ignores paymasterReq and sponsors
+// only via the Alchemy paymaster policy
+// (alchemy_paymaster_policy_id / ALCHEMY_PAYMASTER_POLICY_ID).
+// Returning true under MA v2 only produced misleading "Using paymaster
+// 0xd856…" logs that suggested sponsorship was active when the account was
+// actually self-funded (and often zero-balance → prefund failure).
 func (r *ContractWriteProcessor) shouldUsePaymaster() bool {
-	// If no paymaster is configured, must self-fund
+	if r.smartWalletConfig == nil {
+		return false
+	}
+	if r.smartWalletConfig.UsesModularAccountV2() {
+		if r.vm != nil && r.vm.logger != nil {
+			if r.smartWalletConfig.AlchemyPaymasterPolicyID != "" {
+				r.vm.logger.Debug("MA v2: Alchemy paymaster policy will sponsor the operation",
+					"owner", r.owner.Hex(), "paymaster_policy_set", true)
+			} else {
+				r.vm.logger.Info("MA v2: no Alchemy paymaster policy; smart wallet pays its own gas",
+					"owner", r.owner.Hex(),
+					"hint", "set alchemy_paymaster_policy_id or ALCHEMY_PAYMASTER_POLICY_ID for sponsorship")
+			}
+		}
+		return false
+	}
+
+	// v0.6 SimpleAccount: ALWAYS use the verifying paymaster if configured.
+	// Paymaster sponsors gas, wallet reimburses via executeBatchWithValues.
+	// If wallet can't reimburse, UserOp still completes (paymaster absorbs cost).
 	if (r.smartWalletConfig.PaymasterAddress == common.Address{}) {
-		if r.vm.logger != nil {
+		if r.vm != nil && r.vm.logger != nil {
 			r.vm.logger.Debug("No paymaster configured, proceeding self-funded",
 				"owner", r.owner.Hex())
 		}
 		return false
 	}
-
-	// ALWAYS use paymaster if configured
-	// Paymaster sponsors gas, wallet reimburses via executeBatchWithValues
-	// If wallet can't reimburse, UserOp still completes (paymaster absorbs cost)
-	if r.vm.logger != nil {
+	if r.vm != nil && r.vm.logger != nil {
 		r.vm.logger.Debug("Using paymaster for gas sponsorship (with automatic reimbursement)",
 			"owner", r.owner.Hex(), "paymaster", r.smartWalletConfig.PaymasterAddress.Hex())
 	}
@@ -1833,23 +1890,68 @@ func (r *ContractWriteProcessor) Execute(stepID string, node *avsproto.ContractW
 	// (e.g. approve on the token + swap on the router). Absent = the node-level contract (common case,
 	// so pre-existing tasks — which never carry this new field — are unaffected).
 	perCallTargets := make([]common.Address, len(methodCalls))
+	type aa23CallSnap struct {
+		Index             int    `json:"index"`
+		MethodName        string `json:"methodName"`
+		RawOverride       string `json:"rawOverride"`
+		HasRawOverride    bool   `json:"hasRawOverride"`
+		ResolvedOverride  string `json:"resolvedOverride"`
+		UsedNodeFallback  bool   `json:"usedNodeFallback"`
+		ResolvedTarget    string `json:"resolvedTarget"`
+		NodeLevelContract string `json:"nodeLevelContract"`
+	}
+	aa23Snaps := make([]aa23CallSnap, 0, len(methodCalls))
 	for i, mc := range methodCalls {
 		perCallTargets[i] = contractAddr
-		if override := strings.TrimSpace(mc.GetContractAddress()); override != "" {
+		rawOverride := ""
+		hasRaw := false
+		if mc != nil && mc.ContractAddress != nil {
+			hasRaw = true
+			rawOverride = *mc.ContractAddress
+		}
+		override := strings.TrimSpace(mc.GetContractAddress())
+		snap := aa23CallSnap{
+			Index:             i,
+			MethodName:        mc.GetMethodName(),
+			RawOverride:       rawOverride,
+			HasRawOverride:    hasRaw,
+			UsedNodeFallback:  override == "",
+			NodeLevelContract: contractAddr.Hex(),
+			ResolvedTarget:    contractAddr.Hex(),
+		}
+		if override != "" {
 			resolved := r.vm.preprocessTextWithVariableMapping(override)
+			snap.ResolvedOverride = resolved
 			if !common.IsHexAddress(resolved) {
 				// A per-call target was explicitly provided but did not resolve to a valid address
 				// (unresolved {{template}}, typo, or a variable that resolved to empty). Fail fast
 				// instead of silently falling back to the node-level contract — sending an atomic,
 				// irreversible sub-call to the wrong contract is exactly the footgun this feature
 				// exists to prevent. Mirrors the node-level validation in getInputData.
+				if r.vm != nil && r.vm.logger != nil {
+					r.vm.logger.Error("AA23_DEBUG contractWrite.per-call-target INVALID",
+						"index", i, "method", mc.GetMethodName(),
+						"raw_override", rawOverride, "resolved", resolved)
+				}
 				err = NewInvalidAddressError(resolved)
 				finalizeErrorMsg = err.Error()
 				finalizeSuccess = false
 				return s, err
 			}
 			perCallTargets[i] = common.HexToAddress(resolved)
+			snap.UsedNodeFallback = false
+			snap.ResolvedTarget = perCallTargets[i].Hex()
 		}
+		aa23Snaps = append(aa23Snaps, snap)
+	}
+	// AA23 debug: single summary of how every sub-call target was resolved.
+	// Grep gateway.log for "AA23_DEBUG contractWrite.per-call-targets".
+	if r.vm != nil && r.vm.logger != nil {
+		r.vm.logger.Info("AA23_DEBUG contractWrite.per-call-targets",
+			"node_contract", contractAddr.Hex(),
+			"method_call_count", len(methodCalls),
+			"calls", aa23Snaps,
+		)
 	}
 
 	// Atomic-batch route: on-demand (nodes:run) real execution of more than one method call. Instead

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -49,23 +51,16 @@ func SendUserOpMAv2(
 		return nil, nil, err
 	}
 
-	bundlerURL, err := smartWalletConfig.ActiveBundlerURL()
-	if err != nil {
-		return nil, nil, fmt.Errorf("resolving bundler url: %w", err)
-	}
-
 	ctx := context.Background()
+	// Fail-fast guards (session grant, factory derivation) only need the chain
+	// RPC. Dial the bundler after those checks so a legacy SimpleAccount
+	// runner or missing grant does not waste a bundler round-trip — and so
+	// guard-only tests need no bundler URL.
 	chainRPC, err := ethclient.Dial(smartWalletConfig.EthRpcUrl)
 	if err != nil {
 		return nil, nil, fmt.Errorf("dialing chain rpc: %w", err)
 	}
 	defer chainRPC.Close()
-
-	bundlerRPC, err := rpc.DialContext(ctx, bundlerURL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("dialing bundler: %w", err)
-	}
-	defer bundlerRPC.Close()
 
 	// Nonce reads are plain eth_calls and go to the CHAIN rpc. The bundler
 	// endpoint only advertises the ERC-4337 namespace on some providers
@@ -95,8 +90,8 @@ func SendUserOpMAv2(
 	// wallet — looked up only now, because grants are keyed by the smart
 	// wallet's address and the sender is not known until it is resolved.
 	// Resolving earlier against the owner EOA (or a guessed wallet) finds
-	// nothing and signs as the fallback entity the gateway cannot validate
-	// for.
+	// nothing and used to sign as the fallback entity the gateway cannot
+	// validate for.
 	if auth == nil {
 		if auth, err = resolveSession(smartWalletConfig.ChainID, owner, sender); err != nil {
 			return nil, nil, fmt.Errorf("resolving session authorization for %s: %w", sender.Hex(), err)
@@ -105,17 +100,40 @@ func SendUserOpMAv2(
 			return nil, nil, err
 		}
 	}
-	// Without a session authorization the operation runs as the account's
-	// fallback signer, which only the OWNER's key can do. The gateway does not
-	// hold it, so this path exists for callers that supply their own signer.
-	if auth == nil && smartWalletConfig.ControllerPrivateKey == nil {
-		return nil, nil, fmt.Errorf("no controller private key configured")
+	// MA v2 operations always need a session grant. The gateway does not hold
+	// the owner's key; estimating a controller-signed fallback UserOp only
+	// produces opaque AA23. Callers that supply their own authorization
+	// (integration tests, spikes) pass it explicitly and never hit this.
+	if auth == nil {
+		return nil, nil, fmt.Errorf(
+			"no session authorization for smart wallet %s (owner %s); MA v2 execution requires a session grant — the gateway cannot sign as the owner fallback",
+			sender.Hex(), owner.Hex())
+	}
+
+	// Sender must be the address this chain's factory derives for (owner, salt).
+	// Covers both cases that previously reached the bundler as AA23:
+	//   - undeployed override with the wrong salt/factory (initCode would
+	//     deploy elsewhere)
+	//   - deployed legacy SimpleAccount runner on an MA v2 chain (no initCode,
+	//     v0.7 validation against v0.6 bytecode)
+	derived, derr := aa.DeriveSenderAddressAuto(chainRPC, owner, factory, salt)
+	if derr != nil {
+		return nil, nil, fmt.Errorf("deriving counterfactual address for sender %s: %w", sender.Hex(), derr)
+	}
+	if derived == nil || *derived != sender {
+		want := common.Address{}
+		if derived != nil {
+			want = *derived
+		}
+		return nil, nil, fmt.Errorf(
+			"sender %s does not match the address derived for owner %s salt %s factory %s (derived %s); refusing MA v2 UserOp — wrong account type, salt, or factory (e.g. a legacy SimpleAccount runner on an MA v2 chain)",
+			sender.Hex(), owner.Hex(), salt.String(), factory.Hex(), want.Hex())
 	}
 
 	// A grant carrying execution hooks requires user-op context on EVERY
 	// operation under it — including the one that installs the grant, since
 	// the hooks are live from the moment the install applies mid-validation.
-	if auth != nil && auth.WrapExecuteUserOp {
+	if auth.WrapExecuteUserOp {
 		wrapped, wrapErr := aa.WrapExecuteUserOp(callData)
 		if wrapErr != nil {
 			return nil, nil, fmt.Errorf("wrapping calldata for user-op context: %w", wrapErr)
@@ -134,29 +152,13 @@ func SendUserOpMAv2(
 
 	// An account with no code yet must carry its own deployment. Reading the
 	// code is the authoritative check — a wallet record can exist for an
-	// address that was never deployed, and vice versa.
+	// address that was never deployed, and vice versa. Derive already matched
+	// above, so initCode is safe to attach.
 	deployed, err := isDeployed(ctx, chainRPC, sender)
 	if err != nil {
 		return nil, nil, fmt.Errorf("checking whether %s is deployed: %w", sender.Hex(), err)
 	}
 	if !deployed {
-		// Factory createAccount must produce the same address as `sender`. A
-		// wrong salt (or a legacy SimpleAccount address on an MA v2 chain)
-		// deploys somewhere else while the UserOp claims the override — the
-		// EntryPoint then reverts validation as AA23 with no useful reason.
-		derived, derr := aa.DeriveSenderAddressAuto(chainRPC, owner, factory, salt)
-		if derr != nil {
-			return nil, nil, fmt.Errorf("deriving counterfactual address for deploy of %s: %w", sender.Hex(), derr)
-		}
-		if derived == nil || *derived != sender {
-			want := common.Address{}
-			if derived != nil {
-				want = *derived
-			}
-			return nil, nil, fmt.Errorf(
-				"sender %s is not deployed and does not match the address derived for owner %s salt %s factory %s (derived %s); cannot attach initCode",
-				sender.Hex(), owner.Hex(), salt.String(), factory.Hex(), want.Hex())
-		}
 		deployFactory, factoryData, initErr := aa.DeriveInitCodeAuto(owner, factory, salt)
 		if initErr != nil {
 			return nil, nil, fmt.Errorf("building init code: %w", initErr)
@@ -165,6 +167,29 @@ func SendUserOpMAv2(
 		op.FactoryData = factoryData
 	}
 	op.VerificationGasLimit = seedVerificationGasFor(op, auth)
+
+	// Without a Gas Manager policy the account pays gas from native balance /
+	// EntryPoint deposit. A zero total is a guaranteed prefund failure —
+	// refuse before dialing the bundler so the error is clear and guard tests
+	// need no bundler URL. Sponsorship is alchemy_paymaster_policy_id /
+	// ALCHEMY_PAYMASTER_POLICY_ID (legacy aliases still accepted); when set,
+	// this check is skipped.
+	if smartWalletConfig.AlchemyPaymasterPolicyID == "" {
+		if err := ensureSelfFundedPrefund(ctx, chainRPC, entryPoint, sender); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Bundler is only needed from pricing onwards.
+	bundlerURL, err := smartWalletConfig.ActiveBundlerURL()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving bundler url: %w", err)
+	}
+	bundlerRPC, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dialing bundler: %w", err)
+	}
+	defer bundlerRPC.Close()
 
 	// MA v2 selects its validation function from the NONCE, not the signature.
 	// A zero nonce reverts with ValidationFunctionMissing rather than as a
@@ -211,6 +236,28 @@ func SendUserOpMAv2(
 	}
 	op.Nonce = nonce
 
+	if err := checkDeferredCarrierNonce(auth, op.Nonce, sender); err != nil {
+		return nil, nil, err
+	}
+
+	l.Info("v0.7 user operation prepared",
+		"account_provider", smartWalletConfig.AccountProviderName(),
+		"effective_factory", factory.Hex(),
+		"config_factory_address", smartWalletConfig.FactoryAddress.Hex(),
+		"entry_point", entryPoint.Hex(),
+		"owner", owner.Hex(),
+		"sender", sender.Hex(),
+		"salt", salt.String(),
+		"deployed", deployed,
+		"deploying", op.Factory != nil,
+		"entity", nonceEntity,
+		"deferred", auth.Deferred(),
+		"policy_id", auth.PolicyID,
+		"wrap_execute_user_op", auth.WrapExecuteUserOp,
+		"verification_gas_seed", op.VerificationGasLimit.String(),
+		"paymaster_policy_set", smartWalletConfig.AlchemyPaymasterPolicyID != "",
+	)
+
 	// Estimation of a deferred operation must carry the REAL owner grant.
 	// Ordinary signature validation fails gracefully so estimation can
 	// proceed, but a bad deferred-action signature REVERTS
@@ -234,10 +281,7 @@ func SendUserOpMAv2(
 	// to come after pricing. SendUserOpV07WithRetry only RE-signs, and only
 	// when it tightens the verification gas limit — it will not sign an
 	// unsigned operation, it rejects one.
-	signingKey := smartWalletConfig.ControllerPrivateKey
-	if auth != nil {
-		signingKey = auth.SignerKey
-	}
+	signingKey := auth.SignerKey
 	if auth.Deferred() {
 		if err := SignUserOpV07Deferred(op, entryPoint, chainID, signingKey,
 			auth.DeferredData, auth.OwnerSignature); err != nil {
@@ -268,7 +312,7 @@ func SendUserOpMAv2(
 	}
 	if err != nil {
 		InvalidateNonce(sender, nonceEntity, nonceOptions)
-		return op, nil, fmt.Errorf("sending user operation: %w", err)
+		return op, nil, fmt.Errorf("sending user operation: %w", annotatePrefundError(err, sender))
 	}
 	// Record acceptance NOW — the bundler holds the operation, so the next
 	// one on this key must use the following sequence even though nothing has
@@ -278,7 +322,8 @@ func SendUserOpMAv2(
 	l.Info("v0.7 user operation sent",
 		"sender", sender.Hex(), "userop_hash", opHash.Hex(),
 		"sponsored", op.Paymaster != nil, "deploying", op.Factory != nil,
-		"entity", nonceEntity, "installs_grant", auth.Deferred())
+		"entity", nonceEntity, "installs_grant", auth.Deferred(),
+		"policy_id", auth.PolicyID, "effective_factory", factory.Hex())
 
 	// Reuses the v0.6 confirmation watcher: UserOperationEvent is unchanged
 	// between EntryPoint versions, so only the EntryPoint address differs.
@@ -323,9 +368,93 @@ func SendUserOpMAv2(
 	return op, receipt, nil
 }
 
+// checkDeferredCarrierNonce refuses a deferred operation whose live nonce
+// differs from the nonce the owner signed over at grant time. A mismatch
+// would otherwise surface as AA23 from DeferredActionSignatureInvalid.
+func checkDeferredCarrierNonce(auth *SessionAuthorization, opNonce *big.Int, sender common.Address) error {
+	if auth == nil || !auth.Deferred() || auth.CarrierNonce == nil {
+		return nil
+	}
+	if opNonce == nil {
+		return fmt.Errorf("deferred carrier nonce check: operation nonce is nil")
+	}
+	if auth.CarrierNonce.Cmp(opNonce) != 0 {
+		return fmt.Errorf(
+			"deferred carrier nonce mismatch for %s: grant signed over %s but operation uses %s (entity %d); refusing before estimate",
+			sender.Hex(), auth.CarrierNonce.String(), opNonce.String(), auth.EntityID)
+	}
+	return nil
+}
+
+// ensureSelfFundedPrefund refuses an unsponsored operation when the account
+// has nothing to pay gas with. Estimation can succeed with a zero balance
+// (validation does not charge the account), so without this check the failure
+// only appears at eth_sendUserOperation as a prefund error that Studio users
+// read as another opaque AA / bundler failure.
+//
+// Sponsorship is alchemy_paymaster_policy_id / ALCHEMY_PAYMASTER_POLICY_ID —
+// when set, the caller skips this check and RequestSponsorshipV07 attaches a
+// paymaster.
+func ensureSelfFundedPrefund(ctx context.Context, chainRPC *ethclient.Client, entryPoint, sender common.Address) error {
+	if chainRPC == nil {
+		return fmt.Errorf("nil chain rpc")
+	}
+	balance, err := chainRPC.BalanceAt(ctx, sender, nil)
+	if err != nil {
+		return fmt.Errorf("reading native balance of %s: %w", sender.Hex(), err)
+	}
+	deposit, err := entryPointDeposit(ctx, chainRPC, entryPoint, sender)
+	if err != nil {
+		// Deposit is best-effort: a failed eth_call should not mask a clear
+		// zero-balance situation, but also should not invent a deposit.
+		deposit = big.NewInt(0)
+	}
+	total := new(big.Int).Add(balance, deposit)
+	if total.Sign() > 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"smart wallet %s cannot pay gas: native balance and EntryPoint deposit are both zero, and no Alchemy paymaster policy is configured; set alchemy_paymaster_policy_id (or env ALCHEMY_PAYMASTER_POLICY_ID) for sponsorship, or fund the wallet with Sepolia ETH",
+		sender.Hex())
+}
+
+// entryPointDeposit reads EntryPoint.balanceOf(sender) for v0.7.
+func entryPointDeposit(ctx context.Context, chainRPC *ethclient.Client, entryPoint, sender common.Address) (*big.Int, error) {
+	// cast sig "balanceOf(address)" => 0x70a08231 — same selector as ERC-20.
+	data := append(common.FromHex("0x70a08231"), common.LeftPadBytes(sender.Bytes(), 32)...)
+	out, err := chainRPC.CallContract(ctx, ethereum.CallMsg{To: &entryPoint, Data: data}, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) < 32 {
+		return big.NewInt(0), nil
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+// annotatePrefundError rewrites the bundler's prefund precheck into a message
+// that names the wallet and the Gas Manager escape hatch.
+func annotatePrefundError(err error, sender common.Address) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "balance and deposit together is 0") ||
+		strings.Contains(msg, "AA21") ||
+		strings.Contains(strings.ToLower(msg), "didn't pay prefund") {
+		return fmt.Errorf(
+			"smart wallet %s cannot pay gas (bundler prefund check): %w; set alchemy_paymaster_policy_id / ALCHEMY_PAYMASTER_POLICY_ID or fund the wallet",
+			sender.Hex(), err)
+	}
+	return err
+}
+
 // resolveSenderV07 picks the account the operation runs as. An explicit
 // override is trusted (the caller has already resolved which of the owner's
 // wallets to use); otherwise the address is derived from the factory.
+//
+// Trust here only selects the candidate sender. SendUserOpMAv2 always re-
+// derives against the provider factory and refuses a mismatch before estimate.
 func resolveSenderV07(
 	chainRPC *ethclient.Client,
 	owner, factory common.Address,
@@ -359,7 +488,7 @@ func priceOperationV07(
 	smartWalletConfig *config.SmartWalletConfig,
 	l logger.Logger,
 ) error {
-	if policyID := smartWalletConfig.GasManagerPolicyID; policyID != "" {
+	if policyID := smartWalletConfig.AlchemyPaymasterPolicyID; policyID != "" {
 		if err := RequestSponsorshipV07(ctx, bundlerRPC, op, entryPoint,
 			SponsorshipRequestV07{PolicyID: policyID}); err != nil {
 			// Deliberately fatal. See SendUserOpV07's contract: falling through

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -172,8 +172,8 @@ func SendUserOpMAv2(
 	// EntryPoint deposit. A zero total is a guaranteed prefund failure —
 	// refuse before dialing the bundler so the error is clear and guard tests
 	// need no bundler URL. Sponsorship is alchemy_paymaster_policy_id /
-	// ALCHEMY_PAYMASTER_POLICY_ID (legacy aliases still accepted); when set,
-	// this check is skipped.
+	// ALCHEMY_PAYMASTER_POLICY_ID (config also accepts legacy gas_manager_policy_id /
+	// ALCHEMY_GAS_POLICY_ID); when set, this check is skipped.
 	if smartWalletConfig.AlchemyPaymasterPolicyID == "" {
 		if err := ensureSelfFundedPrefund(ctx, chainRPC, entryPoint, sender); err != nil {
 			return nil, nil, err
@@ -414,7 +414,7 @@ func ensureSelfFundedPrefund(ctx context.Context, chainRPC *ethclient.Client, en
 		return nil
 	}
 	return fmt.Errorf(
-		"smart wallet %s cannot pay gas: native balance and EntryPoint deposit are both zero, and no Alchemy paymaster policy is configured; set alchemy_paymaster_policy_id (or env ALCHEMY_PAYMASTER_POLICY_ID) for sponsorship, or fund the wallet with Sepolia ETH",
+		"smart wallet %s cannot pay gas: native balance and EntryPoint deposit are both zero, and no Alchemy paymaster policy is configured; set alchemy_paymaster_policy_id (or env ALCHEMY_PAYMASTER_POLICY_ID) for sponsorship, or fund the wallet with the chain's native gas token",
 		sender.Hex())
 }
 

--- a/pkg/erc4337/preset/send_v07_guards_test.go
+++ b/pkg/erc4337/preset/send_v07_guards_test.go
@@ -1,0 +1,145 @@
+package preset
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+func TestCheckDeferredCarrierNonce(t *testing.T) {
+	sender := common.HexToAddress("0x46aD59AFc8a21F0dfa3FE74C53A998b7550c7BDd")
+	carrier, err := userop.EncodeNonceMAv2(1,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig := make([]byte, 65)
+
+	t.Run("nil auth is fine", func(t *testing.T) {
+		if err := checkDeferredCarrierNonce(nil, carrier, sender); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("non-deferred skips the check", func(t *testing.T) {
+		auth := &SessionAuthorization{EntityID: 1, SignerKey: testKey(t), CarrierNonce: big.NewInt(99)}
+		if err := checkDeferredCarrierNonce(auth, carrier, sender); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("deferred without stored carrier skips", func(t *testing.T) {
+		auth := &SessionAuthorization{
+			EntityID: 1, SignerKey: testKey(t),
+			DeferredData: []byte{0x01}, OwnerSignature: sig,
+		}
+		if err := checkDeferredCarrierNonce(auth, carrier, sender); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("matching carrier passes", func(t *testing.T) {
+		auth := &SessionAuthorization{
+			EntityID: 1, SignerKey: testKey(t),
+			DeferredData: []byte{0x01}, OwnerSignature: sig,
+			CarrierNonce: new(big.Int).Set(carrier),
+		}
+		if err := checkDeferredCarrierNonce(auth, carrier, sender); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("mismatch fails with both values", func(t *testing.T) {
+		auth := &SessionAuthorization{
+			EntityID: 1, SignerKey: testKey(t),
+			DeferredData: []byte{0x01}, OwnerSignature: sig,
+			CarrierNonce: new(big.Int).Set(carrier),
+		}
+		wrong := big.NewInt(0)
+		err := checkDeferredCarrierNonce(auth, wrong, sender)
+		if err == nil {
+			t.Fatal("expected mismatch error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, carrier.String()) || !strings.Contains(msg, wrong.String()) {
+			t.Errorf("error should name both nonces: %v", err)
+		}
+		if !strings.Contains(msg, sender.Hex()) {
+			t.Errorf("error should name the sender: %v", err)
+		}
+	})
+}
+
+// EffectiveFactory must ignore the raw v0.6 smart_wallet.factory_address when
+// account_provider is modular_account_v2 — the false diagnosis in the AA23
+// factory-mismatch findings was rooted in logging the raw field instead.
+func TestEffectiveFactoryIgnoresV06ConfigUnderMAv2(t *testing.T) {
+	v06 := common.HexToAddress(config.DefaultFactoryProxyAddressHex)
+	swCfg := &config.SmartWalletConfig{
+		AccountProvider: config.AccountProviderModularAccountV2,
+		FactoryAddress:  v06,
+	}
+	got, err := aa.EffectiveFactory(swCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != aa.MAv2FactoryAddress() {
+		t.Errorf("EffectiveFactory = %s, want MA v2 factory %s (raw config was %s)",
+			got.Hex(), aa.MAv2FactoryAddress().Hex(), v06.Hex())
+	}
+	if got == v06 {
+		t.Error("EffectiveFactory must not return the configured v0.6 factory under modular_account_v2")
+	}
+}
+
+// SessionAuthorization.PolicyID / CarrierNonce are optional metadata; Validate
+// must still accept a grant that only has entity + key (applied grants).
+func TestSessionAuthOptionalMetadata(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth := &SessionAuthorization{
+		EntityID:     1,
+		SignerKey:    key,
+		PolicyID:     "01kz8ebkzgv2th9r32w9qrcw79",
+		CarrierNonce: big.NewInt(1),
+	}
+	if err := auth.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnotatePrefundError(t *testing.T) {
+	sender := common.HexToAddress("0x46aD59AFc8a21F0dfa3FE74C53A998b7550c7BDd")
+	raw := fmt.Errorf("eth_sendUserOperation: precheck failed: sender balance and deposit together is 0 but must be at least 1")
+	got := annotatePrefundError(raw, sender)
+	if got == nil {
+		t.Fatal("expected annotated error")
+	}
+	msg := got.Error()
+	if !strings.Contains(msg, sender.Hex()) {
+		t.Errorf("should name sender: %v", got)
+	}
+	if !strings.Contains(msg, "ALCHEMY_PAYMASTER_POLICY_ID") &&
+		!strings.Contains(msg, "alchemy_paymaster_policy_id") {
+		t.Errorf("should point at Alchemy paymaster policy: %v", got)
+	}
+	// Non-prefund errors pass through unchanged (same error value).
+	other := fmt.Errorf("AA25 invalid account nonce")
+	if annotatePrefundError(other, sender) != other {
+		t.Error("non-prefund errors must not be rewrapped into a different identity check beyond annotation")
+	}
+	// Actually annotatePrefundError always wraps only prefund; for non-match returns err as-is
+	if annotatePrefundError(other, sender).Error() != other.Error() {
+		t.Errorf("got %v", annotatePrefundError(other, sender))
+	}
+}

--- a/pkg/erc4337/preset/session_auth.go
+++ b/pkg/erc4337/preset/session_auth.go
@@ -41,6 +41,16 @@ type SessionAuthorization struct {
 	DeferredData   []byte
 	OwnerSignature []byte
 
+	// CarrierNonce is the full 256-bit nonce the owner signed over at grant
+	// time (entity + deferred options + sequence 0). Optional: when set on a
+	// deferred operation, the send path asserts op.Nonce equals this value
+	// before estimation so a drift cannot surface as opaque AA23.
+	CarrierNonce *big.Int
+
+	// PolicyID is the storage id of the SessionPolicy this authorization
+	// came from. Logging only — never affects validation.
+	PolicyID string
+
 	// WrapExecuteUserOp opts the operation into user-op context, which every
 	// operation under a grant carrying EXECUTION hooks must do. It is derived
 	// from the stored grant's contents, not guessed: an ERC-20 spend cap
@@ -149,8 +159,12 @@ func seedVerificationGasFor(op *userop.UserOperationV07, auth *SessionAuthorizat
 }
 
 // SessionResolver answers "under what authority may the gateway execute for
-// this wallet?" — returning nil when there is no grant, which leaves the
-// operation on the owner's fallback signer.
+// this wallet?" — returning nil when there is no grant.
+//
+// A nil result is a hard failure on the MA v2 send path: the gateway cannot
+// sign as the owner fallback, and estimating a doomed controller-as-fallback
+// UserOp only produces opaque AA23. Callers that supply their own
+// SessionAuthorization (tests, spikes) never hit the resolver.
 //
 // This exists so the send path never reaches into storage. The gateway
 // installs one resolver at boot that reads SessionPolicy records; tests and


### PR DESCRIPTION
## Summary

**Root cause (proven with staged debug logs):** `GetNodeDataForExecution` dropped `methodCalls[].contractAddress` on the proto→map→proto round-trip used by `nodes:run`. Atomic Uniswap Auto batches (`approve` + `exactInputSingle`) fell back to the node-level SwapRouter for both calls. Session hooks allowlist USDC.`approve` + router.`exactInputSingle` → hooks rejected approve-on-router → opaque **AA23** at Alchemy Gas Manager.

**Fix:**
- Include `contractAddress` when extracting ContractWrite methodCalls (main path + loop runner)
- Preserve it in `processContractWriteTemplates`
- Temporary `AA23_DEBUG` stages: raw body → post-bind → post-map → per-call targets (leave until prod verification)

**Also in this PR (MA v2 / AA23 campaign):**
- Fail-fast missing session grant / wrong factory or salt (no more opaque AA23)
- Deferred carrier nonce assert; heal path for applied grants
- Canonical `alchemy_paymaster_policy_id` / `ALCHEMY_PAYMASTER_POLICY_ID`
- Effective-factory boot logs; guard unit + integration tests
- `FINDINGS_AA23_FACTORY_MISMATCH.md`

## Live verification (Sepolia)

After packing fix:
- `approve` → USDC (`usedNodeFallback: false`)
- `exactInputSingle` → router
- UserOp sponsored + mined: [`0xd600f285…8078cd`](https://sepolia.etherscan.io/tx/0xd600f2853ab929886666538d3939d7de88a6d76baa6b2660c1a1164c1e8078cd)

## Test plan

- [x] Live Auto swap 1 USDC→ETH on Sepolia succeeds with correct dual targets
- [ ] Unit: `go test ./pkg/erc4337/preset/ -run Send` / guards tests
- [ ] Integration (optional): `TestMAv2SendRejects*` on Sepolia tags
- [ ] Confirm `AA23_DEBUG contractWrite.per-call-targets` shows USDC on approve
- [ ] Follow-up: remove temporary AA23_DEBUG logs after prod soak

## Related

Studio instrumentation PR: https://github.com/AvaProtocol/studio/pull/1455