### PR TITLE
chore(ci): run live tests on the Alchemy bundler

### DIFF
--- a/.github/actions/setup-test-config/action.yml
+++ b/.github/actions/setup-test-config/action.yml
@@ -32,6 +32,13 @@ inputs:
   moralis-api-key:
     description: 'Moralis Web3 Data API key for token balance integration tests'
     required: false
+  alchemy-api-key:
+    description: |
+      Alchemy API key. When set, CI runs bundler_provider: alchemy and derives
+      the endpoint from the key — the same path production uses. Without it CI
+      falls back to the self-hosted bundler (bundler-rpc), which no deployment
+      uses any more.
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -50,6 +57,7 @@ runs:
         TENDERLY_ACCESS_KEY: "${{ inputs.tenderly-access-key }}"
         OWNER_EOA: "${{ inputs.owner-eoa }}"
         MORALIS_API_KEY: "${{ inputs.moralis-api-key }}"
+        ALCHEMY_API_KEY: "${{ inputs.alchemy-api-key }}"
       shell: bash
       run: ./.github/scripts/generate-test-config.sh
 

--- a/.github/scripts/generate-test-config.sh
+++ b/.github/scripts/generate-test-config.sh
@@ -44,18 +44,36 @@ cp config/test.example.yaml config/test.yaml
 sed -i "s|eth_rpc_url:.*|eth_rpc_url: ${CHAIN_RPC}|g" config/test.yaml
 sed -i "s|eth_ws_url:.*|eth_ws_url: ${CHAIN_WS}|g" config/test.yaml
 sed -i "s|ecdsa_private_key:.*|ecdsa_private_key: ${CONTROLLER_PRIVATE_KEY}|g" config/test.yaml
-sed -i "s|bundler_url:.*|bundler_url: ${BUNDLER_RPC}|g" config/test.yaml
-# CI supplies its own bundler via the BUNDLER_RPC secret, so it must declare
-# self_hosted regardless of what the template ships with. The template tracks
-# production, which runs bundler_provider: alchemy — and on that path the
-# endpoint is derived from alchemy_api_key and bundler_url is never read, so
-# inheriting `alchemy` here fails closed at send time with
-# "bundler_provider=alchemy but alchemy_api_key is empty".
+sed -i "s|bundler_url:.*|bundler_url: ${BUNDLER_RPC:-}|g" config/test.yaml
+
+# Bundler provider. CI now exercises the provider production actually uses.
 #
-# The cost is that CI does not exercise the provider production actually uses.
-# Closing that gap means adding an ALCHEMY_API_KEY secret and substituting it
-# below instead of forcing self_hosted.
-sed -i "s|bundler_provider:.*|bundler_provider: self_hosted|g" config/test.yaml
+# With ALCHEMY_API_KEY set, the endpoint is derived from the key and
+# bundler_url is never read — which is the production path, and the reason
+# this gap was worth closing: CI was validating a bundler no deployment uses.
+#
+# Without the key, fall back to the self-hosted bundler so a fork or a
+# secret-less run still works rather than failing closed at send time with
+# "bundler_provider=alchemy but alchemy_api_key is empty". That fallback is
+# meant to disappear once the self-hosted bundlers are retired; when it does,
+# a missing key should become a hard failure rather than a silent downgrade.
+if [ -n "${ALCHEMY_API_KEY:-}" ]; then
+  sed -i "s|bundler_provider:.*|bundler_provider: alchemy|g" config/test.yaml
+  sed -i "s|alchemy_api_key:.*|alchemy_api_key: ${ALCHEMY_API_KEY}|g" config/test.yaml
+  echo "bundler_provider: alchemy (endpoint derived from ALCHEMY_API_KEY)"
+else
+  sed -i "s|bundler_provider:.*|bundler_provider: self_hosted|g" config/test.yaml
+  sed -i "s|alchemy_api_key:.*|alchemy_api_key:|g" config/test.yaml
+  echo "WARNING: ALCHEMY_API_KEY not set — falling back to the self-hosted bundler (BUNDLER_RPC)."
+fi
+
+# CI must never draw on the production Gas Manager policy: the policy's
+# custom-rules webhook points at the production gateway, which would approve
+# and bill a CI run against production's wallet records and credit ledger.
+# The template sets this, but assert it rather than trusting the copy.
+if ! grep -q "^disable_gas_sponsorship: true" config/test.yaml; then
+  printf '\n# CI never draws on the production Gas Manager policy.\ndisable_gas_sponsorship: true\n' >> config/test.yaml
+fi
 sed -i "s|controller_private_key:.*|controller_private_key: ${CONTROLLER_PRIVATE_KEY}|g" config/test.yaml
 sed -i "s|paymaster_address:.*|paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92|g" config/test.yaml
 sed -i "s|tenderly_account:.*|tenderly_account: ${TENDERLY_ACCOUNT}|g" config/test.yaml

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -102,6 +102,9 @@ jobs:
           tenderly-access-key: ${{ secrets.TENDERLY_ACCESS_KEY }}
           owner-eoa: ${{ vars.OWNER_EOA }}
           moralis-api-key: ${{ secrets.MORALIS_API_KEY }}
