### PR TITLE
fix(taskengine): session grants replace instead of stacking

### DIFF
--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -1990,7 +1990,7 @@ type SubmitWalletPolicyResponseObject interface {
 	VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error
 }
 
-type SubmitWalletPolicy201JSONResponse SessionPolicy
+type SubmitWalletPolicy201JSONResponse SubmitPolicyResponse
 
 func (response SubmitWalletPolicy201JSONResponse) VisitSubmitWalletPolicyResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -1486,7 +1486,7 @@ type SubmitPolicyResponse struct {
 	//
 	// Empty on a first grant. Non-empty means the user's earlier
 	// permission is gone, which is worth reflecting in the UI.
-	SupersededPolicyIds *[]Ulid `json:"supersededPolicyIds,omitempty"`
+	SupersededPolicyIds []Ulid `json:"supersededPolicyIds"`
 
 	// ValidUntil Unix milliseconds.
 	ValidUntil int64 `json:"validUntil"`

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -202,8 +202,8 @@ const (
 
 // Defines values for RevokePolicyResponseStatus.
 const (
-	Deleted RevokePolicyResponseStatus = "deleted"
-	Revoked RevokePolicyResponseStatus = "revoked"
+	RevokePolicyResponseStatusDeleted RevokePolicyResponseStatus = "deleted"
+	RevokePolicyResponseStatusRevoked RevokePolicyResponseStatus = "revoked"
 )
 
 // Defines values for SecretScope.
@@ -224,6 +224,13 @@ const (
 const (
 	Approve SignalExecutionRequestDecision = "approve"
 	Reject  SignalExecutionRequestDecision = "reject"
+)
+
+// Defines values for SubmitPolicyResponseStatus.
+const (
+	SubmitPolicyResponseStatusActive  SubmitPolicyResponseStatus = "active"
+	SubmitPolicyResponseStatusPending SubmitPolicyResponseStatus = "pending"
+	SubmitPolicyResponseStatusRevoked SubmitPolicyResponseStatus = "revoked"
 )
 
 // Defines values for TokenMetadataResponseSource.
@@ -1438,6 +1445,56 @@ type SubmitPolicyRequest struct {
 	// ValidUntil The ABSOLUTE expiry from prepare. It is baked into the signed calldata; recomputing it would change the digest.
 	ValidUntil int64 `json:"validUntil"`
 }
+
+// SubmitPolicyResponse defines model for SubmitPolicyResponse.
+type SubmitPolicyResponse struct {
+	AgentLabel     string           `json:"agentLabel"`
+	AllowedActions *[]AllowedAction `json:"allowedActions,omitempty"`
+
+	// ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+	// chain-aware trigger/node configs this is required and must be a
+	// configured chain; on query/filter params it is optional.
+	ChainId ChainId `json:"chainId"`
+
+	// CreatedAt Unix milliseconds.
+	CreatedAt int64 `json:"createdAt"`
+	EntityId  int64 `json:"entityId"`
+
+	// Erc20SpendCap Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+	// token must appear as an `allowedActions` target.
+	Erc20SpendCap *Erc20SpendCap `json:"erc20SpendCap,omitempty"`
+
+	// Id ULID identifier (26-char Crockford base32).
+	Id            Ulid    `json:"id"`
+	Justification *string `json:"justification,omitempty"`
+
+	// Runner Lowercase or checksummed hex EOA / contract address.
+	Runner EthereumAddress `json:"runner"`
+
+	// SessionSigner Lowercase or checksummed hex EOA / contract address.
+	SessionSigner EthereumAddress `json:"sessionSigner"`
+
+	// Status pending = signed and stored, install not yet on-chain (revocable
+	// for free). active = install applied. revoked = grants nothing.
+	Status SubmitPolicyResponseStatus `json:"status"`
+
+	// SupersededPolicyIds Grants revoked to keep this runner's authority a singleton —
+	// the previous grants this submit replaced. Their `status` now
+	// reads `revoked`; the array distinguishes a replacement the
+	// gateway performed from one the user asked for via
+	// `DELETE .../policies/{policyId}`.
+	//
+	// Empty on a first grant. Non-empty means the user's earlier
+	// permission is gone, which is worth reflecting in the UI.
+	SupersededPolicyIds *[]Ulid `json:"supersededPolicyIds,omitempty"`
+
+	// ValidUntil Unix milliseconds.
+	ValidUntil int64 `json:"validUntil"`
+}
+
+// SubmitPolicyResponseStatus pending = signed and stored, install not yet on-chain (revocable
+// for free). active = install applied. revoked = grants nothing.
+type SubmitPolicyResponseStatus string
 
 // Timestamp RFC 3339 timestamp.
 type Timestamp = time.Time

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -305,14 +305,14 @@ func submitPolicyToAPI(p *model.SessionPolicy, superseded []string) generated.Su
 		ValidUntil:     base.ValidUntil,
 		CreatedAt:      base.CreatedAt,
 	}
-	// Always present, empty on a first grant: a client checking "did this
-	// replace anything" should read an empty array, not have to treat a
-	// missing key as the same thing.
+	// Required in the schema and always emitted, empty on a first grant: a
+	// client asking "did this replace anything" reads an empty array rather
+	// than having to treat a missing key as the same thing.
 	ids := make([]generated.Ulid, 0, len(superseded))
 	for _, id := range superseded {
 		ids = append(ids, generated.Ulid(id))
 	}
-	out.SupersededPolicyIds = &ids
+	out.SupersededPolicyIds = ids
 	return out
 }
 

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -136,7 +136,7 @@ func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.Ethereum
 		return badRequest("POLICIES_BAD_PERMISSIONS", "Invalid permissions", err.Error())
 	}
 
