### PR TITLE
feat(taskengine): batch uninstallValidation into the deferred action so a replaced grant leaves the chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,6 @@ tmp/rehearsal-gateway-backup/
 
 # spike harness build outputs
 /deferred_action
+/deferred_replace
 /permission_hooks
 /revoke

--- a/core/chainio/aa/ma_v2_entity_state.go
+++ b/core/chainio/aa/ma_v2_entity_state.go
@@ -8,6 +8,9 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 )
 
 // Reading back what a validation entity actually holds.
@@ -47,6 +50,71 @@ func EntitySignerOnChain(ctx context.Context, client ContractCaller, account com
 			entity, account.Hex(), len(out))
 	}
 	return common.BytesToAddress(out[12:32]), nil
+}
+
+// EntryPointNonce returns the EntryPoint's current nonce for (account, key) —
+// the full 256-bit value, whose low 64 bits are the sequence.
+//
+// This is the second half of "is this validation entity free", and the half
+// that is easy to miss. Teardown clears every module: signer, allowlist, spend
+// cap, time range all read zero afterwards, so an entity looks brand new. Its
+// EntryPoint nonce sequence does NOT reset — nothing can reset it.
+//
+// That matters because a deferred action's digest commits to the FULL nonce of
+// the operation that will carry it, and PrepareSessionGrant can only know that
+// nonce in advance by assuming sequence 0. The assumption holds for an entity
+// that has never been used and fails silently for one that has: the owner signs
+// a nonce the EntryPoint already consumed, and the operation reverts as an
+// opaque AA23 with no on-chain trace of the reason.
+//
+// So an entity id must never be reissued once used, however clean it reads.
+// Observed on Sepolia while implementing #717: entity 1 read clear on all four
+// modules with its deferred nonce sequence at 1, and every grant reallocating
+// it AA23'd during validation.
+func EntryPointNonce(ctx context.Context, client ContractCaller, account common.Address, key *big.Int) (*big.Int, error) {
+	if client == nil {
+		return nil, fmt.Errorf("no chain client")
+	}
+	if key == nil {
+		return nil, fmt.Errorf("no nonce key")
+	}
+	data := crypto.Keccak256([]byte("getNonce(address,uint192)"))[:4]
+	data = append(data, common.LeftPadBytes(account.Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(key.Bytes(), 32)...)
+
+	entryPoint := common.HexToAddress(config.EntryPointV07AddressHex)
+	out, err := client.CallContract(ctx, ethereum.CallMsg{To: &entryPoint, Data: data}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading nonce of %s at key %s: %w", account.Hex(), key, err)
+	}
+	if len(out) < 32 {
+		return nil, fmt.Errorf("getNonce(%s, %s) returned %d bytes, want at least 32",
+			account.Hex(), key, len(out))
+	}
+	return new(big.Int).SetBytes(out[:32]), nil
+}
+
+// EntityDeferredNonceSequence returns the SEQUENCE half of the deferred nonce
+// for (account, entity) — the number that says whether this entity has ever
+// carried a deferred action, and so whether it may be issued to a grant.
+//
+// Read the sequence, never the full nonce. getNonce returns key<<64 | sequence,
+// and the key embeds the entity id, so the full value is non-zero for every
+// entity above 0. Testing that against zero looks exactly like a usage check
+// and is nothing of the kind — it reports every entity as spent.
+func EntityDeferredNonceSequence(ctx context.Context, client ContractCaller, account common.Address, entity uint32) (uint64, error) {
+	key, err := userop.NonceKeyMAv2(entity,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction)
+	if err != nil {
+		return 0, err
+	}
+	nonce, err := EntryPointNonce(ctx, client, account, key)
+	if err != nil {
+		return 0, err
+	}
+	// Low 64 bits. Everything above them is the key.
+	mask := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 64), big.NewInt(1))
+	return new(big.Int).And(nonce, mask).Uint64(), nil
 }
 
 // ContractCaller is the read surface these checks need — satisfied by

--- a/core/chainio/aa/ma_v2_entity_state.go
+++ b/core/chainio/aa/ma_v2_entity_state.go
@@ -1,0 +1,56 @@
+package aa
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Reading back what a validation entity actually holds.
+//
+// This exists because a mined transaction is not evidence that an uninstall
+// did anything. The account catches a hook module's onUninstall revert, flags
+// it only in the ValidationUninstalled event, and leaves the module state in
+// place. Demonstrated on Sepolia while spiking #717: a replace batch mined at
+// 601,275 gas with success=true and left the prior entity holding both its
+// signer and its full 100-token spend cap.
+//
+// So anything that reports a grant revoked on chain has to read the chain.
+
+// EntitySignerOnChain returns the SingleSignerValidationModule signer for
+// (entity, account), or the zero address when the entity holds none.
+//
+// A read failure is returned rather than folded into the zero address: zero
+// means "this entity is clear", and a caller acting on a transient RPC error
+// would report a grant revoked that is still live.
+func EntitySignerOnChain(ctx context.Context, client ContractCaller, account common.Address, entity uint32) (common.Address, error) {
+	if client == nil {
+		return common.Address{}, fmt.Errorf("no chain client")
+	}
+	data := crypto.Keccak256([]byte("signers(uint32,address)"))[:4]
+	data = append(data, common.LeftPadBytes([]byte{
+		byte(entity >> 24), byte(entity >> 16), byte(entity >> 8), byte(entity),
+	}, 32)...)
+	data = append(data, common.LeftPadBytes(account.Bytes(), 32)...)
+
+	module := SingleSignerValidationModuleAddress()
+	out, err := client.CallContract(ctx, ethereum.CallMsg{To: &module, Data: data}, nil)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("reading signer of entity %d on %s: %w", entity, account.Hex(), err)
+	}
+	if len(out) < 32 {
+		return common.Address{}, fmt.Errorf("signers(%d, %s) returned %d bytes, want at least 32",
+			entity, account.Hex(), len(out))
+	}
+	return common.BytesToAddress(out[12:32]), nil
+}
+
+// ContractCaller is the read surface these checks need — satisfied by
+// *ethclient.Client and by anything else that can make an eth_call.
+type ContractCaller interface {
+	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+}

--- a/core/chainio/aa/ma_v2_entity_state_test.go
+++ b/core/chainio/aa/ma_v2_entity_state_test.go
@@ -1,0 +1,118 @@
+package aa
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+// recordingCaller answers one canned value and remembers what it was asked.
+type recordingCaller struct {
+	to     common.Address
+	data   []byte
+	result []byte
+	err    error
+}
+
+func (r *recordingCaller) CallContract(_ context.Context, call ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	if call.To != nil {
+		r.to = *call.To
+	}
+	r.data = call.Data
+	return r.result, r.err
+}
+
+func word(v *big.Int) []byte { return common.LeftPadBytes(v.Bytes(), 32) }
+
+// The sequence is the low 64 bits. Reading the full nonce instead reports every
+// entity as spent, because the key above those bits embeds the entity id — the
+// check still compiles, still returns a number, and is wrong for every input
+// except entity 0.
+func TestEntityDeferredNonceSequenceReadsOnlyTheSequence(t *testing.T) {
+	const entity = uint32(3)
+	key, err := userop.NonceKeyMAv2(entity,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction)
+	require.NoError(t, err)
+	require.NotZero(t, key.Sign(), "precondition: the key is non-zero, which is what makes the full nonce misleading")
+
+	// getNonce returns key<<64 | sequence.
+	full := new(big.Int).Lsh(key, 64)
+	full.Or(full, big.NewInt(7))
+
+	account := common.HexToAddress("0x0643f9d156e2CE584825511C548649F3289619c3")
+	caller := &recordingCaller{result: word(full)}
+	sequence, err := EntityDeferredNonceSequence(context.Background(), caller, account, entity)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), sequence,
+		"the sequence is the low 64 bits; the rest is the key")
+
+	// Pin the WIDTH too. A narrower mask agrees on every small sequence and
+	// only diverges past its boundary, so a test that never crosses one cannot
+	// tell 64 bits from 32.
+	wide := uint64(1)<<40 | 5
+	full = new(big.Int).Lsh(key, 64)
+	full.Or(full, new(big.Int).SetUint64(wide))
+
+	caller = &recordingCaller{result: word(full)}
+	sequence, err = EntityDeferredNonceSequence(context.Background(), caller, account, entity)
+	require.NoError(t, err)
+	require.Equal(t, wide, sequence, "the sequence field is 64 bits wide")
+}
+
+// An entity that has never carried a deferred action must read zero, or the
+// allocator has no way to tell a fresh entity from a spent one.
+func TestEntityDeferredNonceSequenceIsZeroForAnUnusedEntity(t *testing.T) {
+	key, err := userop.NonceKeyMAv2(9,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction)
+	require.NoError(t, err)
+
+	caller := &recordingCaller{result: word(new(big.Int).Lsh(key, 64))}
+	sequence, err := EntityDeferredNonceSequence(context.Background(), caller,
+		common.HexToAddress("0x0643f9d156e2CE584825511C548649F3289619c3"), 9)
+	require.NoError(t, err)
+	require.Zero(t, sequence)
+}
+
+// The call has to reach the EntryPoint with the entity's DEFERRED key. A wrong
+// options byte queries a different nonce key entirely, which answers zero for
+// an entity that is in fact spent — the failure that produces an opaque AA23
+// later, at grant time, with nothing to point at.
+func TestEntityDeferredNonceSequenceQueriesTheDeferredKey(t *testing.T) {
+	const entity = uint32(4)
+	account := common.HexToAddress("0x0643f9d156e2CE584825511C548649F3289619c3")
+
+	caller := &recordingCaller{result: word(big.NewInt(0))}
+	_, err := EntityDeferredNonceSequence(context.Background(), caller, account, entity)
+	require.NoError(t, err)
+
+	require.Equal(t, common.HexToAddress(config.EntryPointV07AddressHex), caller.to,
+		"the nonce lives on the EntryPoint, not on a module")
+	require.Len(t, caller.data, 4+32+32, "getNonce(address,uint192)")
+	require.Equal(t, account, common.BytesToAddress(caller.data[4+12:4+32]))
+
+	wantKey, err := userop.NonceKeyMAv2(entity,
+		userop.ValidationOptionGlobal|userop.ValidationOptionDeferredAction)
+	require.NoError(t, err)
+	require.Equal(t, wantKey, new(big.Int).SetBytes(caller.data[4+32:]),
+		"must query the GLOBAL|DEFERRED key for this entity")
+}
+
+// A read failure must not surface as "sequence 0" — that reads as "this entity
+// is free" and hands a spent entity to the next grant.
+func TestEntityDeferredNonceSequenceReportsReadFailures(t *testing.T) {
+	caller := &recordingCaller{result: word(big.NewInt(1))[:16]} // short return
+	_, err := EntityDeferredNonceSequence(context.Background(), caller,
+		common.HexToAddress("0x0643f9d156e2CE584825511C548649F3289619c3"), 1)
+	require.Error(t, err)
+
+	_, err = EntityDeferredNonceSequence(context.Background(), nil,
+		common.HexToAddress("0x0643f9d156e2CE584825511C548649F3289619c3"), 1)
+	require.Error(t, err, "no client is not evidence that an entity is free")
+}

