### PR TITLE
test(taskengine): production-shaped USDC+WETH grant for Sepolia atomic batch

### DIFF
--- a/FINDINGS_AA23_WETH_SELL_SESSION_SCOPE.md
+++ b/FINDINGS_AA23_WETH_SELL_SESSION_SCOPE.md
@@ -5,6 +5,8 @@
 **Related:** `FINDINGS_AA23_FACTORY_MISMATCH.md` (factory mismatch = red herring; packing/`contractAddress` fixed in #706; USDC buy path proven)  
 **Status:** **Studio grant path landed (2026-08-06)** — compile USDC+WETH, coverage = approve(tokenIn)+router, `SESSION_POLICY_TARGET_NOT_ALLOWED` preflight + card copy. On-chain still needs re-authorize once; AVS optional typed prefix.
 
+**Local test default (2026-08-06):** Studio → `http://localhost:8080` + **self-funded** gateway (`alchemy_paymaster_policy_id: ""`; no `ALCHEMY_PAYMASTER_POLICY_ID` / webhook secret). **Do not** use Gas Manager sponsorship on laptop — fund runner with Sepolia ETH.
+
 ---
 
 ## TL;DR

--- a/core/taskengine/session_grant_testhelper_test.go
+++ b/core/taskengine/session_grant_testhelper_test.go
@@ -183,15 +183,15 @@ func grantControllerAuthorityWithERC20Approves(
 			t.Fatalf("storing declared permissions on grant: %v", err)
 		}
 
-		if installedOnChain(t, swCfg, wallet, pol.EntityID, controller) {
-			// Occupied on-chain — cannot reinstall different hooks on this entity.
-			// Mark revoked in DB so NextSessionEntityID advances.
+		// Any non-zero on-chain signer occupies the entity (controller or not).
+		// Reusing a foreign or stale-hook entity breaks MA v2 uniqueness / install.
+		if existing := entitySignerOnChain(t, swCfg, wallet, pol.EntityID); existing != (common.Address{}) {
 			pol.Status = model.SessionPolicyRevoked
 			if err := StoreSessionPolicy(db, pol); err != nil {
 				t.Fatalf("reserving occupied entity %d: %v", pol.EntityID, err)
 			}
-			t.Logf("grant: entity %d already holds controller on %s; trying next entity for fresh hooks install",
-				pol.EntityID, wallet.Hex())
+			t.Logf("grant: entity %d already occupied on %s by %s; trying next entity for fresh hooks install",
+				pol.EntityID, wallet.Hex(), existing.Hex())
 			continue
 		}
 
@@ -242,8 +242,9 @@ func requireOwnerKey(t *testing.T) *ecdsa.PrivateKey {
 	return key
 }
 
-// installedOnChain reports whether the entity already names this signer.
-func installedOnChain(t *testing.T, swCfg *config.SmartWalletConfig, wallet common.Address, entity uint32, signer common.Address) bool {
+// entitySignerOnChain returns the SingleSignerValidationModule signer for
+// (entity, wallet), or the zero address if unset / unreadable.
+func entitySignerOnChain(t *testing.T, swCfg *config.SmartWalletConfig, wallet common.Address, entity uint32) common.Address {
 	t.Helper()
 	client, err := ethclient.Dial(swCfg.EthRpcUrl)
 	if err != nil {
@@ -256,9 +257,15 @@ func installedOnChain(t *testing.T, swCfg *config.SmartWalletConfig, wallet comm
 	module := aa.SingleSignerValidationModuleAddress()
 	out, err := client.CallContract(context.Background(), ethereum.CallMsg{To: &module, Data: data}, nil)
 	if err != nil || len(out) < 32 {
-		return false
+		return common.Address{}
 	}
-	return common.BytesToAddress(out[12:32]) == signer
+	return common.BytesToAddress(out[12:32])
+}
+
+// installedOnChain reports whether the entity already names this signer.
+func installedOnChain(t *testing.T, swCfg *config.SmartWalletConfig, wallet common.Address, entity uint32, signer common.Address) bool {
+	t.Helper()
+	return entitySignerOnChain(t, swCfg, wallet, entity) == signer
 }
 
 // selectorSSVMSigners is SingleSignerValidationModule.signers(uint32,address).

--- a/core/taskengine/session_grant_testhelper_test.go
+++ b/core/taskengine/session_grant_testhelper_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
@@ -93,6 +95,129 @@ func grantControllerAuthority(
 			policy.EntityID, wallet.Hex())
 	}
 
+	installSessionResolver(t, db, swCfg, controller)
+}
+
+// grantControllerAuthorityWithERC20Approves installs a production-shaped
+// session grant: allowlist approve() on each token, an ERC-20 spend cap on
+// capToken (must be one of the approve targets), TimeRange + AllowlistExecHook
+// so RequiresExecuteUserOp / wrapExecuteUserOp match production Uniswap grants.
+//
+// Long-lived Sepolia fixtures often already have the controller on entity 1
+// with a different hook set (bare global or USDC-only Studio grant). Reusing
+// that entity without reinstall leaves stale hooks and AA23s on WETH approve.
+// This helper skips occupied on-chain entities and allocates a free one so the
+// deferred install rides the test's first operation with the right hooks.
+func grantControllerAuthorityWithERC20Approves(
+	t *testing.T,
+	db storage.Storage,
+	swCfg *config.SmartWalletConfig,
+	owner, wallet common.Address,
+	approveTokens []common.Address,
+	capToken common.Address,
+	capAmount string, // decimal smallest-unit string
+) {
+	t.Helper()
+
+	if len(approveTokens) == 0 {
+		t.Fatal("grantControllerAuthorityWithERC20Approves: need at least one approve token")
+	}
+	ownerKey := requireOwnerKey(t)
+	if got := crypto.PubkeyToAddress(ownerKey.PublicKey); got != owner {
+		t.Fatalf("TEST_PRIVATE_KEY is %s but the test's owner is %s; they must match to authorize a grant",
+			got.Hex(), owner.Hex())
+	}
+	if swCfg.ControllerPrivateKey == nil {
+		t.Fatal("no controller key configured; the gateway cannot be granted anything")
+	}
+	controller := crypto.PubkeyToAddress(swCfg.ControllerPrivateKey.PublicKey)
+
+	actions := make([]model.AllowedAction, 0, len(approveTokens))
+	for _, tok := range approveTokens {
+		a := tok
+		actions = append(actions, model.AllowedAction{
+			Target:    &a,
+			Selectors: []string{"0x095ea7b3"}, // approve(address,uint256)
+		})
+	}
+	cap := capToken
+	perms := SessionPermissions{
+		AllowedActions: actions,
+		SpendCap: &model.ERC20SpendCap{
+			Token:      &cap,
+			Amount:     capAmount,
+			GrantedCap: capAmount,
+		},
+		ValidUntilMs: time.Now().Add(7 * 24 * time.Hour).UnixMilli(),
+	}
+	if err := perms.Validate(); err != nil {
+		t.Fatalf("test grant permissions: %v", err)
+	}
+
+	var policy *model.SessionPolicy
+	for attempt := 0; attempt < 32; attempt++ {
+		policyID := fmt.Sprintf("test-approve-grant-%d", attempt)
+		prepared, err := PrepareSessionGrant(db, swCfg.ChainID, controller, policyID, SessionGrantRequest{
+			Owner:      owner,
+			Wallet:     wallet,
+			AgentLabel: "test-erc20-approves",
+			ValidUntil: perms.ValidUntilMs,
+			HooksFor:   perms.HooksFor,
+		})
+		if err != nil {
+			t.Fatalf("preparing production-shaped test grant (attempt %d): %v", attempt, err)
+		}
+
+		sig, err := crypto.Sign(prepared.Digest.Bytes(), ownerKey)
+		if err != nil {
+			t.Fatalf("signing the grant: %v", err)
+		}
+		sig[64] += 27
+
+		pol, err := SubmitSessionGrant(db, prepared, sig)
+		if err != nil {
+			t.Fatalf("submitting the grant (attempt %d): %v", attempt, err)
+		}
+		attachDeclaredPermissions(pol, perms)
+		if err := StoreSessionPolicy(db, pol); err != nil {
+			t.Fatalf("storing declared permissions on grant: %v", err)
+		}
+
+		if installedOnChain(t, swCfg, wallet, pol.EntityID, controller) {
+			// Occupied on-chain — cannot reinstall different hooks on this entity.
+			// Mark revoked in DB so NextSessionEntityID advances.
+			pol.Status = model.SessionPolicyRevoked
+			if err := StoreSessionPolicy(db, pol); err != nil {
+				t.Fatalf("reserving occupied entity %d: %v", pol.EntityID, err)
+			}
+			t.Logf("grant: entity %d already holds controller on %s; trying next entity for fresh hooks install",
+				pol.EntityID, wallet.Hex())
+			continue
+		}
+
+		// Free entity: leave pending so the install rides the first UserOp.
+		policy = pol
+		t.Logf("grant: entity %d pending on %s (USDC+WETH-style approves, RequiresExecuteUserOp=%v); install rides first operation",
+			pol.EntityID, wallet.Hex(), pol.Grant != nil && pol.Grant.RequiresExecuteUserOp)
+		break
+	}
+	if policy == nil {
+		t.Fatal("could not allocate a free session entity for a production-shaped grant after 32 attempts")
+	}
+	if policy.Grant == nil || !policy.Grant.RequiresExecuteUserOp {
+		t.Fatal("expected RequiresExecuteUserOp=true (allowlist execution hook); grant shape is wrong")
+	}
+
+	installSessionResolver(t, db, swCfg, controller)
+}
+
+func installSessionResolver(
+	t *testing.T,
+	db storage.Storage,
+	swCfg *config.SmartWalletConfig,
+	controller common.Address,
+) {
+	t.Helper()
 	preset.SetSessionResolver(NewSessionResolver(db, func(a common.Address) (*ecdsa.PrivateKey, error) {
 		if a != controller {
 			return nil, fmt.Errorf("no key for session signer %s", a.Hex())

--- a/core/taskengine/userops_batch_swap_test.go
+++ b/core/taskengine/userops_batch_swap_test.go
@@ -155,26 +155,32 @@ func TestUserOpAtomicBatch_Sepolia(t *testing.T) {
 
 	db := testutil.TestMustDB()
 
-	// The gateway cannot sign as this wallet's owner — a stock MA v2 account
-	// trusts only its fallback signer — so it needs a session grant, the same
-	// one the grant screen creates in production.
-	grantControllerAuthority(t, db, cfg.SmartWallet, ownerAddress, *smartWalletAddress)
+	// Production-shaped grant: allowlist approve on USDC + WETH, USDC spend
+	// cap, TimeRange + AllowlistExecHook (RequiresExecuteUserOp). Matches
+	// Studio uniswapV3Capability([USDC,WETH]) — not the bare global fixture.
+	// Cap amount is large enough that two test approves never hit the limit.
+	const usdcCapAmount = "1000000000000" // 1e12 raw units
+	grantControllerAuthorityWithERC20Approves(t, db, cfg.SmartWallet,
+		ownerAddress, *smartWalletAddress,
+		[]common.Address{usdc, weth}, usdc, usdcCapAmount)
 
 	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
 	engine := New(db, cfg, nil, testutil.GetLogger())
 	t.Cleanup(func() { engine.Stop() })
 
 	user := &model.User{Address: ownerAddress, SmartAccountAddress: smartWalletAddress}
-	require.NoError(t, StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
+	// Chain-scoped wallet key must match the grant's chain (Sepolia).
+	require.NoError(t, StoreWallet(db, sepoliaChainID, ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(0),
 	}), "Failed to store wallet")
 
-	// Real execution (is_simulated=false) with paymaster — this is the composed path:
-	// executeBatch(approve, approve) wrapped by the reimbursement wrapper into executeBatchWithValues.
+	// Real execution (is_simulated=false). Sponsorship follows config
+	// (alchemy_paymaster_policy_id); when empty, self-funded prefund applies.
+	// Force paymaster flag is legacy v0.6; MA v2 uses the policy id path.
 	usePaymaster := true
-	t.Logf("🚀 Submitting atomic batch as one UserOp (real, paymaster-sponsored)...")
+	t.Logf("🚀 Submitting atomic batch as one UserOp (real path)...")
 	result, err := engine.RunNodeImmediately("contractWrite", batchConfig, inputVars, user, false, &usePaymaster)
 	require.NoError(t, err, "batch RunNodeImmediately should not error")
 	require.NotNil(t, result, "batch result should not be nil")

--- a/core/taskengine/userops_batch_swap_test.go
+++ b/core/taskengine/userops_batch_swap_test.go
@@ -176,12 +176,11 @@ func TestUserOpAtomicBatch_Sepolia(t *testing.T) {
 		Salt:    big.NewInt(0),
 	}), "Failed to store wallet")
 
-	// Real execution (is_simulated=false). Sponsorship follows config
-	// (alchemy_paymaster_policy_id); when empty, self-funded prefund applies.
-	// Force paymaster flag is legacy v0.6; MA v2 uses the policy id path.
-	usePaymaster := true
-	t.Logf("🚀 Submitting atomic batch as one UserOp (real path)...")
-	result, err := engine.RunNodeImmediately("contractWrite", batchConfig, inputVars, user, false, &usePaymaster)
+	// Real execution: second arg is simulationMode only (false = real UserOp).
+	// Sponsorship follows SmartWalletConfig.AlchemyPaymasterPolicyID (empty →
+	// self-funded). There is no usePaymaster variadic on RunNodeImmediately.
+	t.Logf("🚀 Submitting atomic batch as one UserOp (real path, simulationMode=false)...")
+	result, err := engine.RunNodeImmediately("contractWrite", batchConfig, inputVars, user, false)
 	require.NoError(t, err, "batch RunNodeImmediately should not error")
 	require.NotNil(t, result, "batch result should not be nil")
 


### PR DESCRIPTION
## Summary

Fixes `TestUserOpAtomicBatch_Sepolia` AA23 by using a **production-shaped** session grant:

- Allowlist `approve` on USDC **and** WETH (Studio `uniswapV3Capability` shape)
- ERC-20 spend cap + AllowlistExecHook → `RequiresExecuteUserOp`
- Skip on-chain **occupied** entities so hooks install on a free entity (do not reuse stale entity 1)

Also includes any remaining findings note about local self-funded gateway.

Verified: `go test ./core/taskengine -run TestUserOpAtomicBatch_Sepolia` **PASS** (~18s).

## Test plan
- [x] `TestUserOpAtomicBatch_Sepolia` PASS live Sepolia
- [ ] CI green