### PR TITLE
fix: AA23 cleanup, MA v2 grant guard, Gas Manager webhookData

### DIFF
--- a/FINDINGS_AA23_FACTORY_MISMATCH.md
+++ b/FINDINGS_AA23_FACTORY_MISMATCH.md
@@ -5,9 +5,16 @@
 “factory_address / account_provider mismatch”.  
 **Found during:** Studio live test of Auto-mode Uniswap swap, owner EOA
 `0xc60e71bd…c788`, Sepolia.  
-**Status:** **Resolved for case B (first-use MA v2)** — end-to-end UserOp mined
-on Sepolia under Gas Manager. Earlier Studio AA23 at Gas Manager was not a
-durable send-path bug (see “Resolution” below).
+**Status:** **Resolved** (merged to staging as PR #706). Root cause of Studio
+Auto AA23 was `methodCalls[].contractAddress` dropped on the `nodes:run`
+extract→recreate round-trip (approve fell back to the router). Packing fix
+verified live on Sepolia under Gas Manager.
+
+**AVS follow-ups (this branch):** strip temporary `AA23_DEBUG` logs; refuse
+session grant prepare/submit for non–MA v2 runners (SimpleAccount).
+
+**Not AVS:** Studio Fix C / consent Deny / false-Confirmed hydrate — stay in
+Studio plans. Gas Manager custom-rules webhook still optional ops wiring.
 
 ---
 
@@ -21,7 +28,9 @@ durable send-path bug (see “Resolution” below).
 | 4 | Zero balance without sponsorship | **Fixed as guard** — fail-fast + clear error; sponsorship is the product path |
 | 5 | Misleading boot logs / v0.6 paymaster probe | **Fixed (code)** — effective factory/EP/policy logged; MA v2 skips v0.6 probe |
 | 6 | Moralis “no API key” WARN | **Fixed (config)** — top-level `moralis_api_key` (fee USD only; not UserOps) |
-| 7 | AA23 on first-use MA v2 under Gas Manager | **Resolved** — full path verified; wallet deployed + swap mined |
+| 7 | AA23 on first-use / Auto batch under Gas Manager | **Fixed (#706)** — preserve per-call `contractAddress`; live Sepolia mine |
+| 8 | Temporary `AA23_DEBUG` instrumentation | **Stripped** (cleanup after #706 soak) |
+| 9 | Session grant on SimpleAccount runner | **Fixed** — prepare/submit refuse non–MA v2 |
 
 ---
 

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -1,9 +1,7 @@
 package rest
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -29,33 +27,15 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		return err
 	}
 
-	// AA23 debug: capture the raw HTTP body BEFORE Bind consumes it, so we can
-	// prove whether Studio's JSON carried methodCalls[].contractAddress on the wire.
-	// Grep gateway.log for "AA23_DEBUG". Temporary — remove once root cause is closed.
-	// Always restore Body so Bind still works even when ReadAll fails mid-stream.
-	rawBody, rawErr := io.ReadAll(ctx.Request().Body)
-	ctx.Request().Body = io.NopCloser(bytes.NewReader(rawBody))
-	if rawErr != nil {
-		if s.logger != nil {
-			s.logger.Warn("AA23_DEBUG RunNode: failed to read raw body", "error", rawErr.Error(), "bytes_read", len(rawBody))
-		}
-	} else {
-		s.logAA23RawBodyMethodCalls(rawBody)
-	}
-
 	var body generated.RunNodeRequest
 	if err := ctx.Bind(&body); err != nil {
 		return badRequest("NODES_BAD_REQUEST", "Invalid request body", err.Error())
 	}
 
-	s.logAA23OpenAPIMethodCalls("post-bind", body.Node)
-
 	node, err := mapping.OpenAPIToProtoNode(body.Node)
 	if err != nil {
 		return badRequest("NODES_BAD_NODE", "Invalid node payload", err.Error())
 	}
-
-	s.logAA23ProtoMethodCalls("post-map", node)
 
 	req := &avsproto.RunNodeWithInputsReq{Node: node}
 	if body.ChainId != nil {
@@ -88,165 +68,6 @@ func (s *Server) RunNode(ctx echo.Context) error {
 		return err
 	}
 	return ctx.JSON(http.StatusOK, runNodeRespToOpenAPI(resp))
-}
-
-// logAA23RawBodyMethodCalls extracts methodCalls[].contractAddress from the raw
-// HTTP JSON body before any struct Bind. Proves what Studio put on the wire.
-// Temporary AA23 instrumentation — remove when closed.
-func (s *Server) logAA23RawBodyMethodCalls(raw []byte) {
-	if s.logger == nil {
-		return
-	}
-	var probe struct {
-		Node *struct {
-			ID     string `json:"id"`
-			Type   string `json:"type"`
-			Config *struct {
-				ContractAddress string `json:"contractAddress"`
-				ChainID         int64  `json:"chainId"`
-				IsSimulated     *bool  `json:"isSimulated"`
-				MethodCalls     []struct {
-					MethodName      string   `json:"methodName"`
-					ContractAddress *string  `json:"contractAddress"`
-					MethodParams    []string `json:"methodParams"`
-				} `json:"methodCalls"`
-			} `json:"config"`
-		} `json:"node"`
-	}
-	if err := json.Unmarshal(raw, &probe); err != nil {
-		s.logger.Warn("AA23_DEBUG RunNode.raw-body: JSON parse failed",
-			"error", err.Error(), "body_bytes", len(raw))
-		return
-	}
-	if probe.Node == nil || probe.Node.Config == nil {
-		s.logger.Debug("AA23_DEBUG RunNode.raw-body: no contractWrite config",
-			"body_bytes", len(raw))
-		return
-	}
-	cfg := probe.Node.Config
-	type callSnap struct {
-		Index              int    `json:"index"`
-		MethodName         string `json:"methodName"`
-		HasContractAddress bool   `json:"hasContractAddress"`
-		ContractAddress    string `json:"contractAddress"`
-		MethodParamsCount  int    `json:"methodParamsCount"`
-	}
-	calls := make([]callSnap, 0, len(cfg.MethodCalls))
-	for i, mc := range cfg.MethodCalls {
-		snap := callSnap{
-			Index:             i,
-			MethodName:        mc.MethodName,
-			MethodParamsCount: len(mc.MethodParams),
-		}
-		if mc.ContractAddress != nil {
-			snap.HasContractAddress = true
-			snap.ContractAddress = *mc.ContractAddress
-		}
-		calls = append(calls, snap)
-	}
-	isSim := interface{}(nil)
-	if cfg.IsSimulated != nil {
-		isSim = *cfg.IsSimulated
-	}
-	s.logger.Debug("AA23_DEBUG RunNode.raw-body",
-		"body_bytes", len(raw),
-		"node_id", probe.Node.ID,
-		"node_type", probe.Node.Type,
-		"node_contract", cfg.ContractAddress,
-		"chain_id", cfg.ChainID,
-		"is_simulated", isSim,
-		"method_call_count", len(calls),
-		"method_calls", calls,
-	)
-}
-
-// logAA23OpenAPIMethodCalls logs methodCalls after Echo Bind + AsContractWriteNode.
-// Temporary AA23 instrumentation.
-func (s *Server) logAA23OpenAPIMethodCalls(stage string, n generated.Node) {
-	if s.logger == nil {
-		return
-	}
-	if n.Type != generated.NodeTypeContractWrite {
-		s.logger.Debug("AA23_DEBUG RunNode."+stage+": not contractWrite",
-			"node_id", n.Id, "node_type", string(n.Type))
-		return
-	}
-	cw, err := n.AsContractWriteNode()
-	if err != nil || cw.Config == nil {
-		s.logger.Warn("AA23_DEBUG RunNode."+stage+": AsContractWriteNode failed",
-			"node_id", n.Id, "error", errString(err))
-		return
-	}
-	cfg := cw.Config
-	type callSnap struct {
-		Index              int    `json:"index"`
-		MethodName         string `json:"methodName"`
-		HasContractAddress bool   `json:"hasContractAddress"`
-		ContractAddress    string `json:"contractAddress"`
-	}
-	var calls []callSnap
-	if cfg.MethodCalls != nil {
-		for i, mc := range *cfg.MethodCalls {
-			snap := callSnap{Index: i, MethodName: mc.MethodName}
-			if mc.ContractAddress != nil {
-				snap.HasContractAddress = true
-				snap.ContractAddress = string(*mc.ContractAddress)
-			}
-			calls = append(calls, snap)
-		}
-	}
-	s.logger.Debug("AA23_DEBUG RunNode."+stage,
-		"node_id", n.Id,
-		"node_contract", string(cfg.ContractAddress),
-		"chain_id", cfg.ChainId,
-		"method_call_count", len(calls),
-		"method_calls", calls,
-	)
-}
-
-// logAA23ProtoMethodCalls logs methodCalls after OpenAPI→proto mapping.
-// Temporary AA23 instrumentation.
-func (s *Server) logAA23ProtoMethodCalls(stage string, node *avsproto.TaskNode) {
-	if s.logger == nil || node == nil {
-		return
-	}
-	cw := node.GetContractWrite()
-	if cw == nil || cw.GetConfig() == nil {
-		s.logger.Debug("AA23_DEBUG RunNode."+stage+": no ContractWrite config",
-			"node_id", node.GetId(), "type", node.GetType().String())
-		return
-	}
-	cfg := cw.GetConfig()
-	type callSnap struct {
-		Index              int    `json:"index"`
-		MethodName         string `json:"methodName"`
-		HasContractAddress bool   `json:"hasContractAddress"`
-		ContractAddress    string `json:"contractAddress"`
-	}
-	calls := make([]callSnap, 0, len(cfg.GetMethodCalls()))
-	for i, mc := range cfg.GetMethodCalls() {
-		addr := mc.GetContractAddress()
-		calls = append(calls, callSnap{
-			Index:              i,
-			MethodName:         mc.GetMethodName(),
-			HasContractAddress: mc.ContractAddress != nil && addr != "",
-			ContractAddress:    addr,
-		})
-	}
-	s.logger.Debug("AA23_DEBUG RunNode."+stage,
-		"node_id", node.GetId(),
-		"node_contract", cfg.GetContractAddress(),
-		"chain_id", cfg.GetChainId(),
-		"method_call_count", len(calls),
-		"method_calls", calls,
-	)
-}
-
-func errString(err error) string {
-	if err == nil {
-		return ""
-	}
-	return err.Error()
 }
 
 // openAPIERC20OverridesToProto maps the REST ERC20StateOverride list onto the

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -328,6 +328,8 @@ func filterToDeclaredFields(domain interface{}, declared []apitypes.Type) interf
 // mapPolicyError translates engine sentinels into REST problems.
 func mapPolicyError(err error) error {
 	switch {
+	case errors.Is(err, taskengine.ErrSessionWalletNotMAv2):
+		return badRequest("SESSION_WALLET_NOT_MA_V2", err.Error(), "")
 	case errors.Is(err, taskengine.ErrWalletNotOwned), errors.Is(err, taskengine.ErrSessionPolicyNotFound):
 		// Existence is not confirmed to non-owners: both cases read as 404.
 		return &restmw.HTTPError{Status: http.StatusNotFound, Code: "POLICIES_NOT_FOUND",

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -760,7 +760,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			WhitelistAddresses:       convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
 			MaxWalletsPerOwner:       configRaw.SmartWallet.MaxWalletsPerOwner,
 			AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
-			GasManagerWebhookSecret:  firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
+			GasManagerWebhookSecret:  strings.TrimSpace(firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET"))),
 			// PaymasterOwnerAddress will be populated below by calling owner() on the paymaster contract
 		},
 
@@ -781,7 +781,9 @@ func NewConfig(configFilePath string) (*Config, error) {
 		// Alchemy paymaster policy (Gas Manager) + admin API
 		AlchemyAPISecret:         firstNonEmpty(configRaw.AlchemyAPISecret, os.Getenv("ALCHEMY_API_SECRET")),
 		AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
-		GasManagerWebhookSecret:  firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
+		// Trim: pasted secrets often carry trailing whitespace; webhook compares
+		// with subtle.ConstantTimeCompare on the raw webhookData body field.
+		GasManagerWebhookSecret: strings.TrimSpace(firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET"))),
 
 		// Initialize fee rates - use defaults if no YAML config provided
 		FeeRates: loadFeeRatesFromConfig(configRaw.FeeRates),

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -162,8 +162,8 @@ type Config struct {
 	// GasManagerWebhookSecret, when set, must be echoed as the webhook
 	// request's webhookData. The webhook cannot sit behind the REST JWT
 	// (Alchemy has no token), so this is its only caller authentication.
-	// Optional so the endpoint can be brought up before the sponsorship
-	// caller is taught to send it.
+	// RequestSponsorshipV07 sends this value as Alchemy webhookData when set.
+	// Empty disables the check on both the sponsorship call and the webhook.
 	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
 
 	// Fee rates configuration for task execution pricing
@@ -259,6 +259,12 @@ type SmartWalletConfig struct {
 	// sponsorship without reaching back up. Empty means unsponsored: the
 	// operation is priced by estimation and the account pays its own gas.
 	AlchemyPaymasterPolicyID string
+
+	// GasManagerWebhookSecret is copied down from the top-level config with the
+	// policy id. When set, RequestSponsorshipV07 sends it as Alchemy's
+	// webhookData so the custom-rules webhook can authenticate the call.
+	// Empty omits the field (webhook secret check disabled on the gateway).
+	GasManagerWebhookSecret string
 }
 
 // Bundler provider identifiers for SmartWalletConfig.BundlerProvider.
@@ -754,6 +760,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			WhitelistAddresses:       convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
 			MaxWalletsPerOwner:       configRaw.SmartWallet.MaxWalletsPerOwner,
 			AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
+			GasManagerWebhookSecret:  firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")),
 			// PaymasterOwnerAddress will be populated below by calling owner() on the paymaster contract
 		},
 
@@ -847,8 +854,9 @@ func NewConfig(configFilePath string) (*Config, error) {
 			}
 			// Sponsorship is configured once for the gateway, not per chain, but
 			// the v0.7 send path is only ever handed a SmartWalletConfig. Push
-			// the policy down so every chain can reach it.
+			// the policy and webhook secret down so every chain can reach them.
 			chainCfg.SmartWallet.AlchemyPaymasterPolicyID = config.AlchemyPaymasterPolicyID
+			chainCfg.SmartWallet.GasManagerWebhookSecret = config.GasManagerWebhookSecret
 			config.Chains = append(config.Chains, chainCfg)
 		}
 

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	badger "github.com/dgraph-io/badger/v4"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/oklog/ulid/v2"
@@ -107,20 +108,27 @@ func (n *Engine) requireMAv2SessionWallet(user *model.User, chainID int64, walle
 
 // lookupOwnedWalletRecord loads the stored smart-wallet row for (owner, wallet),
 // preferring the grant's chainID then falling back to any known chain.
-// Missing keys are not errors — the caller treats nil as "no factory recorded".
+// badger.ErrKeyNotFound is "missing" (nil, nil); any other DB error is returned.
 func (n *Engine) lookupOwnedWalletRecord(user *model.User, chainID int64, wallet common.Address) (*model.SmartWallet, error) {
 	if n.db == nil || user == nil {
 		return nil, fmt.Errorf("storage unavailable")
 	}
-	try := func(id int64) *model.SmartWallet {
+	try := func(id int64) (*model.SmartWallet, error) {
 		rec, err := GetWallet(n.db, id, user.Address, wallet.Hex())
-		if err != nil || rec == nil {
-			return nil
+		if err != nil {
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				return nil, nil
+			}
+			return nil, err
 		}
-		return rec
+		return rec, nil
 	}
 	if chainID > 0 {
-		if rec := try(chainID); rec != nil {
+		rec, err := try(chainID)
+		if err != nil {
+			return nil, err
+		}
+		if rec != nil {
 			return rec, nil
 		}
 	}
@@ -128,7 +136,11 @@ func (n *Engine) lookupOwnedWalletRecord(user *model.User, chainID int64, wallet
 		if id == chainID {
 			continue
 		}
-		if rec := try(id); rec != nil {
+		rec, err := try(id)
+		if err != nil {
+			return nil, err
+		}
+		if rec != nil {
 			return rec, nil
 		}
 	}

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/oklog/ulid/v2"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 )
 
@@ -27,6 +28,11 @@ var (
 	ErrSessionEntityTaken = errors.New("validation entity was taken while the grant was being signed")
 	// ErrSessionPolicyNotFound → 404.
 	ErrSessionPolicyNotFound = errors.New("session policy not found")
+	// ErrSessionWalletNotMAv2: grants only validate on Modular Account v2 runners.
+	// A legacy SimpleAccount (or missing factory on the wallet record) must be
+	// refused at prepare/submit so clients never collect a doomed owner signature.
+	// Studio filters Auto to MA v2; this is the gateway belt-and-braces half.
+	ErrSessionWalletNotMAv2 = errors.New("session grants require a Modular Account v2 smart wallet; legacy SimpleAccount cannot host session policies")
 )
 
 // SessionPolicyInput carries one grant's declared shape between prepare and
@@ -78,13 +84,64 @@ func (n *Engine) requireOwnedWallet(user *model.User, wallet common.Address) err
 	return nil
 }
 
+// requireMAv2SessionWallet refuses prepare/submit when the target runner is
+// not Modular Account v2. Session policies install ERC-6900 modules; a v0.6
+// SimpleAccount cannot validate them and would only produce opaque AA23 later.
+func (n *Engine) requireMAv2SessionWallet(user *model.User, chainID int64, wallet common.Address) error {
+	if err := n.requireOwnedWallet(user, wallet); err != nil {
+		return err
+	}
+	rec, err := n.lookupOwnedWalletRecord(user, chainID, wallet)
+	if err != nil {
+		return fmt.Errorf("loading wallet %s for session grant: %w", wallet.Hex(), err)
+	}
+	if rec == nil || rec.Factory == nil || *rec.Factory == (common.Address{}) {
+		return fmt.Errorf("%w: no factory recorded for %s", ErrSessionWalletNotMAv2, wallet.Hex())
+	}
+	if aa.ProviderForFactory(*rec.Factory) != aa.ProviderModularAccountV2 {
+		return fmt.Errorf("%w: wallet %s uses factory %s",
+			ErrSessionWalletNotMAv2, wallet.Hex(), rec.Factory.Hex())
+	}
+	return nil
+}
+
+// lookupOwnedWalletRecord loads the stored smart-wallet row for (owner, wallet),
+// preferring the grant's chainID then falling back to any known chain.
+// Missing keys are not errors — the caller treats nil as "no factory recorded".
+func (n *Engine) lookupOwnedWalletRecord(user *model.User, chainID int64, wallet common.Address) (*model.SmartWallet, error) {
+	if n.db == nil || user == nil {
+		return nil, fmt.Errorf("storage unavailable")
+	}
+	try := func(id int64) *model.SmartWallet {
+		rec, err := GetWallet(n.db, id, user.Address, wallet.Hex())
+		if err != nil || rec == nil {
+			return nil
+		}
+		return rec
+	}
+	if chainID > 0 {
+		if rec := try(chainID); rec != nil {
+			return rec, nil
+		}
+	}
+	for _, id := range n.knownChainIDs() {
+		if id == chainID {
+			continue
+		}
+		if rec := try(id); rec != nil {
+			return rec, nil
+		}
+	}
+	return nil, nil
+}
+
 // PrepareSessionPolicy allocates a grant and returns what the owner signs.
 // Nothing is stored; an abandoned prepare leaves no state.
 func (n *Engine) PrepareSessionPolicy(user *model.User, in SessionPolicyInput) (*PreparedSessionGrant, error) {
 	if err := in.validate(); err != nil {
 		return nil, err
 	}
-	if err := n.requireOwnedWallet(user, in.Wallet); err != nil {
+	if err := n.requireMAv2SessionWallet(user, in.ChainID, in.Wallet); err != nil {
 		return nil, err
 	}
 	signer, err := n.sessionSignerAddress()
@@ -126,7 +183,7 @@ func (n *Engine) SubmitSessionPolicy(
 	if err := in.validate(); err != nil {
 		return nil, err
 	}
-	if err := n.requireOwnedWallet(user, in.Wallet); err != nil {
+	if err := n.requireMAv2SessionWallet(user, in.ChainID, in.Wallet); err != nil {
 		return nil, err
 	}
 	if _, err := ulid.ParseStrict(strings.ToUpper(policyID)); err != nil {

--- a/core/taskengine/engine_session_policy_test.go
+++ b/core/taskengine/engine_session_policy_test.go
@@ -75,6 +75,25 @@ func signDigest(t *testing.T, key *ecdsa.PrivateKey, digest common.Hash) []byte 
 	return sig
 }
 
+func TestSessionPolicyPrepareRejectsSimpleAccountRunner(t *testing.T) {
+	engine, db, _, owner, _ := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	// Legacy v0.6 SimpleAccount factory (not MA v2).
+	v06Factory := common.HexToAddress("0xB99BC2E399e06CddCF5E725c0ea341E8f0322834")
+	v06Wallet := common.HexToAddress("0x00000000000000000000000000000000000000b6")
+	require.NoError(t, StoreWallet(db, testPolicyChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &v06Wallet, Factory: &v06Factory, Salt: big.NewInt(0),
+	}))
+
+	_, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: v06Wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "should refuse",
+		Permissions: testPermissions(),
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSessionWalletNotMAv2)
+}
+
 func TestSessionPolicyPrepareSubmitRoundTrip(t *testing.T) {
 	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
 	user := &model.User{Address: owner}

--- a/core/taskengine/extract_node_config_test.go
+++ b/core/taskengine/extract_node_config_test.go
@@ -722,3 +722,40 @@ func TestExtractNodeConfiguration_ETHTransferNode(t *testing.T) {
 	_, err := structpb.NewValue(config)
 	assert.NoError(t, err, "Protobuf conversion should succeed for ETHTransfer node")
 }
+
+func TestExtractNodeConfiguration_PreservesMethodCallContractAddress(t *testing.T) {
+	// Regression for PR #706: GetNodeDataForExecution round-trip used ExtractNodeConfiguration
+	// then CreateNodeFromType; dropping methodCalls[].contractAddress made atomic
+	// approve+swap send approve to the node-level router → AA23 under session hooks.
+	usdc := "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+	router := "0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E"
+	node := &avsproto.TaskNode{
+		Id:   "cw1",
+		Name: "swap",
+		Type: avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE,
+		TaskType: &avsproto.TaskNode_ContractWrite{
+			ContractWrite: &avsproto.ContractWriteNode{
+				Config: &avsproto.ContractWriteNode_Config{
+					ContractAddress: router,
+					ChainId:         11155111,
+					MethodCalls: []*avsproto.ContractWriteNode_MethodCall{
+						{MethodName: "approve", ContractAddress: &usdc, MethodParams: []string{router, "1"}},
+						{MethodName: "exactInputSingle", MethodParams: []string{"{}"}},
+					},
+				},
+			},
+		},
+	}
+	cfg := ExtractNodeConfiguration(node)
+	require.NotNil(t, cfg)
+	calls, ok := cfg["methodCalls"].([]interface{})
+	require.True(t, ok, "methodCalls should be []interface{}")
+	require.Len(t, calls, 2)
+	first, ok := calls[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, usdc, first["contractAddress"], "approve must keep per-call token address through extract")
+	second, ok := calls[1].(map[string]interface{})
+	require.True(t, ok)
+	_, has := second["contractAddress"]
+	assert.False(t, has, "exactInputSingle without override should omit the field")
+}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -716,7 +716,9 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 		}
 	}
 
-	// Determine if paymaster should be used based on transaction limits and whitelist
+	// Determine if the v0.6 verifying paymaster should be attached. MA v2 never
+	// uses that path (sponsorship is Alchemy Gas Manager policy); log accordingly
+	// so ops do not think "no paymaster" means unsponsored when the policy is set.
 	var paymasterReq *preset.VerifyingPaymasterRequest
 	if r.shouldUsePaymaster() {
 		paymasterReq = preset.GetVerifyingPaymasterRequestForDuration(
@@ -726,6 +728,15 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 		r.vm.logger.Info("Using paymaster for sponsored transaction",
 			"paymaster", r.smartWalletConfig.PaymasterAddress.Hex(),
 			"owner", r.owner.Hex())
+	} else if r.smartWalletConfig != nil && r.smartWalletConfig.UsesModularAccountV2() {
+		if r.smartWalletConfig.AlchemyPaymasterPolicyID != "" {
+			r.vm.logger.Info("MA v2: Gas Manager will sponsor (alchemy_paymaster_policy_id set)",
+				"owner", r.owner.Hex(),
+				"paymaster_policy_set", true)
+		} else {
+			r.vm.logger.Info("MA v2: self-funded (no alchemy_paymaster_policy_id)",
+				"owner", r.owner.Hex())
+		}
 	} else {
 		r.vm.logger.Info("Using regular transaction (no paymaster)",
 			"owner", r.owner.Hex())
@@ -1890,69 +1901,24 @@ func (r *ContractWriteProcessor) Execute(stepID string, node *avsproto.ContractW
 	// (e.g. approve on the token + swap on the router). Absent = the node-level contract (common case,
 	// so pre-existing tasks — which never carry this new field — are unaffected).
 	perCallTargets := make([]common.Address, len(methodCalls))
-	type aa23CallSnap struct {
-		Index             int    `json:"index"`
-		MethodName        string `json:"methodName"`
-		RawOverride       string `json:"rawOverride"`
-		HasRawOverride    bool   `json:"hasRawOverride"`
-		ResolvedOverride  string `json:"resolvedOverride"`
-		UsedNodeFallback  bool   `json:"usedNodeFallback"`
-		ResolvedTarget    string `json:"resolvedTarget"`
-		NodeLevelContract string `json:"nodeLevelContract"`
-	}
-	aa23Snaps := make([]aa23CallSnap, 0, len(methodCalls))
 	for i, mc := range methodCalls {
 		perCallTargets[i] = contractAddr
-		rawOverride := ""
-		hasRaw := false
-		if mc != nil && mc.ContractAddress != nil {
-			hasRaw = true
-			rawOverride = *mc.ContractAddress
-		}
 		override := strings.TrimSpace(mc.GetContractAddress())
-		snap := aa23CallSnap{
-			Index:             i,
-			MethodName:        mc.GetMethodName(),
-			RawOverride:       rawOverride,
-			HasRawOverride:    hasRaw,
-			UsedNodeFallback:  override == "",
-			NodeLevelContract: contractAddr.Hex(),
-			ResolvedTarget:    contractAddr.Hex(),
-		}
 		if override != "" {
 			resolved := r.vm.preprocessTextWithVariableMapping(override)
-			snap.ResolvedOverride = resolved
 			if !common.IsHexAddress(resolved) {
 				// A per-call target was explicitly provided but did not resolve to a valid address
 				// (unresolved {{template}}, typo, or a variable that resolved to empty). Fail fast
 				// instead of silently falling back to the node-level contract — sending an atomic,
 				// irreversible sub-call to the wrong contract is exactly the footgun this feature
 				// exists to prevent. Mirrors the node-level validation in getInputData.
-				if r.vm != nil && r.vm.logger != nil {
-					r.vm.logger.Error("AA23_DEBUG contractWrite.per-call-target INVALID",
-						"index", i, "method", mc.GetMethodName(),
-						"raw_override", rawOverride, "resolved", resolved)
-				}
 				err = NewInvalidAddressError(resolved)
 				finalizeErrorMsg = err.Error()
 				finalizeSuccess = false
 				return s, err
 			}
 			perCallTargets[i] = common.HexToAddress(resolved)
-			snap.UsedNodeFallback = false
-			snap.ResolvedTarget = perCallTargets[i].Hex()
 		}
-		aa23Snaps = append(aa23Snaps, snap)
-	}
-	// AA23 debug: single summary of how every sub-call target was resolved.
-	// Debug level — temporary instrumentation (avoid Info noise on every multi-call write).
-	// Grep gateway.log for "AA23_DEBUG contractWrite.per-call-targets".
-	if r.vm != nil && r.vm.logger != nil {
-		r.vm.logger.Debug("AA23_DEBUG contractWrite.per-call-targets",
-			"node_contract", contractAddr.Hex(),
-			"method_call_count", len(methodCalls),
-			"calls", aa23Snaps,
-		)
 	}
 
 	// Atomic-batch route: on-demand (nodes:run) real execution of more than one method call. Instead

--- a/pkg/erc4337/preset/builder_v07.go
+++ b/pkg/erc4337/preset/builder_v07.go
@@ -287,6 +287,11 @@ func NextNonceV07(ctx context.Context, client *rpc.Client, entryPoint, sender co
 // SponsorshipRequestV07 asks Alchemy's Gas Manager to cover the operation.
 type SponsorshipRequestV07 struct {
 	PolicyID string
+	// WebhookData is echoed by Alchemy to the policy's custom-rules webhook as
+	// webhookData. When the gateway has gas_manager_webhook_secret set, this
+	// must match that secret or the webhook denies sponsorship. Empty omits
+	// the field (no secret check on the webhook side either).
+	WebhookData string
 }
 
 type sponsorshipResultV07 struct {
@@ -312,11 +317,11 @@ type sponsorshipResultV07 struct {
 // an unsponsored operation. That is the shape we want: an operation that
 // silently fell back to self-funded would drain the account instead.
 //
-// Note the webhook is NOT currently configured on the policy (webhookRules is
-// null), so nothing consults the gateway's FeeLedger gate today and any sender
-// reaching the policy is sponsored within its caps. Enabling it is what makes
-// the credit limit bind — and it also means MA v2 wallets must be registered
-// in gateway storage first, or the webhook will refuse every one of them.
+// When the policy's custom-rules webhook is pointed at the gateway
+// (/webhooks/gas-manager), FeeLedger credit checks bind here. MA v2 wallets
+// must be registered in gateway storage or the webhook refuses them. If
+// gas_manager_webhook_secret is set, WebhookData must match or every request
+// is denied.
 func RequestSponsorshipV07(ctx context.Context, client *rpc.Client, op *userop.UserOperationV07, entryPoint common.Address, req SponsorshipRequestV07) error {
 	if client == nil {
 		return fmt.Errorf("nil bundler client")
@@ -346,6 +351,12 @@ func RequestSponsorshipV07(ctx context.Context, client *rpc.Client, op *userop.U
 		"entryPoint":     entryPoint.Hex(),
 		"dummySignature": fmt.Sprintf("0x%x", dummy),
 		"userOperation":  json.RawMessage(payload),
+	}
+	// Only include when non-empty — Alchemy's schema treats webhookData as
+	// optional; sending "" is fine but omitting keeps the body minimal and
+	// matches the "secret unset" deployment path.
+	if req.WebhookData != "" {
+		params["webhookData"] = req.WebhookData
 	}
 
 	var res sponsorshipResultV07

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -490,7 +490,10 @@ func priceOperationV07(
 ) error {
 	if policyID := smartWalletConfig.AlchemyPaymasterPolicyID; policyID != "" {
 		if err := RequestSponsorshipV07(ctx, bundlerRPC, op, entryPoint,
-			SponsorshipRequestV07{PolicyID: policyID}); err != nil {
+			SponsorshipRequestV07{
+				PolicyID:    policyID,
+				WebhookData: smartWalletConfig.GasManagerWebhookSecret,
+			}); err != nil {
 			// Deliberately fatal. See SendUserOpV07's contract: falling through
 			// to an unsponsored send would spend the account's own balance on
 			// an operation the policy just refused to fund.

--- a/pkg/erc4337/preset/sponsorship_webhook_test.go
+++ b/pkg/erc4337/preset/sponsorship_webhook_test.go
@@ -1,29 +1,70 @@
 package preset
 
 import (
+	"context"
 	"encoding/json"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 )
 
-// Ensures RequestSponsorshipV07 request shape includes webhookData only when set.
-// Full RPC is not exercised here; this guards the param map construction contract
-// used against Alchemy's custom-rules webhook (gas_manager_webhook_secret).
-func TestSponsorshipRequestV07_WebhookDataOptional(t *testing.T) {
-	t.Parallel()
-	if (SponsorshipRequestV07{PolicyID: "p", WebhookData: "secret"}).WebhookData != "secret" {
-		t.Fatal("WebhookData field must be settable on SponsorshipRequestV07")
-	}
-	if (SponsorshipRequestV07{PolicyID: "p"}).WebhookData != "" {
-		t.Fatal("WebhookData must default empty")
-	}
+// stubAlchemySponsorship is a tiny JSON-RPC server that records the first
+// alchemy_requestGasAndPaymasterAndData params for assertion.
+type stubAlchemySponsorship struct {
+	t      *testing.T
+	params map[string]interface{}
+	srv    *httptest.Server
+}
 
-	// Smoke that a UserOp still marshals for the userOperation field (unchanged).
-	op := &userop.UserOperationV07{
+func startStubAlchemy(t *testing.T) *stubAlchemySponsorship {
+	t.Helper()
+	s := &stubAlchemySponsorship{t: t}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Method string            `json:"method"`
+			Params []json.RawMessage `json:"params"`
+			ID     int               `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		if body.Method == "alchemy_requestGasAndPaymasterAndData" && len(body.Params) > 0 {
+			if err := json.Unmarshal(body.Params[0], &s.params); err != nil {
+				t.Errorf("unmarshal params: %v", err)
+			}
+		}
+		// Minimal v0.7-shaped success response.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      body.ID,
+			"result": map[string]string{
+				"paymaster":                     "0x2cc0c7981D846b9F2a16276556f6e8cb52BfB633",
+				"paymasterData":                 "0x",
+				"paymasterVerificationGasLimit": "0x186a0",
+				"paymasterPostOpGasLimit":       "0x0",
+				"callGasLimit":                  "0x5208",
+				"verificationGasLimit":          "0x186a0",
+				"preVerificationGas":            "0xc350",
+				"maxFeePerGas":                  "0x1",
+				"maxPriorityFeePerGas":          "0x1",
+			},
+		})
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func sponsorshipTestOp() *userop.UserOperationV07 {
+	return &userop.UserOperationV07{
 		Sender:               common.HexToAddress("0x1"),
 		Nonce:                big.NewInt(0),
 		CallData:             []byte{0x01},
@@ -34,7 +75,60 @@ func TestSponsorshipRequestV07_WebhookDataOptional(t *testing.T) {
 		MaxPriorityFeePerGas: big.NewInt(0),
 		Signature:            dummySignatureV07(),
 	}
-	if _, err := json.Marshal(op); err != nil {
-		t.Fatalf("marshal op: %v", err)
+}
+
+func TestRequestSponsorshipV07_IncludesWebhookDataWhenSet(t *testing.T) {
+	stub := startStubAlchemy(t)
+	client, err := rpc.DialHTTP(stub.srv.URL)
+	if err != nil {
+		t.Fatalf("dial stub: %v", err)
+	}
+	t.Cleanup(client.Close)
+
+	op := sponsorshipTestOp()
+	err = RequestSponsorshipV07(context.Background(), client, op, EntryPointV07(), SponsorshipRequestV07{
+		PolicyID:    "bf905871-55d7-4197-a020-605302f4bc87",
+		WebhookData: "super-secret",
+	})
+	if err != nil {
+		t.Fatalf("RequestSponsorshipV07: %v", err)
+	}
+	if stub.params == nil {
+		t.Fatal("stub did not capture params")
+	}
+	got, _ := stub.params["webhookData"].(string)
+	if got != "super-secret" {
+		t.Fatalf("webhookData = %q, want super-secret", got)
+	}
+	if _, ok := stub.params["policyId"]; !ok {
+		t.Fatal("policyId missing from params")
+	}
+}
+
+func TestRequestSponsorshipV07_OmitsWebhookDataWhenEmpty(t *testing.T) {
+	stub := startStubAlchemy(t)
+	client, err := rpc.DialHTTP(stub.srv.URL)
+	if err != nil {
+		t.Fatalf("dial stub: %v", err)
+	}
+	t.Cleanup(client.Close)
+
+	op := sponsorshipTestOp()
+	err = RequestSponsorshipV07(context.Background(), client, op, EntryPointV07(), SponsorshipRequestV07{
+		PolicyID: "bf905871-55d7-4197-a020-605302f4bc87",
+		// WebhookData empty
+	})
+	if err != nil {
+		t.Fatalf("RequestSponsorshipV07: %v", err)
+	}
+	if stub.params == nil {
+		t.Fatal("stub did not capture params")
+	}
+	if _, ok := stub.params["webhookData"]; ok {
+		t.Fatalf("webhookData should be omitted when empty, got %v", stub.params["webhookData"])
+	}
+	// Sanity: request still had required fields
+	if !strings.HasPrefix(stub.params["entryPoint"].(string), "0x") {
+		t.Fatalf("entryPoint unexpected: %v", stub.params["entryPoint"])
 	}
 }

--- a/pkg/erc4337/preset/sponsorship_webhook_test.go
+++ b/pkg/erc4337/preset/sponsorship_webhook_test.go
@@ -1,0 +1,40 @@
+package preset
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// Ensures RequestSponsorshipV07 request shape includes webhookData only when set.
+// Full RPC is not exercised here; this guards the param map construction contract
+// used against Alchemy's custom-rules webhook (gas_manager_webhook_secret).
+func TestSponsorshipRequestV07_WebhookDataOptional(t *testing.T) {
+	t.Parallel()
+	if (SponsorshipRequestV07{PolicyID: "p", WebhookData: "secret"}).WebhookData != "secret" {
+		t.Fatal("WebhookData field must be settable on SponsorshipRequestV07")
+	}
+	if (SponsorshipRequestV07{PolicyID: "p"}).WebhookData != "" {
+		t.Fatal("WebhookData must default empty")
+	}
+
+	// Smoke that a UserOp still marshals for the userOperation field (unchanged).
+	op := &userop.UserOperationV07{
+		Sender:               common.HexToAddress("0x1"),
+		Nonce:                big.NewInt(0),
+		CallData:             []byte{0x01},
+		CallGasLimit:         big.NewInt(1),
+		VerificationGasLimit: big.NewInt(1),
+		PreVerificationGas:   big.NewInt(1),
+		MaxFeePerGas:         big.NewInt(0),
+		MaxPriorityFeePerGas: big.NewInt(0),
+		Signature:            dummySignatureV07(),
+	}
+	if _, err := json.Marshal(op); err != nil {
+		t.Fatalf("marshal op: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Post-#706 cleanup and Gas Manager webhook readiness for production custom rules.

- **Strip AA23_DEBUG** temporary instrumentation from nodes:run and contract-write (root cause fixed in #706).
- **Reject session grants** on non-MA v2 runners (SimpleAccount / missing factory) at prepare/submit with ErrSessionWalletNotMAv2, REST SESSION_WALLET_NOT_MA_V2.
- **Plumb webhookData** on alchemy_requestGasAndPaymasterAndData from GAS_MANAGER_WEBHOOK_SECRET / gas_manager_webhook_secret so Alchemy custom-rules webhook can authenticate.
- **Clearer MA v2 logs** when Alchemy policy sponsors vs self-funded (no more misleading "no paymaster").
- Regression tests: extract preserves methodCalls contractAddress; SimpleAccount grant prepare rejected.

## Test plan

- [x] go test ./core/taskengine/ -run SessionPolicy|ExtractNodeConfiguration_PreservesMethodCall
- [x] go test ./pkg/erc4337/preset/ -run SponsorshipRequest
- [x] Production webhook smoke: POST /webhooks/gas-manager returns 200 (approved true for known MA v2 wallet, false for unknown / wrong policy)
- [ ] After merge/deploy: one Sepolia Auto swap under Gas Manager with webhook URL set and Sponsor on error or timeout OFF
- [ ] If GAS_MANAGER_WEBHOOK_SECRET is set on Railway, deploy this before relying on sponsorship (old binaries omit webhookData and deny-all)

## Deploy note

Do not enable GAS_MANAGER_WEBHOOK_SECRET on a build without this PR. Empty secret omits webhookData (safe default until secret is intentionally set).