-	policy, err := s.engine.SubmitSessionPolicy(user, taskengine.SessionPolicyInput{
+	policy, superseded, err := s.engine.SubmitSessionPolicy(user, taskengine.SessionPolicyInput{
 		Wallet:        wallet,
 		ChainID:       int64(req.ChainId),
 		AgentLabel:    req.AgentLabel,
@@ -146,7 +146,7 @@ func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.Ethereum
 	if err != nil {
 		return mapPolicyError(err)
 	}
-	return ctx.JSON(http.StatusCreated, policyToAPI(policy))
+	return ctx.JSON(http.StatusCreated, submitPolicyToAPI(policy, superseded))
 }
 
 // ListWalletPolicies lists the wallet's grants, newest first.
@@ -282,6 +282,40 @@ func policyToAPI(p *model.SessionPolicy) generated.SessionPolicy {
 	return out
 }
 
+// submitPolicyToAPI renders the submit response: the stored policy plus the
+// grants this submit replaced.
+//
+// SubmitPolicyResponse is `allOf: [SessionPolicy, {supersededPolicyIds}]`,
+// which oapi-codegen flattens into a separate struct rather than an embedded
+// one — hence the field-by-field copy. TestSubmitPolicyResponseCarriesEverySessionPolicyField
+// fails if the two schemas ever drift apart.
+func submitPolicyToAPI(p *model.SessionPolicy, superseded []string) generated.SubmitPolicyResponse {
+	base := policyToAPI(p)
+	out := generated.SubmitPolicyResponse{
+		Id:             base.Id,
+		Runner:         base.Runner,
+		ChainId:        base.ChainId,
+		Status:         generated.SubmitPolicyResponseStatus(base.Status),
+		EntityId:       base.EntityId,
+		SessionSigner:  base.SessionSigner,
+		AgentLabel:     base.AgentLabel,
+		Justification:  base.Justification,
+		AllowedActions: base.AllowedActions,
+		Erc20SpendCap:  base.Erc20SpendCap,
+		ValidUntil:     base.ValidUntil,
+		CreatedAt:      base.CreatedAt,
+	}
+	// Always present, empty on a first grant: a client checking "did this
+	// replace anything" should read an empty array, not have to treat a
+	// missing key as the same thing.
+	ids := make([]generated.Ulid, 0, len(superseded))
+	for _, id := range superseded {
+		ids = append(ids, generated.Ulid(id))
+	}
+	out.SupersededPolicyIds = &ids
+	return out
+}
+
 // typedDataJSON renders the eth_signTypedData_v4 payload for the prepare
 // response — built from the SAME fields the digest was computed over, so the
 // wallet signs exactly what submit will verify.
@@ -337,6 +371,14 @@ func mapPolicyError(err error) error {
 	case errors.Is(err, taskengine.ErrSessionEntityTaken):
 		return &restmw.HTTPError{Status: http.StatusConflict, Code: "POLICIES_ENTITY_TAKEN",
 			Title: "Grant allocation superseded", Detail: err.Error() + " Prepare the grant again."}
+	case errors.Is(err, taskengine.ErrSessionPolicySupersedeFailed):
+		// The grant IS stored. Do not tell the client to retry the submit —
+		// the entity is spent, so a retry only fails. The wallet now holds
+		// more than one usable grant and will refuse to execute until the
+		// leftovers are revoked (or another grant replaces them all).
+		return &restmw.HTTPError{Status: http.StatusInternalServerError, Code: "POLICIES_SUPERSEDE_FAILED",
+			Title: "Grant stored, previous grant not replaced", Detail: err.Error() +
+				" List this wallet's policies and revoke the older usable ones, or grant again to replace them."}
 	case errors.Is(err, taskengine.ErrGrantSignerMismatch):
 		return badRequest("POLICIES_BAD_SIGNATURE", "Signature does not match", err.Error())
 	default:

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -340,12 +340,11 @@ func TestPoliciesSubmitReplacesThePreviousGrantOverHTTP(t *testing.T) {
 	address := generated.EthereumAddress(rig.wallet.Hex())
 
 	first := rig.grantOverHTTP(t)
-	require.NotNil(t, first.SupersededPolicyIds)
-	require.Empty(t, *first.SupersededPolicyIds, "a first grant replaces nothing, and says so with an empty array")
+	require.NotNil(t, first.SupersededPolicyIds, "the field is required, so it is present even when empty")
+	require.Empty(t, first.SupersededPolicyIds, "a first grant replaces nothing, and says so with an empty array")
 
 	second := rig.grantOverHTTP(t)
-	require.NotNil(t, second.SupersededPolicyIds)
-	require.Equal(t, []generated.Ulid{first.Id}, *second.SupersededPolicyIds)
+	require.Equal(t, []generated.Ulid{first.Id}, second.SupersededPolicyIds)
 
 	// The list shows both records — one usable, one revoked for audit.
 	rec := rig.call(t, nil, func(c echo.Context) error {

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -294,3 +294,121 @@ func TestTypedDataDomainCarriesOnlyDeclaredFields(t *testing.T) {
 		require.Contains(t, domain, declared)
 	}
 }
+
+// grantOverHTTP runs prepare → sign → submit and returns the decoded response.
+func (r *policyTestRig) grantOverHTTP(t *testing.T) generated.SubmitPolicyResponse {
+	t.Helper()
+	address := generated.EthereumAddress(r.wallet.Hex())
+
+	rec := r.call(t, prepareBody(policyTestChain), func(c echo.Context) error {
+		return r.server.PrepareWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+
+	digest := common.FromHex(prepared.Digest)
+	sig, err := crypto.Sign(digest, r.ownerKey)
+	require.NoError(t, err)
+	sig[64] += 27
+
+	body := prepareBody(policyTestChain)
+	rec = r.call(t, generated.SubmitPolicyRequest{
+		ChainId:        body.ChainId,
+		PolicyId:       prepared.PolicyId,
+		EntityId:       prepared.EntityId,
+		Deadline:       prepared.Deadline,
+		ValidUntil:     prepared.ValidUntil,
+		AgentLabel:     body.AgentLabel,
+		AllowedActions: body.AllowedActions,
+		Erc20SpendCap:  body.Erc20SpendCap,
+		Signature:      fmt.Sprintf("0x%x", sig),
+	}, func(c echo.Context) error {
+		return r.server.SubmitWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var submitted generated.SubmitPolicyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &submitted))
+	return submitted
+}
+
+// Re-granting over HTTP replaces, and says what it replaced. The client does
+// not have to revoke first, and does not have to ask for replacement.
+func TestPoliciesSubmitReplacesThePreviousGrantOverHTTP(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+
+	first := rig.grantOverHTTP(t)
+	require.NotNil(t, first.SupersededPolicyIds)
+	require.Empty(t, *first.SupersededPolicyIds, "a first grant replaces nothing, and says so with an empty array")
+
+	second := rig.grantOverHTTP(t)
+	require.NotNil(t, second.SupersededPolicyIds)
+	require.Equal(t, []generated.Ulid{first.Id}, *second.SupersededPolicyIds)
+
+	// The list shows both records — one usable, one revoked for audit.
+	rec := rig.call(t, nil, func(c echo.Context) error {
+		return rig.server.ListWalletPolicies(c, address, generated.ListWalletPoliciesParams{})
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list generated.SessionPolicyList
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list.Items, 2)
+
+	status := map[generated.Ulid]string{}
+	for _, item := range list.Items {
+		status[item.Id] = string(item.Status)
+	}
+	require.Equal(t, "revoked", status[first.Id], "the replaced grant is retained, not deleted")
+	require.Equal(t, "pending", status[second.Id])
+
+	// Replacement must not leak grant material either.
+	for _, marker := range []string{"install_call", "owner_signature", "carrier_nonce", "installCall", "ownerSignature"} {
+		require.NotContains(t, rec.Body.String(), marker, "grant material leaked")
+	}
+}
+
+// SubmitPolicyResponse is `allOf: [SessionPolicy, {supersededPolicyIds}]`, and
+// oapi-codegen flattens that into a separate struct that submitPolicyToAPI has
+// to fill in by hand. If a field is ever added to SessionPolicy and not copied
+// across, the submit response would silently start omitting it.
+func TestSubmitPolicyResponseCarriesEverySessionPolicyField(t *testing.T) {
+	token := common.HexToAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238")
+	router := common.HexToAddress("0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E")
+	owner := common.HexToAddress("0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557")
+	wallet := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	// Every optional field populated, so none can pass by being absent in both.
+	policy := &model.SessionPolicy{
+		ID: "01legacygrantaaaaaaaaaaaaa", Owner: &owner, Runner: &wallet,
+		ChainID: policyTestChain, EntityID: 7, SessionSigner: &signer,
+		AgentLabel: "TradingBot", Justification: "because",
+		AllowedActions: []model.AllowedAction{
+			{Target: &router, Selectors: []string{"0x04e45aaf"}},
+			{Target: &token, Selectors: []string{"0x095ea7b3"}},
+		},
+		ERC20SpendCap: &model.ERC20SpendCap{Token: &token, Amount: "500000000", GrantedCap: "500000000"},
+		ValidUntil:    1785541743000,
+		Status:        model.SessionPolicyPending,
+		CreatedAt:     1785441743000,
+	}
+
+	asPolicy, err := json.Marshal(policyToAPI(policy))
+	require.NoError(t, err)
+	asSubmit, err := json.Marshal(submitPolicyToAPI(policy, []string{"01replacedgrantaaaaaaaaaa"}))
+	require.NoError(t, err)
+
+	var policyFields, submitFields map[string]any
+	require.NoError(t, json.Unmarshal(asPolicy, &policyFields))
+	require.NoError(t, json.Unmarshal(asSubmit, &submitFields))
+
+	require.NotEmpty(t, policyFields)
+	for name, want := range policyFields {
+		got, ok := submitFields[name]
+		require.True(t, ok, "submit response drops SessionPolicy field %q — copy it in submitPolicyToAPI", name)
+		require.Equal(t, want, got, "submit response disagrees with the policy on %q", name)
+	}
+	require.Equal(t, []any{"01replacedgrantaaaaaaaaaa"}, submitFields["supersededPolicyIds"])
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1791,6 +1791,24 @@ components:
           format: int64
           description: Unix milliseconds.
 
+    SubmitPolicyResponse:
+      allOf:
+        - $ref: '#/components/schemas/SessionPolicy'
+        - type: object
+          properties:
+            supersededPolicyIds:
+              type: array
+              items: { $ref: '#/components/schemas/Ulid' }
+              description: |
+                Grants revoked to keep this runner's authority a singleton —
+                the previous grants this submit replaced. Their `status` now
+                reads `revoked`; the array distinguishes a replacement the
+                gateway performed from one the user asked for via
+                `DELETE .../policies/{policyId}`.
+
+                Empty on a first grant. Non-empty means the user's earlier
+                permission is gone, which is worth reflecting in the UI.
+
     SessionPolicyList:
       type: object
       required: [items]
@@ -2577,6 +2595,21 @@ paths:
         allocation inside the write, and stores the policy as `pending`. The
         install itself rides the first workflow operation on this wallet —
         nothing reaches the chain here.
+
+        **This REPLACES the runner's previous grants.** A wallet carries at
+        most one usable grant: the send path resolves exactly one and refuses
+        to execute when it finds more, so grants do not stack. Every other
+        usable grant on this runner is revoked as part of this call, and the
+        ones revoked come back in `supersededPolicyIds`. There is no flag to
+        opt out, and clients do not need to revoke the previous grant first.
+
+        Replacement is scoped to the runner, not to a capability: submitting a
+        grant for one capability revokes the runner's grant for any other.
+
+        Off-chain only. The superseded grants' validation entities and ERC-20
+        spend caps stay installed on the account until the owner signs
+        `uninstallValidation` — replacing a grant does not reduce what the
+        account could authorize on chain, only what this gateway will use.
       operationId: submitWalletPolicy
       requestBody:
         required: true
@@ -2588,7 +2621,7 @@ paths:
           description: Grant stored; the gateway may now execute within it.
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/SessionPolicy' }
+              schema: { $ref: '#/components/schemas/SubmitPolicyResponse' }
         '400': { $ref: '#/components/responses/BadRequest' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1795,6 +1795,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/SessionPolicy'
         - type: object
+          required: [supersededPolicyIds]
           properties:
             supersededPolicyIds:
               type: array

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -34,6 +34,12 @@ var (
 	// refused at prepare/submit so clients never collect a doomed owner signature.
 	// Studio filters Auto to MA v2; this is the gateway belt-and-braces half.
 	ErrSessionWalletNotMAv2 = errors.New("session grants require a Modular Account v2 smart wallet; legacy SimpleAccount cannot host session policies")
+	// ErrSessionPolicySupersedeFailed: the new grant is stored and usable, but
+	// revoking a previous one failed, so the runner is left ambiguous and
+	// execute will refuse it. Distinct from a plain rejection because the
+	// submit DID take effect — the client must not retry it (the entity is
+	// spent), only clear the named leftovers.
+	ErrSessionPolicySupersedeFailed = errors.New("the grant was stored but replacing the previous grant failed")
 )
 
 // SessionPolicyInput carries one grant's declared shape between prepare and
@@ -176,7 +182,8 @@ func (n *Engine) PrepareSessionPolicy(user *model.User, in SessionPolicyInput) (
 }
 
 // SubmitSessionPolicy verifies the owner's signature over a deterministic
-// re-preparation of the grant and stores it as pending.
+// re-preparation of the grant, stores it as pending, and REPLACES whatever the
+// runner had before. superseded lists the grants it revoked to do so.
 //
 // The client's echo is input, never truth: the install calldata, digest, and
 // carrier nonce are all recomputed here from the declared permissions and the
@@ -184,6 +191,21 @@ func (n *Engine) PrepareSessionPolicy(user *model.User, in SessionPolicyInput) (
 // signature recovery or is a differently-shaped grant that must survive full
 // validation on its own merits — there is no path on which stored bytes
 // diverge from what the owner's wallet displayed and signed.
+//
+// Replacement is unconditional rather than a flag the client sets. The send
+// path uses exactly one grant per runner and refuses the rest, so a stacked
+// second grant is unusable by construction — an opt-in would only mean the
+// default leaves the wallet broken, and every client that never learned the
+// flag (scripts, partners) would keep recreating the dual-grant failure.
+// Scoping is per runner, matching what the send path resolves; it is
+// deliberately NOT per capability, which would permit a pair the send path
+// then refuses.
+//
+// The write lock spans the entity re-check, the store, and the supersede.
+// Store-then-supersede is the order that matters on a crash: it can leave two
+// usable grants, which fails closed and is repaired by granting again, whereas
+// superseding first can leave zero — working authority destroyed for a
+// replacement that never landed.
 func (n *Engine) SubmitSessionPolicy(
 	user *model.User,
 	in SessionPolicyInput,
@@ -191,23 +213,27 @@ func (n *Engine) SubmitSessionPolicy(
 	entityID uint32,
 	deadline uint64,
 	ownerSignature []byte,
-) (*model.SessionPolicy, error) {
+) (policy *model.SessionPolicy, superseded []string, err error) {
 	if err := in.validate(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := n.requireMAv2SessionWallet(user, in.ChainID, in.Wallet); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err := ulid.ParseStrict(strings.ToUpper(policyID)); err != nil {
-		return nil, fmt.Errorf("policy id %q is not a ULID", policyID)
+		return nil, nil, fmt.Errorf("policy id %q is not a ULID", policyID)
 	}
 	if deadline <= uint64(time.Now().Unix()) {
-		return nil, fmt.Errorf("the signing window (deadline %d) has expired; prepare the grant again", deadline)
+		return nil, nil, fmt.Errorf("the signing window (deadline %d) has expired; prepare the grant again", deadline)
 	}
 	signer, err := n.sessionSignerAddress()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	lock := sessionAuthorityLock(in.ChainID, user.Address, in.Wallet)
+	lock.Lock()
+	defer lock.Unlock()
 
 	prepared, err := PrepareSessionGrant(n.db, in.ChainID, signer, strings.ToLower(policyID), SessionGrantRequest{
 		Owner:         user.Address,
@@ -219,14 +245,25 @@ func (n *Engine) SubmitSessionPolicy(
 		Deadline:      deadline,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if prepared.Policy.EntityID != entityID {
-		return nil, fmt.Errorf("%w: prepared entity %d, next free is now %d",
+		return nil, nil, fmt.Errorf("%w: prepared entity %d, next free is now %d",
 			ErrSessionEntityTaken, entityID, prepared.Policy.EntityID)
 	}
 	attachDeclaredPermissions(prepared.Policy, in.Permissions)
-	return SubmitSessionGrant(n.db, prepared, ownerSignature)
+
+	stored, err := SubmitSessionGrant(n.db, prepared, ownerSignature)
+	if err != nil {
+		return nil, nil, err
+	}
+	superseded, err = supersedeUsablePolicies(n.db, in.ChainID, user.Address, in.Wallet, stored.ID)
+	if err != nil {
+		// The grant landed; the runner is ambiguous. Say so rather than
+		// returning a 201 the send path will refuse.
+		return nil, superseded, fmt.Errorf("%w: %w", ErrSessionPolicySupersedeFailed, err)
+	}
+	return stored, superseded, nil
 }
 
 // ListSessionPoliciesForWallet returns the wallet's policies, newest first.
@@ -268,7 +305,18 @@ func (n *Engine) GetSessionPolicyByID(user *model.User, chainID int64, wallet co
 // case (record removed outright); cleanupRequired reports that the grant's
 // validation is still installed on the account and needs the owner's
 // uninstallValidation.
+//
+// Takes the runner's write lock for the same reason submit does: it changes
+// which grant the send path will resolve, and must not interleave with a
+// submit deciding the same question.
 func (n *Engine) RevokeSessionPolicyByID(user *model.User, chainID int64, wallet common.Address, policyID string) (deleted, cleanupRequired bool, err error) {
+	if err := n.requireOwnedWallet(user, wallet); err != nil {
+		return false, false, err
+	}
+	lock := sessionAuthorityLock(chainID, user.Address, wallet)
+	lock.Lock()
+	defer lock.Unlock()
+
 	policy, err := n.GetSessionPolicyByID(user, chainID, wallet, policyID)
 	if err != nil {
 		return false, false, err

--- a/core/taskengine/engine_session_policy_test.go
+++ b/core/taskengine/engine_session_policy_test.go
@@ -113,7 +113,7 @@ func TestSessionPolicyPrepareSubmitRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, policies)
 
-	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+	stored, _, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
 		Wallet: wallet, ChainID: testPolicyChain,
 		AgentLabel: "TradingBot", Justification: "swaps you approve",
 		Permissions: perms,
@@ -147,7 +147,7 @@ func TestSessionPolicySubmitRejectsTamperedEcho(t *testing.T) {
 	tampered := testPermissions()
 	tampered.SpendCap.Amount = "500000000000" // 1000x the signed cap
 
-	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+	_, _, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: tampered,
 	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline, sig)
 	require.Error(t, err)
@@ -164,7 +164,7 @@ func TestSessionPolicySubmitRejectsWrongSigner(t *testing.T) {
 
 	strangerKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+	_, _, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot", Permissions: testPermissions(),
 	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
 		signDigest(t, strangerKey, prepared.Digest))
@@ -188,13 +188,13 @@ func TestSessionPolicySubmitDetectsEntityRace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, preparedA.Policy.EntityID, preparedB.Policy.EntityID, "both prepares saw entity 1")
 
-	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+	_, _, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "A", Permissions: testPermissions(),
 	}, preparedA.Policy.ID, preparedA.Policy.EntityID, preparedA.Policy.Grant.Deadline,
 		signDigest(t, ownerKey, preparedA.Digest))
 	require.NoError(t, err)
 
-	_, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+	_, _, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "B", Permissions: testPermissions(),
 	}, preparedB.Policy.ID, preparedB.Policy.EntityID, preparedB.Policy.Grant.Deadline,
 		signDigest(t, ownerKey, preparedB.Digest))
@@ -224,7 +224,7 @@ func TestSessionPolicyRevokePendingDeletesOutright(t *testing.T) {
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
 	})
 	require.NoError(t, err)
-	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+	stored, _, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
 	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
 		signDigest(t, ownerKey, prepared.Digest))

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -272,7 +272,21 @@ func MarkSessionGrantApplied(db storage.Storage, policy *model.SessionPolicy, us
 //   - Status not pending: never overwrite. Re-storing a stale in-memory
 //     policy here could resurrect a revoked grant as active, which is why
 //     this exists instead of handing the callback the old pointer.
-func MarkSessionGrantAppliedByID(db storage.Storage, chainID int64, owner common.Address, policyID, userOpHash string) error {
+//
+// The re-read and the write happen under the runner's write lock, because
+// re-reading alone is not enough: a submit that supersedes this grant between
+// the read and the store would be overwritten by the store, resurrecting a
+// grant the user just replaced and leaving the runner with two usable ones.
+// Replacement is routine, so that window is reachable in normal use.
+//
+// Safe to take here because the resolver has already released its read lock by
+// the time this callback fires — it is invoked after the operation confirms,
+// not while authority is being resolved.
+func MarkSessionGrantAppliedByID(db storage.Storage, chainID int64, owner, runner common.Address, policyID, userOpHash string) error {
+	lock := sessionAuthorityLock(chainID, owner, runner)
+	lock.Lock()
+	defer lock.Unlock()
+
 	raw, err := db.GetKey(SessionPolicyKey(chainID, owner, policyID))
 	if errors.Is(err, badger.ErrKeyNotFound) {
 		return nil // no record — revoked while in flight; see above

--- a/core/taskengine/session_grant_applied_test.go
+++ b/core/taskengine/session_grant_applied_test.go
@@ -74,8 +74,8 @@ func TestMarkAppliedByIDIsIdempotentAndRaceSafe(t *testing.T) {
 	owner := user.Address
 
 	// Idempotent: marking twice keeps the first record.
-	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xfirst"))
-	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xsecond"))
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, wallet, stored.ID, "0xfirst"))
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, wallet, stored.ID, "0xsecond"))
 	updated, err := engine.GetSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
 	require.NoError(t, err)
 	require.Equal(t, "0xfirst", updated.Grant.AppliedUserOpHash)
@@ -85,7 +85,7 @@ func TestMarkAppliedByIDIsIdempotentAndRaceSafe(t *testing.T) {
 	_, cleanup, err := engine.RevokeSessionPolicyByID(user, testPolicyChain, wallet, stored.ID)
 	require.NoError(t, err)
 	require.True(t, cleanup, "an applied grant's revoke leaves on-chain state")
-	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, stored.ID, "0xlate"))
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, wallet, stored.ID, "0xlate"))
 	after, err := ListSessionPolicies(engine.db, testPolicyChain, owner)
 	require.NoError(t, err)
 	require.Len(t, after, 1)
@@ -93,5 +93,5 @@ func TestMarkAppliedByIDIsIdempotentAndRaceSafe(t *testing.T) {
 
 	// Deleted-in-flight (a PENDING grant revoked while its op was in the
 	// mempool): no record left; the mark is a no-op, not an error.
-	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, "01jarbitrarymissingpolicyid", ""))
+	require.NoError(t, MarkSessionGrantAppliedByID(engine.db, testPolicyChain, owner, wallet, "01jarbitrarymissingpolicyid", ""))
 }

--- a/core/taskengine/session_grant_applied_test.go
+++ b/core/taskengine/session_grant_applied_test.go
@@ -25,7 +25,7 @@ func storedPendingGrant(t *testing.T) (*Engine, *model.User, common.Address, *mo
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
 	})
 	require.NoError(t, err)
-	stored, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+	stored, _, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
 		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "Bot", Permissions: testPermissions(),
 	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
 		signDigest(t, ownerKey, prepared.Digest))

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -90,17 +89,26 @@ var sessionAuthorityLocks [sessionAuthorityLockShards]sync.RWMutex
 // It is NOT reentrant: a write-lock holder must never call anything that takes
 // the read lock — ActiveSessionPolicyForWallet above all.
 func sessionAuthorityLock(chainID int64, owner, runner common.Address) *sync.RWMutex {
-	// FNV-1a — allocation-free, deterministic (same runner → same shard).
+	// FNV-1a over the raw bytes: allocation-free, and deterministic in the way
+	// that matters — the same runner must always reach the same mutex, or two
+	// writers would serialize on different locks and not serialize at all.
+	//
+	// Hashing the address VALUES rather than their hex avoids both the
+	// allocation and the question of checksum casing: common.Address is already
+	// a canonical 20 bytes, so there is no normalization to get wrong.
 	var hash uint32 = 2166136261
-	mix := func(s string) {
-		for i := 0; i < len(s); i++ {
-			hash ^= uint32(s[i])
-			hash *= 16777619
-		}
+	for i := 0; i < 8; i++ {
+		hash ^= uint32(byte(chainID >> (8 * i)))
+		hash *= 16777619
 	}
-	mix(strconv.FormatInt(chainID, 10))
-	mix(strings.ToLower(owner.Hex()))
-	mix(strings.ToLower(runner.Hex()))
+	for i := 0; i < common.AddressLength; i++ {
+		hash ^= uint32(owner[i])
+		hash *= 16777619
+	}
+	for i := 0; i < common.AddressLength; i++ {
+		hash ^= uint32(runner[i])
+		hash *= 16777619
+	}
 	return &sessionAuthorityLocks[hash%sessionAuthorityLockShards]
 }
 
@@ -288,8 +296,9 @@ func NewSessionResolver(
 				auth.CarrierNonce = new(big.Int).Set(policy.Grant.CarrierNonce)
 			}
 			policyID, policyChain, policyOwner := policy.ID, policy.ChainID, *policy.Owner
+			policyRunner := *policy.Runner
 			auth.OnApplied = func(userOpHash string) error {
-				return MarkSessionGrantAppliedByID(db, policyChain, policyOwner, policyID, userOpHash)
+				return MarkSessionGrantAppliedByID(db, policyChain, policyOwner, policyRunner, policyID, userOpHash)
 			}
 		}
 		return auth, nil

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -4,6 +4,9 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -56,13 +59,78 @@ func StoreSessionPolicy(db storage.Storage, policy *model.SessionPolicy) error {
 	return db.Set(SessionPolicyKey(policy.ChainID, *policy.Owner, policy.ID), body)
 }
 
+// Authority on one runner is a SINGLETON, and these locks are what make that
+// true at write time rather than merely checked at read time.
+//
+// A grant is not additive: the send path resolves exactly one usable policy per
+// runner and refuses the rest (see ActiveSessionPolicyForWallet), so a second
+// stacked grant cannot be used — it can only break the wallet. Submitting one
+// therefore REPLACES the others, and the whole read-decide-write sequence has
+// to be indivisible or two writers interleave into the broken state the
+// replacement exists to prevent.
+//
+// An in-process lock is sufficient here, and that is a property of the
+// deployment rather than an assumption: the store is an embedded BadgerDB
+// opened once per aggregator (aggregator.go, storage.NewWithPath), and Badger
+// holds an exclusive lock on its directory — a second writer process cannot
+// exist to be raced with. Nothing distributed is needed unless that changes.
+const sessionAuthorityLockShards = 64
+
+// sessionAuthorityLocks is sharded so a fixed set of mutexes bounds memory;
+// the same runner always maps to the same shard. Unrelated wallets that
+// collide on a shard merely serialize, which costs nothing at this rate.
+var sessionAuthorityLocks [sessionAuthorityLockShards]sync.RWMutex
+
+// sessionAuthorityLock guards the policy set of one (chainID, owner, runner).
+//
+// Writers (submit, revoke) take it exclusively; readers (the resolver and the
+// contract-write preflight) take it shared, which is what keeps submit's
+// store-then-supersede window invisible to an executing workflow.
+//
+// It is NOT reentrant: a write-lock holder must never call anything that takes
+// the read lock — ActiveSessionPolicyForWallet above all.
+func sessionAuthorityLock(chainID int64, owner, runner common.Address) *sync.RWMutex {
+	// FNV-1a — allocation-free, deterministic (same runner → same shard).
+	var hash uint32 = 2166136261
+	mix := func(s string) {
+		for i := 0; i < len(s); i++ {
+			hash ^= uint32(s[i])
+			hash *= 16777619
+		}
+	}
+	mix(strconv.FormatInt(chainID, 10))
+	mix(strings.ToLower(owner.Hex()))
+	mix(strings.ToLower(runner.Hex()))
+	return &sessionAuthorityLocks[hash%sessionAuthorityLockShards]
+}
+
+// SessionPolicyAmbiguousCode prefixes the refusal when a runner carries more
+// than one usable grant. Clients branch on the code, not the prose — same
+// contract as SESSION_POLICY_TARGET_NOT_ALLOWED (see session_grant_coverage.go).
+//
+// Submitting a grant now supersedes the others, so reaching this needs records
+// that predate that, or a supersede that failed partway. Both are cleared by
+// granting again.
+const SessionPolicyAmbiguousCode = "SESSION_POLICY_AMBIGUOUS"
+
 // ActiveSessionPolicyForWallet returns the usable grant for one wallet.
 //
 // Exactly one usable grant per wallet is expected. More than one is refused
 // rather than resolved by picking: two grants mean two entities, and silently
 // choosing would sign under one while the caller may have provisioned the
-// other — an authority question is not a place for a heuristic.
+// other — an authority question is not a place for a heuristic. Submit keeps
+// the set to one; this stays as the backstop that fails closed if it ever
+// isn't.
 func ActiveSessionPolicyForWallet(db storage.Storage, chainID int64, owner, wallet common.Address) (*model.SessionPolicy, error) {
+	lock := sessionAuthorityLock(chainID, owner, wallet)
+	lock.RLock()
+	defer lock.RUnlock()
+	return activeSessionPolicyLocked(db, chainID, owner, wallet)
+}
+
+// activeSessionPolicyLocked is ActiveSessionPolicyForWallet's body, split out
+// for callers that already hold the runner's lock.
+func activeSessionPolicyLocked(db storage.Storage, chainID int64, owner, wallet common.Address) (*model.SessionPolicy, error) {
 	policies, err := ListSessionPolicies(db, chainID, owner)
 	if err != nil {
 		return nil, err
@@ -74,12 +142,48 @@ func ActiveSessionPolicyForWallet(db storage.Storage, chainID int64, owner, wall
 		}
 		if found != nil {
 			return nil, fmt.Errorf(
-				"wallet %s has more than one usable session policy (%s, %s); revoke one before executing",
-				wallet.Hex(), found.ID, p.ID)
+				"%s: wallet %s has more than one usable session policy (%s, %s); grant again to replace them, or revoke one before executing",
+				SessionPolicyAmbiguousCode, wallet.Hex(), found.ID, p.ID)
 		}
 		found = p
 	}
 	return found, nil
+}
+
+// supersedeUsablePolicies revokes every usable grant on one runner except
+// keepID, and reports what it revoked. The caller must hold the runner's write
+// lock.
+//
+// Revoked, never deleted — even for a pending grant, which RevokeSessionGrant
+// would delete outright. NextSessionEntityID derives the next entity by
+// scanning stored records and counts revoked ones deliberately, so a deleted
+// record frees its entity for reuse. Superseding a pending grant whose install
+// is already in flight would then hand that entity to the next grant, whose
+// installValidation would land on an entity the chain already has. Keeping the
+// record keeps the entity spoken for.
+func supersedeUsablePolicies(db storage.Storage, chainID int64, owner, runner common.Address, keepID string) ([]string, error) {
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	if err != nil {
+		return nil, err
+	}
+	superseded := make([]string, 0, len(policies))
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != runner || !p.Usable() {
+			continue
+		}
+		if strings.EqualFold(p.ID, keepID) {
+			continue
+		}
+		p.Status = model.SessionPolicyRevoked
+		if err := StoreSessionPolicy(db, p); err != nil {
+			// Partial supersede: report what landed so the caller can name the
+			// rest. Reporting success here would leave the runner ambiguous
+			// behind a 201.
+			return superseded, fmt.Errorf("superseding session policy %s: %w", p.ID, err)
+		}
+		superseded = append(superseded, p.ID)
+	}
+	return superseded, nil
 }
 
 // NextSessionEntityID picks an unused validation entity for a wallet.

--- a/core/taskengine/session_policy_supersede_test.go
+++ b/core/taskengine/session_policy_supersede_test.go
@@ -1,0 +1,306 @@
+package taskengine
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Granting REPLACES. A runner carries at most one usable grant, and submit is
+// what keeps it that way — the send path's refusal to pick between two is the
+// backstop, not the mechanism.
+
+// grantOn runs a full prepare → sign → submit against one wallet.
+func grantOn(
+	t *testing.T,
+	engine *Engine,
+	ownerKey *ecdsa.PrivateKey,
+	owner, wallet common.Address,
+) (*model.SessionPolicy, []string) {
+	t.Helper()
+	user := &model.User{Address: owner}
+	in := SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "replace the last one",
+		Permissions: testPermissions(),
+	}
+	prepared, err := engine.PrepareSessionPolicy(user, in)
+	require.NoError(t, err)
+	stored, superseded, err := engine.SubmitSessionPolicy(user, in,
+		prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.NoError(t, err)
+	return stored, superseded
+}
+
+// usableOn returns the wallet's usable policies straight from storage.
+func usableOn(t *testing.T, db storage.Storage, owner, wallet common.Address) []*model.SessionPolicy {
+	t.Helper()
+	all, err := ListSessionPolicies(db, testPolicyChain, owner)
+	require.NoError(t, err)
+	usable := make([]*model.SessionPolicy, 0, len(all))
+	for _, p := range all {
+		if p.Runner != nil && *p.Runner == wallet && p.Usable() {
+			usable = append(usable, p)
+		}
+	}
+	return usable
+}
+
+// seedUsablePolicy writes a usable grant directly, bypassing submit — the only
+// way to reproduce a runner that stacked grants before replacement existed.
+func seedUsablePolicy(t *testing.T, db storage.Storage, owner, wallet common.Address, id string, entity uint32) {
+	t.Helper()
+	ownerAddr, walletAddr, signer := owner, wallet, common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+	require.NoError(t, StoreSessionPolicy(db, &model.SessionPolicy{
+		ID: id, Owner: &ownerAddr, Runner: &walletAddr, ChainID: testPolicyChain,
+		EntityID: entity, SessionSigner: &signer, Status: model.SessionPolicyActive,
+		Grant: &model.SessionGrantAuthorization{
+			InstallCall:    []byte{0x1b, 0xbf, 0x56, 0x4c, 0x01},
+			CarrierNonce:   big.NewInt(1),
+			Deadline:       1785541743,
+			OwnerSignature: make([]byte, 65),
+			AppliedAt:      1,
+		},
+	}))
+}
+
+// The regression this whole change exists for: two grants in sequence used to
+// leave two usable policies, and the wallet then refused to execute at all.
+// No concurrency involved — an ordinary re-grant was enough.
+func TestSecondGrantReplacesTheFirst(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+
+	first, superseded := grantOn(t, engine, ownerKey, owner, wallet)
+	require.Empty(t, superseded, "a first grant replaces nothing")
+
+	second, superseded := grantOn(t, engine, ownerKey, owner, wallet)
+	require.Equal(t, []string{first.ID}, superseded, "the second grant reports what it replaced")
+
+	usable := usableOn(t, db, owner, wallet)
+	require.Len(t, usable, 1, "a runner carries exactly one usable grant")
+	require.Equal(t, second.ID, usable[0].ID, "the newest grant is the one that survives")
+
+	// And the send path resolves it rather than refusing the wallet.
+	resolved, err := ActiveSessionPolicyForWallet(db, testPolicyChain, owner, wallet)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Equal(t, second.ID, resolved.ID)
+}
+
+// A superseded grant is revoked, never deleted. NextSessionEntityID counts
+// stored records to find the next free entity, so deleting one would hand its
+// entity to the next grant — and if the deleted grant's install had already
+// reached the chain, that install would land on an entity the account already
+// has.
+func TestSupersededGrantIsRetainedAndKeepsItsEntity(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+
+	first, _ := grantOn(t, engine, ownerKey, owner, wallet)
+	require.EqualValues(t, 1, first.EntityID)
+	second, _ := grantOn(t, engine, ownerKey, owner, wallet)
+	require.EqualValues(t, 2, second.EntityID)
+
+	// The superseded record still exists, marked revoked.
+	stored, err := engine.GetSessionPolicyByID(&model.User{Address: owner}, testPolicyChain, wallet, first.ID)
+	require.NoError(t, err)
+	require.Equal(t, model.SessionPolicyRevoked, stored.Status)
+	require.False(t, stored.Usable())
+
+	// So entity 1 is never handed out again.
+	next, err := NextSessionEntityID(db, testPolicyChain, owner, wallet)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, next, "a superseded entity is spent, not recycled")
+}
+
+// Replacement is scoped to the runner: granting on one wallet must not disturb
+// the owner's other wallets.
+func TestSupersedeIsScopedToTheRunner(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+
+	otherWallet := common.HexToAddress("0x00000000000000000000000000000000000000a2")
+	factory := common.HexToAddress("0x00000000000017c61b5bEe81050EC8eFc9c6fecd")
+	require.NoError(t, StoreWallet(db, testPolicyChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &otherWallet, Factory: &factory, Salt: big.NewInt(1),
+	}))
+
+	onOther, _ := grantOn(t, engine, ownerKey, owner, otherWallet)
+	grantOn(t, engine, ownerKey, owner, wallet)
+	replacement, superseded := grantOn(t, engine, ownerKey, owner, wallet)
+	require.NotContains(t, superseded, onOther.ID, "another wallet's grant is not this wallet's business")
+
+	require.Len(t, usableOn(t, db, owner, otherWallet), 1)
+	require.Equal(t, onOther.ID, usableOn(t, db, owner, otherWallet)[0].ID)
+	require.Equal(t, replacement.ID, usableOn(t, db, owner, wallet)[0].ID)
+}
+
+// Grants that stacked before replacement existed — the wallets already stuck
+// in the wild — are repaired by granting again. No migration, no cleanup call.
+func TestGrantingAgainRepairsAWalletThatAlreadyStacked(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+
+	seedUsablePolicy(t, db, owner, wallet, "01legacygrantaaaaaaaaaaaaa", 1)
+	seedUsablePolicy(t, db, owner, wallet, "01legacygrantbbbbbbbbbbbbb", 2)
+	require.Len(t, usableOn(t, db, owner, wallet), 2, "precondition: the broken state")
+
+	_, err := ActiveSessionPolicyForWallet(db, testPolicyChain, owner, wallet)
+	require.Error(t, err, "precondition: the send path refuses this wallet")
+
+	fresh, superseded := grantOn(t, engine, ownerKey, owner, wallet)
+	require.Len(t, superseded, 2, "both leftovers are replaced")
+
+	usable := usableOn(t, db, owner, wallet)
+	require.Len(t, usable, 1)
+	require.Equal(t, fresh.ID, usable[0].ID)
+	resolved, err := ActiveSessionPolicyForWallet(db, testPolicyChain, owner, wallet)
+	require.NoError(t, err, "the wallet executes again")
+	require.Equal(t, fresh.ID, resolved.ID)
+}
+
+// The backstop keeps a stable machine code. Studio branches on the code; the
+// prose around it is free to change.
+func TestAmbiguousWalletRefusalCarriesItsCode(t *testing.T) {
+	_, db, _, owner, wallet := newPolicyTestEngine(t)
+	seedUsablePolicy(t, db, owner, wallet, "01legacygrantaaaaaaaaaaaaa", 1)
+	seedUsablePolicy(t, db, owner, wallet, "01legacygrantbbbbbbbbbbbbb", 2)
+
+	_, err := ActiveSessionPolicyForWallet(db, testPolicyChain, owner, wallet)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), SessionPolicyAmbiguousCode)
+}
+
+// Concurrent submits cannot both land. They race for the same validation
+// entity, and the loser is told to prepare again rather than being stored
+// alongside the winner.
+func TestConcurrentSubmitsLeaveExactlyOneUsableGrant(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	in := SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "two tabs, one wallet",
+		Permissions: testPermissions(),
+	}
+
+	// Every writer prepares before any of them submits — the two-tabs case.
+	const writers = 6
+	prepared := make([]*PreparedSessionGrant, writers)
+	signatures := make([][]byte, writers)
+	for i := range prepared {
+		p, err := engine.PrepareSessionPolicy(user, in)
+		require.NoError(t, err)
+		prepared[i], signatures[i] = p, signDigest(t, ownerKey, p.Digest)
+		require.EqualValues(t, 1, p.Policy.EntityID, "all of them allocated the same free entity")
+	}
+
+	var accepted atomic.Int32
+	var wg sync.WaitGroup
+	for i := range prepared {
+		wg.Add(1)
+		go func(p *PreparedSessionGrant, sig []byte) {
+			defer wg.Done()
+			if _, _, err := engine.SubmitSessionPolicy(user, in,
+				p.Policy.ID, p.Policy.EntityID, p.Policy.Grant.Deadline, sig); err == nil {
+				accepted.Add(1)
+			}
+		}(prepared[i], signatures[i])
+	}
+	wg.Wait()
+
+	require.EqualValues(t, 1, accepted.Load(), "exactly one concurrent submit is accepted")
+	require.Len(t, usableOn(t, db, owner, wallet), 1)
+	_, err := ActiveSessionPolicyForWallet(db, testPolicyChain, owner, wallet)
+	require.NoError(t, err)
+}
+
+// Submit stores the new grant and then revokes the old one — two writes, and
+// between them the runner momentarily has two usable grants. The resolver
+// takes the same lock in shared mode, so an execution running alongside a
+// re-grant never observes that window. Worth running under -race.
+func TestReGrantingIsNeverVisibleAsAnAmbiguousWallet(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+
+	const grants = 25
+	done := make(chan struct{})
+	var readerErr atomic.Value
+	var reads atomic.Int64
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if _, err := ActiveSessionPolicyForWallet(db, testPolicyChain, owner, wallet); err != nil {
+				readerErr.Store(err)
+				return
+			}
+			reads.Add(1)
+		}
+	}()
+
+	for i := 0; i < grants; i++ {
+		grantOn(t, engine, ownerKey, owner, wallet)
+	}
+	close(done)
+
+	if err, ok := readerErr.Load().(error); ok && err != nil {
+		t.Fatalf("the send path saw a wallet mid-replacement: %v", err)
+	}
+	require.Positive(t, reads.Load(), "the reader has to actually have run for this to mean anything")
+	require.Len(t, usableOn(t, db, owner, wallet), 1)
+}
+
+// failSetOnPolicy fails the write of one policy id and passes everything else
+// through, so a supersede can be made to fail after the new grant has landed.
+type failSetOnPolicy struct {
+	storage.Storage
+	policyID string
+}
+
+func (f failSetOnPolicy) Set(key, value []byte) error {
+	if strings.Contains(string(key), f.policyID) {
+		return fmt.Errorf("storage is down")
+	}
+	return f.Storage.Set(key, value)
+}
+
+// A supersede that fails partway must not answer 201. The grant did land, so
+// the client must not retry the submit — the entity is spent — but the wallet
+// is ambiguous until the leftovers are cleared.
+func TestFailedSupersedeIsReportedRatherThanSwallowed(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	first, _ := grantOn(t, engine, ownerKey, owner, wallet)
+	engine.db = failSetOnPolicy{Storage: db, policyID: first.ID}
+
+	in := SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Justification: "supersede will fail",
+		Permissions: testPermissions(),
+	}
+	prepared, err := engine.PrepareSessionPolicy(user, in)
+	require.NoError(t, err)
+	stored, superseded, err := engine.SubmitSessionPolicy(user, in,
+		prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSessionPolicySupersedeFailed)
+	require.Nil(t, stored, "no policy is returned on a failed replace")
+	require.Empty(t, superseded, "nothing was successfully superseded")
+
+	// The new grant IS stored — which is exactly why this cannot report success.
+	require.Len(t, usableOn(t, db, owner, wallet), 2)
+}

