### PR TITLE
fix(worker): carry Gas Manager sponsorship into worker config

### DIFF
--- a/aggregator/task_engine.go
+++ b/aggregator/task_engine.go
@@ -75,7 +75,7 @@ func (agg *Aggregator) startTaskEngine(ctx context.Context) {
 			"effective_factory", effectiveFactory.Hex(),
 			"config_factory_address", sw.FactoryAddress.Hex(),
 			"entry_point", sw.EntryPointAddress().Hex(),
-			"paymaster_policy_set", sw.AlchemyPaymasterPolicyID != "",
+			"paymaster_policy_set", sw.SponsorshipPolicyID() != "",
 			"legacy_v06_paymaster", sw.PaymasterAddress.Hex(),
 		)
 	}

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -187,3 +187,15 @@ notifications:
     provider:     context-memory
     api_endpoint: "http://localhost:3010"
     api_key:      ""
+
+# Gas Manager sponsorship is DISABLED for local/development runs, deliberately.
+#
+# The policy's custom-rules webhook is a single URL pointing at the PRODUCTION
+# gateway, so a locally-run process that requests sponsorship has production
+# approve it — deciding against production's wallet records and billing
+# production's budget for your machine. Leave this true locally and fund the
+# test smart wallet with the chain's native token instead.
+#
+# It is an explicit setting rather than an inference from `environment` so that
+# changing log verbosity can never change who pays for gas.
+disable_gas_sponsorship: true

--- a/config/test.example.yaml
+++ b/config/test.example.yaml
@@ -118,3 +118,15 @@ notifications:
     provider:     context-memory
     api_endpoint: "http://localhost:3010"
     api_key:      ""
+
+# Gas Manager sponsorship is DISABLED for local/development runs, deliberately.
+#
+# The policy's custom-rules webhook is a single URL pointing at the PRODUCTION
+# gateway, so a locally-run process that requests sponsorship has production
+# approve it — deciding against production's wallet records and billing
+# production's budget for your machine. Leave this true locally and fund the
+# test smart wallet with the chain's native token instead.
+#
+# It is an explicit setting rather than an inference from `environment` so that
+# changing log verbosity can never change who pays for gas.
+disable_gas_sponsorship: true

--- a/config/worker-base-sepolia.example.yaml
+++ b/config/worker-base-sepolia.example.yaml
@@ -57,3 +57,15 @@ gas_manager_webhook_secret:  ${GAS_MANAGER_WEBHOOK_SECRET}
 smart_wallet:
   controller_private_key: <testnet-controller-private-key-hex>
   paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
+
+# Gas Manager sponsorship is DISABLED for local/development runs, deliberately.
+#
+# The policy's custom-rules webhook is a single URL pointing at the PRODUCTION
+# gateway, so a locally-run process that requests sponsorship has production
+# approve it — deciding against production's wallet records and billing
+# production's budget for your machine. Leave this true locally and fund the
+# test smart wallet with the chain's native token instead.
+#
+# It is an explicit setting rather than an inference from `environment` so that
+# changing log verbosity can never change who pays for gas.
+disable_gas_sponsorship: true

--- a/config/worker-base-sepolia.example.yaml
+++ b/config/worker-base-sepolia.example.yaml
@@ -39,6 +39,20 @@ bundler_url:      ${BASE_SEPOLIA_BUNDLER_URL}
 bundler_provider: self_hosted
 alchemy_api_key:  ${ALCHEMY_API_KEY}
 
+# Gas Manager sponsorship — MUST match the gateway, or this worker sends
+# UNSPONSORED operations.
+#
+# Sponsorship is requested only when a policy id is present. Without one, every
+# operation this worker sends has to be paid for out of the smart wallet's own
+# balance, so a wallet holding only tokens cannot move them — which is how
+# withdrawals routed through a worker silently stopped being sponsored (#722).
+#
+# The webhook endpoint itself stays on the gateway (POST /webhooks/gas-manager).
+# What the worker needs is the SECRET: it is echoed to Alchemy as webhookData,
+# and the gateway's webhook rejects any request whose value does not match.
+alchemy_paymaster_policy_id: ${ALCHEMY_PAYMASTER_POLICY_ID}
+gas_manager_webhook_secret:  ${GAS_MANAGER_WEBHOOK_SECRET}
+
 # Smart wallet / account abstraction config.
 smart_wallet:
   controller_private_key: <testnet-controller-private-key-hex>

--- a/config/worker-sepolia.example.yaml
+++ b/config/worker-sepolia.example.yaml
@@ -39,6 +39,20 @@ bundler_url:      ${SEPOLIA_BUNDLER_URL}
 bundler_provider: self_hosted
 alchemy_api_key:  ${ALCHEMY_API_KEY}
 
+# Gas Manager sponsorship — MUST match the gateway, or this worker sends
+# UNSPONSORED operations.
+#
+# Sponsorship is requested only when a policy id is present. Without one, every
+# operation this worker sends has to be paid for out of the smart wallet's own
+# balance, so a wallet holding only tokens cannot move them — which is how
+# withdrawals routed through a worker silently stopped being sponsored (#722).
+#
+# The webhook endpoint itself stays on the gateway (POST /webhooks/gas-manager).
+# What the worker needs is the SECRET: it is echoed to Alchemy as webhookData,
+# and the gateway's webhook rejects any request whose value does not match.
+alchemy_paymaster_policy_id: ${ALCHEMY_PAYMASTER_POLICY_ID}
+gas_manager_webhook_secret:  ${GAS_MANAGER_WEBHOOK_SECRET}
+
 # Smart wallet / account abstraction config.
 smart_wallet:
   controller_private_key: <testnet-controller-private-key-hex>

--- a/config/worker-sepolia.example.yaml
+++ b/config/worker-sepolia.example.yaml
@@ -57,3 +57,15 @@ gas_manager_webhook_secret:  ${GAS_MANAGER_WEBHOOK_SECRET}
 smart_wallet:
   controller_private_key: <testnet-controller-private-key-hex>
   paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
+
+# Gas Manager sponsorship is DISABLED for local/development runs, deliberately.
+#
+# The policy's custom-rules webhook is a single URL pointing at the PRODUCTION
+# gateway, so a locally-run process that requests sponsorship has production
+# approve it — deciding against production's wallet records and billing
+# production's budget for your machine. Leave this true locally and fund the
+# test smart wallet with the chain's native token instead.
+#
+# It is an explicit setting rather than an inference from `environment` so that
+# changing log verbosity can never change who pays for gas.
+disable_gas_sponsorship: true

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -872,6 +872,18 @@ func NewConfig(configFilePath string) (*Config, error) {
 			"default_chain_id", config.DefaultChainID)
 	}
 
+	// Say once, at boot, whether this process can have operations sponsored.
+	// A development process is refused deliberately — see
+	// SponsorshipRefusedForEnvironment — and that should read as a decision
+	// rather than as a missing policy someone ought to go and set.
+	if SponsorshipRefusedForEnvironment(string(configRaw.Environment)) {
+		logger.Info("Gas Manager sponsorship refused: development environment; operations run self-funded",
+			"hint", "the policy's webhook points at the production gateway; fund the test smart wallet instead")
+	} else if config.AlchemyPaymasterPolicyID == "" {
+		logger.Warn("No Gas Manager policy configured: operations run self-funded",
+			"hint", "set alchemy_paymaster_policy_id or ALCHEMY_PAYMASTER_POLICY_ID")
+	}
+
 	// If HttpBindAddress is empty, HTTP server will be disabled (startup code will skip starting it)
 	config.validate()
 	return config, nil