--- a/core/chainio/aa/ma_v2_uninstall_from_install.go
+++ b/core/chainio/aa/ma_v2_uninstall_from_install.go
@@ -39,6 +39,10 @@ import (
 //
 // Wrong ordering does not error here or on chain. It mines and does nothing.
 func SessionSignerUninstallFromInstall(entityID uint32, installCall []byte) ([]byte, error) {
+	installCall, err := InstallValidationWithin(installCall)
+	if err != nil {
+		return nil, fmt.Errorf("locating the install for entity %d: %w", entityID, err)
+	}
 	hooks, err := DecodeInstallValidationHooks(installCall)
 	if err != nil {
 		return nil, fmt.Errorf("recovering hooks for entity %d: %w", entityID, err)
@@ -104,4 +108,39 @@ func DecodeInstallValidationHooks(installCall []byte) ([][]byte, error) {
 		return nil, fmt.Errorf("installValidation hooks decoded to %T, not [][]byte", args[3])
 	}
 	return hooks, nil
+}
+
+// InstallValidationWithin returns the installValidation calldata inside a
+// stored deferred call, unwrapping an executeBatch when it finds one.
+//
+// A grant that replaced another stores its deferred call as a batch of
+// [install(new), uninstall(prior)] — the shape the owner signed. Anything
+// reading that record for the INSTALL alone, teardown included, has to look
+// past the wrapper. Anything replaying it as a payload must not: the signature
+// commits to the batch.
+func InstallValidationWithin(deferredCall []byte) ([]byte, error) {
+	if err := ensureInstallABIs(); err != nil {
+		return nil, err
+	}
+	method, ok := installValidationABI.Methods["installValidation"]
+	if !ok {
+		return nil, fmt.Errorf("installValidation is missing from the ABI")
+	}
+	if len(deferredCall) < 4 {
+		return nil, fmt.Errorf("deferred call is %d bytes, shorter than a selector", len(deferredCall))
+	}
+	if string(deferredCall[:4]) == string(method.ID) {
+		return deferredCall, nil
+	}
+
+	_, _, datas, err := UnpackExecuteCalldata(deferredCall)
+	if err != nil {
+		return nil, fmt.Errorf("deferred call is neither installValidation nor an unpackable batch: %w", err)
+	}
+	for _, data := range datas {
+		if len(data) >= 4 && string(data[:4]) == string(method.ID) {
+			return data, nil
+		}
+	}
+	return nil, fmt.Errorf("no installValidation found among the batch's %d calls", len(datas))
 }

--- a/core/chainio/aa/ma_v2_uninstall_from_install.go
+++ b/core/chainio/aa/ma_v2_uninstall_from_install.go
@@ -144,3 +144,51 @@ func InstallValidationWithin(deferredCall []byte) ([]byte, error) {
 	}
 	return nil, fmt.Errorf("no installValidation found among the batch's %d calls", len(datas))
 }
+
+// UninstalledEntityWithin returns the entity a stored deferred call tears
+// down, when it carries one.
+//
+// The payload is the source of truth for what the owner's signature actually
+// authorized, so verification reads the target from it rather than from a
+// separately-stored field that could disagree with the bytes that were signed.
+// Returns found=false for a plain install — a grant that replaced nothing.
+func UninstalledEntityWithin(deferredCall []byte) (entity uint32, found bool, err error) {
+	if err := ensureUninstallABI(); err != nil {
+		return 0, false, err
+	}
+	method, ok := uninstallABI.Methods["uninstallValidation"]
+	if !ok {
+		return 0, false, fmt.Errorf("uninstallValidation is missing from the ABI")
+	}
+	if len(deferredCall) < 4 {
+		return 0, false, nil
+	}
+
+	candidates := [][]byte{deferredCall}
+	if string(deferredCall[:4]) != string(method.ID) {
+		_, _, datas, unpackErr := UnpackExecuteCalldata(deferredCall)
+		if unpackErr != nil {
+			return 0, false, nil // a plain install, or something that is not a batch
+		}
+		candidates = datas
+	}
+
+	for _, data := range candidates {
+		if len(data) < 4 || string(data[:4]) != string(method.ID) {
+			continue
+		}
+		args, err := method.Inputs.Unpack(data[4:])
+		if err != nil {
+			return 0, false, fmt.Errorf("decoding uninstallValidation: %w", err)
+		}
+		moduleEntity, ok := args[0].([24]byte)
+		if !ok {
+			return 0, false, fmt.Errorf("uninstallValidation target decoded to %T, not bytes24", args[0])
+		}
+		// ModuleEntity is module (20) ++ entityId (4, big-endian).
+		e := uint32(moduleEntity[20])<<24 | uint32(moduleEntity[21])<<16 |
+			uint32(moduleEntity[22])<<8 | uint32(moduleEntity[23])
+		return e, true, nil
+	}
+	return 0, false, nil
+}

--- a/core/chainio/aa/ma_v2_uninstall_from_install.go
+++ b/core/chainio/aa/ma_v2_uninstall_from_install.go
@@ -1,0 +1,107 @@
+package aa
+
+import (
+	"fmt"
+)
+
+// Deriving a grant's teardown from the call that created it.
+//
+// A grant's hooks cannot be torn down from current code. Each hook module's
+// onUninstall payload is the SAME (entityId, inputs) tuple it was INSTALLED
+// with, so rebuilding it from today's permission structs would silently
+// diverge the moment a grant's shape changes — and the divergence does not
+// announce itself. That is why model.SessionPolicy retains Grant.InstallCall:
+// it is the only faithful record of what a given entity actually carries.
+//
+// Getting this wrong produces a SUCCESSFUL transaction that clears nothing.
+// The account catches onUninstall reverts, flags them only in the
+// ValidationUninstalled event, and strands the module state. Proven on Sepolia
+// while spiking #717: an identical batch mined at 601,275 gas with
+// success=true and left the prior entity holding both its signer and its full
+// 100-token spend cap, because two teardown entries were misrouted. The
+// corrected payload cleared both.
+//
+// Consequences, both non-negotiable for callers:
+//
+//   - Derive from the stored install call, never from live config.
+//   - Treat a mined transaction as no evidence of teardown. Read the module
+//     state back before reporting an entity revoked.
+
+// SessionSignerUninstallFromInstall builds the uninstallValidation calldata
+// that reverses installCall — the calldata a grant was created with.
+//
+// hookUninstallData must carry one entry per installed hook in the ACCOUNT's
+// STORED order. The account keeps hooks as a prepend-on-add list, so stored
+// order is the REVERSE of install order. A hook that carried install data is
+// torn down with that same data; one that carried none (the allowlist's
+// execution-hook entry, whose module state belongs to its validation-hook
+// entry) takes an empty slot.
+//
+// Wrong ordering does not error here or on chain. It mines and does nothing.
+func SessionSignerUninstallFromInstall(entityID uint32, installCall []byte) ([]byte, error) {
+	hooks, err := DecodeInstallValidationHooks(installCall)
+	if err != nil {
+		return nil, fmt.Errorf("recovering hooks for entity %d: %w", entityID, err)
+	}
+
+	// Reverse into the account's stored order, keeping each hook's own install
+	// data as its teardown payload.
+	teardown := make([][]byte, 0, len(hooks))
+	for i := len(hooks) - 1; i >= 0; i-- {
+		entry := hooks[i]
+		if len(entry) < hookConfigLen {
+			return nil, fmt.Errorf("hook %d of entity %d is %d bytes, shorter than a hook config",
+				i, entityID, len(entry))
+		}
+		// Everything after the 25-byte config is the module's install data,
+		// which is exactly what its onUninstall expects back. An entry that is
+		// config-only yields nil, not an empty non-nil slice — the ABI encodes
+		// both as zero-length bytes, and nil states the intent.
+		if data := entry[hookConfigLen:]; len(data) > 0 {
+			teardown = append(teardown, append([]byte(nil), data...))
+		} else {
+			teardown = append(teardown, nil)
+		}
+	}
+
+	return PackSessionSignerUninstall(entityID, teardown)
+}
+
+// hookConfigLen is the packed HookConfig width: module (20) ++ entityId (4) ++
+// flags (1). See PackHookConfig.
+const hookConfigLen = 25
+
+// DecodeInstallValidationHooks recovers the hooks array from installValidation
+// calldata, in INSTALL order.
+//
+// Exposed separately because callers other than teardown need it — verifying
+// that an entity carries the hook set a stored policy claims, for instance,
+// which is the only honest way to confirm a revoke landed.
+func DecodeInstallValidationHooks(installCall []byte) ([][]byte, error) {
+	if err := ensureInstallABIs(); err != nil {
+		return nil, err
+	}
+	method, ok := installValidationABI.Methods["installValidation"]
+	if !ok {
+		return nil, fmt.Errorf("installValidation is missing from the ABI")
+	}
+	if len(installCall) < 4 {
+		return nil, fmt.Errorf("install call is %d bytes, shorter than a selector", len(installCall))
+	}
+	if string(installCall[:4]) != string(method.ID) {
+		return nil, fmt.Errorf("install call selector is 0x%x, not installValidation (0x%x)",
+			installCall[:4], method.ID)
+	}
+	args, err := method.Inputs.Unpack(installCall[4:])
+	if err != nil {
+		return nil, fmt.Errorf("decoding installValidation: %w", err)
+	}
+	if len(args) != 4 {
+		return nil, fmt.Errorf("installValidation decoded to %d arguments, want 4", len(args))
+	}
+	hooks, ok := args[3].([][]byte)
+	if !ok {
+		return nil, fmt.Errorf("installValidation hooks decoded to %T, not [][]byte", args[3])
+	}
+	return hooks, nil
+}

--- a/core/chainio/aa/ma_v2_uninstall_from_install_test.go
+++ b/core/chainio/aa/ma_v2_uninstall_from_install_test.go
@@ -1,0 +1,168 @@
+package aa
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// The teardown these tests pin was established on Sepolia while spiking #717.
+// Two payload shapes were tried against the same batch. Both MINED with
+// success=true. Only one actually cleared anything:
+//
+//	601,275 gas  entity kept its signer AND its full 100-token spend cap
+//	636,341 gas  signer cleared to 0x0, cap cleared to 0
+//
+// Nothing on chain distinguishes them — the account catches onUninstall
+// reverts and strands the module state. So these assertions are the guard: if
+// the ordering or the payloads drift, no test that watches a receipt will
+// notice, and a wallet keeps a live spend cap the product believes is revoked.
+
+const (
+	testEntity  = uint32(1)
+	spikeCapWei = 100
+)
+
+func testGrantInstall(t *testing.T, entity uint32) (call []byte, token common.Address, allowlistData, timeRangeData []byte) {
+	t.Helper()
+	token = common.HexToAddress("0xaA4D01B75fdEB5fbbD98276EC7755eF71801c2E7")
+	signer := common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB")
+
+	inputs := []AllowlistInput{{
+		Target:               token,
+		HasSelectorAllowlist: true,
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}},
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      new(big.Int).Mul(big.NewInt(spikeCapWei), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
+	}}
+
+	allowlistHook, err := AllowlistValidationHook(entity, inputs)
+	require.NoError(t, err)
+	timeRangeHook, err := TimeRangeValidationHook(entity, 1785541743, 0)
+	require.NoError(t, err)
+
+	// Install order, matching SessionPermissions.HooksFor exactly.
+	call, err = PackSessionSignerInstall(SessionGrant{
+		EntityID: entity,
+		Signer:   signer,
+		Global:   true,
+		Hooks:    [][]byte{allowlistHook, AllowlistExecHook(entity), timeRangeHook},
+	})
+	require.NoError(t, err)
+
+	allowlistData, err = PackAllowlistInstallData(entity, inputs)
+	require.NoError(t, err)
+	timeRangeData, err = PackTimeRangeInstallData(entity, 1785541743, 0)
+	require.NoError(t, err)
+	return call, token, allowlistData, timeRangeData
+}
+
+func TestDecodeInstallValidationHooksRecoversInstallOrder(t *testing.T) {
+	call, _, allowlistData, timeRangeData := testGrantInstall(t, testEntity)
+
+	hooks, err := DecodeInstallValidationHooks(call)
+	require.NoError(t, err)
+	require.Len(t, hooks, 3, "a policied grant installs allowlist-validation, allowlist-exec, time-range")
+
+	// Each entry is config(25) ++ that module's install data.
+	require.Equal(t, allowlistData, hooks[0][hookConfigLen:], "hook 0 carries the allowlist tuple")
+	require.Len(t, hooks[1], hookConfigLen, "the exec hook carries no install data — its state belongs to hook 0")
+	require.Equal(t, timeRangeData, hooks[2][hookConfigLen:], "hook 2 carries the time range")
+}
+
+// The ordering finding, stated as an assertion. Install order is
+// [allowlist-validation, allowlist-exec, time-range]; the account stores hooks
+// prepend-on-add, so teardown must be the reverse.
+func TestUninstallReversesIntoStoredOrder(t *testing.T) {
+	call, _, allowlistData, timeRangeData := testGrantInstall(t, testEntity)
+
+	uninstall, err := SessionSignerUninstallFromInstall(testEntity, call)
+	require.NoError(t, err)
+
+	hookData := decodeUninstallHookData(t, uninstall)
+	require.Len(t, hookData, 3, "one entry per installed hook, or the account reverts ArrayLengthMismatch")
+
+	require.Equal(t, timeRangeData, hookData[0],
+		"stored order puts the LAST-installed hook first — time range")
+	require.Empty(t, hookData[1],
+		"the allowlist's exec-hook entry installed no state, so its teardown slot is empty")
+	require.Equal(t, allowlistData, hookData[2],
+		"the allowlist's teardown is the same (entityId, inputs) tuple it was installed with")
+}
+
+// Rebuilding the payload from current code instead of the stored call is the
+// mistake this whole file exists to prevent: it compiles, it mines, and it
+// clears nothing. Pinning the derivation to the stored bytes means a grant
+// whose shape predates a code change still tears down correctly.
+func TestTeardownFollowsTheStoredCallNotCurrentCode(t *testing.T) {
+	call, _, allowlistData, _ := testGrantInstall(t, testEntity)
+
+	// A grant installed with a DIFFERENT cap — as an older policy would have.
+	otherInputs := []AllowlistInput{{
+		Target:               common.HexToAddress("0xaA4D01B75fdEB5fbbD98276EC7755eF71801c2E7"),
+		HasSelectorAllowlist: true,
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}},
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      big.NewInt(7), // nothing today would produce this
+	}}
+	otherHook, err := AllowlistValidationHook(testEntity, otherInputs)
+	require.NoError(t, err)
+	timeRangeHook, err := TimeRangeValidationHook(testEntity, 1785541743, 0)
+	require.NoError(t, err)
+	otherCall, err := PackSessionSignerInstall(SessionGrant{
+		EntityID: testEntity,
+		Signer:   common.HexToAddress("0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB"),
+		Global:   true,
+		Hooks:    [][]byte{otherHook, AllowlistExecHook(testEntity), timeRangeHook},
+	})
+	require.NoError(t, err)
+
+	otherTeardown, err := SessionSignerUninstallFromInstall(testEntity, otherCall)
+	require.NoError(t, err)
+	otherData := decodeUninstallHookData(t, otherTeardown)
+
+	otherAllowlistData, err := PackAllowlistInstallData(testEntity, otherInputs)
+	require.NoError(t, err)
+	require.Equal(t, otherAllowlistData, otherData[2],
+		"teardown must reproduce the cap the entity was installed with, not the current one")
+	require.NotEqual(t, allowlistData, otherData[2],
+		"precondition: the two grants really do differ")
+
+	// And the round trip is stable for the original.
+	teardown, err := SessionSignerUninstallFromInstall(testEntity, call)
+	require.NoError(t, err)
+	require.Equal(t, allowlistData, decodeUninstallHookData(t, teardown)[2])
+}
+
+func TestUninstallFromInstallRejectsUnusableInput(t *testing.T) {
+	call, _, _, _ := testGrantInstall(t, testEntity)
+
+	_, err := SessionSignerUninstallFromInstall(testEntity, nil)
+	require.Error(t, err, "no stored call means no faithful teardown — refuse rather than guess")
+
+	_, err = SessionSignerUninstallFromInstall(testEntity, []byte{0xde, 0xad, 0xbe, 0xef})
+	require.Error(t, err)
+
+	// Entity 0 is the owner's fallback signer and must never be torn down.
+	_, err = SessionSignerUninstallFromInstall(0, call)
+	require.Error(t, err)
+}
+
+// decodeUninstallHookData pulls hookUninstallData back out of packed
+// uninstallValidation calldata.
+func decodeUninstallHookData(t *testing.T, uninstallCall []byte) [][]byte {
+	t.Helper()
+	require.NoError(t, ensureUninstallABI())
+	method, ok := uninstallABI.Methods["uninstallValidation"]
+	require.True(t, ok)
+	require.Equal(t, method.ID, uninstallCall[:4])
+
+	args, err := method.Inputs.Unpack(uninstallCall[4:])
+	require.NoError(t, err)
+	require.Len(t, args, 3)
+	hookData, ok := args[2].([][]byte)
+	require.True(t, ok)
+	return hookData
+}

--- a/core/chainio/aa/ma_v2_uninstall_from_install_test.go
+++ b/core/chainio/aa/ma_v2_uninstall_from_install_test.go
@@ -166,3 +166,37 @@ func decodeUninstallHookData(t *testing.T, uninstallCall []byte) [][]byte {
 	require.True(t, ok)
 	return hookData
 }
+
+// Verification reads its target from the payload the owner signed, not from a
+// separately-stored field that could disagree with those bytes.
+func TestUninstalledEntityWithinReadsTheSignedTarget(t *testing.T) {
+	install, _, _, _ := testGrantInstall(t, 2)
+	priorInstall, _, _, _ := testGrantInstall(t, 1)
+	account := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+
+	// A plain install replaced nothing.
+	entity, found, err := UninstalledEntityWithin(install)
+	require.NoError(t, err)
+	require.False(t, found, "a first grant tears nothing down")
+	require.Zero(t, entity)
+
+	// A replace batch names the entity it removes.
+	uninstall, err := SessionSignerUninstallFromInstall(1, priorInstall)
+	require.NoError(t, err)
+	batch, err := PackExecuteBatchMAv2([]Call{
+		{Target: account, Value: big.NewInt(0), Data: install},
+		{Target: account, Value: big.NewInt(0), Data: uninstall},
+	})
+	require.NoError(t, err)
+
+	entity, found, err = UninstalledEntityWithin(batch)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint32(1), entity, "the entity read back must be the one the batch removes")
+
+	// And the install is still recoverable from the same batch, for teardown
+	// of THIS grant later.
+	inner, err := InstallValidationWithin(batch)
+	require.NoError(t, err)
+	require.Equal(t, install, inner)
+}