--- a/core/taskengine/session_policy_supersede_test.go
+++ b/core/taskengine/session_policy_supersede_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -303,4 +304,100 @@ func TestFailedSupersedeIsReportedRatherThanSwallowed(t *testing.T) {
 
 	// The new grant IS stored — which is exactly why this cannot report success.
 	require.Len(t, usableOn(t, db, owner, wallet), 2)
+}
+
+// The same runner must always reach the same mutex. Sharding is only safe
+// because of this: two writers that hashed differently would each hold a lock
+// and neither would exclude the other.
+func TestRunnerAuthorityLockIsStable(t *testing.T) {
+	owner := common.HexToAddress("0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557")
+	wallet := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+
+	first := sessionAuthorityLock(testPolicyChain, owner, wallet)
+	for i := 0; i < 32; i++ {
+		require.Same(t, first, sessionAuthorityLock(testPolicyChain, owner, wallet),
+			"the same runner must always resolve to the same lock")
+	}
+
+	// All three components participate, so unrelated runners are not forced to
+	// serialize on one shard. (A collision is possible and harmless — this
+	// asserts the inputs are used at all, not that they never collide.)
+	spread := map[*sync.RWMutex]struct{}{}
+	for i := 0; i < 64; i++ {
+		var other common.Address
+		other[19] = byte(i)
+		spread[sessionAuthorityLock(testPolicyChain, owner, other)] = struct{}{}
+		spread[sessionAuthorityLock(int64(i+1), owner, wallet)] = struct{}{}
+		spread[sessionAuthorityLock(testPolicyChain, other, wallet)] = struct{}{}
+	}
+	require.Greater(t, len(spread), 1, "chain, owner and runner must all feed the shard")
+}
+
+// A grant's install can confirm after a later grant has already replaced it.
+// Ordered that way, the re-read alone is enough: the record already reads
+// revoked, so the mark is a no-op. See the concurrent case below for the half
+// the lock is actually there for.
+func TestLateInstallConfirmationCannotResurrectASupersededGrant(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+
+	first, _ := grantOn(t, engine, ownerKey, owner, wallet)
+	require.Equal(t, model.SessionPolicyPending, first.Status)
+
+	// The replacement lands while the first grant's install is still in flight.
+	second, superseded := grantOn(t, engine, ownerKey, owner, wallet)
+	require.Equal(t, []string{first.ID}, superseded)
+
+	// Now the in-flight operation confirms and reports the install applied.
+	require.NoError(t, MarkSessionGrantAppliedByID(db, testPolicyChain, owner, wallet, first.ID, "0xlate"))
+
+	usable := usableOn(t, db, owner, wallet)
+	require.Len(t, usable, 1, "the late confirmation must not add a second usable grant")
+	require.Equal(t, second.ID, usable[0].ID)
+
+	stale, err := engine.GetSessionPolicyByID(&model.User{Address: owner}, testPolicyChain, wallet, first.ID)
+	require.NoError(t, err)
+	require.Equal(t, model.SessionPolicyRevoked, stale.Status, "the superseded grant stays revoked")
+}
+
+// The lock is asserted directly, because the race it closes cannot be won
+// reliably from a test: the confirmation's read-then-write is a few
+// microseconds, while the submit racing it spends far longer in signature
+// recovery before it supersedes anything, so the interleaving effectively
+// never occurs on demand.
+//
+// What is checkable is the property that was actually changed — that marking a
+// grant applied acquires the runner's write lock, and therefore cannot run
+// between a submit's store and its supersede. Hold the lock, and the
+// confirmation must wait for it.
+func TestApplyingAGrantWaitsForTheRunnersWriteLock(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	pending, _ := grantOn(t, engine, ownerKey, owner, wallet)
+
+	lock := sessionAuthorityLock(testPolicyChain, owner, wallet)
+	lock.Lock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- MarkSessionGrantAppliedByID(db, testPolicyChain, owner, wallet, pending.ID, "0xinflight")
+	}()
+
+	select {
+	case <-done:
+		lock.Unlock()
+		t.Fatal("marking a grant applied did not wait for the runner's write lock: a replacement " +
+			"landing between its read and its write would be overwritten, resurrecting a superseded grant")
+	case <-time.After(150 * time.Millisecond):
+		// Still blocked, which is the point. Without the lock this completes
+		// in microseconds.
+	}
+
+	lock.Unlock()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("still blocked after the runner's lock was released")
+	}
+
+	require.Len(t, usableOn(t, db, owner, wallet), 1)
 }