@@ -963,13 +975,36 @@ func firstNonEmpty(values ...string) string {
 // file, and the gateway and worker disagreeing about where sponsorship comes
 // from is exactly how worker-routed operations ended up unsponsored (#722).
 // One resolver, so they cannot drift apart again.
-func ResolveAlchemyPaymasterPolicyID(canonicalYaml, legacyYaml string) string {
+func ResolveAlchemyPaymasterPolicyID(environment, canonicalYaml, legacyYaml string) string {
+	if SponsorshipRefusedForEnvironment(environment) {
+		return ""
+	}
 	return strings.TrimSpace(firstNonEmpty(
 		canonicalYaml,
 		os.Getenv("ALCHEMY_PAYMASTER_POLICY_ID"),
 		legacyYaml,
 		os.Getenv("ALCHEMY_GAS_POLICY_ID"),
 	))
+}
+
+// SponsorshipRefusedForEnvironment reports whether this process must not ask
+// Alchemy to sponsor, whatever its config says.
+//
+// A development process must not, and the reason is not tidiness. The Gas
+// Manager policy's custom-rules webhook is a single URL pointing at the
+// PRODUCTION gateway, so a locally-run gateway or worker that requests
+// sponsorship has Alchemy call production to approve it. Production then
+// decides using its own wallet records and its own credit ledger — so a local
+// test either gets a confusing denial for a wallet production has never heard
+// of, or, for a shared test wallet production does know, succeeds and bills
+// the production sponsorship budget for someone's laptop.
+//
+// This is a refusal rather than a convention because the policy id resolves
+// from the ENVIRONMENT as well as from yaml: an ALCHEMY_PAYMASTER_POLICY_ID
+// exported in a shell or sitting in a .env is enough to opt a local process in
+// by accident. Development runs self-funded; fund the test wallet instead.
+func SponsorshipRefusedForEnvironment(environment string) bool {
+	return strings.EqualFold(strings.TrimSpace(environment), string(sdklogging.Development))
 }
 
 // ResolveGasManagerWebhookSecret returns the secret echoed to Alchemy as
@@ -981,7 +1016,7 @@ func ResolveGasManagerWebhookSecret(yamlValue string) string {
 }
 
 func resolveAlchemyPaymasterPolicyID(raw ConfigRaw) string {
-	return ResolveAlchemyPaymasterPolicyID(raw.AlchemyPaymasterPolicyID, raw.GasManagerPolicyID)
+	return ResolveAlchemyPaymasterPolicyID(string(raw.Environment), raw.AlchemyPaymasterPolicyID, raw.GasManagerPolicyID)
 }
 
 func ReadYamlConfig(path string, o interface{}) error {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -338,6 +338,36 @@ func (c *SmartWalletConfig) SponsorshipPolicyID() string {
 	return c.AlchemyPaymasterPolicyID
 }
 
+// ValidateSponsorship refuses a Gas Manager policy the chain cannot use.
+//
+// Sponsorship is requested with alchemy_requestGasAndPaymasterAndData against
+// ActiveBundlerURL. A self-hosted Voltaire bundler does not implement it, so
+// the request fails the operation instead of sponsoring it. Configuring a
+// policy on such a chain is therefore always a mistake — either the policy
+// does not belong there or the bundler should be Alchemy.
+//
+// Refused at load rather than tolerated, because the alternative is a chain
+// that looks sponsored in config and silently is not: the send path would fall
+// back to self-funded, and the first symptom is a user's operation failing for
+// a wallet nobody thought needed a gas balance. Naming the two config lines is
+// better than that.
+//
+// An opted-out chain is exempt — disable_gas_sponsorship already says the
+// policy is not to be used, so the bundler is irrelevant.
+func (c *SmartWalletConfig) ValidateSponsorship() error {
+	if c == nil || c.DisableGasSponsorship || c.AlchemyPaymasterPolicyID == "" {
+		return nil
+	}
+	if c.ProviderName() != BundlerProviderAlchemy {
+		return fmt.Errorf(
+			"chain_id=%d has a Gas Manager policy but bundler_provider is %q: sponsorship needs %q "+
+				"(alchemy_requestGasAndPaymasterAndData is not implemented by a self-hosted bundler). "+
+				"Set bundler_provider: %s, or set disable_gas_sponsorship: true to run self-funded",
+			c.ChainID, c.ProviderName(), BundlerProviderAlchemy, BundlerProviderAlchemy)
+	}
+	return nil
+}
+
 // UsesModularAccountV2 reports whether this chain derives MA v2 accounts.
 func (c *SmartWalletConfig) UsesModularAccountV2() bool {
 	return c.AccountProviderName() == AccountProviderModularAccountV2
@@ -880,6 +910,9 @@ func NewConfig(configFilePath string) (*Config, error) {
 	// at startup where it's diagnosable, not hours later on a real workflow.
 	// Same fail-at-boot rule for the top-level smart_wallet as for each chain.
 	if config.SmartWallet != nil {
+		if err := config.SmartWallet.ValidateSponsorship(); err != nil {
+			return nil, err
+		}
 		if err := config.SmartWallet.ValidateAccountProvider(); err != nil {
 			return nil, fmt.Errorf("top-level smart_wallet: %w", err)
 		}
@@ -930,10 +963,6 @@ func NewConfig(configFilePath string) (*Config, error) {
 	case config.AlchemyPaymasterPolicyID == "":
 		logger.Warn("No Gas Manager policy configured; operations run self-funded",
 			"hint", "set alchemy_paymaster_policy_id or ALCHEMY_PAYMASTER_POLICY_ID")
-	case config.SmartWallet != nil && config.SmartWallet.SponsorshipPolicyID() == "":
-		logger.Warn("Gas Manager policy is set but unusable on this bundler; operations run self-funded",
-			"bundler_provider", config.SmartWallet.ProviderName(),
-			"hint", "sponsorship needs bundler_provider: alchemy — alchemy_requestGasAndPaymasterAndData is not implemented by a self-hosted bundler")
 	}
 
 	// If HttpBindAddress is empty, HTTP server will be disabled (startup code will skip starting it)
@@ -1187,6 +1216,9 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 	// derivation. A typo silently reads as simple_account, so a chain the
 	// operator believed was on MA v2 would quietly hand users v0.6 addresses —
 	// visible only much later, and not obviously as a config error.
+	if err := chainCfg.SmartWallet.ValidateSponsorship(); err != nil {
+		return nil, err
+	}
 	if err := chainCfg.SmartWallet.ValidateAccountProvider(); err != nil {
 		return nil, fmt.Errorf("chain %s (chain_id=%d): %w", raw.Name, raw.ChainID, err)
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -770,7 +770,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			WhitelistAddresses:       convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
 			MaxWalletsPerOwner:       configRaw.SmartWallet.MaxWalletsPerOwner,
 			AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
-			GasManagerWebhookSecret:  strings.TrimSpace(firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET"))),
+			GasManagerWebhookSecret:  ResolveGasManagerWebhookSecret(configRaw.GasManagerWebhookSecret),
 			// PaymasterOwnerAddress will be populated below by calling owner() on the paymaster contract
 		},
 
@@ -793,7 +793,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 		AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
 		// Trim: pasted secrets often carry trailing whitespace; webhook compares
 		// with subtle.ConstantTimeCompare on the raw webhookData body field.
-		GasManagerWebhookSecret: strings.TrimSpace(firstNonEmpty(configRaw.GasManagerWebhookSecret, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET"))),
+		GasManagerWebhookSecret: ResolveGasManagerWebhookSecret(configRaw.GasManagerWebhookSecret),
 
 		// Initialize fee rates - use defaults if no YAML config provided
 		FeeRates: loadFeeRatesFromConfig(configRaw.FeeRates),
@@ -951,17 +951,37 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-// resolveAlchemyPaymasterPolicyID returns the Alchemy paymaster policy UUID.
+// ResolveAlchemyPaymasterPolicyID returns the Alchemy paymaster policy UUID
+// from a config's canonical and legacy yaml fields, falling back to the
+// environment in the same order.
+//
 // Canonical: yaml alchemy_paymaster_policy_id / env ALCHEMY_PAYMASTER_POLICY_ID.
 // Legacy aliases still accepted so existing deployments do not silently lose
 // sponsorship: yaml gas_manager_policy_id / env ALCHEMY_GAS_POLICY_ID.
-func resolveAlchemyPaymasterPolicyID(raw ConfigRaw) string {
-	return firstNonEmpty(
-		raw.AlchemyPaymasterPolicyID,
+//
+// Exported because the worker resolves the same setting from its own config
+// file, and the gateway and worker disagreeing about where sponsorship comes
+// from is exactly how worker-routed operations ended up unsponsored (#722).
+// One resolver, so they cannot drift apart again.
+func ResolveAlchemyPaymasterPolicyID(canonicalYaml, legacyYaml string) string {
+	return strings.TrimSpace(firstNonEmpty(
+		canonicalYaml,
 		os.Getenv("ALCHEMY_PAYMASTER_POLICY_ID"),
-		raw.GasManagerPolicyID,
+		legacyYaml,
 		os.Getenv("ALCHEMY_GAS_POLICY_ID"),
-	)
+	))
+}
+
+// ResolveGasManagerWebhookSecret returns the secret echoed to Alchemy as
+// webhookData. Same reasoning as ResolveAlchemyPaymasterPolicyID: a worker that
+// requests sponsorship must send the same secret the gateway's webhook checks,
+// or the policy's custom-rules callback rejects every request.
+func ResolveGasManagerWebhookSecret(yamlValue string) string {
+	return strings.TrimSpace(firstNonEmpty(yamlValue, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")))
+}
+
+func resolveAlchemyPaymasterPolicyID(raw ConfigRaw) string {
+	return ResolveAlchemyPaymasterPolicyID(raw.AlchemyPaymasterPolicyID, raw.GasManagerPolicyID)
 }
 
 func ReadYamlConfig(path string, o interface{}) error {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -942,9 +942,24 @@ func NewConfig(configFilePath string) (*Config, error) {
 			}
 			// Sponsorship is configured once for the gateway, not per chain, but
 			// the v0.7 send path is only ever handed a SmartWalletConfig. Push
-			// the policy and webhook secret down so every chain can reach them.
+			// the policy, webhook secret and opt-out down so every chain reaches
+			// the same answer the top-level config would give.
+			//
+			// The opt-out has to travel with the policy. Without it a gateway
+			// that set disable_gas_sponsorship would still sponsor on every
+			// chain, because the chains inherited the policy and nothing else —
+			// which is precisely the local-development case the opt-out exists
+			// for, and gateway mode is how local development runs.
 			chainCfg.SmartWallet.AlchemyPaymasterPolicyID = config.AlchemyPaymasterPolicyID
 			chainCfg.SmartWallet.GasManagerWebhookSecret = config.GasManagerWebhookSecret
+			chainCfg.SmartWallet.DisableGasSponsorship = config.SmartWallet.DisableGasSponsorship
+
+			// Validated here rather than inside parseChainConfig: the policy a
+			// chain ends up with is the inherited one, so checking before the
+			// lines above would only ever see an empty policy and pass.
+			if err := chainCfg.SmartWallet.ValidateSponsorship(); err != nil {
+				return nil, fmt.Errorf("chain %s (chain_id=%d): %w", chainRaw.Name, chainRaw.ChainID, err)
+			}
 			config.Chains = append(config.Chains, chainCfg)
 		}
 
@@ -1216,9 +1231,6 @@ func parseChainConfig(raw ChainConfigRaw, logger sdklogging.Logger) (*ChainConfi
 	// derivation. A typo silently reads as simple_account, so a chain the
 	// operator believed was on MA v2 would quietly hand users v0.6 addresses —
 	// visible only much later, and not obviously as a config error.
-	if err := chainCfg.SmartWallet.ValidateSponsorship(); err != nil {
-		return nil, err
-	}
 	if err := chainCfg.SmartWallet.ValidateAccountProvider(); err != nil {
 		return nil, fmt.Errorf("chain %s (chain_id=%d): %w", raw.Name, raw.ChainID, err)
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -154,6 +154,12 @@ type Config struct {
 	// whereas an unmounted route 404s loudly.
 	AlchemyPaymasterPolicyID string
 
+	// DisableGasSponsorship opts the whole process out of Gas Manager
+	// sponsorship. Set it in every local/development config: the policy's
+	// webhook points at the production gateway, so a local process that
+	// requests sponsorship is approved and billed by production.
+	DisableGasSponsorship bool
+
 	// GasManagerWebhookSecret, when set, must be echoed as the webhook
 	// request's webhookData. The webhook cannot sit behind the REST JWT
 	// (Alchemy has no token), so this is its only caller authentication.
@@ -249,6 +255,10 @@ type SmartWalletConfig struct {
 	// legacy v0.6 SimpleAccount fork. See AccountProviderName.
 	AccountProvider string
 
+	// DisableGasSponsorship opts this deployment out of the Gas Manager policy
+	// regardless of what is configured. See SponsorshipPolicyID.
+	DisableGasSponsorship bool
+
 	// AlchemyPaymasterPolicyID is copied down from the top-level config so the
 	// v0.7 send path — which is handed only a SmartWalletConfig — can request
 	// sponsorship without reaching back up. Empty means unsponsored: the
@@ -293,6 +303,39 @@ func (c *SmartWalletConfig) AccountProviderName() string {
 		return AccountProviderModularAccountV2
 	}
 	return p
+}
+
+// SponsorshipPolicyID returns the Gas Manager policy this chain may actually
+// use, or "" when it must run self-funded. Every decision about sponsorship
+// reads this rather than AlchemyPaymasterPolicyID directly, so the conditions
+// cannot be applied in one place and forgotten in another.
+//
+// Two things disqualify a configured policy:
+//
+//   - DisableGasSponsorship. An explicit opt-out for any deployment that must
+//     not draw on the policy. Local development is the reason it exists: the
+//     policy's custom-rules webhook is a single URL pointing at the PRODUCTION
+//     gateway, so a locally-run process asking for sponsorship has production
+//     approve it — deciding against production's wallet records and billing
+//     production's budget for someone's laptop. A policy id can arrive from the
+//     environment as well as from yaml, so an exported
+//     ALCHEMY_PAYMASTER_POLICY_ID is enough to opt in by accident; the local
+//     templates set this so that cannot happen.
+//
+//   - A non-Alchemy bundler. Sponsorship is requested with
+//     alchemy_requestGasAndPaymasterAndData against ActiveBundlerURL, which a
+//     self-hosted Voltaire endpoint does not implement. Sending it there fails
+//     the operation instead of sponsoring it, so a policy on a self_hosted
+//     chain is inert — bnb-mainnet is configured exactly that way today. Better
+//     to run self-funded, which is what that chain already did.
+func (c *SmartWalletConfig) SponsorshipPolicyID() string {
+	if c == nil || c.DisableGasSponsorship {
+		return ""
+	}
+	if c.ProviderName() != BundlerProviderAlchemy {
+		return ""
+	}
+	return c.AlchemyPaymasterPolicyID
 }
 
 // UsesModularAccountV2 reports whether this chain derives MA v2 accounts.
@@ -509,6 +552,9 @@ type ConfigRaw struct {
 	// Alchemy paymaster policy (Gas Manager) + admin API (optional; see Config)
 	AlchemyAPISecret         string `yaml:"alchemy_api_secret"`
 	AlchemyPaymasterPolicyID string `yaml:"alchemy_paymaster_policy_id"`
+	// DisableGasSponsorship opts this process out of the Gas Manager policy.
+	// Local/development configs set it; see SmartWalletConfig.SponsorshipPolicyID.
+	DisableGasSponsorship bool `yaml:"disable_gas_sponsorship"`
 	// GasManagerPolicyID is a legacy yaml alias for alchemy_paymaster_policy_id.
 	// Still resolved as a fallback so existing configs keep sponsorship.
 	GasManagerPolicyID      string `yaml:"gas_manager_policy_id"`
@@ -770,6 +816,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 			WhitelistAddresses:       convertToAddressSlice(configRaw.SmartWallet.WhitelistAddresses),
 			MaxWalletsPerOwner:       configRaw.SmartWallet.MaxWalletsPerOwner,
 			AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
+			DisableGasSponsorship:    configRaw.DisableGasSponsorship,
 			GasManagerWebhookSecret:  ResolveGasManagerWebhookSecret(configRaw.GasManagerWebhookSecret),
 			// PaymasterOwnerAddress will be populated below by calling owner() on the paymaster contract
 		},
@@ -791,6 +838,7 @@ func NewConfig(configFilePath string) (*Config, error) {
 		// Alchemy paymaster policy (Gas Manager) + admin API
 		AlchemyAPISecret:         firstNonEmpty(configRaw.AlchemyAPISecret, os.Getenv("ALCHEMY_API_SECRET")),
 		AlchemyPaymasterPolicyID: resolveAlchemyPaymasterPolicyID(configRaw),
+		DisableGasSponsorship:    configRaw.DisableGasSponsorship,
 		// Trim: pasted secrets often carry trailing whitespace; webhook compares
 		// with subtle.ConstantTimeCompare on the raw webhookData body field.
 		GasManagerWebhookSecret: ResolveGasManagerWebhookSecret(configRaw.GasManagerWebhookSecret),
@@ -872,16 +920,20 @@ func NewConfig(configFilePath string) (*Config, error) {
 			"default_chain_id", config.DefaultChainID)
 	}
 
-	// Say once, at boot, whether this process can have operations sponsored.
-	// A development process is refused deliberately — see
-	// SponsorshipRefusedForEnvironment — and that should read as a decision
-	// rather than as a missing policy someone ought to go and set.
-	if SponsorshipRefusedForEnvironment(string(configRaw.Environment)) {
-		logger.Info("Gas Manager sponsorship refused: development environment; operations run self-funded",
-			"hint", "the policy's webhook points at the production gateway; fund the test smart wallet instead")
-	} else if config.AlchemyPaymasterPolicyID == "" {
-		logger.Warn("No Gas Manager policy configured: operations run self-funded",
+	// Say once, at boot, whether this process can have operations sponsored,
+	// and if not, which condition ruled it out. Each of these is a decision
+	// rather than a missing setting, so they read differently.
+	switch {
+	case config.SmartWallet != nil && config.SmartWallet.DisableGasSponsorship:
+		logger.Info("Gas Manager sponsorship disabled by config; operations run self-funded",
+			"hint", "disable_gas_sponsorship is set — expected for local/development, where the policy's webhook points at production")
+	case config.AlchemyPaymasterPolicyID == "":
+		logger.Warn("No Gas Manager policy configured; operations run self-funded",
 			"hint", "set alchemy_paymaster_policy_id or ALCHEMY_PAYMASTER_POLICY_ID")
+	case config.SmartWallet != nil && config.SmartWallet.SponsorshipPolicyID() == "":
+		logger.Warn("Gas Manager policy is set but unusable on this bundler; operations run self-funded",
+			"bundler_provider", config.SmartWallet.ProviderName(),
+			"hint", "sponsorship needs bundler_provider: alchemy — alchemy_requestGasAndPaymasterAndData is not implemented by a self-hosted bundler")
 	}
 
 	// If HttpBindAddress is empty, HTTP server will be disabled (startup code will skip starting it)
@@ -975,48 +1027,28 @@ func firstNonEmpty(values ...string) string {
 // file, and the gateway and worker disagreeing about where sponsorship comes
 // from is exactly how worker-routed operations ended up unsponsored (#722).
 // One resolver, so they cannot drift apart again.
-func ResolveAlchemyPaymasterPolicyID(environment, canonicalYaml, legacyYaml string) string {
-	if SponsorshipRefusedForEnvironment(environment) {
-		return ""
-	}
-	return strings.TrimSpace(firstNonEmpty(
-		canonicalYaml,
-		os.Getenv("ALCHEMY_PAYMASTER_POLICY_ID"),
-		legacyYaml,
-		os.Getenv("ALCHEMY_GAS_POLICY_ID"),
-	))
-}
-
-// SponsorshipRefusedForEnvironment reports whether this process must not ask
-// Alchemy to sponsor, whatever its config says.
-//
-// A development process must not, and the reason is not tidiness. The Gas
-// Manager policy's custom-rules webhook is a single URL pointing at the
-// PRODUCTION gateway, so a locally-run gateway or worker that requests
-// sponsorship has Alchemy call production to approve it. Production then
-// decides using its own wallet records and its own credit ledger — so a local
-// test either gets a confusing denial for a wallet production has never heard
-// of, or, for a shared test wallet production does know, succeeds and bills
-// the production sponsorship budget for someone's laptop.
-//
-// This is a refusal rather than a convention because the policy id resolves
-// from the ENVIRONMENT as well as from yaml: an ALCHEMY_PAYMASTER_POLICY_ID
-// exported in a shell or sitting in a .env is enough to opt a local process in
-// by accident. Development runs self-funded; fund the test wallet instead.
-func SponsorshipRefusedForEnvironment(environment string) bool {
-	return strings.EqualFold(strings.TrimSpace(environment), string(sdklogging.Development))
+func ResolveAlchemyPaymasterPolicyID(canonicalYaml, legacyYaml string) string {
+	// Trim each candidate BEFORE choosing, not after. A yaml value of " " is
+	// non-empty, so trimming the winner would select the blank and discard a
+	// perfectly good environment fallback — silently unsponsored.
+	return firstNonEmpty(
+		strings.TrimSpace(canonicalYaml),
+		strings.TrimSpace(os.Getenv("ALCHEMY_PAYMASTER_POLICY_ID")),
+		strings.TrimSpace(legacyYaml),
+		strings.TrimSpace(os.Getenv("ALCHEMY_GAS_POLICY_ID")),
+	)
 }
 
 // ResolveGasManagerWebhookSecret returns the secret echoed to Alchemy as
-// webhookData. Same reasoning as ResolveAlchemyPaymasterPolicyID: a worker that
+// webhookData. Shared for the same reason as the policy resolver: a worker that
 // requests sponsorship must send the same secret the gateway's webhook checks,
 // or the policy's custom-rules callback rejects every request.
 func ResolveGasManagerWebhookSecret(yamlValue string) string {
-	return strings.TrimSpace(firstNonEmpty(yamlValue, os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")))
+	return firstNonEmpty(strings.TrimSpace(yamlValue), strings.TrimSpace(os.Getenv("GAS_MANAGER_WEBHOOK_SECRET")))
 }
 
 func resolveAlchemyPaymasterPolicyID(raw ConfigRaw) string {
-	return ResolveAlchemyPaymasterPolicyID(string(raw.Environment), raw.AlchemyPaymasterPolicyID, raw.GasManagerPolicyID)
+	return ResolveAlchemyPaymasterPolicyID(raw.AlchemyPaymasterPolicyID, raw.GasManagerPolicyID)
 }
 
 func ReadYamlConfig(path string, o interface{}) error {

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -96,21 +96,64 @@ func TestTypoIsRejectedAtLoad(t *testing.T) {
 }
 
 // The gateway resolves the same way the worker does, through the same
-// function — including the development refusal. Pinned here as well as in the
-// worker package because the two disagreeing about where sponsorship comes
-// from is the bug this whole path exists to prevent.
-func TestSponsorshipResolutionIsSharedAndEnvironmentGated(t *testing.T) {
+// function. Pinned here as well as in the worker package because the two
+// disagreeing about where sponsorship comes from is the bug this path exists
+// to prevent.
+func TestSponsorshipResolutionIsShared(t *testing.T) {
 	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
 	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
 
-	require.Equal(t, "policy", ResolveAlchemyPaymasterPolicyID("production", "policy", ""))
-	require.Equal(t, "legacy", ResolveAlchemyPaymasterPolicyID("production", "", "legacy"),
+	require.Equal(t, "policy", ResolveAlchemyPaymasterPolicyID("policy", ""))
+	require.Equal(t, "legacy", ResolveAlchemyPaymasterPolicyID("", "legacy"),
 		"the legacy yaml alias must keep working")
-	require.Empty(t, ResolveAlchemyPaymasterPolicyID("development", "policy", ""),
-		"development must not draw on the production policy, however it is configured")
 
 	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "from-env")
-	require.Equal(t, "from-env", ResolveAlchemyPaymasterPolicyID("production", "", ""))
-	require.Empty(t, ResolveAlchemyPaymasterPolicyID("development", "", ""),
-		"an environment-inherited policy is exactly the accident the guard is for")
+	require.Equal(t, "from-env", ResolveAlchemyPaymasterPolicyID("", ""))
+
+	// A blank-but-present yaml value must not swallow a good fallback: trimming
+	// the winner instead of each candidate would select " " and resolve to "",
+	// silently unsponsored.
+	require.Equal(t, "from-env", ResolveAlchemyPaymasterPolicyID("   ", ""),
+		"a whitespace-only yaml value must fall through to the environment")
+	t.Setenv("GAS_MANAGER_WEBHOOK_SECRET", "secret-from-env")
+	require.Equal(t, "secret-from-env", ResolveGasManagerWebhookSecret("  "),
+		"same rule for the webhook secret")
+}
+
+// SponsorshipPolicyID is the single place that decides whether an operation can
+// be sponsored, so every disqualifying condition has to be visible here.
+func TestSponsorshipPolicyIDAppliesEveryCondition(t *testing.T) {
+	alchemy := func() *SmartWalletConfig {
+		return &SmartWalletConfig{
+			ChainID:                  11155111,
+			BundlerProvider:          BundlerProviderAlchemy,
+			AlchemyAPIKey:            "key",
+			AlchemyPaymasterPolicyID: "policy",
+		}
+	}
+
+	require.Equal(t, "policy", alchemy().SponsorshipPolicyID(),
+		"an Alchemy chain with a policy and no opt-out sponsors")
+
+	optedOut := alchemy()
+	optedOut.DisableGasSponsorship = true
+	require.Empty(t, optedOut.SponsorshipPolicyID(),
+		"an explicit opt-out wins over a configured policy — this is what keeps a local run off the production policy")
+
+	// bnb-mainnet is configured exactly this way. Sponsorship is requested with
+	// alchemy_requestGasAndPaymasterAndData, which a self-hosted Voltaire
+	// bundler does not implement, so asking would fail the operation rather
+	// than sponsor it.
+	selfHosted := alchemy()
+	selfHosted.BundlerProvider = BundlerProviderSelfHosted
+	selfHosted.BundlerURL = "http://bundler.internal"
+	require.Empty(t, selfHosted.SponsorshipPolicyID(),
+		"a policy is inert on a non-Alchemy bundler and must not be attempted")
+
+	noPolicy := alchemy()
+	noPolicy.AlchemyPaymasterPolicyID = ""
+	require.Empty(t, noPolicy.SponsorshipPolicyID())
+
+	var nilConfig *SmartWalletConfig
+	require.Empty(t, nilConfig.SponsorshipPolicyID(), "must be nil-safe")
 }

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -157,3 +157,43 @@ func TestSponsorshipPolicyIDAppliesEveryCondition(t *testing.T) {
 	var nilConfig *SmartWalletConfig
 	require.Empty(t, nilConfig.SponsorshipPolicyID(), "must be nil-safe")
 }
+
+// A policy on a non-Alchemy bundler is refused at load rather than silently
+// running self-funded. Sponsorship is requested with
+// alchemy_requestGasAndPaymasterAndData, which a self-hosted Voltaire bundler
+// does not implement — so the config promises sponsorship the chain cannot
+// deliver, and the first symptom would be a user's operation failing for a
+// wallet nobody thought needed a gas balance.
+func TestSponsorshipValidationRefusesANonAlchemyBundler(t *testing.T) {
+	withPolicy := func(provider string) *SmartWalletConfig {
+		return &SmartWalletConfig{
+			ChainID:                  56,
+			BundlerProvider:          provider,
+			BundlerURL:               "http://bundler.internal",
+			AlchemyAPIKey:            "key",
+			AlchemyPaymasterPolicyID: "policy",
+		}
+	}
+
+	err := withPolicy(BundlerProviderSelfHosted).ValidateSponsorship()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), BundlerProviderAlchemy, "the error must name the fix")
+	require.Contains(t, err.Error(), "disable_gas_sponsorship", "and the other way out")
+
+	require.NoError(t, withPolicy(BundlerProviderAlchemy).ValidateSponsorship())
+
+	// An explicit opt-out settles it: the policy is not to be used, so which
+	// bundler serves the chain no longer matters.
+	optedOut := withPolicy(BundlerProviderSelfHosted)
+	optedOut.DisableGasSponsorship = true
+	require.NoError(t, optedOut.ValidateSponsorship(),
+		"an opted-out chain must still boot on a self-hosted bundler")
+
+	// No policy, no promise to break.
+	noPolicy := withPolicy(BundlerProviderSelfHosted)
+	noPolicy.AlchemyPaymasterPolicyID = ""
+	require.NoError(t, noPolicy.ValidateSponsorship())
+
+	var nilConfig *SmartWalletConfig
+	require.NoError(t, nilConfig.ValidateSponsorship(), "must be nil-safe")
+}

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Mirrors the aa-package default test at the config layer, because the two
@@ -91,4 +93,24 @@ func TestTypoIsRejectedAtLoad(t *testing.T) {
 	if err := c.ValidateAccountProvider(); err == nil {
 		t.Fatal("a typo must be rejected at config load, not at first derivation")
 	}
+}
+
+// The gateway resolves the same way the worker does, through the same
+// function — including the development refusal. Pinned here as well as in the
+// worker package because the two disagreeing about where sponsorship comes
+// from is the bug this whole path exists to prevent.
+func TestSponsorshipResolutionIsSharedAndEnvironmentGated(t *testing.T) {
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+
+	require.Equal(t, "policy", ResolveAlchemyPaymasterPolicyID("production", "policy", ""))
+	require.Equal(t, "legacy", ResolveAlchemyPaymasterPolicyID("production", "", "legacy"),
+		"the legacy yaml alias must keep working")
+	require.Empty(t, ResolveAlchemyPaymasterPolicyID("development", "policy", ""),
+		"development must not draw on the production policy, however it is configured")
+
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "from-env")
+	require.Equal(t, "from-env", ResolveAlchemyPaymasterPolicyID("production", "", ""))
+	require.Empty(t, ResolveAlchemyPaymasterPolicyID("development", "", ""),
+		"an environment-inherited policy is exactly the accident the guard is for")
 }

--- a/core/config/config_account_provider_test.go
+++ b/core/config/config_account_provider_test.go
@@ -197,3 +197,34 @@ func TestSponsorshipValidationRefusesANonAlchemyBundler(t *testing.T) {
 	var nilConfig *SmartWalletConfig
 	require.NoError(t, nilConfig.ValidateSponsorship(), "must be nil-safe")
 }
+
+// Gateway chains inherit sponsorship from the top-level config, so both the
+// opt-out and the validation have to account for that — checking a chain
+// before it inherits only ever sees an empty policy and passes.
+//
+// This is the shape production actually runs (gateway mode, several chains)
+// and the shape local development runs, so a hole here is a hole everywhere.
+func TestChainsInheritSponsorshipAndAreValidatedAfterwards(t *testing.T) {
+	t.Run("a chain inherits the opt-out, not just the policy", func(t *testing.T) {
+		// Reproduces the hole: inheriting the policy alone left every chain
+		// sponsoring even though the gateway had opted out.
+		chain := &SmartWalletConfig{ChainID: 11155111, BundlerProvider: BundlerProviderAlchemy, AlchemyAPIKey: "k"}
+		chain.AlchemyPaymasterPolicyID = "policy"
+		chain.DisableGasSponsorship = true
+		require.Empty(t, chain.SponsorshipPolicyID(),
+			"an opted-out gateway must not sponsor on any of its chains")
+	})
+
+	t.Run("validation sees the inherited policy", func(t *testing.T) {
+		// Before inheritance a self-hosted chain looks fine, because it carries
+		// no policy of its own. It is only a misconfiguration once it inherits.
+		chain := &SmartWalletConfig{
+			ChainID: 56, BundlerProvider: BundlerProviderSelfHosted, BundlerURL: "http://bundler.internal",
+		}
+		require.NoError(t, chain.ValidateSponsorship(), "nothing to object to yet")
+
+		chain.AlchemyPaymasterPolicyID = "policy" // as the gateway pushes down
+		require.Error(t, chain.ValidateSponsorship(),
+			"once inherited, a policy on a self-hosted bundler must be refused")
+	})
+}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -722,7 +722,7 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 	// Sponsorship on MA v2 is the chain's Alchemy Gas Manager policy, applied
 	// inside the send path — there is nothing to attach here. Logged so ops do
 	// not read "no paymaster" as "unsponsored" when a policy is configured.
-	if r.smartWalletConfig != nil && r.smartWalletConfig.AlchemyPaymasterPolicyID != "" {
+	if r.smartWalletConfig.SponsorshipPolicyID() != "" {
 		r.vm.logger.Info("Gas Manager will sponsor (alchemy_paymaster_policy_id set)",
 			"owner", r.owner.Hex())
 	} else {
@@ -762,7 +762,7 @@ func (r *ContractWriteProcessor) submitSmartWalletUserOp(
 	// Sponsorship is decided inside the send path by the chain's Gas Manager
 	// policy, so the log records whether one is configured rather than an
 	// attached request.
-	if r.smartWalletConfig != nil && r.smartWalletConfig.AlchemyPaymasterPolicyID != "" {
+	if r.smartWalletConfig.SponsorshipPolicyID() != "" {
 		executionLogBuilder.WriteString("Sponsored by the Alchemy Gas Manager policy\n")
 	} else {
 		executionLogBuilder.WriteString("No sponsorship policy (self-funded transaction)\n")

--- a/core/taskengine/vm_runner_eth_transfer.go
+++ b/core/taskengine/vm_runner_eth_transfer.go
@@ -168,7 +168,7 @@ func (p *ETHTransferProcessor) Execute(stepID string, node *avsproto.ETHTransfer
 		// wrong: a sponsored chain with no legacy address was refused, and a
 		// self-funded chain that still carried a stale address was allowed to
 		// try and then failed on chain.
-		if isMaxTransfer && p.smartWalletConfig.AlchemyPaymasterPolicyID == "" {
+		if isMaxTransfer && p.smartWalletConfig.SponsorshipPolicyID() == "" {
 			err = fmt.Errorf("cannot use MAX amount without sponsorship: set alchemy_paymaster_policy_id, " +
 				"or leave a gas reserve and transfer a fixed amount")
 			return executionLog, err
@@ -328,7 +328,7 @@ func (p *ETHTransferProcessor) executeRealETHTransfer(stepID, destination, amoun
 	// inside the send path. A MAX transfer used to need the v0.6 paymaster's
 	// SkipReimbursement so the whole balance could move; with reimbursement
 	// gone there is nothing to skip.
-	if p.smartWalletConfig != nil && p.smartWalletConfig.AlchemyPaymasterPolicyID != "" {
+	if p.smartWalletConfig.SponsorshipPolicyID() != "" {
 		p.vm.logger.Info("Gas Manager will sponsor the ETH transfer",
 			"owner", p.taskOwner.Hex())
 	} else {

--- a/pkg/erc4337/preset/send_v07.go
+++ b/pkg/erc4337/preset/send_v07.go
@@ -174,7 +174,7 @@ func SendUserOpMAv2(
 	// need no bundler URL. Sponsorship is alchemy_paymaster_policy_id /
 	// ALCHEMY_PAYMASTER_POLICY_ID (config also accepts legacy gas_manager_policy_id /
 	// ALCHEMY_GAS_POLICY_ID); when set, this check is skipped.
-	if smartWalletConfig.AlchemyPaymasterPolicyID == "" {
+	if smartWalletConfig.SponsorshipPolicyID() == "" {
 		if err := ensureSelfFundedPrefund(ctx, chainRPC, entryPoint, sender); err != nil {
 			return nil, nil, err
 		}
@@ -255,7 +255,7 @@ func SendUserOpMAv2(
 		"policy_id", auth.PolicyID,
 		"wrap_execute_user_op", auth.WrapExecuteUserOp,
 		"verification_gas_seed", op.VerificationGasLimit.String(),
-		"paymaster_policy_set", smartWalletConfig.AlchemyPaymasterPolicyID != "",
+		"paymaster_policy_set", smartWalletConfig.SponsorshipPolicyID() != "",
 	)
 
 	// Estimation of a deferred operation must carry the REAL owner grant.
@@ -488,7 +488,7 @@ func priceOperationV07(
 	smartWalletConfig *config.SmartWalletConfig,
 	l logger.Logger,
 ) error {
-	if policyID := smartWalletConfig.AlchemyPaymasterPolicyID; policyID != "" {
+	if policyID := smartWalletConfig.SponsorshipPolicyID(); policyID != "" {
 		if err := RequestSponsorshipV07(ctx, bundlerRPC, op, entryPoint,
 			SponsorshipRequestV07{
 				PolicyID:    policyID,

--- a/worker/config.go
+++ b/worker/config.go
@@ -72,17 +72,6 @@ func NewWorkerConfig(configPath string) (*WorkerConfig, error) {
 	return &cfg, nil
 }
 
-// SponsorshipConfigured reports whether this worker can ask Alchemy to sponsor.
-// False means every operation it sends must be covered by the smart wallet's
-// own balance.
-func (c *WorkerConfig) SponsorshipConfigured() bool {
-	smartWalletConfig, err := c.ToSmartWalletConfig()
-	if err != nil {
-		return false
-	}
-	return smartWalletConfig.SponsorshipPolicyID() != ""
-}
-
 // ToSmartWalletConfig converts the worker's raw config into the shared SmartWalletConfig
 // used by existing execution code (preset.SendUserOp, aa.GetNonce, etc.)
 func (c *WorkerConfig) ToSmartWalletConfig() (*config.SmartWalletConfig, error) {

--- a/worker/config.go
+++ b/worker/config.go
@@ -23,6 +23,22 @@ type WorkerConfig struct {
 	BundlerProvider string `yaml:"bundler_provider"`
 	AlchemyAPIKey   string `yaml:"alchemy_api_key"`
 
+	// Gas Manager sponsorship. A worker that omits these sends UNSPONSORED
+	// operations: priceOperationV07 only asks Alchemy to sponsor when a policy
+	// id is present, and otherwise requires the smart wallet to cover its own
+	// prefund — which a wallet holding only tokens cannot do.
+	//
+	// The webhook itself stays on the gateway (POST /webhooks/gas-manager);
+	// what the worker needs is the SECRET, because it is echoed to Alchemy as
+	// webhookData and the gateway's webhook rejects any request whose value
+	// does not match.
+	AlchemyPaymasterPolicyID string `yaml:"alchemy_paymaster_policy_id"`
+	// GasManagerPolicyID is the legacy alias, accepted for the same reason the
+	// gateway accepts it: an existing deployment must not silently lose
+	// sponsorship on rename.
+	GasManagerPolicyID      string `yaml:"gas_manager_policy_id"`
+	GasManagerWebhookSecret string `yaml:"gas_manager_webhook_secret"`
+
 	SmartWallet SmartWalletRaw `yaml:"smart_wallet"`
 }
 
@@ -50,6 +66,13 @@ func NewWorkerConfig(configPath string) (*WorkerConfig, error) {
 	}
 
 	return &cfg, nil
+}
+
+// SponsorshipConfigured reports whether this worker can ask Alchemy to sponsor.
+// False means every operation it sends must be covered by the smart wallet's
+// own balance.
+func (c *WorkerConfig) SponsorshipConfigured() bool {
+	return config.ResolveAlchemyPaymasterPolicyID(c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID) != ""
 }
 
 // ToSmartWalletConfig converts the worker's raw config into the shared SmartWalletConfig
@@ -83,6 +106,10 @@ func (c *WorkerConfig) ToSmartWalletConfig() (*config.SmartWalletConfig, error) 
 	paymasterAddr := common.HexToAddress(c.SmartWallet.PaymasterAddress)
 
 	return &config.SmartWalletConfig{
+		AlchemyPaymasterPolicyID: config.ResolveAlchemyPaymasterPolicyID(
+			c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID),
+		GasManagerWebhookSecret: config.ResolveGasManagerWebhookSecret(c.GasManagerWebhookSecret),
+
 		EthRpcUrl:             c.EthRpcUrl,
 		EthWsUrl:              c.EthWsUrl,
 		BundlerURL:            c.BundlerURL,

--- a/worker/config.go
+++ b/worker/config.go
@@ -33,6 +33,10 @@ type WorkerConfig struct {
 	// webhookData and the gateway's webhook rejects any request whose value
 	// does not match.
 	AlchemyPaymasterPolicyID string `yaml:"alchemy_paymaster_policy_id"`
+	// DisableGasSponsorship opts this worker out of the Gas Manager policy.
+	// Local/development worker configs set it — see
+	// config.SmartWalletConfig.SponsorshipPolicyID for why that matters.
+	DisableGasSponsorship bool `yaml:"disable_gas_sponsorship"`
 	// GasManagerPolicyID is the legacy alias, accepted for the same reason the
 	// gateway accepts it: an existing deployment must not silently lose
 	// sponsorship on rename.
@@ -72,7 +76,11 @@ func NewWorkerConfig(configPath string) (*WorkerConfig, error) {
 // False means every operation it sends must be covered by the smart wallet's
 // own balance.
 func (c *WorkerConfig) SponsorshipConfigured() bool {
-	return config.ResolveAlchemyPaymasterPolicyID(c.Environment, c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID) != ""
+	smartWalletConfig, err := c.ToSmartWalletConfig()
+	if err != nil {
+		return false
+	}
+	return smartWalletConfig.SponsorshipPolicyID() != ""
 }
 
 // ToSmartWalletConfig converts the worker's raw config into the shared SmartWalletConfig
@@ -107,7 +115,8 @@ func (c *WorkerConfig) ToSmartWalletConfig() (*config.SmartWalletConfig, error) 
 
 	return &config.SmartWalletConfig{
 		AlchemyPaymasterPolicyID: config.ResolveAlchemyPaymasterPolicyID(
-			c.Environment, c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID),
+			c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID),
+		DisableGasSponsorship:   c.DisableGasSponsorship,
 		GasManagerWebhookSecret: config.ResolveGasManagerWebhookSecret(c.GasManagerWebhookSecret),
 
 		EthRpcUrl:             c.EthRpcUrl,

--- a/worker/config.go
+++ b/worker/config.go
@@ -72,7 +72,7 @@ func NewWorkerConfig(configPath string) (*WorkerConfig, error) {
 // False means every operation it sends must be covered by the smart wallet's
 // own balance.
 func (c *WorkerConfig) SponsorshipConfigured() bool {
-	return config.ResolveAlchemyPaymasterPolicyID(c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID) != ""
+	return config.ResolveAlchemyPaymasterPolicyID(c.Environment, c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID) != ""
 }
 
 // ToSmartWalletConfig converts the worker's raw config into the shared SmartWalletConfig
@@ -107,7 +107,7 @@ func (c *WorkerConfig) ToSmartWalletConfig() (*config.SmartWalletConfig, error) 
 
 	return &config.SmartWalletConfig{
 		AlchemyPaymasterPolicyID: config.ResolveAlchemyPaymasterPolicyID(
-			c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID),
+			c.Environment, c.AlchemyPaymasterPolicyID, c.GasManagerPolicyID),
 		GasManagerWebhookSecret: config.ResolveGasManagerWebhookSecret(c.GasManagerWebhookSecret),
 
 		EthRpcUrl:             c.EthRpcUrl,

--- a/worker/config_sponsorship_test.go
+++ b/worker/config_sponsorship_test.go
@@ -6,6 +6,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// sponsors resolves sponsorship the way the worker does at startup: through the
+// SmartWalletConfig the send path is handed, not a parallel predicate. Keeping
+// the test on the same path as production is the point — a second way to answer
+// "will this sponsor?" is how the gateway and worker drifted apart to begin with.
+func sponsors(t *testing.T, cfg *WorkerConfig) bool {
+	t.Helper()
+	smartWalletConfig, err := cfg.ToSmartWalletConfig()
+	require.NoError(t, err)
+	return smartWalletConfig.SponsorshipPolicyID() != ""
+}
+
 // A worker that cannot request sponsorship sends operations the smart wallet
 // has to pay for itself — and a wallet holding only tokens cannot, so the
 // user's withdrawal fails. That is #722, and it happened because the policy
@@ -22,7 +33,7 @@ func TestWorkerCarriesTheGasManagerPolicyIntoSmartWalletConfig(t *testing.T) {
 		AlchemyPaymasterPolicyID: "policy-uuid",
 		GasManagerWebhookSecret:  "shhh",
 	}
-	require.True(t, cfg.SponsorshipConfigured())
+	require.True(t, sponsors(t, cfg))
 
 	smartWalletConfig, err := cfg.ToSmartWalletConfig()
 	require.NoError(t, err)
@@ -39,7 +50,7 @@ func TestWorkerWithoutAPolicyReportsItCannotSponsor(t *testing.T) {
 	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
 
 	cfg := &WorkerConfig{ChainID: 11155111}
-	require.False(t, cfg.SponsorshipConfigured())
+	require.False(t, sponsors(t, cfg))
 
 	smartWalletConfig, err := cfg.ToSmartWalletConfig()
 	require.NoError(t, err)
@@ -62,7 +73,7 @@ func TestWorkerPolicyResolutionMatchesTheGateway(t *testing.T) {
 		t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "env-uuid")
 		t.Setenv("GAS_MANAGER_WEBHOOK_SECRET", "env-secret")
 		cfg := &WorkerConfig{ChainID: 1}
-		require.True(t, cfg.SponsorshipConfigured())
+		require.True(t, sponsors(t, cfg))
 		smartWalletConfig, err := cfg.ToSmartWalletConfig()
 		require.NoError(t, err)
 		require.Equal(t, "env-uuid", smartWalletConfig.AlchemyPaymasterPolicyID)
@@ -110,7 +121,7 @@ func TestDisableGasSponsorshipDropsAConfiguredPolicy(t *testing.T) {
 		GasManagerWebhookSecret:  "shhh",
 		DisableGasSponsorship:    true,
 	}
-	require.False(t, cfg.SponsorshipConfigured())
+	require.False(t, sponsors(t, cfg))
 
 	smartWalletConfig, err := cfg.ToSmartWalletConfig()
 	require.NoError(t, err)
@@ -129,10 +140,10 @@ func TestOptOutIgnoresAPolicyInheritedFromTheEnvironment(t *testing.T) {
 		AlchemyAPIKey:         "key",
 		DisableGasSponsorship: true,
 	}
-	require.False(t, cfg.SponsorshipConfigured())
+	require.False(t, sponsors(t, cfg))
 
 	cfg.DisableGasSponsorship = false
-	require.True(t, cfg.SponsorshipConfigured(),
+	require.True(t, sponsors(t, cfg),
 		"the opt-out must be what disables it, not sponsorship being broken outright")
 }
 
@@ -149,6 +160,6 @@ func TestSelfHostedBundlerCannotSponsor(t *testing.T) {
 		BundlerURL:               "http://bundler.internal",
 		AlchemyPaymasterPolicyID: "policy-uuid",
 	}
-	require.False(t, cfg.SponsorshipConfigured(),
+	require.False(t, sponsors(t, cfg),
 		"a policy on a self-hosted bundler is inert; attempting it would fail the send")
 }

--- a/worker/config_sponsorship_test.go
+++ b/worker/config_sponsorship_test.go
@@ -1,0 +1,91 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A worker that cannot request sponsorship sends operations the smart wallet
+// has to pay for itself — and a wallet holding only tokens cannot, so the
+// user's withdrawal fails. That is #722, and it happened because the policy
+// existed on the gateway's config and nowhere else. These tests pin the
+// plumbing so the two cannot drift apart again.
+
+func TestWorkerCarriesTheGasManagerPolicyIntoSmartWalletConfig(t *testing.T) {
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+	t.Setenv("GAS_MANAGER_WEBHOOK_SECRET", "")
+
+	cfg := &WorkerConfig{
+		ChainID:                  11155111,
+		AlchemyPaymasterPolicyID: "policy-uuid",
+		GasManagerWebhookSecret:  "shhh",
+	}
+	require.True(t, cfg.SponsorshipConfigured())
+
+	smartWalletConfig, err := cfg.ToSmartWalletConfig()
+	require.NoError(t, err)
+	require.Equal(t, "policy-uuid", smartWalletConfig.AlchemyPaymasterPolicyID,
+		"without this, priceOperationV07 never asks Alchemy to sponsor")
+	require.Equal(t, "shhh", smartWalletConfig.GasManagerWebhookSecret,
+		"echoed to Alchemy as webhookData; the gateway's webhook rejects a mismatch")
+}
+
+// The regression itself: a worker with no policy configured must report that
+// it cannot sponsor, rather than looking fine and failing at send time.
+func TestWorkerWithoutAPolicyReportsItCannotSponsor(t *testing.T) {
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+
+	cfg := &WorkerConfig{ChainID: 11155111}
+	require.False(t, cfg.SponsorshipConfigured())
+
+	smartWalletConfig, err := cfg.ToSmartWalletConfig()
+	require.NoError(t, err)
+	require.Empty(t, smartWalletConfig.AlchemyPaymasterPolicyID,
+		"an empty policy is what sends send_v07 down the self-funded prefund path")
+}
+
+func TestWorkerPolicyResolutionMatchesTheGateway(t *testing.T) {
+	t.Run("legacy yaml alias is accepted", func(t *testing.T) {
+		t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+		t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+		cfg := &WorkerConfig{ChainID: 1, GasManagerPolicyID: "legacy-uuid"}
+		smartWalletConfig, err := cfg.ToSmartWalletConfig()
+		require.NoError(t, err)
+		require.Equal(t, "legacy-uuid", smartWalletConfig.AlchemyPaymasterPolicyID,
+			"renaming the key must not silently drop sponsorship on an existing deployment")
+	})
+
+	t.Run("env fills in when yaml is empty", func(t *testing.T) {
+		t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "env-uuid")
+		t.Setenv("GAS_MANAGER_WEBHOOK_SECRET", "env-secret")
+		cfg := &WorkerConfig{ChainID: 1}
+		require.True(t, cfg.SponsorshipConfigured())
+		smartWalletConfig, err := cfg.ToSmartWalletConfig()
+		require.NoError(t, err)
+		require.Equal(t, "env-uuid", smartWalletConfig.AlchemyPaymasterPolicyID)
+		require.Equal(t, "env-secret", smartWalletConfig.GasManagerWebhookSecret)
+	})
+
+	t.Run("canonical yaml wins over the legacy alias", func(t *testing.T) {
+		t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+		t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+		cfg := &WorkerConfig{ChainID: 1, AlchemyPaymasterPolicyID: "canonical", GasManagerPolicyID: "legacy"}
+		smartWalletConfig, err := cfg.ToSmartWalletConfig()
+		require.NoError(t, err)
+		require.Equal(t, "canonical", smartWalletConfig.AlchemyPaymasterPolicyID)
+	})
+
+	t.Run("surrounding whitespace is trimmed", func(t *testing.T) {
+		t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+		t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+		cfg := &WorkerConfig{ChainID: 1, AlchemyPaymasterPolicyID: "  padded  ", GasManagerWebhookSecret: " s "}
+		smartWalletConfig, err := cfg.ToSmartWalletConfig()
+		require.NoError(t, err)
+		require.Equal(t, "padded", smartWalletConfig.AlchemyPaymasterPolicyID,
+			"a policy id with stray whitespace would be rejected by Alchemy as an unknown policy")
+		require.Equal(t, "s", smartWalletConfig.GasManagerWebhookSecret)
+	})
+}

--- a/worker/config_sponsorship_test.go
+++ b/worker/config_sponsorship_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 )
 
 // A worker that cannot request sponsorship sends operations the smart wallet
@@ -92,62 +90,65 @@ func TestWorkerPolicyResolutionMatchesTheGateway(t *testing.T) {
 	})
 }
 
-// A development process must never draw on the Gas Manager policy.
+// A worker that must not draw on the production policy says so explicitly.
 //
 // The policy's custom-rules webhook is a single URL pointing at the PRODUCTION
-// gateway, so a locally-run worker that requests sponsorship has production
-// approve it — deciding against production's wallet records and charging
-// production's credit ledger for a laptop. Refused in code rather than by
-// convention, because the policy id also resolves from the environment: an
-// exported ALCHEMY_PAYMASTER_POLICY_ID is enough to opt in by accident.
-func TestDevelopmentRefusesSponsorshipEvenWhenConfigured(t *testing.T) {
+// gateway, so a locally-run worker requesting sponsorship has production
+// approve it — deciding against production's wallet records and billing
+// production's budget for a laptop. The opt-out is a dedicated setting rather
+// than an inference from the logging environment, so a logging change can
+// never move money.
+func TestDisableGasSponsorshipDropsAConfiguredPolicy(t *testing.T) {
 	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
 	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
 
 	cfg := &WorkerConfig{
 		ChainID:                  11155111,
-		Environment:              "development",
+		BundlerProvider:          "alchemy",
+		AlchemyAPIKey:            "key",
 		AlchemyPaymasterPolicyID: "policy-uuid",
 		GasManagerWebhookSecret:  "shhh",
+		DisableGasSponsorship:    true,
 	}
-	require.False(t, cfg.SponsorshipConfigured(),
-		"a development worker must not report itself as able to sponsor")
-
-	smartWalletConfig, err := cfg.ToSmartWalletConfig()
-	require.NoError(t, err)
-	require.Empty(t, smartWalletConfig.AlchemyPaymasterPolicyID,
-		"an explicitly configured policy must still be dropped in development")
-}
-
-// The accident this guards against: the policy is never written to a local
-// config file, it just exists in the developer's environment.
-func TestDevelopmentIgnoresAPolicyInheritedFromTheEnvironment(t *testing.T) {
-	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "leaked-from-shell")
-
-	cfg := &WorkerConfig{ChainID: 11155111, Environment: "development"}
 	require.False(t, cfg.SponsorshipConfigured())
 
 	smartWalletConfig, err := cfg.ToSmartWalletConfig()
 	require.NoError(t, err)
-	require.Empty(t, smartWalletConfig.AlchemyPaymasterPolicyID)
-
-	// Same worker, production environment: the policy applies.
-	cfg.Environment = "production"
-	require.True(t, cfg.SponsorshipConfigured())
-	smartWalletConfig, err = cfg.ToSmartWalletConfig()
-	require.NoError(t, err)
-	require.Equal(t, "leaked-from-shell", smartWalletConfig.AlchemyPaymasterPolicyID,
-		"the guard must key on the environment, not disable sponsorship outright")
+	require.Empty(t, smartWalletConfig.SponsorshipPolicyID(),
+		"an explicitly configured policy must still be dropped when opted out")
 }
 
-// Only development is refused. Anything else — production, staging, an unset
-// value — keeps whatever sponsorship it was given, so the guard cannot quietly
-// switch a deployed chain to self-funded.
-func TestOnlyDevelopmentIsRefused(t *testing.T) {
-	for _, env := range []string{"production", "Production", "staging", ""} {
-		require.False(t, config.SponsorshipRefusedForEnvironment(env), "env %q", env)
+// The accident the opt-out guards against: the policy is never written into a
+// local config file, it just exists in the developer's environment.
+func TestOptOutIgnoresAPolicyInheritedFromTheEnvironment(t *testing.T) {
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "leaked-from-shell")
+
+	cfg := &WorkerConfig{
+		ChainID:               11155111,
+		BundlerProvider:       "alchemy",
+		AlchemyAPIKey:         "key",
+		DisableGasSponsorship: true,
 	}
-	for _, env := range []string{"development", "Development", "  development  "} {
-		require.True(t, config.SponsorshipRefusedForEnvironment(env), "env %q", env)
+	require.False(t, cfg.SponsorshipConfigured())
+
+	cfg.DisableGasSponsorship = false
+	require.True(t, cfg.SponsorshipConfigured(),
+		"the opt-out must be what disables it, not sponsorship being broken outright")
+}
+
+// bnb-mainnet runs a self-hosted bundler. Sponsorship there would send an
+// Alchemy-only method to Voltaire and fail the operation, so the worker must
+// report that it cannot sponsor even though a policy is configured.
+func TestSelfHostedBundlerCannotSponsor(t *testing.T) {
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+
+	cfg := &WorkerConfig{
+		ChainID:                  56,
+		BundlerProvider:          "self_hosted",
+		BundlerURL:               "http://bundler.internal",
+		AlchemyPaymasterPolicyID: "policy-uuid",
 	}
+	require.False(t, cfg.SponsorshipConfigured(),
+		"a policy on a self-hosted bundler is inert; attempting it would fail the send")
 }

--- a/worker/config_sponsorship_test.go
+++ b/worker/config_sponsorship_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 )
 
 // A worker that cannot request sponsorship sends operations the smart wallet
@@ -88,4 +90,64 @@ func TestWorkerPolicyResolutionMatchesTheGateway(t *testing.T) {
 			"a policy id with stray whitespace would be rejected by Alchemy as an unknown policy")
 		require.Equal(t, "s", smartWalletConfig.GasManagerWebhookSecret)
 	})
+}
+
+// A development process must never draw on the Gas Manager policy.
+//
+// The policy's custom-rules webhook is a single URL pointing at the PRODUCTION
+// gateway, so a locally-run worker that requests sponsorship has production
+// approve it — deciding against production's wallet records and charging
+// production's credit ledger for a laptop. Refused in code rather than by
+// convention, because the policy id also resolves from the environment: an
+// exported ALCHEMY_PAYMASTER_POLICY_ID is enough to opt in by accident.
+func TestDevelopmentRefusesSponsorshipEvenWhenConfigured(t *testing.T) {
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "")
+	t.Setenv("ALCHEMY_GAS_POLICY_ID", "")
+
+	cfg := &WorkerConfig{
+		ChainID:                  11155111,
+		Environment:              "development",
+		AlchemyPaymasterPolicyID: "policy-uuid",
+		GasManagerWebhookSecret:  "shhh",
+	}
+	require.False(t, cfg.SponsorshipConfigured(),
+		"a development worker must not report itself as able to sponsor")
+
+	smartWalletConfig, err := cfg.ToSmartWalletConfig()
+	require.NoError(t, err)
+	require.Empty(t, smartWalletConfig.AlchemyPaymasterPolicyID,
+		"an explicitly configured policy must still be dropped in development")
+}
+
+// The accident this guards against: the policy is never written to a local
+// config file, it just exists in the developer's environment.
+func TestDevelopmentIgnoresAPolicyInheritedFromTheEnvironment(t *testing.T) {
+	t.Setenv("ALCHEMY_PAYMASTER_POLICY_ID", "leaked-from-shell")
+
+	cfg := &WorkerConfig{ChainID: 11155111, Environment: "development"}
+	require.False(t, cfg.SponsorshipConfigured())
+
+	smartWalletConfig, err := cfg.ToSmartWalletConfig()
+	require.NoError(t, err)
+	require.Empty(t, smartWalletConfig.AlchemyPaymasterPolicyID)
+
+	// Same worker, production environment: the policy applies.
+	cfg.Environment = "production"
+	require.True(t, cfg.SponsorshipConfigured())
+	smartWalletConfig, err = cfg.ToSmartWalletConfig()
+	require.NoError(t, err)
+	require.Equal(t, "leaked-from-shell", smartWalletConfig.AlchemyPaymasterPolicyID,
+		"the guard must key on the environment, not disable sponsorship outright")
+}
+
+// Only development is refused. Anything else — production, staging, an unset
+// value — keeps whatever sponsorship it was given, so the guard cannot quietly
+// switch a deployed chain to self-funded.
+func TestOnlyDevelopmentIsRefused(t *testing.T) {
+	for _, env := range []string{"production", "Production", "staging", ""} {
+		require.False(t, config.SponsorshipRefusedForEnvironment(env), "env %q", env)
+	}
+	for _, env := range []string{"development", "Development", "  development  "} {
+		require.True(t, config.SponsorshipRefusedForEnvironment(env), "env %q", env)
+	}
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -77,7 +77,17 @@ func (w *Worker) Start(ctx context.Context) error {
 	// withdrawal failing: without a policy every operation this worker sends
 	// must be paid for by the smart wallet itself, so a wallet holding only
 	// tokens cannot move them.
-	if !w.config.SponsorshipConfigured() {
+	switch {
+	case config.SponsorshipRefusedForEnvironment(w.config.Environment):
+		// Deliberate, and not a misconfiguration to fix: the policy's webhook
+		// points at the production gateway, so a development process asking
+		// for sponsorship would have production approve — and pay for — it.
+		w.logger.Info("Chain worker runs self-funded: sponsorship is refused in a development environment",
+			"chain_id", w.config.ChainID,
+			"chain_name", w.config.ChainName,
+			"hint", "fund the test smart wallet with the chain's native token",
+		)
+	case !w.config.SponsorshipConfigured():
 		w.logger.Warn("Chain worker has no Gas Manager policy: operations it sends will be self-funded",
 			"chain_id", w.config.ChainID,
 			"chain_name", w.config.ChainName,

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -65,29 +65,32 @@ func New(cfg *WorkerConfig) (*Worker, error) {
 }
 
 func (w *Worker) Start(ctx context.Context) error {
+	// Read sponsorship off the SmartWalletConfig the send path will actually
+	// use — w.smartWalletCfg, built once in NewWorker — rather than deriving a
+	// second answer from the raw config. Two sources for one question is the
+	// shape of the bug this change exists to fix, and it would also re-parse
+	// the controller key on every call.
+	sponsorshipPolicy := w.smartWalletCfg.SponsorshipPolicyID()
+
 	w.logger.Info("Starting chain worker",
 		"chain_id", w.config.ChainID,
 		"chain_name", w.config.ChainName,
 		"listen_address", w.config.ListenAddress,
 		"health_address", w.config.HealthAddress,
-		"sponsorship_configured", w.config.SponsorshipConfigured(),
+		"sponsorship_configured", sponsorshipPolicy != "",
 	)
 
-	// Say it plainly at boot rather than letting it surface as a user's
-	// withdrawal failing: without a policy every operation this worker sends
-	// must be paid for by the smart wallet itself, so a wallet holding only
-	// tokens cannot move them.
 	// Say which of the three states this worker is in, once, at boot — rather
 	// than letting it surface later as a user's withdrawal failing.
 	switch {
-	case w.config.DisableGasSponsorship:
+	case w.smartWalletCfg.DisableGasSponsorship:
 		w.logger.Info("Chain worker runs self-funded: sponsorship disabled by config",
 			"chain_id", w.config.ChainID, "chain_name", w.config.ChainName,
 			"hint", "expected for local/development — the policy's webhook points at the production gateway")
-	case !w.config.SponsorshipConfigured():
+	case sponsorshipPolicy == "":
 		w.logger.Warn("Chain worker will send unsponsored operations",
 			"chain_id", w.config.ChainID, "chain_name", w.config.ChainName,
-			"bundler_provider", w.config.BundlerProvider,
+			"bundler_provider", w.smartWalletCfg.ProviderName(),
 			"hint", "needs alchemy_paymaster_policy_id, gas_manager_webhook_secret, and bundler_provider: alchemy")
 	}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -77,22 +77,18 @@ func (w *Worker) Start(ctx context.Context) error {
 	// withdrawal failing: without a policy every operation this worker sends
 	// must be paid for by the smart wallet itself, so a wallet holding only
 	// tokens cannot move them.
+	// Say which of the three states this worker is in, once, at boot — rather
+	// than letting it surface later as a user's withdrawal failing.
 	switch {
-	case config.SponsorshipRefusedForEnvironment(w.config.Environment):
-		// Deliberate, and not a misconfiguration to fix: the policy's webhook
-		// points at the production gateway, so a development process asking
-		// for sponsorship would have production approve — and pay for — it.
-		w.logger.Info("Chain worker runs self-funded: sponsorship is refused in a development environment",
-			"chain_id", w.config.ChainID,
-			"chain_name", w.config.ChainName,
-			"hint", "fund the test smart wallet with the chain's native token",
-		)
+	case w.config.DisableGasSponsorship:
+		w.logger.Info("Chain worker runs self-funded: sponsorship disabled by config",
+			"chain_id", w.config.ChainID, "chain_name", w.config.ChainName,
+			"hint", "expected for local/development — the policy's webhook points at the production gateway")
 	case !w.config.SponsorshipConfigured():
-		w.logger.Warn("Chain worker has no Gas Manager policy: operations it sends will be self-funded",
-			"chain_id", w.config.ChainID,
-			"chain_name", w.config.ChainName,
-			"hint", "set alchemy_paymaster_policy_id (and gas_manager_webhook_secret) to match the gateway",
-		)
+		w.logger.Warn("Chain worker will send unsponsored operations",
+			"chain_id", w.config.ChainID, "chain_name", w.config.ChainName,
+			"bundler_provider", w.config.BundlerProvider,
+			"hint", "needs alchemy_paymaster_policy_id, gas_manager_webhook_secret, and bundler_provider: alchemy")
 	}
 
 	// Connect to chain RPC

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -70,7 +70,20 @@ func (w *Worker) Start(ctx context.Context) error {
 		"chain_name", w.config.ChainName,
 		"listen_address", w.config.ListenAddress,
 		"health_address", w.config.HealthAddress,
+		"sponsorship_configured", w.config.SponsorshipConfigured(),
 	)
+
+	// Say it plainly at boot rather than letting it surface as a user's
+	// withdrawal failing: without a policy every operation this worker sends
+	// must be paid for by the smart wallet itself, so a wallet holding only
+	// tokens cannot move them.
+	if !w.config.SponsorshipConfigured() {
+		w.logger.Warn("Chain worker has no Gas Manager policy: operations it sends will be self-funded",
+			"chain_id", w.config.ChainID,
+			"chain_name", w.config.ChainName,
+			"hint", "set alchemy_paymaster_policy_id (and gas_manager_webhook_secret) to match the gateway",
+		)
+	}
 
 	// Connect to chain RPC
 	var err error


### PR DESCRIPTION
Closes #722.

## Summary

Operations sent through a chain worker were **unsponsored**. `priceOperationV07` only asks Alchemy to sponsor when `AlchemyPaymasterPolicyID` is set on the `SmartWalletConfig`, and worker config had no such field for `ToSmartWalletConfig` to copy — so every worker-sent operation fell through to `ensureSelfFundedPrefund`, which a smart wallet holding only tokens cannot satisfy.

## What it actually affected

I traced the blast radius rather than assuming it was everything. The worker is a chain-RPC proxy: reads, plus exactly one write path, `ExecuteUserOp`. That has exactly one caller — `sendUserOpWithGlobalWs` — which itself has exactly one caller: **`ExecuteWithdraw`**.

So task execution was fine (it runs in the gateway process against the gateway's config, which does carry the policy). What was broken is **withdrawal — the escape hatch**. A wallet holding USDC but no ETH could not pay its own prefund, so the user could not get their tokens out.

**Not a regression from #721.** The MA v2 branch never received the old `paymasterReq` either:

```go
if smartWalletConfig.UsesModularAccountV2() {
    op, receipt, err := SendUserOpMAv2(smartWalletConfig, owner, callData, senderOverride, saltOverride, nil, lgr)
    // paymasterReq deliberately not threaded through; it was v0.6-only
}
```

This has been true since the EntryPoint v0.7 cutover. Removing the v0.6 plumbing only stopped the path from *looking* sponsored.

## The non-obvious half

The worker also needs `gas_manager_webhook_secret`, which reads like gateway-only config. The webhook endpoint does stay on the gateway (`POST /webhooks/gas-manager`) — but the secret is echoed to Alchemy as `webhookData`, and the gateway's webhook rejects any request whose value does not match. A worker that requests sponsorship without it gets refused by the policy's custom rules.

## Approach

Resolution moves into exported `config.ResolveAlchemyPaymasterPolicyID` / `ResolveGasManagerWebhookSecret`, now used by **both** gateway and worker. The bug was the two disagreeing about where sponsorship comes from; one function is harder to drift than two copies. Legacy `gas_manager_policy_id` and the env fallbacks are preserved exactly, so no existing deployment silently loses sponsorship.

A worker with no policy now says so at startup. Deliberately a **warning, not a refusal** — a chain may legitimately run self-funded, and the send path already fails with a message naming `alchemy_paymaster_policy_id` when a wallet cannot cover prefund. That existing error is good, so I did not add a second one.

## Deployment — this needs an avs-infra change

The code cannot fix this alone. Worker configs in `avs-infra/railway/configs/` currently carry **no** `alchemy_paymaster_policy_id` — the key appears only in `gateway-railway.yaml`. Each worker needs both fields set to match the gateway before sponsorship actually resumes.

Open question for whoever does that: whether workers share the gateway's policy or hold their own. Sharing is simpler and matches how the gateway is configured today; separate policies would give per-chain spend caps. I have not assumed either — the config reads whatever is supplied.

## Test plan

- [x] Policy and webhook secret reach `SmartWalletConfig`
- [x] A worker without a policy reports it cannot sponsor (the regression itself)
- [x] Legacy `gas_manager_policy_id` alias accepted; canonical wins when both set
- [x] Env fallback fills in when yaml is empty
- [x] Whitespace trimmed — a padded policy id reads to Alchemy as an unknown policy
- [x] `go build`, `go vet`, `gofmt`, `make storage-check` clean
- [ ] CI green
- [ ] avs-infra: set both fields on every worker, then confirm a withdrawal from a zero-ETH wallet succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)