--- a/core/taskengine/session_fixture_permissions_test.go
+++ b/core/taskengine/session_fixture_permissions_test.go
@@ -345,6 +345,11 @@ const (
 	fixtureSaltSequentialWrites  = 0
 	fixtureSaltUniswapSimulation = 0
 	fixtureSaltBatchSwap         = 0
+	// Salt 13 is funded and its entity space is clean, so unlike the fixtures
+	// above this one is genuinely isolated. The replace check installs and
+	// removes entities; doing that on a shared runner would churn another
+	// test's entity layout.
+	fixtureSaltGrantReplace = 13
 )
 
 // resetInitialPermissions brings the fixture's runner to the permission state

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -466,7 +466,7 @@ func recheckSupersededGrant(db storage.Storage, prepared *PreparedSessionGrant, 
 // TeardownVerifier reads back whether a validation entity is clear on chain.
 // Supplied by the aggregator, which owns the chain client; nil in tests and in
 // any process without one, where verification is skipped rather than faked.
-type TeardownVerifier func(ctx context.Context, account common.Address, entity uint32) (cleared bool, err error)
+type TeardownVerifier func(ctx context.Context, chainID int64, account common.Address, entity uint32) (cleared bool, err error)
 
 // VerifySupersededTeardown checks that the entity a replacement was supposed
 // to remove is actually gone, and records the answer on the superseded policy.
@@ -495,7 +495,7 @@ func VerifySupersededTeardown(
 		return nil // no chain client: skip honestly rather than assume success
 	}
 
-	cleared, err := verify(ctx, *superseded.Runner, superseded.EntityID)
+	cleared, err := verify(ctx, superseded.ChainID, *superseded.Runner, superseded.EntityID)
 	if err != nil {
 		// Unknown is not cleared. Say so rather than recording either answer.
 		if logger != nil {

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -97,6 +98,23 @@ type PreparedSessionGrant struct {
 
 	// DeferredData is the encoded action the signature authorizes.
 	DeferredData []byte
+
+	// Supersedes is the grant this one replaces ON CHAIN, when the deferred
+	// action carries its uninstall. Empty when there was nothing installed to
+	// remove — a first grant, or a prior grant still pending, which has no
+	// on-chain entity.
+	//
+	// Echoed to Submit so the write can re-check that the grant it is about to
+	// remove is still the one the owner signed away. The signature commits to
+	// a specific entity's teardown; if a different grant occupies that entity
+	// by then, the payload is stale in the same way a taken entity is.
+	Supersedes *SupersededGrant
+}
+
+// SupersededGrant identifies the on-chain grant a prepared replacement removes.
+type SupersededGrant struct {
+	PolicyID string
+	EntityID uint32
 }
 
 // PrepareSessionGrant allocates the grant and returns the payload to sign.
@@ -148,6 +166,41 @@ func PrepareSessionGrant(
 		return nil, fmt.Errorf("building the grant for wallet %s: %w", req.Wallet.Hex(), err)
 	}
 
+	// A grant REPLACES the runner's previous one, and #716 made that true in
+	// storage. Here it becomes true on chain: when a prior grant is actually
+	// installed, the owner's one signature carries its uninstall alongside the
+	// new install, so the account ends up holding exactly one entity rather
+	// than one per grant ever issued.
+	//
+	// Proven on Sepolia (#717): the batch composes with the NEW entity as the
+	// outer validation and needs no second owner signature. §3.6's refusal was
+	// specific to removing the validation that was validating the operation —
+	// a replace removes a different one.
+	deferredCall := installCall
+	superseded, ambiguous, err := supersededOnChainGrant(db, chainID, req.Owner, req.Wallet)
+	if err != nil {
+		return nil, err
+	}
+	// ambiguous: more than one grant is installed. Install only, so granting
+	// still repairs the wallet in storage (#716) instead of refusing the very
+	// wallets that need repairing. The leftovers stay on chain.
+	if superseded != nil && !ambiguous {
+		uninstallCall, err := aa.SessionSignerUninstallFromInstall(
+			superseded.EntityID, superseded.Grant.InstallCall)
+		if err != nil {
+			return nil, fmt.Errorf("building the teardown for the grant being replaced: %w", err)
+		}
+		// Install FIRST: the operation carrying this is validated by the new
+		// entity, which has to exist by the time the outer validation runs.
+		deferredCall, err = aa.PackExecuteBatchMAv2([]aa.Call{
+			{Target: req.Wallet, Value: big.NewInt(0), Data: installCall},
+			{Target: req.Wallet, Value: big.NewInt(0), Data: uninstallCall},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("packing the replace batch: %w", err)
+		}
+	}
+
 	deadline := req.Deadline
 	if deadline == 0 {
 		window := req.SigningWindow
@@ -167,21 +220,26 @@ func PrepareSessionGrant(
 	}
 
 	digest, err := userop.DeferredActionDigest(
-		big.NewInt(chainID), req.Wallet, carrierNonce, deadline, installCall)
+		big.NewInt(chainID), req.Wallet, carrierNonce, deadline, deferredCall)
 	if err != nil {
 		return nil, fmt.Errorf("building the grant digest: %w", err)
 	}
 
 	deferredData, err := userop.EncodeDeferredActionData(
-		userop.FallbackSignerLocator(), deadline, installCall)
+		userop.FallbackSignerLocator(), deadline, deferredCall)
 	if err != nil {
 		return nil, fmt.Errorf("encoding the deferred action: %w", err)
 	}
 
 	owner, wallet, signer := req.Owner, req.Wallet, sessionSigner
+	var supersedes *SupersededGrant
+	if superseded != nil {
+		supersedes = &SupersededGrant{PolicyID: superseded.ID, EntityID: superseded.EntityID}
+	}
 	return &PreparedSessionGrant{
 		Digest:       digest,
 		DeferredData: deferredData,
+		Supersedes:   supersedes,
 		Policy: &model.SessionPolicy{
 			ID:            policyID,
 			Owner:         &owner,
@@ -195,7 +253,7 @@ func PrepareSessionGrant(
 			Status:        model.SessionPolicyPending,
 			CreatedAt:     time.Now().UnixMilli(),
 			Grant: &model.SessionGrantAuthorization{
-				InstallCall:           installCall,
+				InstallCall:           deferredCall,
 				CarrierNonce:          carrierNonce,
 				Deadline:              deadline,
 				RequiresExecuteUserOp: grant.HasExecutionHook(),
@@ -235,6 +293,15 @@ func SubmitSessionGrant(db storage.Storage, prepared *PreparedSessionGrant, owne
 		return nil, fmt.Errorf(
 			"entity %d was taken while this grant was being signed (next free is %d); prepare it again",
 			policy.EntityID, entity)
+	}
+
+	// Re-check what this grant REPLACES, for the same reason and with the same
+	// remedy. The signature commits to tearing down one specific entity, so a
+	// payload prepared against a grant that has since been revoked or replaced
+	// would remove something the owner did not agree to remove — or nothing at
+	// all, which is worse, because it mines.
+	if err := recheckSupersededGrant(db, prepared, policy); err != nil {
+		return nil, err
 	}
 
 	policy.Grant.OwnerSignature = ownerSignature
@@ -349,3 +416,47 @@ func verifyGrantSignature(digest common.Hash, signature []byte, owner common.Add
 // address other than the wallet owner. Exposed as a sentinel so the REST
 // layer can map it to a 400 with errors.Is rather than matching error text.
 var ErrGrantSignerMismatch = errors.New("grant was signed by the wrong key")
+
+// recheckSupersededGrant refuses a replacement whose target moved between
+// prepare and submit.
+//
+// Three ways it can move, all treated alike: the grant was revoked outright,
+// it was itself replaced by another submit, or a grant now occupies the entity
+// that is different from the one prepared against. In every case the owner
+// signed away a specific entity's authority and that is no longer what the
+// payload would do, so it is refused the way a taken entity is — prepare
+// again, which rebuilds the batch against whatever is actually installed.
+func recheckSupersededGrant(db storage.Storage, prepared *PreparedSessionGrant, policy *model.SessionPolicy) error {
+	current, ambiguous, err := supersededOnChainGrant(db, policy.ChainID, *policy.Owner, *policy.Runner)
+	if err != nil {
+		return err
+	}
+	if ambiguous {
+		// Same reasoning as prepare: a stacked wallet is repaired, not refused.
+		// The payload installs only, so there is no teardown target to re-check.
+		return nil
+	}
+
+	switch {
+	case prepared.Supersedes == nil && current == nil:
+		return nil // nothing to replace then, nothing now
+	case prepared.Supersedes == nil && current != nil:
+		return fmt.Errorf(
+			"%w: grant %s (entity %d) was installed on %s while this one was being signed, "+
+				"so this payload would leave it in place; prepare again to replace it",
+			ErrSessionEntityTaken, current.ID, current.EntityID, policy.Runner.Hex())
+	case prepared.Supersedes != nil && current == nil:
+		return fmt.Errorf(
+			"%w: the grant this replaces (%s, entity %d) is no longer installed on %s; "+
+				"prepare again",
+			ErrSessionEntityTaken, prepared.Supersedes.PolicyID, prepared.Supersedes.EntityID,
+			policy.Runner.Hex())
+	case !strings.EqualFold(prepared.Supersedes.PolicyID, current.ID) ||
+		prepared.Supersedes.EntityID != current.EntityID:
+		return fmt.Errorf(
+			"%w: this replaces grant %s (entity %d) but %s now holds %s (entity %d); prepare again",
+			ErrSessionEntityTaken, prepared.Supersedes.PolicyID, prepared.Supersedes.EntityID,
+			policy.Runner.Hex(), current.ID, current.EntityID)
+	}
+	return nil
+}

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -1,12 +1,14 @@
 package taskengine
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 	"time"
 
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	badger "github.com/dgraph-io/badger/v4"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -459,4 +461,62 @@ func recheckSupersededGrant(db storage.Storage, prepared *PreparedSessionGrant, 
 			policy.Runner.Hex(), current.ID, current.EntityID)
 	}
 	return nil
+}
+
+// TeardownVerifier reads back whether a validation entity is clear on chain.
+// Supplied by the aggregator, which owns the chain client; nil in tests and in
+// any process without one, where verification is skipped rather than faked.
+type TeardownVerifier func(ctx context.Context, account common.Address, entity uint32) (cleared bool, err error)
+
+// VerifySupersededTeardown checks that the entity a replacement was supposed
+// to remove is actually gone, and records the answer on the superseded policy.
+//
+// This is not belt-and-braces. A replace batch that mines proves the operation
+// executed, NOT that the uninstall did anything: the account catches a hook
+// module's onUninstall revert and strands the state. Sepolia showed the two
+// outcomes are indistinguishable from a receipt — 601,275 gas and success=true
+// with the entity still holding its signer and its full spend cap, against
+// 636,341 gas and a clean teardown. Without this read, the product would
+// report an entity revoked on the strength of a transaction that removed
+// nothing.
+//
+// A failed verification does not error the caller. The new grant is already
+// installed and usable, and the operation has mined — there is nothing to roll
+// back. What matters is that the stranded entity stops being invisible, so it
+// is marked and logged for the sweep that #717 tracks.
+func VerifySupersededTeardown(
+	ctx context.Context,
+	db storage.Storage,
+	verify TeardownVerifier,
+	superseded *model.SessionPolicy,
+	logger sdklogging.Logger,
+) error {
+	if verify == nil || superseded == nil || superseded.Runner == nil {
+		return nil // no chain client: skip honestly rather than assume success
+	}
+
+	cleared, err := verify(ctx, *superseded.Runner, superseded.EntityID)
+	if err != nil {
+		// Unknown is not cleared. Say so rather than recording either answer.
+		if logger != nil {
+			logger.Warn("could not verify that a replaced grant was torn down on chain",
+				"policy", superseded.ID, "runner", superseded.Runner.Hex(),
+				"entity", superseded.EntityID, "error", err)
+		}
+		return err
+	}
+	if cleared {
+		return nil
+	}
+
+	// Mined, and cleared nothing. The entity is still live authority on the
+	// account even though storage has it revoked.
+	if logger != nil {
+		logger.Error("a replaced grant is still installed on chain after its teardown mined",
+			"policy", superseded.ID, "runner", superseded.Runner.Hex(),
+			"entity", superseded.EntityID,
+			"hint", "the account catches onUninstall reverts and strands module state; this entity needs an explicit uninstall")
+	}
+	return fmt.Errorf("entity %d on %s survived its teardown (policy %s)",
+		superseded.EntityID, superseded.Runner.Hex(), superseded.ID)
 }

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -469,7 +469,8 @@ func recheckSupersededGrant(db storage.Storage, prepared *PreparedSessionGrant, 
 type TeardownVerifier func(ctx context.Context, chainID int64, account common.Address, entity uint32) (cleared bool, err error)
 
 // VerifySupersededTeardown checks that the entity a replacement was supposed
-// to remove is actually gone, and records the answer on the superseded policy.
+// to remove is actually gone on chain, and returns an error when the check
+// fails or is inconclusive. It logs that outcome; it does not write storage.
 //
 // This is not belt-and-braces. A replace batch that mines proves the operation
 // executed, NOT that the uninstall did anything: the account catches a hook
@@ -480,10 +481,11 @@ type TeardownVerifier func(ctx context.Context, chainID int64, account common.Ad
 // report an entity revoked on the strength of a transaction that removed
 // nothing.
 //
-// A failed verification does not error the caller. The new grant is already
-// installed and usable, and the operation has mined — there is nothing to roll
-// back. What matters is that the stranded entity stops being invisible, so it
-// is marked and logged for the sweep that #717 tracks.
+// Callers on the send path must not fail the operation on this error: the new
+// grant is already installed and usable, and there is nothing to roll back.
+// Logging here is what makes a stranded entity visible until the #717 sweep
+// can mark and clear leftovers. db is reserved for that mark and is unused
+// today.
 func VerifySupersededTeardown(
 	ctx context.Context,
 	db storage.Storage,
@@ -491,13 +493,14 @@ func VerifySupersededTeardown(
 	superseded *model.SessionPolicy,
 	logger sdklogging.Logger,
 ) error {
+	_ = db // reserved for marking stranded entities once the #717 sweep lands
 	if verify == nil || superseded == nil || superseded.Runner == nil {
 		return nil // no chain client: skip honestly rather than assume success
 	}
 
 	cleared, err := verify(ctx, superseded.ChainID, *superseded.Runner, superseded.EntityID)
 	if err != nil {
-		// Unknown is not cleared. Say so rather than recording either answer.
+		// Unknown is not cleared. Say so rather than treating the read as success.
 		if logger != nil {
 			logger.Warn("could not verify that a replaced grant was torn down on chain",
 				"policy", superseded.ID, "runner", superseded.Runner.Hex(),

--- a/core/taskengine/session_grant_applied_test.go
+++ b/core/taskengine/session_grant_applied_test.go
@@ -41,7 +41,7 @@ func TestResolverMarksAppliedAndStopsAttachingTheInstall(t *testing.T) {
 	engine, user, wallet, stored := storedPendingGrant(t)
 	controllerKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	resolver := NewSessionResolver(engine.db, testResolverKey(controllerKey))
+	resolver := NewSessionResolver(engine.db, testResolverKey(controllerKey), nil)
 
 	// First resolution: pending grant → deferred install attached, with the
 	// callback that will record its landing.

--- a/core/taskengine/session_grant_replace_live_test.go
+++ b/core/taskengine/session_grant_replace_live_test.go
@@ -1,0 +1,323 @@
+//go:build integration
+// +build integration
+
+package taskengine
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// Replacing a grant, end to end, through the code that actually runs in
+// production — PrepareSessionPolicy → SubmitSessionPolicy → a real operation
+// → the resolver's teardown verification.
+//
+// scripts/spike/deferred_replace already proved the MECHANISM composes on
+// Sepolia. It did so with hand-built payloads; this proves the GATEWAY builds
+// the same thing and that the prior entity is genuinely gone afterwards. The
+// two failures it is here to catch are ones no offline test can see: a batch
+// the account rejects, and a batch it accepts while clearing nothing.
+//
+// Behind the `integration` build tag with the rest of the live suite (#727).
+// Each run also consumes two validation entities on its runner, and entities
+// cannot be recycled (#719), so this is an on-demand check rather than a
+// per-PR one even among live tests.
+//
+//	SPIKE-style env: OWNER_EOA, TEST_PRIVATE_KEY, config/test.yaml.
+//	go test ./core/taskengine -run TestGrantReplaceClearsThePriorEntity_Sepolia -v
+func TestGrantReplaceClearsThePriorEntity_Sepolia(t *testing.T) {
+	cfg, err := config.NewConfig(testutil.GetConfigPath(testutil.DefaultConfigPath))
+	require.NoError(t, err, "config/test.yaml must load")
+
+	client, err := ethclient.Dial(cfg.SmartWallet.EthRpcUrl)
+	require.NoError(t, err, "cannot reach the configured RPC; a live test with no chain proves nothing")
+	t.Cleanup(func() { client.Close() })
+
+	chainID, err := client.ChainID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(11155111), chainID.Int64(),
+		"this check is Sepolia-specific; skipping on a misconfigured RPC would report green while proving nothing")
+
+	ownerHex := strings.TrimSpace(os.Getenv("OWNER_EOA"))
+	require.NotEmpty(t, ownerHex, "OWNER_EOA must be set: the grant is authorized by that owner")
+	owner := common.HexToAddress(ownerHex)
+
+	ownerKey := requireOwnerKey(t)
+	require.Equal(t, owner, crypto.PubkeyToAddress(ownerKey.PublicKey),
+		"TEST_PRIVATE_KEY must be OWNER_EOA's key — only the owner can authorize a grant")
+
+	setGlobalFactory(t, cfg.SmartWallet)
+	runner, err := aa.GetSenderAddressMAv2(client, owner, big.NewInt(fixtureSaltGrantReplace))
+	require.NoError(t, err)
+	t.Logf("runner %s (salt %d)", runner.Hex(), fixtureSaltGrantReplace)
+
+	// Operations here are self-funded: the fixture is not wired to the Gas
+	// Manager policy, and pointing a test at it would have production approve
+	// and bill the run.
+	requireFundedRunner(t, cfg.SmartWallet, *runner, big.NewInt(3_000_000_000_000_000)) // 0.003 ETH
+
+	// An account with no code answers every signers() read with zero, so the
+	// entity assertions below would all pass while proving nothing. Deploying
+	// is fixture setup, not this test's subject — fail loudly instead.
+	code, err := client.CodeAt(context.Background(), *runner, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, code,
+		"runner %s is not deployed; deploy it first — an undeployed account reads every entity as clear",
+		runner.Hex())
+
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+	engine := New(db, cfg, nil, testutil.GetLogger())
+	t.Cleanup(engine.Stop)
+	engine.InstallSessionResolver()
+	t.Cleanup(func() { preset.SetSessionResolver(nil) })
+
+	factoryAddr := effectiveFactoryAddr(t, cfg.SmartWallet)
+	require.NoError(t, StoreWallet(db, chainID.Int64(), owner, &model.SmartWallet{
+		Owner: &owner, Address: runner, Factory: &factoryAddr,
+		Salt: big.NewInt(fixtureSaltGrantReplace),
+	}))
+	user := &model.User{Address: owner, SmartAccountAddress: runner}
+	seedEntitiesConsumedOnChain(t, db, client, cfg.SmartWallet, ownerKey, chainID.Int64(), owner, *runner)
+
+	// ── 1. First grant. Nothing installed yet, so the payload is a plain
+	// install and the entity it claims must be free on chain.
+	first := grantThroughEngine(t, engine, user, ownerKey, *runner)
+	require.Nil(t, firstPrepared(t, engine, user).Supersedes,
+		"precondition: nothing installed to supersede")
+	requireEntityClear(t, client, *runner, first.EntityID, true)
+
+	// ── 2. Land it. The install rides this operation, so afterwards the
+	// entity is real and the next grant has something to replace.
+	runOperationUnderGrant(t, engine, user, *runner)
+	requireEntityClear(t, client, *runner, first.EntityID, false)
+	t.Logf("grant %s installed at entity %d", first.ID, first.EntityID)
+
+	// ── 3. Replace it. This is the assertion that matters: the gateway must
+	// now build a batch, not a bare install.
+	prepared := firstPrepared(t, engine, user)
+	require.NotNil(t, prepared.Supersedes, "an installed grant must be superseded on chain too")
+	require.Equal(t, first.EntityID, prepared.Supersedes.EntityID)
+
+	second := submitPrepared(t, engine, user, ownerKey, prepared)
+	require.NotEqual(t, first.EntityID, second.EntityID, "the replacement takes a fresh entity")
+
+	// ── 4. Land the batch, then read the chain. A mined operation is not
+	// evidence of teardown — the account catches onUninstall reverts and
+	// strands module state, which is exactly the failure this test exists for.
+	runOperationUnderGrant(t, engine, user, *runner)
+
+	requireEntityClear(t, client, *runner, first.EntityID, true)
+	requireEntityClear(t, client, *runner, second.EntityID, false)
+	t.Logf("✅ entity %d cleared, entity %d holds the replacement", first.EntityID, second.EntityID)
+
+	// And storage agrees: exactly one usable grant, the new one.
+	usable := usableOn(t, db, owner, *runner)
+	require.Len(t, usable, 1)
+	require.Equal(t, second.ID, usable[0].ID)
+}
+
+// firstPrepared runs the production prepare for a standard grant.
+func firstPrepared(t *testing.T, engine *Engine, user *model.User) *PreparedSessionGrant {
+	t.Helper()
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: *user.SmartAccountAddress, ChainID: 11155111,
+		AgentLabel: "ReplaceLive", Justification: "live replace check",
+		Permissions: livePermissions(),
+	})
+	require.NoError(t, err)
+	return prepared
+}
+
+func submitPrepared(t *testing.T, engine *Engine, user *model.User,
+	ownerKey *ecdsa.PrivateKey, prepared *PreparedSessionGrant) *model.SessionPolicy {
+	t.Helper()
+	sig, err := crypto.Sign(prepared.Digest.Bytes(), ownerKey)
+	require.NoError(t, err)
+	sig[64] += 27
+
+	stored, _, err := engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: *user.SmartAccountAddress, ChainID: 11155111,
+		AgentLabel: "ReplaceLive", Justification: "live replace check",
+		Permissions: livePermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline, sig)
+	require.NoError(t, err)
+	return stored
+}
+
+func grantThroughEngine(t *testing.T, engine *Engine, user *model.User, ownerKey *ecdsa.PrivateKey, runner common.Address) *model.SessionPolicy {
+	t.Helper()
+	return submitPrepared(t, engine, user, ownerKey, firstPrepared(t, engine, user))
+}
+
+// runOperationUnderGrant sends one real operation so a pending grant's
+// deferred action reaches the chain.
+//
+// It must be an operation the grant PERMITS. An ETH transfer to the owner
+// AA23s here: the allowlist hook rejects a target the grant never named, and
+// because the install rides this operation, a rejected call also means the
+// grant never lands. approve() on the allowlisted token is the same shape
+// production uses.
+func runOperationUnderGrant(t *testing.T, engine *Engine, user *model.User, runner common.Address) {
+	t.Helper()
+	// Unique per call, so nothing here can pass on a previous run's allowance.
+	approveAmount := big.NewInt(time.Now().Unix())
+	result, err := engine.RunNodeImmediately("contractWrite", map[string]interface{}{
+		"contractAddress": SEPOLIA_USDC,
+		"contractAbi":     approveABIForReplace(),
+		// Post-G5 the node itself must name its chain; only the RPC entry
+		// stamps one from the request, and this calls the engine directly.
+		"chainId": int64(11155111),
+		"methodCalls": []interface{}{
+			map[string]interface{}{
+				"methodName":   "approve",
+				"methodParams": []interface{}{SEPOLIA_SWAPROUTER, approveAmount.String()},
+			},
+		},
+	}, map[string]interface{}{
+		"settings": map[string]interface{}{
+			"runner": runner.Hex(), "smartWallet": runner.Hex(), "chain_id": int64(11155111),
+		},
+	}, user, false)
+	require.NoError(t, err, "the operation carrying the grant must not error")
+	require.NotNil(t, result)
+	if success, ok := result["success"].(bool); ok && !success {
+		t.Fatalf("operation failed: %v", result["error"])
+	}
+	// The install applies during validation; give the receipt path a moment to
+	// record it before the next grant reads the chain.
+	time.Sleep(2 * time.Second)
+}
+
+// requireEntityClear asserts an entity's on-chain occupancy. This is the only
+// honest check: the receipt says the operation ran, not that the uninstall
+// removed anything.
+func requireEntityClear(t *testing.T, client *ethclient.Client, runner common.Address, entity uint32, wantClear bool) {
+	t.Helper()
+	signer, err := aa.EntitySignerOnChain(context.Background(), client, runner, entity)
+	require.NoError(t, err, "reading entity %d", entity)
+	if wantClear {
+		require.Equal(t, common.Address{}, signer,
+			"entity %d must be clear — a surviving entity is live authority the product believes is revoked", entity)
+		return
+	}
+	require.NotEqual(t, common.Address{}, signer, "entity %d must be installed", entity)
+}
+
+// livePermissions is a production-shaped grant: allowlist + spend cap + time
+// range, which is what makes this test meaningful. A bare global grant carries
+// no hooks, and hooks are exactly what a replace has to tear down — the stale
+// spend cap this whole change exists to remove.
+func livePermissions() SessionPermissions {
+	token := common.HexToAddress(SEPOLIA_USDC)
+	return SessionPermissions{
+		AllowedActions: []model.AllowedAction{
+			{Target: &token, Selectors: []string{"0x095ea7b3"}}, // approve(address,uint256)
+		},
+		// Large enough that repeated runs never exhaust it; the cap is here to
+		// give the entity hook state to strand, not to be tested for itself.
+		SpendCap: &model.ERC20SpendCap{
+			Token: &token, Amount: "1000000000000", GrantedCap: "1000000000000",
+		},
+		ValidUntilMs: time.Now().Add(7 * 24 * time.Hour).UnixMilli(),
+	}
+}
+
+func approveABIForReplace() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"inputs": []interface{}{
+				map[string]interface{}{"name": "spender", "type": "address"},
+				map[string]interface{}{"name": "amount", "type": "uint256"},
+			},
+			"name":            "approve",
+			"outputs":         []interface{}{map[string]interface{}{"name": "", "type": "bool"}},
+			"stateMutability": "nonpayable",
+			"type":            "function",
+		},
+	}
+}
+
+// seedEntitiesConsumedOnChain makes storage reflect the entities this runner
+// has already spent, so the allocator does not hand one out twice.
+//
+// NextSessionEntityID allocates from storage alone — max(entityID)+1 across the
+// owner's policies, revoked ones included. That is correct in production, where
+// a revoked policy is retained precisely so its entity is never reissued. It
+// must never be reissued, and teardown is what makes that non-obvious: a
+// torn-down entity reads clear on every module (signer, allowlist, spend cap,
+// time range) while its EntryPoint deferred nonce key keeps its sequence
+// forever. PrepareSessionGrant signs a carrier nonce at sequence 0 — knowable
+// in advance only for a never-used key — so a reissued entity signs a nonce the
+// EntryPoint already consumed, and the operation AA23s during validation with
+// nothing on chain to explain why. See aa.EntryPointNonce.
+//
+// A live test starts from an empty database against a chain that remembers, so
+// it restores that invariant itself. The record it writes is a real grant built
+// by the production builder and signed by the real owner, marked revoked — the
+// same thing storage would hold had the earlier run been this gateway.
+func seedEntitiesConsumedOnChain(
+	t *testing.T,
+	db storage.Storage,
+	client *ethclient.Client,
+	swCfg *config.SmartWalletConfig,
+	ownerKey *ecdsa.PrivateKey,
+	chainID int64,
+	owner, runner common.Address,
+) {
+	t.Helper()
+
+	highest := uint32(0)
+	for entity := uint32(1); entity <= 32; entity++ {
+		sequence, err := aa.EntityDeferredNonceSequence(context.Background(), client, runner, entity)
+		require.NoError(t, err, "reading the deferred nonce sequence of entity %d", entity)
+
+		signer, err := aa.EntitySignerOnChain(context.Background(), client, runner, entity)
+		require.NoError(t, err)
+
+		if sequence != 0 || signer != (common.Address{}) {
+			highest = entity
+		}
+	}
+	if highest == 0 {
+		return
+	}
+
+	// The allocator takes the maximum, so one record at the highest spent id
+	// covers everything below it.
+	controller := crypto.PubkeyToAddress(swCfg.ControllerPrivateKey.PublicKey)
+	prepared, err := PrepareSessionGrant(db, chainID, controller, "seed-entities-consumed-on-chain",
+		SessionGrantRequest{
+			Owner: owner, Wallet: runner,
+			AgentLabel:              "seed",
+			AllowSelfAdministration: true,
+		})
+	require.NoError(t, err)
+	prepared.Policy.EntityID = highest
+	prepared.Policy.Status = model.SessionPolicyRevoked
+
+	sig, err := crypto.Sign(prepared.Digest.Bytes(), ownerKey)
+	require.NoError(t, err)
+	sig[64] += 27
+	prepared.Policy.Grant.OwnerSignature = sig
+
+	require.NoError(t, StoreSessionPolicy(db, prepared.Policy))
+	t.Logf("entities 1..%d are already spent on chain; allocating above them", highest)
+}

--- a/core/taskengine/session_grant_teardown_test.go
+++ b/core/taskengine/session_grant_teardown_test.go
@@ -1,0 +1,84 @@
+package taskengine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// A replace batch that mines proves the operation executed, not that the
+// uninstall did anything: the account catches a hook module's onUninstall
+// revert and strands the state. On Sepolia the two outcomes were
+// indistinguishable from a receipt — 601,275 gas with the entity still holding
+// its signer and full spend cap, against 636,341 gas and a clean teardown.
+//
+// So these tests pin the one rule that follows: never report an entity revoked
+// on the strength of a transaction.
+
+func teardownFixture(t *testing.T) (storage.Storage, *model.SessionPolicy) {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	owner := common.HexToAddress("0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557")
+	runner := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	return db, &model.SessionPolicy{
+		ID: "01supersededaaaaaaaaaaaaaa", Owner: &owner, Runner: &runner,
+		ChainID: testPolicyChain, EntityID: 4, Status: model.SessionPolicyRevoked,
+	}
+}
+
+func TestTeardownVerificationAcceptsAClearedEntity(t *testing.T) {
+	db, superseded := teardownFixture(t)
+	verify := func(context.Context, common.Address, uint32) (bool, error) { return true, nil }
+
+	require.NoError(t, VerifySupersededTeardown(context.Background(), db, verify, superseded, nil))
+}
+
+// The failure the spike surfaced: the operation mined and the entity survived.
+func TestTeardownVerificationRejectsASurvivingEntity(t *testing.T) {
+	db, superseded := teardownFixture(t)
+	verify := func(context.Context, common.Address, uint32) (bool, error) { return false, nil }
+
+	err := VerifySupersededTeardown(context.Background(), db, verify, superseded, nil)
+	require.Error(t, err, "a surviving entity is live authority and must not pass silently")
+	require.Contains(t, err.Error(), "survived its teardown")
+	require.Contains(t, err.Error(), superseded.ID, "the error must name the policy to chase")
+}
+
+// Unknown is not cleared. A transient RPC failure must not read as success —
+// that would report an entity revoked while it is still spendable.
+func TestTeardownVerificationTreatsAReadFailureAsUnverified(t *testing.T) {
+	db, superseded := teardownFixture(t)
+	verify := func(context.Context, common.Address, uint32) (bool, error) {
+		return false, fmt.Errorf("rpc unavailable")
+	}
+
+	err := VerifySupersededTeardown(context.Background(), db, verify, superseded, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rpc unavailable")
+}
+
+// A process with no chain client skips verification rather than assuming it
+// passed. Silence is honest; a fabricated success is not.
+func TestTeardownVerificationSkipsWithoutAChainClient(t *testing.T) {
+	db, superseded := teardownFixture(t)
+	require.NoError(t, VerifySupersededTeardown(context.Background(), db, nil, superseded, nil))
+}
+
+// Nothing was superseded — nothing to verify.
+func TestTeardownVerificationIgnoresAFirstGrant(t *testing.T) {
+	db, _ := teardownFixture(t)
+	called := false
+	verify := func(context.Context, common.Address, uint32) (bool, error) { called = true; return true, nil }
+
+	require.NoError(t, VerifySupersededTeardown(context.Background(), db, verify, nil, nil))
+	require.False(t, called, "a first grant removes nothing, so nothing is read")
+}

--- a/core/taskengine/session_grant_teardown_test.go
+++ b/core/taskengine/session_grant_teardown_test.go
@@ -37,7 +37,7 @@ func teardownFixture(t *testing.T) (storage.Storage, *model.SessionPolicy) {
 
 func TestTeardownVerificationAcceptsAClearedEntity(t *testing.T) {
 	db, superseded := teardownFixture(t)
-	verify := func(context.Context, common.Address, uint32) (bool, error) { return true, nil }
+	verify := func(context.Context, int64, common.Address, uint32) (bool, error) { return true, nil }
 
 	require.NoError(t, VerifySupersededTeardown(context.Background(), db, verify, superseded, nil))
 }
@@ -45,7 +45,7 @@ func TestTeardownVerificationAcceptsAClearedEntity(t *testing.T) {
 // The failure the spike surfaced: the operation mined and the entity survived.
 func TestTeardownVerificationRejectsASurvivingEntity(t *testing.T) {
 	db, superseded := teardownFixture(t)
-	verify := func(context.Context, common.Address, uint32) (bool, error) { return false, nil }
+	verify := func(context.Context, int64, common.Address, uint32) (bool, error) { return false, nil }
 
 	err := VerifySupersededTeardown(context.Background(), db, verify, superseded, nil)
 	require.Error(t, err, "a surviving entity is live authority and must not pass silently")
@@ -57,7 +57,7 @@ func TestTeardownVerificationRejectsASurvivingEntity(t *testing.T) {
 // that would report an entity revoked while it is still spendable.
 func TestTeardownVerificationTreatsAReadFailureAsUnverified(t *testing.T) {
 	db, superseded := teardownFixture(t)
-	verify := func(context.Context, common.Address, uint32) (bool, error) {
+	verify := func(context.Context, int64, common.Address, uint32) (bool, error) {
 		return false, fmt.Errorf("rpc unavailable")
 	}
 
@@ -77,7 +77,7 @@ func TestTeardownVerificationSkipsWithoutAChainClient(t *testing.T) {
 func TestTeardownVerificationIgnoresAFirstGrant(t *testing.T) {
 	db, _ := teardownFixture(t)
 	called := false
-	verify := func(context.Context, common.Address, uint32) (bool, error) { called = true; return true, nil }
+	verify := func(context.Context, int64, common.Address, uint32) (bool, error) { called = true; return true, nil }
 
 	require.NoError(t, VerifySupersededTeardown(context.Background(), db, verify, nil, nil))
 	require.False(t, called, "a first grant removes nothing, so nothing is read")

--- a/core/taskengine/session_grant_test.go
+++ b/core/taskengine/session_grant_test.go
@@ -80,7 +80,7 @@ func TestSessionGrantRoundTrip(t *testing.T) {
 			return nil, fmt.Errorf("unexpected signer %s", a.Hex())
 		}
 		return signerKey, nil
-	})
+	}, nil)
 	auth, err := resolve(spChain, owner, spWallet)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)

--- a/core/taskengine/session_grant_testhelper_test.go
+++ b/core/taskengine/session_grant_testhelper_test.go
@@ -176,7 +176,7 @@ func installSessionResolver(
 			return nil, fmt.Errorf("no key for session signer %s", a.Hex())
 		}
 		return swCfg.ControllerPrivateKey, nil
-	}))
+	}, nil))
 	t.Cleanup(func() { preset.SetSessionResolver(nil) })
 }
 

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -335,3 +335,40 @@ func controllerSessionSigner(cfg *config.Config) func(common.Address) (*ecdsa.Pr
 		return cfg.SmartWallet.ControllerPrivateKey, nil
 	}
 }
+
+// supersededOnChainGrant returns the runner's grant whose install has actually
+// REACHED THE CHAIN, so a replacement can carry its teardown.
+//
+// Only an applied grant qualifies. A pending one has no on-chain entity — its
+// install is still riding an operation, or never will — so batching an
+// uninstall for it would tear down something that does not exist. Superseding
+// a pending grant stays what #716 made it: a storage-only revoke.
+//
+// ambiguous reports that the runner carries MORE THAN ONE installed grant, in
+// which case no policy is returned and the caller must NOT batch a teardown.
+// This is the deliberate half. #716 gave granting a self-healing property — a
+// wallet stuck with stacked usable grants is repaired by granting again — and
+// refusing here would take that away precisely from the wallets that need it
+// most. A replacement can only remove one entity, so it removes none, the
+// storage-level supersede still collapses the set to one usable grant, and the
+// on-chain leftovers stay exactly as they were. Degraded, not broken: no worse
+// than before replacement carried teardown at all.
+//
+// Clearing those leftovers needs an N-way batch or a sweep, tracked on #717.
+func supersededOnChainGrant(db storage.Storage, chainID int64, owner, runner common.Address) (policy *model.SessionPolicy, ambiguous bool, err error) {
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	if err != nil {
+		return nil, false, err
+	}
+	var found *model.SessionPolicy
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != runner || !p.Usable() || !p.Grant.Applied() {
+			continue
+		}
+		if found != nil {
+			return nil, true, nil
+		}
+		found = p
+	}
+	return found, false, nil
+}

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
@@ -9,7 +10,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
@@ -234,7 +237,31 @@ func NextSessionEntityID(db storage.Storage, chainID int64, owner, wallet common
 // explicitly; tests that need one install their own scoped to their own
 // database.
 func (n *Engine) InstallSessionResolver() {
-	preset.SetSessionResolver(NewSessionResolver(n.db, controllerSessionSigner(n.config)))
+	preset.SetSessionResolver(NewSessionResolver(n.db, controllerSessionSigner(n.config), n.teardownVerifier()))
+}
+
+// teardownVerifier reads a validation entity's signer on the chain the grant
+// lives on. Dialled per check rather than held open: verification runs once
+// per replacement, and the alternative is a pool of long-lived clients for
+// every configured chain to serve a call that happens rarely.
+func (n *Engine) teardownVerifier() TeardownVerifier {
+	return func(ctx context.Context, chainID int64, account common.Address, entity uint32) (bool, error) {
+		swCfg := n.ResolveSmartWalletConfig(chainID)
+		if swCfg == nil || swCfg.EthRpcUrl == "" {
+			return false, fmt.Errorf("no RPC configured for chain %d", chainID)
+		}
+		client, err := ethclient.DialContext(ctx, swCfg.EthRpcUrl)
+		if err != nil {
+			return false, fmt.Errorf("dialing chain %d: %w", chainID, err)
+		}
+		defer client.Close()
+
+		signer, err := aa.EntitySignerOnChain(ctx, client, account, entity)
+		if err != nil {
+			return false, err
+		}
+		return signer == (common.Address{}), nil
+	}
 }
 
 // NewSessionResolver builds the resolver the send path consults, backed by
@@ -243,9 +270,16 @@ func (n *Engine) InstallSessionResolver() {
 // signerKeyFor maps a session-signer ADDRESS to its private key. It is a
 // callback rather than a map so key material stays wherever the gateway keeps
 // it and never has to live on this record.
+// verifyTeardown, when supplied, closes the loop on a replacement: after the
+// grant's deferred action reaches the chain it reads back whether the entity
+// the batch was supposed to remove is actually gone. nil disables the check —
+// tests and any process without a chain client skip it honestly rather than
+// assume it passed. See VerifySupersededTeardown for why a receipt is not
+// enough.
 func NewSessionResolver(
 	db storage.Storage,
 	signerKeyFor func(signer common.Address) (*ecdsa.PrivateKey, error),
+	verifyTeardown TeardownVerifier,
 ) preset.SessionResolver {
 	return func(chainID int64, owner, wallet common.Address) (*preset.SessionAuthorization, error) {
 		policy, err := ActiveSessionPolicyForWallet(db, chainID, owner, wallet)
@@ -297,8 +331,33 @@ func NewSessionResolver(
 			}
 			policyID, policyChain, policyOwner := policy.ID, policy.ChainID, *policy.Owner
 			policyRunner := *policy.Runner
+			// Captured now, from the payload the owner signed: if this grant
+			// replaced an installed one, its batch carries that entity's
+			// uninstall, and the entity it names is what must be verified gone.
+			replacedEntity, replacedSomething, entityErr := aa.UninstalledEntityWithin(policy.Grant.InstallCall)
+			if entityErr != nil {
+				return nil, fmt.Errorf("session policy %s: reading the teardown target: %w", policy.ID, entityErr)
+			}
 			auth.OnApplied = func(userOpHash string) error {
-				return MarkSessionGrantAppliedByID(db, policyChain, policyOwner, policyRunner, policyID, userOpHash)
+				if err := MarkSessionGrantAppliedByID(db, policyChain, policyOwner, policyRunner, policyID, userOpHash); err != nil {
+					return err
+				}
+				if !replacedSomething || verifyTeardown == nil {
+					return nil
+				}
+				// The batch has mined, which says the operation ran — not that
+				// the uninstall did anything. A failed check does not fail the
+				// send: the new grant is installed and there is nothing to roll
+				// back. It makes a stranded entity visible instead of assumed.
+				replaced := &model.SessionPolicy{
+					ID: policyID, ChainID: policyChain, Runner: &policyRunner, EntityID: replacedEntity,
+				}
+				if err := VerifySupersededTeardown(context.Background(), db, verifyTeardown, replaced, globalLogger); err != nil {
+					if globalLogger != nil {
+						globalLogger.Warn("replacement teardown unverified", "policy", policyID, "error", err)
+					}
+				}
+				return nil
 			}
 		}
 		return auth, nil

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -19,6 +20,12 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
+
+// teardownVerifyTimeout bounds the post-apply chain read that checks a
+// replaced entity is gone. OnApplied must not hang on a slow or stuck RPC:
+// the new grant is already installed, verification is best-effort, and a
+// hung dial would stall the send path's applied callback.
+const teardownVerifyTimeout = 10 * time.Second
 
 // Session-policy storage and the resolver that connects it to the send path.
 //
@@ -348,15 +355,14 @@ func NewSessionResolver(
 				// The batch has mined, which says the operation ran — not that
 				// the uninstall did anything. A failed check does not fail the
 				// send: the new grant is installed and there is nothing to roll
-				// back. It makes a stranded entity visible instead of assumed.
+				// back. VerifySupersededTeardown logs the outcome; we only
+				// bound the RPC so a hung dial cannot stall OnApplied.
 				replaced := &model.SessionPolicy{
 					ID: policyID, ChainID: policyChain, Runner: &policyRunner, EntityID: replacedEntity,
 				}
-				if err := VerifySupersededTeardown(context.Background(), db, verifyTeardown, replaced, globalLogger); err != nil {
-					if globalLogger != nil {
-						globalLogger.Warn("replacement teardown unverified", "policy", policyID, "error", err)
-					}
-				}
+				ctx, cancel := context.WithTimeout(context.Background(), teardownVerifyTimeout)
+				defer cancel()
+				_ = VerifySupersededTeardown(ctx, db, verifyTeardown, replaced, globalLogger)
 				return nil
 			}
 		}

--- a/core/taskengine/session_policy_supersede_test.go
+++ b/core/taskengine/session_policy_supersede_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
@@ -400,4 +402,138 @@ func TestApplyingAGrantWaitsForTheRunnersWriteLock(t *testing.T) {
 	}
 
 	require.Len(t, usableOn(t, db, owner, wallet), 1)
+}
+
+// A replacement carries the prior grant's teardown, so one owner signature
+// makes the replacement true on chain as well as in storage (#717). Proven on
+// Sepolia; these tests pin the payload the gateway builds.
+
+// installValidationCount reports how many installValidation calls a deferred
+// payload carries, and whether it is a batch.
+func deferredShape(t *testing.T, deferred []byte) (batch bool, installs, uninstalls int) {
+	t.Helper()
+	installSel := crypto.Keccak256([]byte("installValidation(bytes25,bytes4[],bytes,bytes[])"))[:4]
+	uninstallSel := crypto.Keccak256([]byte("uninstallValidation(bytes24,bytes,bytes[])"))[:4]
+
+	if len(deferred) >= 4 && string(deferred[:4]) == string(installSel) {
+		return false, 1, 0
+	}
+	_, _, datas, err := aa.UnpackExecuteCalldata(deferred)
+	require.NoError(t, err, "a non-install deferred payload must be an unpackable batch")
+	for _, d := range datas {
+		if len(d) < 4 {
+			continue
+		}
+		switch string(d[:4]) {
+		case string(installSel):
+			installs++
+		case string(uninstallSel):
+			uninstalls++
+		}
+	}
+	return true, installs, uninstalls
+}
+
+// A first grant has nothing installed to remove, so it stays a bare install —
+// the payload shape, and therefore the digest the owner signs, is unchanged
+// from before this feature.
+func TestFirstGrantCarriesNoTeardown(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot",
+		Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, prepared.Supersedes, "nothing installed, nothing to supersede")
+
+	batch, _, _ := deferredShape(t, prepared.Policy.Grant.InstallCall)
+	require.False(t, batch, "a first grant is a plain installValidation")
+	_ = ownerKey
+}
+
+// A grant that is only PENDING has no on-chain entity, so replacing it must
+// not batch a teardown for something that was never installed.
+func TestReplacingAPendingGrantCarriesNoTeardown(t *testing.T) {
+	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	first, _ := grantOn(t, engine, ownerKey, owner, wallet)
+	require.Equal(t, model.SessionPolicyPending, first.Status, "precondition: not applied")
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot",
+		Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, prepared.Supersedes,
+		"a pending grant's install never reached the chain — there is nothing to uninstall")
+	batch, _, _ := deferredShape(t, prepared.Policy.Grant.InstallCall)
+	require.False(t, batch)
+}
+
+// The feature: replacing an APPLIED grant batches its teardown into the same
+// owner signature. Install first — the operation carrying this is validated by
+// the new entity, which must exist before the outer validation runs.
+func TestReplacingAnAppliedGrantBatchesItsTeardown(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	first, _ := grantOn(t, engine, ownerKey, owner, wallet)
+	require.NoError(t, MarkSessionGrantApplied(db, first, "0xapplied"))
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot",
+		Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, prepared.Supersedes, "an installed grant must be superseded on chain too")
+	require.Equal(t, first.ID, prepared.Supersedes.PolicyID)
+	require.Equal(t, first.EntityID, prepared.Supersedes.EntityID)
+
+	batch, installs, uninstalls := deferredShape(t, prepared.Policy.Grant.InstallCall)
+	require.True(t, batch, "a replacement is a batch")
+	require.Equal(t, 1, installs)
+	require.Equal(t, 1, uninstalls)
+
+	// The stored payload must remain replayable as-is: the resolver rebuilds
+	// the signed data from it, so the batch — not the bare install — is what
+	// the owner's signature covers.
+	install, err := aa.InstallValidationWithin(prepared.Policy.Grant.InstallCall)
+	require.NoError(t, err)
+	require.NotEqual(t, prepared.Policy.Grant.InstallCall, install,
+		"the stored call is the batch; the install is inside it")
+}
+
+// The regression this nearly shipped: #716 made granting SELF-HEALING for a
+// wallet stuck with stacked grants. A replacement can only remove one entity,
+// so a stacked wallet must fall back to install-only rather than refuse —
+// otherwise the wallets most in need of repair are the ones that cannot be.
+func TestStackedInstalledGrantsStillAllowGranting(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+
+	for _, id := range []string{"01stackedaaaaaaaaaaaaaaaaa", "01stackedbbbbbbbbbbbbbbbbb"} {
+		seedUsablePolicy(t, db, owner, wallet, id, uint32(len(id)%3+1))
+	}
+	require.Len(t, usableOn(t, db, owner, wallet), 2, "precondition: the broken state")
+
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain, AgentLabel: "TradingBot",
+		Permissions: testPermissions(),
+	})
+	require.NoError(t, err, "a stacked wallet must still be grantable — that is how it gets repaired")
+	require.Nil(t, prepared.Supersedes,
+		"with two installed grants a replacement removes neither; the leftovers stay on chain")
+	batch, _, _ := deferredShape(t, prepared.Policy.Grant.InstallCall)
+	require.False(t, batch)
+
+	// And the storage-level repair from #716 still lands.
+	fresh, superseded := grantOn(t, engine, ownerKey, owner, wallet)
+	require.Len(t, superseded, 2)
+	usable := usableOn(t, db, owner, wallet)
+	require.Len(t, usable, 1)
+	require.Equal(t, fresh.ID, usable[0].ID)
 }