--- a/docs/changes/20260806-session-grant-replace-on-submit.md
+++ b/docs/changes/20260806-session-grant-replace-on-submit.md
@@ -1,0 +1,152 @@
+# Session grants replace instead of stacking
+
+**Date:** 2026-08-06
+**Status:** Implemented
+**Branch:** `feat/session-policy-atomic-supersede`
+**Related:** [#715](https://github.com/AvaProtocol/EigenLayer-AVS/issues/715), Studio [#1458](https://github.com/AvaProtocol/studio/pull/1458)
+
+## Summary
+
+Submitting a session grant now revokes every other usable grant on the same
+runner, so a wallet carries at most one. Replacement is unconditional — there is
+no flag — and the submit response reports what it replaced in
+`supersededPolicyIds`.
+
+## Problem
+
+A smart wallet could accumulate usable grants, and the send path refuses to
+execute when it finds more than one (`ActiveSessionPolicyForWallet`). So a
+second grant did not extend the user's permission; it bricked the wallet until
+someone revoked one by hand. That is what blocked Auto on Sepolia after a
+second successful grant sign.
+
+The issue framed this as a race between concurrent clients. It is mostly not.
+Two grants in plain sequence were enough:
+
+1. First grant takes entity 1 and is stored.
+2. Later, `NextSessionEntityID` returns 2, the owner signs for entity 2, and
+   submit's entity re-check passes because 2 *is* the next free one.
+3. Two usable grants. Execute refuses.
+
+The pre-existing `ErrSessionEntityTaken` guard does not catch this. It protects
+entity uniqueness, not policy singleton-ness: it only fires when two grants were
+prepared against the same free entity, so any two grants separated by a
+completed submit sail through it.
+
+## Decision
+
+**Replace, always, scoped to the runner.**
+
+- `SubmitSessionPolicy` holds a write lock on `(chainID, owner, runner)` across
+  the entity re-check, the store, and the supersede. `RevokeSessionPolicyByID`
+  takes the same lock; the resolver and the contract-write preflight take it
+  shared.
+- An in-process sharded `RWMutex` is sufficient, and that is a property of the
+  deployment rather than an assumption: the store is an embedded BadgerDB opened
+  once per aggregator, and Badger holds an exclusive lock on its directory, so a
+  second writer process cannot exist. Nothing distributed is needed unless that
+  changes.
+- Order is store-then-supersede. On a crash that can leave two usable grants,
+  which fails closed and is repaired by granting again; superseding first could
+  leave zero — working authority destroyed for a replacement that never landed.
+- A failed supersede returns `ErrSessionPolicySupersedeFailed` (HTTP 500,
+  `POLICIES_SUPERSEDE_FAILED`) rather than a 201. The grant *did* land, so the
+  client must not retry the submit — the entity is spent — only clear the
+  named leftovers.
+
+Because replace supersedes *all* other usable grants, the operation is
+idempotent and self-healing: **a wallet already stuck with dual rows is repaired
+by the next successful grant.** No migration, no cleanup endpoint.
+
+### Scoped to the runner, not the capability
+
+The issue asked for ≤1 usable grant per `(runner, chainId, capability)`. The
+send path already enforces something stricter — ≤1 per runner, whatever the
+capability — so capability-scoped supersede would deliberately permit a pair
+that execute then rejects.
+
+v1 is therefore runner-scoped, which removes the whole capability prerequisite:
+no `capabilityId` on `SessionPolicy`, no server-side allowlist fingerprint, no
+mirroring Studio's `exactInputSingle` (`0x04e45aaf`) heuristic in the gateway.
+Capability becomes real only alongside concurrent multi-class grants and
+execute-time selection, which changes the execute guard too.
+
+### Superseding revokes, never deletes
+
+`RevokeSessionGrant` deletes a *pending* policy outright, on the grounds that
+nothing was installed. Supersede must not reuse that path.
+`NextSessionEntityID` derives the next entity by scanning stored records and
+counts revoked ones deliberately, so a deleted record frees its entity for
+reuse. Superseding a pending grant whose install was already in flight would
+hand entity N to the next grant, whose `installValidation` would land on an
+entity the account already has. Keeping the record keeps the entity spoken for.
+
+## Alternatives
+
+- **`replaceExisting: true` (issue Option A) / reject-unless-replace (Option
+  C).** Both make correct behavior opt-in, i.e. a flag whose default value is
+  "break." They also leave the clients the issue worried about — non-Studio
+  writers that never learned the flag — still broken. Unconditional replace
+  fixes them with no change on their side, and needs no request-shape change.
+- **Dedicated `policies.supersede` (Option B).** Its only job is cleaning up
+  legacy dual rows, which a plain re-grant already does.
+- **Pointer record** (`sp:active:<chain>:<owner>:<runner>` → policy id). Makes
+  authority a single key, so the flip is atomic in one write and needs no lock.
+  Rejected for v1: it adds a second source of truth that can drift, needs
+  legacy-fallback logic, and leaves already-broken wallets inert-but-dirty
+  rather than repaired. Reconsider if the gateway ever becomes multi-writer.
+- **Collapsing the key to one record per runner.** History is load-bearing:
+  revoked records rebuild the uninstall payload and back entity allocation.
+- **Deterministic selection at execute** (newest entity wins). Removes the
+  fail-closed backstop and lets an accidental grant silently take over while the
+  previous spend cap stops applying.
+
+## Client contract
+
+- **Nothing to opt into.** Do not revoke the previous grant before submitting;
+  submit does it. There is no `replace` flag.
+- **`supersededPolicyIds`** is always present on the 201, empty on a first
+  grant. Non-empty means the user's earlier permission is gone — worth
+  reflecting in the UI. The superseded records' `status` reads `revoked`; the
+  array is what distinguishes a gateway-performed replacement from a
+  user-requested `DELETE .../policies/{policyId}`.
+- **`SESSION_POLICY_AMBIGUOUS`** now prefixes the >1-usable refusal from the
+  send path, so clients branch on the code instead of the prose. Reaching it
+  needs records that predate this change or a supersede that failed partway;
+  both are cleared by granting again.
+- **`POLICIES_SUPERSEDE_FAILED`** (500) means the new grant is stored but a
+  previous one was not revoked. Do not retry the submit. Revoke the older usable
+  policies, or grant again.
+
+## Off-chain only
+
+Superseding marks a grant unusable **by this gateway**. The validation entity
+and its ERC-20 spend cap stay installed on the account until the owner signs
+`uninstallValidation`. After three re-grants the wallet carries three live
+entities and three caps, of which the gateway will use one — so "update
+permission" does not reduce what the account *could* authorize on chain.
+
+Closing that half means making the deferred action a batch that uninstalls the
+prior entity as it installs the new one, so both sides agree under a single
+owner signature. That is real work on payload shape and signature semantics and
+is deliberately out of scope here; it needs its own issue.
+
+## Verification
+
+`core/taskengine/session_policy_supersede_test.go`, all under `-race`:
+
+- a second grant replaces the first and reports it (the sequential regression)
+- a superseded grant is retained as `revoked` and its entity is never recycled
+- replacement does not touch the owner's other wallets
+- a wallet seeded with two usable grants is repaired by granting again
+- the ambiguity refusal carries `SESSION_POLICY_AMBIGUOUS`
+- six concurrent submits: exactly one is accepted, one usable grant remains
+- 25 sequential re-grants against a spinning resolver never expose the
+  store-then-supersede window (fails reliably without the resolver's read lock)
+- a supersede failure surfaces as an error, not a 201
+
+`aggregator/rest/handlers_policies_test.go` covers the HTTP round trip and pins
+`SubmitPolicyResponse` against `SessionPolicy` so the hand-written converter for
+the flattened `allOf` cannot silently drop a field.
+
+`make storage-check`: no key or model changes.


### PR DESCRIPTION
Closes #715.

## Summary

A smart wallet may carry only one usable session grant — the send path refuses to execute when it finds more than one. Nothing enforced that at **write** time, so a second grant did not extend the user's permission, it bricked the wallet until someone revoked one by hand. That is what blocked Auto on Sepolia after a second successful grant sign.

Submit now revokes every other usable grant on the runner, and reports what it replaced in `supersededPolicyIds`.

## The issue's framing was off, and it changed the design

**This is mostly not a concurrency bug.** Two grants in plain sequence were enough: the first takes entity 1, then `NextSessionEntityID` returns 2, the owner signs for entity 2, and submit's entity re-check passes because 2 *is* the next free one. The pre-existing `ErrSessionEntityTaken` guard protects entity uniqueness, not policy singleton-ness, so any two grants separated by a completed submit sail through it.

**Capability scoping came out of v1.** The issue asked for ≤1 usable grant per `(runner, chainId, capability)`, but `ActiveSessionPolicyForWallet` already enforces something stricter — ≤1 per runner, whatever the capability. Capability-scoped supersede would deliberately permit a pair that execute then rejects. Scoping to the runner instead removes the entire prerequisite: no `capabilityId` field, no server-side fingerprint, no mirroring Studio's `exactInputSingle` heuristic in the gateway.

**None of Options A/B/C as written.** A (`replaceExisting: true`) and C (reject-unless-replace) make correct behavior opt-in — a flag whose default value is "break" — and leave non-Studio writers that never learned the flag still broken. Replace is therefore unconditional, which fixes those clients with no change on their side and needs no request-shape change. B (a dedicated supersede endpoint) only existed to clean up legacy dual rows, which a plain re-grant now does.

Full reasoning: [design note on #715](https://github.com/AvaProtocol/EigenLayer-AVS/issues/715#issuecomment-5210598485).

## How it works

- `SubmitSessionPolicy` holds a write lock on `(chainID, owner, runner)` across the entity re-check, the store, and the supersede. `RevokeSessionPolicyByID` takes the same lock; the resolver and the contract-write preflight take it **shared**, so an executing workflow never observes the window between the two writes.
- An in-process sharded `RWMutex` suffices, and that is a property of the deployment rather than an assumption: Badger is embedded, opened once per aggregator, and holds an exclusive directory lock — a second writer process cannot exist.
- Because it supersedes *all* other usable grants, the operation is **self-healing**: wallets already stuck with dual rows are repaired by the next grant. No migration, no cleanup endpoint.

### Two details that bite

- **Superseding revokes, never deletes.** `RevokeSessionGrant` deletes pending policies, but `NextSessionEntityID` counts stored records — so a deleted record frees its entity. Superseding a pending grant whose install was in flight would hand that entity to the next grant, whose `installValidation` would land on an entity the account already has.
- **Store-then-supersede, not the reverse.** A crash between the two leaves two usable grants, which fails closed and self-heals. Superseding first could leave *zero* — working authority destroyed for a replacement that never landed.

## Client-visible changes

| Change | Kind |
| --- | --- |
| Submit revokes the runner's other usable grants | Behavior — no opt-in, no opt-out |
| `supersededPolicyIds` on the 201 (always present, empty on a first grant) | Additive |
| `SESSION_POLICY_AMBIGUOUS:` prefix on the >1-usable refusal | Additive; Studio currently string-matches the prose |
| `POLICIES_SUPERSEDE_FAILED` (500) — grant stored, previous not revoked; do **not** retry the submit, the entity is spent | New error |

`SubmitPolicyResponse` is `allOf: [SessionPolicy, {supersededPolicyIds}]`, a wire-compatible superset — the existing test that decodes the 201 as `SessionPolicy` still passes unchanged.

## Off-chain only

Superseding marks a grant unusable **by this gateway**. The validation entity and its ERC-20 spend cap stay installed until the owner signs `uninstallValidation`, so "update permission" does not reduce what the account *could* authorize on chain. Closing that half means batching the uninstall into the deferred action — real work on payload shape and signature semantics, deliberately out of scope, needs its own issue.

## Test plan

`core/taskengine/session_policy_supersede_test.go`, all under `-race`:

- [x] a second grant replaces the first and reports it (the sequential regression)
- [x] a superseded grant is retained as `revoked` and its entity is never recycled
- [x] replacement does not touch the owner's other wallets
- [x] a wallet seeded with two usable grants is repaired by granting again
- [x] the ambiguity refusal carries `SESSION_POLICY_AMBIGUOUS`
- [x] six concurrent submits: exactly one accepted, one usable grant remains
- [x] 25 sequential re-grants against a spinning resolver never expose the store-then-supersede window — **verified to fail 3/3 without the resolver's read lock**
- [x] a supersede failure surfaces as an error, not a 201

REST: HTTP round trip for replace, plus a drift guard pinning `SubmitPolicyResponse` against `SessionPolicy` so the hand-written converter for the flattened `allOf` cannot silently drop a field — **verified to fail when a field is removed**.

- [x] `make storage-check` — no key or model changes
- [ ] CI green
- [ ] SDK consumes `supersededPolicyIds`; Studio drops its supersede-after-submit mitigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
