### PR TITLE
chore: WETH-sell findings update, CI path-filter fix, skip live batch under -short

### DIFF
--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -64,14 +64,20 @@ jobs:
           # Get list of changed files
           CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH...HEAD)
 
-          # Check if any changes are in relevant directories
-          RELEVANT_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.go$|go\.mod|go\.sum|^core/|^pkg/|^aggregator/|^operator/|^model/|^cmd/|^version/|^config/')
+          # Check if any changes are in relevant directories.
+          # `|| true` is required: with bash -e, grep exit 1 (no match) aborts
+          # the job as failure instead of setting should_run=false.
+          RELEVANT_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.go$|go\.mod|go\.sum|^core/|^pkg/|^aggregator/|^operator/|^model/|^cmd/|^version/|^config/' || true)
 
           if [ -n "$RELEVANT_CHANGES" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "Relevant changes:"
+            echo "$RELEVANT_CHANGES"
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
             echo "No relevant changes found. Skipping tests."
+            echo "Changed files:"
+            echo "$CHANGED_FILES"
           fi
 
   lint:

--- a/FINDINGS_AA23_WETH_SELL_SESSION_SCOPE.md
+++ b/FINDINGS_AA23_WETH_SELL_SESSION_SCOPE.md
@@ -1,9 +1,9 @@
 # Findings — Auto swap AA23 on ETH/WETH sell (session allowlist / Gas Manager)
 
 **Date:** 2026-08-06  
-**Owner for fix:** AVS gateway (+ Alchemy Gas Manager ops where noted); Studio residual already landed  
+**Owner for fix:** User **re-grant** (new allowlist) + AVS typed errors / Gas Manager ops  
 **Related:** `FINDINGS_AA23_FACTORY_MISMATCH.md` (factory mismatch = red herring; packing/`contractAddress` fixed in #706; USDC buy path proven)  
-**Status:** **Open (Studio remaining)** — gateway preflight + SDK builders landed; Studio grant compile / demote coverage still handoff
+**Status:** **Studio grant path landed (2026-08-06)** — compile USDC+WETH, coverage = approve(tokenIn)+router, `SESSION_POLICY_TARGET_NOT_ALLOWED` preflight + card copy. On-chain still needs re-authorize once; AVS optional typed prefix.
 
 ---
 
@@ -12,9 +12,9 @@
 | Item | Detail |
 |------|--------|
 | **Symptom (UI)** | Studio Auto card: “Smart-wallet validation failed (AA23)…” on **sell 0.0001 ETH → USDC** (Sepolia) |
-| **Studio residual** | **OK** — demotes ETH-in → WETH when `nativeWei=0` and WETH balance covers need |
-| **Where it fails** | **Prod** `nodes:run` → bundler/session validation → `Smart wallet validation failed (AA23)` on **both** `approve` and `exactInputSingle` |
-| **Likely root cause** | Session grant allowlist is **router `exactInputSingle` + approve(cap token only, default USDC)** — WETH `approve` is **off-allowlist** → hooks grant returns AA23 |
+| **Studio residual** | **OK** — demote + grant compile (cap USDC + WETH approve) + demote coverage + typed fail-closed |
+| **Where it fails** | **Prod** `nodes:run` → bundler/session validation → AA23 when grant lacks WETH approve (preflight now blocks with re-authorize copy) |
+| **Likely root cause** | Session grant allowlist was **router + approve(USDC only)** — WETH `approve` off-allowlist |
 | **Not the problem** | Wrong runner (using MA v2 `0x46aD…`), missing WETH balance (~0.00043), Studio demote, factory mismatch (already closed) |
 | **Local gateway** | Idle for this failure (`GATEWAY_URL` points at prod). Older local run failed for a **different** reason (Gas Manager webhook **404**) |
 

--- a/core/taskengine/userops_batch_swap_test.go
+++ b/core/taskengine/userops_batch_swap_test.go
@@ -35,6 +35,11 @@ import (
 // Uses the same live infra + key as the Sepolia withdraw test (OWNER_EOA + controller key from .env);
 // paymaster sponsors gas and the wallet reimburses, so the wallet needs a little ETH.
 func TestUserOpAtomicBatch_Sepolia(t *testing.T) {
+	// Live Sepolia + paymaster; excluded from CI `go test -short` (make test
+	// / PR unit jobs). Run via: go test ./core/taskengine -run TestUserOpAtomicBatch_Sepolia
+	if testing.Short() {
+		t.Skip("skipping live Sepolia atomic-batch proof under -short")
+	}
 	cfg, err := config.NewConfig(testutil.GetConfigPath(testutil.DefaultConfigPath))
 	if err != nil {
 		cfg, err = config.NewConfig("../../config/test.yaml")


### PR DESCRIPTION
## Summary

Follow-up after #711 merge:

1. **Docs** — update `FINDINGS_AA23_WETH_SELL_SESSION_SCOPE.md` status (Studio grant path landed; re-grant still needed).
2. **CI** — `Check Changed Files` used `grep` under `bash -e`; no match exited 1 and marked the job **failed** (unit tests skipped). Use `|| true` so `should_run=false` is a clean skip.
3. **Tests** — `TestUserOpAtomicBatch_Sepolia` is live Sepolia; skip under `-short` so PR unit jobs do not hit AA23 on fixture grants.

## Test plan
- [x] `go test ./core/taskengine/ -short -run 'MissingGrantCalls|AtomicBatchOnDemand|SessionPolicy|…'`
- [ ] CI unit tests green on this PR