--- a/core/taskengine/session_policy_test.go
+++ b/core/taskengine/session_policy_test.go
@@ -65,7 +65,7 @@ func TestSessionResolverReturnsTheWalletsGrant(t *testing.T) {
 		t.Fatalf("StoreSessionPolicy: %v", err)
 	}
 
-	resolve := NewSessionResolver(db, keyFor)
+	resolve := NewSessionResolver(db, keyFor, nil)
 	auth, err := resolve(spChain, spOwner, spWallet)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -113,7 +113,7 @@ func TestSessionResolverDoesNotReplayAnAppliedGrant(t *testing.T) {
 		t.Fatalf("StoreSessionPolicy: %v", err)
 	}
 
-	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	auth, err := NewSessionResolver(db, keyFor, nil)(spChain, spOwner, spWallet)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestSessionResolverNoGrant(t *testing.T) {
 	db := testutil.TestMustDB()
 	defer storage.Destroy(db.(*storage.BadgerStorage))
 	keyFor, _ := spKeyFor(t)
-	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	auth, err := NewSessionResolver(db, keyFor, nil)(spChain, spOwner, spWallet)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestRevokedGrantIsNotUsableButStillConsumesItsEntity(t *testing.T) {
 		t.Fatalf("StoreSessionPolicy: %v", err)
 	}
 
-	auth, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet)
+	auth, err := NewSessionResolver(db, keyFor, nil)(spChain, spOwner, spWallet)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestTwoUsableGrantsOnOneWalletIsRefused(t *testing.T) {
 			t.Fatalf("StoreSessionPolicy: %v", err)
 		}
 	}