+          # Runs CI on the same bundler production uses. Without it CI falls
+          # back to the self-hosted bundler, which nothing deploys against.
+          alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -170,6 +173,9 @@ jobs:
           # action exports it to the job environment for the test step.
           test-private-key: ${{ secrets.TEST_PRIVATE_KEY }}
           moralis-api-key: ${{ secrets.MORALIS_API_KEY }}
+          # Runs CI on the same bundler production uses. Without it CI falls
+          # back to the self-hosted bundler, which nothing deploys against.
+          alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}
 
       - name: Run Go test
         env:


### PR DESCRIPTION
Step 1 of retiring the self-hosted bundler services (follow-up to #722).

## Why

`generate-test-config.sh` forced `bundler_provider: self_hosted` regardless of the template. Its own comment named the fix:

> The cost is that CI does not exercise the provider production actually uses. Closing that gap means adding an `ALCHEMY_API_KEY` secret and substituting it below instead of forcing self_hosted.

That cost turned out to be larger than "an untested code path". Tracing who still calls the self-hosted bundlers: `bundler-sepolia` logged **131 `eth_sendUserOperation` calls over Aug 5–7**, and the senders are our own fixture wallets — including `0x209eb31c…`, the salt-0 runner from #720. **This workflow is the traffic.** The bundlers were being kept alive largely by CI validating a bundler nothing deploys against.

## What changed

- `ALCHEMY_API_KEY` secret added to the repo and threaded through `setup-test-config` → `generate-test-config.sh`.
- With the key, CI runs `bundler_provider: alchemy` and derives the endpoint from it — production's path.
- Without it, the script still falls back to `self_hosted` so a fork or secret-less run works rather than failing closed with `bundler_provider=alchemy but alchemy_api_key is empty`. **That fallback should become a hard failure once the self-hosted bundlers are retired** — at that point a missing key means a misconfigured CI, not a valid mode.
- The generated config now asserts `disable_gas_sponsorship`. The Gas Manager policy's custom-rules webhook is a single URL pointing at the production gateway, so a CI run requesting sponsorship would have production approve it and bill production's credit ledger for a test. The template sets it; asserting it here means a template edit cannot quietly drop it.

Companion change in ava-sdk-js: [chore/ci-alchemy-bundler](https://github.com/AvaProtocol/ava-sdk-js/tree/chore/ci-alchemy-bundler) — its E2E gateway declared no `bundler_provider` at all, so it defaulted to alchemy with no key and would fail closed.

## Not in this PR

The bundler services stay running. The plan is to watch their logs go quiet for a few days once both CI paths are on Alchemy, then retire proxy → backends → DNS. Three separate readings of "is this used" have contradicted each other already, so the next step should be an observation, not an inference.

## Test plan

- [x] `bash -n` on the generator
- [ ] CI green — and the live Sepolia tests still pass on the Alchemy bundler, which is the real check here
- [ ] `bundler-sepolia` logs show no `eth_sendUserOperation` from fixture wallets after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)