-	if _, err := NewSessionResolver(db, keyFor)(spChain, spOwner, spWallet); err == nil {
+	if _, err := NewSessionResolver(db, keyFor, nil)(spChain, spOwner, spWallet); err == nil {
 		t.Error("expected a refusal when a wallet has two usable grants")
 	}
 }

--- a/model/session_policy.go
+++ b/model/session_policy.go
@@ -81,8 +81,15 @@ type ERC20SpendCap struct {
 
 // SessionGrantAuthorization is the owner's signed deferred action.
 type SessionGrantAuthorization struct {
-	// InstallCall is the exact installValidation calldata the signature
-	// commits to.
+	// InstallCall is the exact deferred calldata the signature commits to, and
+	// must be re-encoded verbatim — the resolver rebuilds the signed payload
+	// from it, so any difference invalidates the owner's signature.
+	//
+	// Usually installValidation. When the grant REPLACES one that was already
+	// installed on chain, it is an executeBatch carrying that install AND the
+	// prior entity's uninstall, so a single owner signature makes the
+	// replacement true on both sides (#717). Readers that want the install
+	// alone must unwrap the batch — see aa.InstallValidationWithin.
 	InstallCall []byte `json:"install_call"`
 
 	// CarrierNonce is the FULL 256-bit nonce of the operation that will carry

--- a/scripts/fixture_wallet/main.go
+++ b/scripts/fixture_wallet/main.go
@@ -1,0 +1,277 @@
+// Fixture-wallet setup for the live Sepolia suite: deploy a runner, fund it, or
+// report what its validation entities hold.
+//
+//	go run ./scripts/fixture_wallet -salt 13            # report
+//	go run ./scripts/fixture_wallet -salt 13 -deploy
+//	go run ./scripts/fixture_wallet -salt 13 -fund 0.03
+//
+// Two things a live test cannot do for itself:
+//
+// Deploy. A wallet normally deploys via initCode on its first UserOp, but a
+// fixture wants to be deployed BEFORE the test, so the test measures a grant
+// replace rather than a first-deployment path. An undeployed account also
+// answers every module read with zero, which makes "this entity is free" look
+// true of an account that cannot tell you anything.
+//
+// Fund. Each live replace run costs roughly 0.0036 ETH self-funded, and a plain
+// 21000-gas transfer to a smart account reverts — its receive() needs more.
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "\nDEPLOY FAILED: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	saltArg := flag.String("salt", "", "fixture salt (see fixtureSalt* in session_fixture_permissions_test.go)")
+	doDeploy := flag.Bool("deploy", false, "deploy the account if it has no code")
+	fundEth := flag.String("fund", "", "top the runner up by this many ETH")
+	flag.Parse()
+
+	if *saltArg == "" {
+		return fmt.Errorf("-salt is required")
+	}
+	salt, ok := new(big.Int).SetString(*saltArg, 10)
+	if !ok {
+		return fmt.Errorf("-salt %q is not a number", *saltArg)
+	}
+
+	cfg, err := config.NewConfig("config/test.yaml")
+	if err != nil {
+		return fmt.Errorf("loading config/test.yaml: %w", err)
+	}
+	client, err := ethclient.Dial(cfg.SmartWallet.EthRpcUrl)
+	if err != nil {
+		return fmt.Errorf("dialing RPC: %w", err)
+	}
+	defer client.Close()
+
+	keyHex := strings.TrimPrefix(strings.TrimSpace(os.Getenv("TEST_PRIVATE_KEY")), "0x")
+	key, err := crypto.HexToECDSA(keyHex)
+	if err != nil {
+		return fmt.Errorf("TEST_PRIVATE_KEY: %w", err)
+	}
+	owner := crypto.PubkeyToAddress(key.PublicKey)
+
+	aa.SetFactoryAddress(cfg.SmartWallet.FactoryAddress)
+	factory, err := aa.EffectiveFactory(cfg.SmartWallet)
+	if err != nil {
+		return fmt.Errorf("resolving effective factory: %w", err)
+	}
+	sender, err := aa.GetSenderAddressMAv2(client, owner, salt)
+	if err != nil {
+		return fmt.Errorf("deriving sender: %w", err)
+	}
+
+	ctx := context.Background()
+	code, err := client.CodeAt(ctx, *sender, nil)
+	if err != nil {
+		return fmt.Errorf("reading code at %s: %w", sender.Hex(), err)
+	}
+	balance, err := client.BalanceAt(ctx, *sender, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("owner   %s\nfactory %s\nsalt    %s\nsender  %s\n  code    %d bytes\n  balance %s wei\n",
+		owner.Hex(), factory.Hex(), salt, sender.Hex(), len(code), balance)
+
+	if len(code) > 0 {
+		if err := reportEntities(ctx, client, *sender); err != nil {
+			return err
+		}
+	}
+
+	if *fundEth != "" {
+		if err := fund(ctx, client, key, *sender, *fundEth); err != nil {
+			return err
+		}
+	}
+	if !*doDeploy {
+		if len(code) == 0 {
+			fmt.Println("\nnot deployed — re-run with -deploy")
+		}
+		return nil
+	}
+	if len(code) > 0 {
+		fmt.Println("\nalready deployed — nothing to do")
+		return nil
+	}
+
+	deployFactory, factoryData, err := aa.DeriveInitCodeAuto(owner, factory, salt)
+	if err != nil {
+		return fmt.Errorf("building init code: %w", err)
+	}
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+	nonce, err := client.PendingNonceAt(ctx, owner)
+	if err != nil {
+		return err
+	}
+	tip, err := client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	head, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	feeCap := new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+
+	gas, err := client.EstimateGas(ctx, ethereumCallMsg(owner, deployFactory, factoryData))
+	if err != nil {
+		return fmt.Errorf("estimating deploy gas: %w", err)
+	}
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID: chainID, Nonce: nonce, To: &deployFactory,
+		Gas: gas * 12 / 10, GasFeeCap: feeCap, GasTipCap: tip, Data: factoryData,
+	})
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	if err != nil {
+		return err
+	}
+	if err := client.SendTransaction(ctx, signed); err != nil {
+		return fmt.Errorf("sending deploy tx: %w", err)
+	}
+	fmt.Printf("\ndeploy tx https://sepolia.etherscan.io/tx/%s\n", signed.Hash().Hex())
+
+	receipt, err := waitMined(ctx, client, signed.Hash())
+	if err != nil {
+		return err
+	}
+	if receipt.Status != 1 {
+		return fmt.Errorf("deploy reverted in block %d", receipt.BlockNumber)
+	}
+	code, err = client.CodeAt(ctx, *sender, nil)
+	if err != nil {
+		return err
+	}
+	if len(code) == 0 {
+		return fmt.Errorf("tx succeeded but %s still has no code — wrong factory or salt", sender.Hex())
+	}
+	fmt.Printf("✅ deployed %s (%d bytes of code) in block %d\n", sender.Hex(), len(code), receipt.BlockNumber)
+	return nil
+}
+
+func ethereumCallMsg(from, to common.Address, data []byte) ethereum.CallMsg {
+	return ethereum.CallMsg{From: from, To: &to, Data: data}
+}
+
+func waitMined(ctx context.Context, client *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
+	for i := 0; i < 60; i++ {
+		receipt, err := client.TransactionReceipt(ctx, hash)
+		if err == nil {
+			return receipt, nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return nil, fmt.Errorf("deploy tx %s not mined within 3 minutes", hash.Hex())
+}
+
+// fund tops the runner up from the owner EOA.
+func fund(ctx context.Context, client *ethclient.Client, key *ecdsa.PrivateKey, to common.Address, amountEth string) error {
+	f, ok := new(big.Float).SetString(amountEth)
+	if !ok {
+		return fmt.Errorf("-fund %q is not a number", amountEth)
+	}
+	wei, _ := new(big.Float).Mul(f, big.NewFloat(1e18)).Int(nil)
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+	nonce, err := client.PendingNonceAt(ctx, from)
+	if err != nil {
+		return err
+	}
+	tip, err := client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	head, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID: chainID, Nonce: nonce, To: &to, Value: wei,
+		// A smart account's receive() needs more than a plain 21000 transfer,
+		// which reverts at exactly its gas limit with no useful error.
+		Gas:       120000,
+		GasFeeCap: new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2))),
+		GasTipCap: tip,
+	})
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	if err != nil {
+		return err
+	}
+	if err := client.SendTransaction(ctx, signed); err != nil {
+		return err
+	}
+	fmt.Printf("\nfunding %s with %s ETH\nhttps://sepolia.etherscan.io/tx/%s\n", to.Hex(), amountEth, signed.Hash().Hex())
+	receipt, err := waitMined(ctx, client, signed.Hash())
+	if err != nil {
+		return err
+	}
+	if receipt.Status != 1 {
+		return fmt.Errorf("funding tx reverted")
+	}
+	balance, err := client.BalanceAt(ctx, to, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✅ %s now holds %s wei\n", to.Hex(), balance)
+	return nil
+}
+
+// reportEntities prints what each validation entity holds and, just as
+// importantly, whether its deferred nonce has been spent. An entity that reads
+// clear on every module is still unusable once that sequence is non-zero — see
+// aa.EntryPointNonce.
+func reportEntities(ctx context.Context, client *ethclient.Client, account common.Address) error {
+	fmt.Printf("\n%-7s %-44s %s\n", "entity", "signer", "deferredNonceSeq")
+	for entity := uint32(1); entity <= 8; entity++ {
+		signer, err := aa.EntitySignerOnChain(ctx, client, account, entity)
+		if err != nil {
+			return err
+		}
+		sequence, err := aa.EntityDeferredNonceSequence(ctx, client, account, entity)
+		if err != nil {
+			return err
+		}
+		state := ""
+		switch {
+		case signer != (common.Address{}):
+			state = "  ← installed"
+		case sequence != 0:
+			state = "  ← spent; never reissue"
+		}
+		fmt.Printf("%-7d %-44s %d%s\n", entity, signer.Hex(), sequence, state)
+	}
+	return nil
+}

--- a/scripts/spike/deferred_replace/main.go
+++ b/scripts/spike/deferred_replace/main.go
@@ -1,0 +1,526 @@
+// Deferred-replace spike — can one owner signature both install a new grant
+// and remove the one it replaces?
+//
+// EigenLayer-AVS #716 made submitting a grant REPLACE the runner's other
+// usable grants, but only off-chain: the superseded entity and its hooks stay
+// installed until someone signs uninstallValidation. #717 proposes closing
+// that by batching uninstall(prior) + install(new) into the grant's existing
+// deferred action, so replacement means the same thing on both sides with no
+// extra prompt.
+//
+// The results doc §3.6 already probed the adjacent composition and found a
+// hard limit:
+//
+//	U-A  deferred uninstall, OUTER validation = the entity being removed.
+//	     REFUSED — the deferred call removes it mid-validation, so the outer
+//	     validation runs against a validation that no longer exists.
+//	U-B  deferred uninstall, OUTER validation = the owner's fallback.
+//	     MINED — but the owner signs the OP, so revoke is not gaslessly
+//	     pre-signable the way a grant is.
+//
+// #717 is NOT the same arrangement. A replace removes the PRIOR entity while
+// the outer validation is the NEW one — which U-A never tested. That is the
+// open question, and three things have to hold for #717 as written:
+//
+//	Q1  can a deferred action carry executeBatch at all? _handleDeferredAction
+//	    runs a single self-call, and the install must land before the outer
+//	    validation resolves — so the batch order is install-then-uninstall.
+//	    MA v2 also guards self-administration, which is what a batch of two
+//	    account-targeting calls is.
+//	Q2  does removing a DIFFERENT entity mid-validation disturb the outer
+//	    validation, or was U-A specific to removing the validator itself?
+//	Q3  does the prior grant's hook state actually clear? §3.5 warns a
+//	    misrouted onUninstall entry is caught and silently stranded, so the
+//	    only proof is reading module state back — never a successful tx.
+//
+// Probes, in order, each a strict step up from the last:
+//
+//	R-0  control: install-only deferred action, outer = new entity. This is
+//	     today's grant flow (§3.2). PREDICT: mined. If this fails the fixture
+//	     is wrong, not the hypothesis.
+//	R-A  batch install(new)+uninstall(prior), outer = NEW entity. The shape
+//	     #717 asks for — one owner signature, no extra prompt.
+//	     PREDICT: unknown. This is the spike.
+//	R-B  same batch, outer = owner's FALLBACK. The §3.6 U-B arrangement
+//	     applied to a replace. PREDICT: mined, if Q1 holds — but the owner
+//	     signs the op, so it costs a prompt and #717's "no additional owner
+//	     signature" criterion fails even on success.
+//
+// Whichever mines, Q3 is settled by reading back: prior entity's signer must
+// be zero AND its spend cap cleared; new entity's signer must be the
+// controller.
+//
+// Env: SPIKE_OWNER_KEY, SPIKE_CONTROLLER_KEY, SPIKE_BUNDLER_URL,
+//
+//	SPIKE_RPC_URL (opt), SPIKE_SALT (opt, default 9),
+//	SPIKE_TOKEN (opt, default the §3.4 SpikeToken).
+//
+// Run: go run ./scripts/spike/deferred_replace
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/userop"
+)
+
+const (
+	defaultRPC   = "https://ethereum-sepolia-rpc.publicnode.com"
+	defaultToken = "0xaA4D01B75fdEB5fbbD98276EC7755eF71801c2E7"
+	defaultSalt  = 9
+)
+
+var oneToken = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "\nSPIKE FAILED: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func env(name, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
+	raw := strings.TrimPrefix(strings.TrimSpace(os.Getenv(name)), "0x")
+	if raw == "" {
+		return nil, common.Address{}, fmt.Errorf("%s is required", name)
+	}
+	key, err := crypto.HexToECDSA(raw)
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("%s is not a private key: %w", name, err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func run() error {
+	ctx := context.Background()
+
+	ownerKey, owner, err := requireKey("SPIKE_OWNER_KEY")
+	if err != nil {
+		return err
+	}
+	controllerKey, controller, err := requireKey("SPIKE_CONTROLLER_KEY")
+	if err != nil {
+		return err
+	}
+	bundlerURL := strings.TrimSpace(os.Getenv("SPIKE_BUNDLER_URL"))
+	if bundlerURL == "" {
+		return fmt.Errorf("SPIKE_BUNDLER_URL is required")
+	}
+	token := common.HexToAddress(env("SPIKE_TOKEN", defaultToken))
+
+	salt := big.NewInt(defaultSalt)
+	if v := strings.TrimSpace(os.Getenv("SPIKE_SALT")); v != "" {
+		parsed, ok := new(big.Int).SetString(v, 10)
+		if !ok {
+			return fmt.Errorf("SPIKE_SALT %q is not a number", v)
+		}
+		salt = parsed
+	}
+
+	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return fmt.Errorf("dialing chain: %w", err)
+	}
+	defer chain.Close()
+	chainRPC, err := rpc.DialContext(ctx, env("SPIKE_RPC_URL", defaultRPC))
+	if err != nil {
+		return fmt.Errorf("dialing chain rpc: %w", err)
+	}
+	defer chainRPC.Close()
+	bundler, err := rpc.DialContext(ctx, bundlerURL)
+	if err != nil {
+		return fmt.Errorf("dialing bundler: %w", err)
+	}
+	defer bundler.Close()
+
+	chainID, err := chain.ChainID(ctx)
+	if err != nil {
+		return fmt.Errorf("reading chain id: %w", err)
+	}
+	entryPoint := preset.EntryPointV07()
+
+	account, err := aa.GetSenderAddressMAv2(chain, owner, salt)
+	if err != nil {
+		return fmt.Errorf("deriving account: %w", err)
+	}
+
+	fmt.Printf("chain     %s\n", chainID)
+	fmt.Printf("owner     %s\n", owner.Hex())
+	fmt.Printf("controller%s\n", controller.Hex())
+	fmt.Printf("account   %s (salt %s)\n", account.Hex(), salt)
+	fmt.Printf("token     %s\n\n", token.Hex())
+
+	// Fixture: the PRIOR grant. Policied, matching what production installs —
+	// allowlist + spend cap + time range — because a bare grant would make the
+	// exec-hook question vanish and the spike would prove nothing about the
+	// grants that actually exist.
+	prior := uint32(1)
+	next := uint32(2)
+
+	priorSigner, err := readSigner(ctx, chain, prior, *account)
+	if err != nil {
+		return fmt.Errorf("reading prior signer: %w", err)
+	}
+	if priorSigner == (common.Address{}) {
+		return fmt.Errorf(
+			"entity %d on %s is unset — this spike needs an EXISTING policied grant to replace.\n"+
+				"Install one first (scripts/spike/permission_hooks installs the §3.4 shape), or\n"+
+				"point SPIKE_SALT at an account that already carries one",
+			prior, account.Hex())
+	}
+	if priorSigner != controller {
+		return fmt.Errorf("entity %d is held by %s, not the controller %s — refusing to touch it",
+			prior, priorSigner.Hex(), controller.Hex())
+	}
+	if s, err := readSigner(ctx, chain, next, *account); err == nil && s != (common.Address{}) {
+		return fmt.Errorf("entity %d is already installed (%s); pick a fresh SPIKE_SALT so the probes start clean",
+			next, s.Hex())
+	}
+	fmt.Printf("fixture: entity %d holds the controller (the grant to be replaced); entity %d is free\n\n", prior, next)
+
+	// The two halves of the replace, built once and reused across probes.
+	installNew, err := policiedInstall(next, controller, token)
+	if err != nil {
+		return fmt.Errorf("building the new grant's install: %w", err)
+	}
+	uninstallPrior, err := policiedUninstall(prior)
+	if err != nil {
+		return fmt.Errorf("building the prior grant's uninstall: %w", err)
+	}
+
+	// Q1 — the batch itself. Both calls target the ACCOUNT, which is what
+	// makes this a self-administration batch and the reason it may be refused
+	// outright rather than at validation.
+	batch, err := aa.PackExecuteBatchMAv2([]aa.Call{
+		{Target: *account, Value: big.NewInt(0), Data: installNew},
+		{Target: *account, Value: big.NewInt(0), Data: uninstallPrior},
+	})
+	if err != nil {
+		return fmt.Errorf("packing the replace batch: %w", err)
+	}
+	fmt.Printf("replace batch: install(entity %d) + uninstall(entity %d), %d bytes\n\n", next, prior, len(batch))
+
+	type probe struct {
+		name       string
+		deferred   []byte
+		outerEnt   uint32
+		outerKey   *ecdsa.PrivateKey
+		wrap       bool
+		predict    string
+		fallbackOK bool
+	}
+	probes := []probe{
+		{
+			name: "R-0  control: install-only, outer = NEW entity (today's grant flow)",
+			// Note this deliberately installs entity `next` on its own, so it
+			// must run LAST or it would occupy the entity the other probes
+			// need free. Ordering is handled below.
+			deferred: installNew, outerEnt: next, outerKey: controllerKey, wrap: true,
+			predict: "mined (§3.2)",
+		},
+		{
+			name:     "R-A  replace batch, outer = NEW entity (what #717 asks for)",
+			deferred: batch, outerEnt: next, outerKey: controllerKey, wrap: true,
+			predict: "unknown — this is the spike",
+		},
+		{
+			name:     "R-B  replace batch, outer = owner's FALLBACK (§3.6 U-B shape)",
+			deferred: batch, outerEnt: 0, outerKey: ownerKey, wrap: false,
+			predict: "mined if Q1 holds — but the owner signs the op, so #717's no-extra-prompt criterion fails",
+			// entity 0 is the owner's fallback signer.
+			fallbackOK: true,
+		},
+	}
+
+	// R-A first: it is the question. R-B only matters if R-A fails, and R-0 is
+	// a fixture check that would consume the free entity.
+	order := []int{1, 2, 0}
+
+	for _, i := range order {
+		p := probes[i]
+		fmt.Printf("── %s\n   predict: %s\n", p.name, p.predict)
+
+		if !p.fallbackOK && p.outerEnt == 0 {
+			fmt.Printf("   SKIPPED: outer entity 0 is the owner fallback and this probe did not opt in\n\n")
+			continue
+		}
+		err := attemptDeferred(ctx, chain, chainRPC, bundler, entryPoint, chainID,
+			*account, owner, ownerKey, p.outerEnt, p.outerKey, p.deferred, p.wrap, token, controller)
+		if err != nil {
+			fmt.Printf("   RESULT: refused — %v\n", firstLine(err.Error()))
+		} else {
+			fmt.Printf("   RESULT: mined\n")
+		}
+
+		// Q3 — the only proof that matters. A successful tx says nothing about
+		// hook teardown: §3.5 records that a misrouted onUninstall is caught
+		// and the module state silently stranded.
+		ps, _ := readSigner(ctx, chain, prior, *account)
+		ns, _ := readSigner(ctx, chain, next, *account)
+		fmt.Printf("   state: entity %d signer=%s | entity %d signer=%s\n",
+			prior, short(ps), next, short(ns))
+		if cap, err := readSpendLimit(ctx, chain, prior, token, *account); err == nil {
+			fmt.Printf("          entity %d spend cap=%s (must be 0 for a clean teardown)\n", prior, cap)
+		}
+		fmt.Println()
+
+		if err == nil && ps == (common.Address{}) && ns == controller {
+			fmt.Printf("   ✅ replace composed: the prior entity is gone and the new one holds the controller\n\n")
+			return nil
+		}
+		if err == nil {
+			fmt.Printf("   ⚠️  op mined but the end state is not a clean replace — see the readback above\n\n")
+			return nil
+		}
+	}
+
+	fmt.Println("no probe produced a clean replace — #717 cannot be built as specified; see the refusals above")
+	return nil
+}
+
+// policiedInstall builds the production grant shape: a global session signer
+// with allowlist + spend cap + time range. Matching production matters — a
+// bare grant has no execution hook, and the exec hook is the thing that makes
+// self-administration interesting.
+func policiedInstall(entity uint32, signer, token common.Address) ([]byte, error) {
+	validUntil := uint64(time.Now().Add(7 * 24 * time.Hour).Unix())
+	allowlist, err := aa.PackAllowlistInstallData(entity, []aa.AllowlistInput{
+		{Target: token, Selectors: [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}}}, // transfer
+	})
+	if err != nil {
+		return nil, err
+	}
+	timeRange, err := aa.PackTimeRangeInstallData(entity, validUntil, 0)
+	if err != nil {
+		return nil, err
+	}
+	return aa.PackSessionSignerInstall(aa.SessionGrant{
+		EntityID: entity,
+		Signer:   signer,
+		Global:   true,
+		Hooks:    [][]byte{allowlist, timeRange},
+	})
+}
+
+// policiedUninstall rebuilds the prior grant's teardown. The hook data must be
+// one entry per installed hook in the ACCOUNT's stored order — reverse of
+// install, because the hook set is a prepend-on-add list (§3.5). A misrouted
+// entry does not revert; it strands module state silently, which is why the
+// probes read the cap back rather than trusting the receipt.
+func policiedUninstall(entity uint32) ([]byte, error) {
+	singleSigner, err := aa.PackSingleSignerUninstallData(entity)
+	if err != nil {
+		return nil, err
+	}
+	timeRange, err := aa.PackTimeRangeUninstallData(entity)
+	if err != nil {
+		return nil, err
+	}
+	// Stored order: validation hooks reversed (timeRange installed last, so it
+	// is first), then execution hooks. The allowlist appears twice — once as a
+	// validation hook, once as an execution hook — and takes the same
+	// (entityId, inputs) payload it was installed with, which for the spike's
+	// fixture is the allowlist install data.
+	return aa.PackSessionSignerUninstall(entity, [][]byte{timeRange, singleSigner})
+}
+
+// attemptDeferred sends one probe: `deferred` runs during validation under the
+// owner's fallback authority; the op itself is validated by outerEntity.
+func attemptDeferred(ctx context.Context, chain *ethclient.Client, chainRPC, bundler *rpc.Client,
+	entryPoint common.Address, chainID *big.Int, account, owner common.Address,
+	ownerKey *ecdsa.PrivateKey, outerEntity uint32, outerKey *ecdsa.PrivateKey,
+	deferred []byte, wrap bool, token, controller common.Address) error {
+
+	opts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
+	nonce, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, outerEntity, opts)
+	if err != nil {
+		return fmt.Errorf("reading nonce: %w", err)
+	}
+	deadline := uint64(time.Now().Add(time.Hour).Unix())
+
+	digest, err := userop.DeferredActionDigest(chainID, account, nonce, deadline, deferred)
+	if err != nil {
+		return err
+	}
+	ownerSig, err := crypto.Sign(digest.Bytes(), ownerKey) // inner = owner's fallback
+	if err != nil {
+		return err
+	}
+	ownerSig[64] += 27
+	encoded, err := userop.EncodeDeferredActionData(userop.FallbackSignerLocator(), deadline, deferred)
+	if err != nil {
+		return err
+	}
+
+	// The op's own call. When the outer validation is a policied entity its
+	// allowlist VALIDATION hook inspects this calldata, so it must be an
+	// allowlisted action — a token transfer, as in the §3.6 harness — not an
+	// arbitrary call.
+	transfer := append([]byte{0xa9, 0x05, 0x9c, 0xbb}, common.LeftPadBytes(controller.Bytes(), 32)...)
+	transfer = append(transfer, common.LeftPadBytes(oneToken.Bytes(), 32)...)
+	exec, err := aa.PackExecute(token, big.NewInt(0), transfer)
+	if err != nil {
+		return err
+	}
+	callData := exec
+	if wrap {
+		if callData, err = aa.WrapExecuteUserOp(exec); err != nil {
+			return err
+		}
+	}
+
+	op := &userop.UserOperationV07{
+		Sender:               account,
+		Nonce:                nonce,
+		CallData:             callData,
+		VerificationGasLimit: big.NewInt(900_000), // batches verify heavier than a lone install
+	}
+	if err := priceOp(ctx, chain, bundler, op, entryPoint, encoded, ownerSig); err != nil {
+		return fmt.Errorf("pricing: %w", err)
+	}
+	if err := preset.SignUserOpV07Deferred(op, entryPoint, chainID, outerKey, encoded, ownerSig); err != nil {
+		return err
+	}
+	hash, err := preset.SendUserOpV07(ctx, bundler, op, entryPoint)
+	if err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+	r, err := waitReceipt(ctx, bundler, hash)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("   op mined: success=%v gas=%s tx=%s\n", r.Success, r.ActualGasUsed, r.TxHash)
+	if !r.Success {
+		return fmt.Errorf("op mined but reverted")
+	}
+	return nil
+}
+
+func short(a common.Address) string {
+	if a == (common.Address{}) {
+		return "0x0 (cleared)"
+	}
+	return a.Hex()
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// ── helpers, lifted from scripts/spike/deferred_uninstall so each spike runs
+// standalone (they are single-file programs by convention).
+
+type userOpReceipt struct {
+	Success       bool
+	ActualGasUsed *big.Int
+	TxHash        string
+}
+
+func callWords(ctx context.Context, chain *ethclient.Client, to common.Address, sig string, args ...[]byte) ([]byte, error) {
+	data := crypto.Keccak256([]byte(sig))[:4]
+	for _, a := range args {
+		data = append(data, common.LeftPadBytes(a, 32)...)
+	}
+	return chain.CallContract(ctx, ethereum.CallMsg{To: &to, Data: data}, nil)
+}
+
+func readSigner(ctx context.Context, chain *ethclient.Client, entity uint32, account common.Address) (common.Address, error) {
+	out, err := callWords(ctx, chain, aa.SingleSignerValidationModuleAddress(),
+		"signers(uint32,address)", big.NewInt(int64(entity)).Bytes(), account.Bytes())
+	if err != nil || len(out) < 32 {
+		return common.Address{}, fmt.Errorf("reading signer: %w", err)
+	}
+	return common.BytesToAddress(out[12:32]), nil
+}
+
+func readSpendLimit(ctx context.Context, chain *ethclient.Client, entity uint32, token, account common.Address) (*big.Int, error) {
+	out, err := callWords(ctx, chain, aa.AllowlistModuleAddress(),
+		"erc20SpendLimits(uint32,address,address)", big.NewInt(int64(entity)).Bytes(), token.Bytes(), account.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+func priceOp(ctx context.Context, chain *ethclient.Client, bundler *rpc.Client,
+	op *userop.UserOperationV07, entryPoint common.Address, encodedData, ownerSig []byte) error {
+	tip, err := chain.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	var bundlerTipHex string
+	if err := bundler.CallContext(ctx, &bundlerTipHex, "rundler_maxPriorityFeePerGas"); err == nil {
+		if bt, ok := new(big.Int).SetString(trim0x(bundlerTipHex), 16); ok && bt.Cmp(tip) > 0 {
+			tip = bt
+		}
+	}
+	head, err := chain.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	op.MaxPriorityFeePerGas = tip
+	op.MaxFeePerGas = new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2)))
+	if encodedData != nil {
+		sig, sErr := preset.DeferredEstimationSignature(encodedData, ownerSig)
+		if sErr != nil {
+			return sErr
+		}
+		op.Signature = sig
+		defer func() { op.Signature = nil }()
+	}
+	if _, err := preset.EstimateUserOpGasV07(ctx, bundler, op, entryPoint); err != nil {
+		return fmt.Errorf("estimating gas: %w", err)
+	}
+	return nil
+}
+
+func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (*userOpReceipt, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var raw json.RawMessage
+		if err := bundler.CallContext(ctx, &raw, "eth_getUserOperationReceipt", opHash.Hex()); err == nil &&
+			len(raw) > 0 && string(raw) != "null" {
+			var p struct {
+				Success       bool   `json:"success"`
+				ActualGasUsed string `json:"actualGasUsed"`
+				Receipt       struct {
+					TransactionHash string `json:"transactionHash"`
+				} `json:"receipt"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return nil, err
+			}
+			g, _ := new(big.Int).SetString(trim0x(p.ActualGasUsed), 16)
+			return &userOpReceipt{Success: p.Success, ActualGasUsed: g, TxHash: p.Receipt.TransactionHash}, nil
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return nil, fmt.Errorf("no receipt for %s in 3m", opHash)
+}
+
+func trim0x(s string) string { return strings.TrimPrefix(s, "0x") }

--- a/scripts/spike/deferred_replace/main.go
+++ b/scripts/spike/deferred_replace/main.go
@@ -255,7 +255,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("building the new grant's install: %w", err)
 	}
-	uninstallPrior, err := policiedUninstall(prior)
+	uninstallPrior, err := policiedUninstall(prior, token)
 	if err != nil {
 		return fmt.Errorf("building the prior grant's uninstall: %w", err)
 	}
@@ -350,50 +350,71 @@ func run() error {
 	return nil
 }
 
-// policiedInstall builds the production grant shape: a global session signer
-// with allowlist + spend cap + time range. Matching production matters — a
-// bare grant has no execution hook, and the exec hook is the thing that makes
-// self-administration interesting.
+// policiedInstall builds the production grant shape, using the SAME builders
+// SessionPermissions.HooksFor uses and in the same order — allowlist
+// validation hook, allowlist EXEC hook, time-range validation hook.
+//
+// Getting this wrong is not a subtle failure: passing raw install data where a
+// hook ENTRY is expected (config ++ data) packs fine and then reverts AA23 at
+// estimation, and omitting the exec hook changes the grant into the bare shape
+// whose self-administration is exactly what the spike is not testing.
+func allowlistInputs(token common.Address) []aa.AllowlistInput {
+	return []aa.AllowlistInput{{
+		Target:               token,
+		HasSelectorAllowlist: true,
+		Selectors:            [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}}, // transfer
+		HasERC20SpendLimit:   true,
+		ERC20SpendLimit:      new(big.Int).Mul(big.NewInt(100), oneToken),
+	}}
+}
+
 func policiedInstall(entity uint32, signer, token common.Address) ([]byte, error) {
-	validUntil := uint64(time.Now().Add(7 * 24 * time.Hour).Unix())
-	allowlist, err := aa.PackAllowlistInstallData(entity, []aa.AllowlistInput{
-		{Target: token, Selectors: [][4]byte{{0xa9, 0x05, 0x9c, 0xbb}}}, // transfer
-	})
+	inputs := allowlistInputs(token)
+	allowlistHook, err := aa.AllowlistValidationHook(entity, inputs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("allowlist validation hook: %w", err)
 	}
-	timeRange, err := aa.PackTimeRangeInstallData(entity, validUntil, 0)
+	timeRangeHook, err := aa.TimeRangeValidationHook(entity, uint64(time.Now().Add(7*24*time.Hour).Unix()), 0)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("time-range hook: %w", err)
 	}
 	return aa.PackSessionSignerInstall(aa.SessionGrant{
 		EntityID: entity,
 		Signer:   signer,
 		Global:   true,
-		Hooks:    [][]byte{allowlist, timeRange},
+		Hooks:    [][]byte{allowlistHook, aa.AllowlistExecHook(entity), timeRangeHook},
 	})
 }
 
-// policiedUninstall rebuilds the prior grant's teardown. The hook data must be
-// one entry per installed hook in the ACCOUNT's stored order — reverse of
-// install, because the hook set is a prepend-on-add list (§3.5). A misrouted
-// entry does not revert; it strands module state silently, which is why the
-// probes read the cap back rather than trusting the receipt.
-func policiedUninstall(entity uint32) ([]byte, error) {
-	singleSigner, err := aa.PackSingleSignerUninstallData(entity)
-	if err != nil {
-		return nil, err
-	}
+// policiedUninstall rebuilds the prior grant's teardown.
+//
+// Two things this got wrong the first time, both of which mined a SUCCESSFUL
+// transaction that cleared nothing — the §3.5 hazard exactly:
+//
+//   - PackSessionSignerUninstall already packs the validation module's own
+//     teardown (PackSingleSignerUninstallData) as uninstallData. Passing it
+//     AGAIN as a hook entry displaced the allowlist's payload, so the
+//     allowlist was handed data meant for a different module.
+//   - hookUninstallData is one entry per installed hook in the ACCOUNT's
+//     STORED order — the reverse of install, because the hook set is a
+//     prepend-on-add list. Install order is [allowlist-validation,
+//     allowlist-exec, time-range], so stored order is [time-range,
+//     allowlist-exec, allowlist-validation].
+//
+// The allowlist's teardown is the SAME (entityId, inputs) tuple it was
+// installed with; its exec-hook entry carries no install data, so its slot is
+// empty. A misrouted entry does not revert — onUninstall reverts are caught
+// and the state stranded — which is why every probe reads the cap back.
+func policiedUninstall(entity uint32, token common.Address) ([]byte, error) {
 	timeRange, err := aa.PackTimeRangeUninstallData(entity)
 	if err != nil {
 		return nil, err
 	}
-	// Stored order: validation hooks reversed (timeRange installed last, so it
-	// is first), then execution hooks. The allowlist appears twice — once as a
-	// validation hook, once as an execution hook — and takes the same
-	// (entityId, inputs) payload it was installed with, which for the spike's
-	// fixture is the allowlist install data.
-	return aa.PackSessionSignerUninstall(entity, [][]byte{timeRange, singleSigner})
+	allowlist, err := aa.PackAllowlistInstallData(entity, allowlistInputs(token))
+	if err != nil {
+		return nil, err
+	}
+	return aa.PackSessionSignerUninstall(entity, [][]byte{timeRange, nil, allowlist})
 }
 
 // attemptDeferred sends one probe: `deferred` runs during validation under the

--- a/scripts/spike/deferred_replace/main.go
+++ b/scripts/spike/deferred_replace/main.go
@@ -50,10 +50,30 @@
 // be zero AND its spend cap cleared; new entity's signer must be the
 // controller.
 //
-// Env: SPIKE_OWNER_KEY, SPIKE_CONTROLLER_KEY, SPIKE_BUNDLER_URL,
+// What it needs. The account is derived from the owner + a salt, prefunded
+// from the owner EOA, and — if the salt is fresh — bootstrapped with the prior
+// policied grant before any probe runs. So a dedicated salt is genuinely all
+// that is required; nothing has to be set up by hand.
 //
-//	SPIKE_RPC_URL (opt), SPIKE_SALT (opt, default 9),
-//	SPIKE_TOKEN (opt, default the §3.4 SpikeToken).
+//	SPIKE_OWNER_KEY       owner's private key. Falls back to TEST_PRIVATE_KEY,
+//	                      so the repo's own .env works unchanged.
+//	SPIKE_CONTROLLER_KEY  controller's private key. Falls back to
+//	                      CONTROLLER_PRIVATE_KEY (config/test.yaml has it).
+//	SPIKE_BUNDLER_URL     any ERC-4337 bundler for Sepolia. This is only where
+//	                      UserOperations are submitted — the spike is not
+//	                      testing the bundler. Use the Alchemy endpoint the
+//	                      fleet now runs on:
+//	                      https://eth-sepolia.g.alchemy.com/v2/<ALCHEMY_API_KEY>
+//	SPIKE_SALT            optional, default 9. Pick one nothing else uses; the
+//	                      probes install and remove validation entities on it.
+//	SPIKE_RPC_URL         optional. Default is a public endpoint — prefer the
+//	                      paid Dwellir one, per the no-public-RPC rule.
+//	SPIKE_TOKEN           optional, default the §3.4 SpikeToken. Only used as
+//	                      an allowlisted call target; no balance is needed
+//	                      because the probes transfer zero.
+//
+// Cost: ~0.006 ETH prefunded to the account, plus gas for up to four
+// operations. No paymaster — sponsorship is not what this measures.
 //
 // Run: go run ./scripts/spike/deferred_replace
 package main
@@ -70,6 +90,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -85,7 +106,13 @@ const (
 	defaultSalt  = 9
 )
 
-var oneToken = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+var (
+	oneToken = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	// prefundWei covers the probes' gas; the account pays its own way (no
+	// paymaster here — sponsorship is not what this spike is testing).
+	prefundWei = big.NewInt(6_000_000_000_000_000) // 0.006 ETH
+	spikeSalt  *big.Int
+)
 
 func main() {
 	if err := run(); err != nil {
@@ -101,10 +128,16 @@ func env(name, fallback string) string {
 	return fallback
 }
 
-func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
-	raw := strings.TrimPrefix(strings.TrimSpace(os.Getenv(name)), "0x")
+func requireKey(names ...string) (*ecdsa.PrivateKey, common.Address, error) {
+	var raw, name string
+	for _, n := range names {
+		if v := strings.TrimPrefix(strings.TrimSpace(os.Getenv(n)), "0x"); v != "" {
+			raw, name = v, n
+			break
+		}
+	}
 	if raw == "" {
-		return nil, common.Address{}, fmt.Errorf("%s is required", name)
+		return nil, common.Address{}, fmt.Errorf("set one of: %s", strings.Join(names, ", "))
 	}
 	key, err := crypto.HexToECDSA(raw)
 	if err != nil {
@@ -116,11 +149,13 @@ func requireKey(name string) (*ecdsa.PrivateKey, common.Address, error) {
 func run() error {
 	ctx := context.Background()
 
-	ownerKey, owner, err := requireKey("SPIKE_OWNER_KEY")
+	// SPIKE_OWNER_KEY falls back to TEST_PRIVATE_KEY so this runs straight from
+	// the repo's .env — it is the same key, the smart wallet's owner.
+	ownerKey, owner, err := requireKey("SPIKE_OWNER_KEY", "TEST_PRIVATE_KEY")
 	if err != nil {
 		return err
 	}
-	controllerKey, controller, err := requireKey("SPIKE_CONTROLLER_KEY")
+	controllerKey, controller, err := requireKey("SPIKE_CONTROLLER_KEY", "CONTROLLER_PRIVATE_KEY")
 	if err != nil {
 		return err
 	}
@@ -138,6 +173,7 @@ func run() error {
 		}
 		salt = parsed
 	}
+	spikeSalt = salt
 
 	chain, err := ethclient.Dial(env("SPIKE_RPC_URL", defaultRPC))
 	if err != nil {
@@ -184,11 +220,25 @@ func run() error {
 		return fmt.Errorf("reading prior signer: %w", err)
 	}
 	if priorSigner == (common.Address{}) {
-		return fmt.Errorf(
-			"entity %d on %s is unset — this spike needs an EXISTING policied grant to replace.\n"+
-				"Install one first (scripts/spike/permission_hooks installs the §3.4 shape), or\n"+
-				"point SPIKE_SALT at an account that already carries one",
-			prior, account.Hex())
+		// Bootstrap: a fresh salt has no grant to replace, so install one. This
+		// is the ordinary grant flow (§3.2) and doubles as the R-0 control —
+		// if it fails, the fixture is wrong and no probe result means anything.
+		fmt.Printf("entity %d is free — installing the prior policied grant to replace (bootstrap)\n", prior)
+		if err := sendETH(ctx, chain, chainID, ownerKey, owner, *account, prefundWei); err != nil {
+			return fmt.Errorf("prefunding %s: %w", account.Hex(), err)
+		}
+		bootstrap, err := policiedInstall(prior, controller, token)
+		if err != nil {
+			return fmt.Errorf("building the bootstrap grant: %w", err)
+		}
+		if err := attemptDeferred(ctx, chain, chainRPC, bundler, entryPoint, chainID,
+			*account, owner, ownerKey, prior, controllerKey, bootstrap, true, token, controller, true); err != nil {
+			return fmt.Errorf("bootstrap install failed — the fixture is wrong, not the hypothesis: %w", err)
+		}
+		if priorSigner, err = readSigner(ctx, chain, prior, *account); err != nil {
+			return fmt.Errorf("re-reading prior signer: %w", err)
+		}
+		fmt.Printf("bootstrap done: entity %d now holds %s\n\n", prior, short(priorSigner))
 	}
 	if priorSigner != controller {
 		return fmt.Errorf("entity %d is held by %s, not the controller %s — refusing to touch it",
@@ -267,7 +317,7 @@ func run() error {
 			continue
 		}
 		err := attemptDeferred(ctx, chain, chainRPC, bundler, entryPoint, chainID,
-			*account, owner, ownerKey, p.outerEnt, p.outerKey, p.deferred, p.wrap, token, controller)
+			*account, owner, ownerKey, p.outerEnt, p.outerKey, p.deferred, p.wrap, token, controller, false)
 		if err != nil {
 			fmt.Printf("   RESULT: refused — %v\n", firstLine(err.Error()))
 		} else {
@@ -351,7 +401,7 @@ func policiedUninstall(entity uint32) ([]byte, error) {
 func attemptDeferred(ctx context.Context, chain *ethclient.Client, chainRPC, bundler *rpc.Client,
 	entryPoint common.Address, chainID *big.Int, account, owner common.Address,
 	ownerKey *ecdsa.PrivateKey, outerEntity uint32, outerKey *ecdsa.PrivateKey,
-	deferred []byte, wrap bool, token, controller common.Address) error {
+	deferred []byte, wrap bool, token, controller common.Address, deploy bool) error {
 
 	opts := uint8(userop.ValidationOptionGlobal | userop.ValidationOptionDeferredAction)
 	nonce, err := preset.NextNonceV07(ctx, chainRPC, entryPoint, account, outerEntity, opts)
@@ -378,8 +428,12 @@ func attemptDeferred(ctx context.Context, chain *ethclient.Client, chainRPC, bun
 	// allowlist VALIDATION hook inspects this calldata, so it must be an
 	// allowlisted action — a token transfer, as in the §3.6 harness — not an
 	// arbitrary call.
+	// Zero amount on purpose: the allowlist hook checks target + selector and
+	// the spend cap permits 0, so the probe needs no token balance — only ETH
+	// for gas. The question is whether VALIDATION composes; the transfer is
+	// just a call the hooks will accept.
 	transfer := append([]byte{0xa9, 0x05, 0x9c, 0xbb}, common.LeftPadBytes(controller.Bytes(), 32)...)
-	transfer = append(transfer, common.LeftPadBytes(oneToken.Bytes(), 32)...)
+	transfer = append(transfer, common.LeftPadBytes(big.NewInt(0).Bytes(), 32)...)
 	exec, err := aa.PackExecute(token, big.NewInt(0), transfer)
 	if err != nil {
 		return err
@@ -396,6 +450,13 @@ func attemptDeferred(ctx context.Context, chain *ethclient.Client, chainRPC, bun
 		Nonce:                nonce,
 		CallData:             callData,
 		VerificationGasLimit: big.NewInt(900_000), // batches verify heavier than a lone install
+	}
+	if deploy {
+		factory, factoryData, err := aa.GetInitCodeMAv2(owner, spikeSalt)
+		if err != nil {
+			return err
+		}
+		op.Factory, op.FactoryData = &factory, factoryData
 	}
 	if err := priceOp(ctx, chain, bundler, op, entryPoint, encoded, ownerSig); err != nil {
 		return fmt.Errorf("pricing: %w", err)
@@ -524,3 +585,45 @@ func waitReceipt(ctx context.Context, bundler *rpc.Client, opHash common.Hash) (
 }
 
 func trim0x(s string) string { return strings.TrimPrefix(s, "0x") }
+
+func sendETH(ctx context.Context, chain *ethclient.Client, chainID *big.Int,
+	ownerKey *ecdsa.PrivateKey, owner, to common.Address, amount *big.Int) error {
+	if bal, err := chain.BalanceAt(ctx, to, nil); err == nil && bal.Cmp(amount) >= 0 {
+		return nil
+	}
+	nonce, err := chain.PendingNonceAt(ctx, owner)
+	if err != nil {
+		return err
+	}
+	gp, err := chain.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+	gl, err := chain.EstimateGas(ctx, ethereum.CallMsg{From: owner, To: &to, Value: amount})
+	if err != nil {
+		return err
+	}
+	tx := types.NewTransaction(nonce, to, amount, gl+10_000, gp, nil)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), ownerKey)
+	if err != nil {
+		return err
+	}
+	if err := chain.SendTransaction(ctx, signed); err != nil {
+		return err
+	}
+	_, err = waitMined(ctx, chain, signed.Hash())
+	return err
+}
+
+func waitMined(ctx context.Context, chain *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
+	for range 60 {
+		if r, err := chain.TransactionReceipt(ctx, hash); err == nil {
+			if r.Status != types.ReceiptStatusSuccessful {
+				return nil, fmt.Errorf("tx %s failed", hash)
+			}
+			return r, nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return nil, fmt.Errorf("tx %s not mined in 3m", hash)
+}

--- a/scripts/spike/deferred_replace/main.go
+++ b/scripts/spike/deferred_replace/main.go
@@ -255,9 +255,13 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("building the new grant's install: %w", err)
 	}
-	uninstallPrior, err := policiedUninstall(prior, token)
+	priorInstall, err := policiedInstall(prior, controller, token)
 	if err != nil {
-		return fmt.Errorf("building the prior grant's uninstall: %w", err)
+		return fmt.Errorf("rebuilding the prior grant's install for teardown: %w", err)
+	}
+	uninstallPrior, err := aa.SessionSignerUninstallFromInstall(prior, priorInstall)
+	if err != nil {
+		return fmt.Errorf("deriving the prior grant's uninstall: %w", err)
 	}
 
 	// Q1 — the batch itself. Both calls target the ACCOUNT, which is what
@@ -386,36 +390,11 @@ func policiedInstall(entity uint32, signer, token common.Address) ([]byte, error
 	})
 }
 
-// policiedUninstall rebuilds the prior grant's teardown.
-//
-// Two things this got wrong the first time, both of which mined a SUCCESSFUL
-// transaction that cleared nothing — the §3.5 hazard exactly:
-//
-//   - PackSessionSignerUninstall already packs the validation module's own
-//     teardown (PackSingleSignerUninstallData) as uninstallData. Passing it
-//     AGAIN as a hook entry displaced the allowlist's payload, so the
-//     allowlist was handed data meant for a different module.
-//   - hookUninstallData is one entry per installed hook in the ACCOUNT's
-//     STORED order — the reverse of install, because the hook set is a
-//     prepend-on-add list. Install order is [allowlist-validation,
-//     allowlist-exec, time-range], so stored order is [time-range,
-//     allowlist-exec, allowlist-validation].
-//
-// The allowlist's teardown is the SAME (entityId, inputs) tuple it was
-// installed with; its exec-hook entry carries no install data, so its slot is
-// empty. A misrouted entry does not revert — onUninstall reverts are caught
-// and the state stranded — which is why every probe reads the cap back.
-func policiedUninstall(entity uint32, token common.Address) ([]byte, error) {
-	timeRange, err := aa.PackTimeRangeUninstallData(entity)
-	if err != nil {
-		return nil, err
-	}
-	allowlist, err := aa.PackAllowlistInstallData(entity, allowlistInputs(token))
-	if err != nil {
-		return nil, err
-	}
-	return aa.PackSessionSignerUninstall(entity, [][]byte{timeRange, nil, allowlist})
-}
+// The teardown now comes from aa.SessionSignerUninstallFromInstall, derived
+// from the very install call this spike built — so the spike exercises the
+// production deriver rather than a parallel hand-rolled copy. The payload that
+// mined and cleared state on salt 15 is what that function reproduces; if it
+// ever stops matching, this probe stops clearing and says so in the readback.
 
 // attemptDeferred sends one probe: `deferred` runs during validation under the
 // owner's fallback authority; the op itself is validated by outerEntity.


### PR DESCRIPTION
Closes half of #717. A grant's deferred action now carries the prior grant's `uninstallValidation` alongside the new `installValidation`, committed to by the owner's single existing signature. Replacing a grant means the same thing on both sides, with no extra prompt.

#716 made replacement true in storage. This makes it true on chain.

## What was actually hard

**`uninstallValidation` does not fail loudly.** The account catches a hook module's `onUninstall` revert, flags it only in the `ValidationUninstalled` event, and leaves the module state in place. Two payload shapes were tried against the same batch on Sepolia. Both mined with `success = true`:

| gas | result |
|---|---|
| 601,275 | entity kept its signer **and** its full 100-token spend cap |
| 636,341 | signer cleared to `0x0`, cap cleared to `0` |

Nothing on chain distinguishes them. `hookUninstallData` must carry one entry per installed hook in the account's **stored** order, which is the reverse of install order — the account keeps hooks as a prepend-on-add list. Misroute an entry and it mines, clears nothing, and reports success.

Two consequences, both enforced here:

- **Derive teardown from the stored install call, never from live config.** Each hook's `onUninstall` payload is the same `(entityId, inputs)` tuple it was installed with, so rebuilding from today's permission structs diverges silently the moment a grant's shape changes. `SessionPolicy.Grant.InstallCall` is the only faithful record. `TestTeardownFollowsTheStoredCallNotCurrentCode` pins this.
- **A mined transaction is not evidence of teardown.** Anything reporting a grant revoked reads the module state back — `aa.EntitySignerOnChain`, wired into the resolver via `VerifySupersededTeardown`.

## Verification

`TestGrantReplaceClearsThePriorEntity_Sepolia` runs the production path end to end — `PrepareSessionPolicy` → `SubmitSessionPolicy` → a real operation → on-chain readback — behind the `integration` build tag (#727).

It passes on Sepolia, and it is verified to be worth having: with the replace batch removed, it fails on exactly the teardown assertion (the prior entity still holds the controller), not anywhere earlier.

The offline tests were mutation-checked too. Four mutants of the new nonce read — returning the key instead of the sequence, masking 32 bits instead of 64, querying a module instead of the EntryPoint, swallowing a short return — are all caught.

## A finding worth knowing: a torn-down entity is not reusable

After teardown an entity reads zero on **every** module — signer, allowlist, spend cap, time range. Its EntryPoint nonce sequence for the deferred key does not reset, and nothing can reset it. `PrepareSessionGrant` signs a carrier nonce at sequence 0, knowable in advance only for a never-used key, so a reissued entity signs a nonce the EntryPoint already consumed and the operation AA23s during validation with nothing on chain to say why.

Observed directly on Sepolia: entity 1 clear on all four modules, sequence 1, every grant reallocating it AA23'd.

**Production is safe from this today** — storage retains revoked policies and `NextSessionEntityID` takes max+1, so ids are never reissued. The invariant was implicit; it is now stated in `aa.EntryPointNonce`. `aa.EntityDeferredNonceSequence` encapsulates the read because the obvious version is wrong: `getNonce` returns `key<<64 | sequence` and the key embeds the entity id, so testing the full nonce against zero reports *every* entity as spent while looking exactly like a usage check.

## TODO — what this PR does not do

Tracked on #717; none of these are regressions, all are pre-existing gaps this PR narrows but does not close.

- [ ] **1. Explicit revoke still reports into the void.** `RevokeSessionGrant` (`core/taskengine/session_grant.go`) returns `onChainCleanupRequired = true` and retains the record so the payload can be rebuilt — and nothing rebuilds it. This is acceptance criterion 3 on #717 and is now the cheapest one left, since `aa.SessionSignerUninstallFromInstall` exists and the record already carries `Grant.InstallCall`.
- [ ] **2. Wallets with more than one installed grant are still not cleaned.** When several are installed the code deliberately degrades to install-only, so granting keeps repairing storage (#716) instead of refusing the very wallets that need repairing — but the leftovers stay on chain. That leaves acceptance criterion 1 unmet for the dual-row wallets #715 was filed for. Needs the N-way-batch vs. sweep-later decision, not just implementation.
- [ ] **3. Failure semantics.** If the batch reverts, the new grant does not install either — the honest outcome — but the client-facing error should say so rather than surfacing a bare AA23.
- [ ] **4. The in-flight orphan.** A superseded *pending* install that lands after supersede leaves an entity on chain with no usable record behind it, and this batch does not catch it. #717's own read is that this wants a reconciliation pass rather than more signing.

### One decision, if you want it in scope

The entity-nonce invariant above is only documented. A guard in `PrepareSessionGrant` — refuse when the allocated entity's deferred sequence is non-zero — would turn an opaque AA23 into a clear error, matching how the rest of this code treats AA23s. It needs a chain client threaded into the grant path, so I did not add it unilaterally.

## Notes for review

- `scripts/fixture_wallet` deploys, funds and reports on a live-test runner. The Sepolia test hard-fails when its runner has no code — an undeployed account answers every module read with zero, so the entity assertions would pass while proving nothing — and that instruction needed a tool behind it.
- The live test seeds storage to reflect entities the chain has already spent, using a real grant built by the production builder and signed by the real owner, marked revoked. A live test starts from an empty database against a chain that remembers, so it restores the production invariant itself.
- The spike harness under `scripts/spike/deferred_replace` is retained: it is what established the ordering finding, and it probes shapes the unit tests now pin.
