### PR TITLE
test(taskengine): live Sepolia proof for N-way teardown and the cleared-candidate drop

### DIFF
--- a/core/taskengine/session_grant_nway_live_test.go
+++ b/core/taskengine/session_grant_nway_live_test.go
@@ -146,18 +146,27 @@ func TestGrantReplaceClearsSeveralPriorEntities_Sepolia(t *testing.T) {
 	clearTornDownMark(t, db, chainID.Int64(), owner, *runner, first.EntityID)
 
 	afterCleanup := firstPrepared(t, engine, user)
-	for _, s := range afterCleanup.Supersedes {
-		require.NotEqual(t, first.EntityID, s.EntityID,
-			"entity %d is already clear on chain; batching its uninstall reverts the whole grant",
-			first.EntityID)
-	}
+
+	// Pin the whole set, not just the absence of the stale one. Dropping every
+	// candidate would also satisfy "the cleared entity is gone" while quietly
+	// letting the new grant install over a live one — the stacking this exists
+	// to prevent. Exactly one entity is installed at this point (third), so
+	// exactly one must ride the batch.
+	require.Len(t, afterCleanup.Supersedes, 1,
+		"only the already-clear entity may drop out; the installed grant must still be torn down")
+	require.Equal(t, third.EntityID, afterCleanup.Supersedes[0].EntityID,
+		"the batch must supersede the entity that is actually installed")
 	require.True(t, tornDownOnRecord(t, db, chainID.Int64(), owner, *runner, first.EntityID),
 		"a candidate found clear on chain must be recorded torn down, or every later grant re-reads it")
 
 	fourth := submitPrepared(t, engine, user, ownerKey, afterCleanup)
 	runOperationUnderGrant(t, engine, user, *runner)
+
 	requireEntityClear(t, client, *runner, fourth.EntityID, false)
-	t.Logf("✅ stale candidate %d dropped; grant %d still landed", first.EntityID, fourth.EntityID)
+	requireEntityClear(t, client, *runner, third.EntityID, true)
+	requireEntityClear(t, client, *runner, first.EntityID, true)
+	t.Logf("✅ stale candidate %d dropped, live entity %d still torn down; grant %d landed",
+		first.EntityID, third.EntityID, fourth.EntityID)
 }
 
 // clearTornDownMark removes the TornDownAt marker from whichever policy holds

--- a/core/taskengine/session_grant_nway_live_test.go
+++ b/core/taskengine/session_grant_nway_live_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+// +build integration
+
+package taskengine
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// The two things #731 shipped that had never run on a chain.
+//
+// TestGrantReplaceClearsThePriorEntity_Sepolia covers one prior entity. #731
+// generalised that to N and added a chain read that drops candidates already
+// clear, and neither generalisation had live coverage — the existing test
+// asserts exactly one supersede, so it passes unchanged either way.
+//
+// Both are the kind of thing offline tests cannot see. An uninstall whose
+// hookUninstallData is misrouted MINES with success=true and clears nothing,
+// and an uninstall aimed at an entity that is already clear REVERTS, taking
+// the whole deferred batch with it — so the new grant never installs. That
+// second one is why dropClearedTeardownTargets exists: storage believes an
+// entity is installed long after the owner cleared it by hand through
+// onChainCleanup, because nothing tells the gateway it happened.
+//
+//	OWNER_EOA, TEST_PRIVATE_KEY, config/test.yaml.
+//	go test -tags=integration ./core/taskengine -run TestGrantReplaceClearsSeveralPriorEntities_Sepolia -v
+func TestGrantReplaceClearsSeveralPriorEntities_Sepolia(t *testing.T) {
+	cfg, err := config.NewConfig(testutil.GetConfigPath(testutil.DefaultConfigPath))
+	require.NoError(t, err, "config/test.yaml must load")
+
+	client, err := ethclient.Dial(cfg.SmartWallet.EthRpcUrl)
+	require.NoError(t, err, "cannot reach the configured RPC; a live test with no chain proves nothing")
+	t.Cleanup(func() { client.Close() })
+
+	chainID, err := client.ChainID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(11155111), chainID.Int64(),
+		"this check is Sepolia-specific; skipping on a misconfigured RPC would report green while proving nothing")
+
+	ownerHex := strings.TrimSpace(os.Getenv("OWNER_EOA"))
+	require.NotEmpty(t, ownerHex, "OWNER_EOA must be set: the grant is authorized by that owner")
+	owner := common.HexToAddress(ownerHex)
+
+	ownerKey := requireOwnerKey(t)
+	require.Equal(t, owner, crypto.PubkeyToAddress(ownerKey.PublicKey),
+		"TEST_PRIVATE_KEY must be OWNER_EOA's key — only the owner can authorize a grant")
+
+	setGlobalFactory(t, cfg.SmartWallet)
+	runner, err := aa.GetSenderAddressMAv2(client, owner, big.NewInt(fixtureSaltGrantReplace))
+	require.NoError(t, err)
+	t.Logf("runner %s (salt %d)", runner.Hex(), fixtureSaltGrantReplace)
+
+	// Four operations, each self-funded — the fixture is not on the Gas
+	// Manager policy and pointing a test at it would have production pay.
+	requireFundedRunner(t, cfg.SmartWallet, *runner, big.NewInt(12_000_000_000_000_000)) // 0.012 ETH
+
+	code, err := client.CodeAt(context.Background(), *runner, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, code,
+		"runner %s is not deployed; deploy it with scripts/fixture_wallet -salt %d -deploy — an undeployed account reads every entity as clear",
+		runner.Hex(), fixtureSaltGrantReplace)
+
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+	engine := New(db, cfg, nil, testutil.GetLogger())
+	t.Cleanup(engine.Stop)
+	engine.InstallSessionResolver()
+	t.Cleanup(func() { preset.SetSessionResolver(nil) })
+
+	factoryAddr := effectiveFactoryAddr(t, cfg.SmartWallet)
+	require.NoError(t, StoreWallet(db, chainID.Int64(), owner, &model.SmartWallet{
+		Owner: &owner, Address: runner, Factory: &factoryAddr,
+		Salt: big.NewInt(fixtureSaltGrantReplace),
+	}))
+	user := &model.User{Address: owner, SmartAccountAddress: runner}
+	seedEntitiesConsumedOnChain(t, db, client, cfg.SmartWallet, ownerKey, chainID.Int64(), owner, *runner)
+
+	// ── 1. Build a wallet carrying TWO installed entities.
+	//
+	// Every install here rides a real operation, so both InstallCalls are the
+	// bytes the owner actually signed — teardown is derived from those, and a
+	// reconstructed payload would mine and clear nothing.
+	//
+	// Marking the first torn down between the grants is what keeps the second
+	// from replacing it. That is exactly the shape of a wallet that stacked
+	// before on-chain replace shipped, which is the case #717 AC1 names.
+	first := grantThroughEngine(t, engine, user, ownerKey, *runner)
+	runOperationUnderGrant(t, engine, user, *runner)
+	requireEntityClear(t, client, *runner, first.EntityID, false)
+	require.NoError(t, MarkEntityTornDown(db, chainID.Int64(), owner, *runner, first.EntityID))
+
+	second := grantThroughEngine(t, engine, user, ownerKey, *runner)
+	require.NotEqual(t, first.EntityID, second.EntityID)
+	runOperationUnderGrant(t, engine, user, *runner)
+	requireEntityClear(t, client, *runner, second.EntityID, false)
+
+	// Un-hide the first: storage now agrees with the chain that both are live.
+	clearTornDownMark(t, db, chainID.Int64(), owner, *runner, first.EntityID)
+	t.Logf("stacked: entities %d and %d both installed", first.EntityID, second.EntityID)
+
+	// ── 2. One grant, N-way teardown. This is the part that has never run.
+	prepared := firstPrepared(t, engine, user)
+	require.Len(t, prepared.Supersedes, 2,
+		"both installed entities must ride this batch; one-at-a-time is what #717 AC1 rejects")
+	require.ElementsMatch(t,
+		[]uint32{first.EntityID, second.EntityID},
+		[]uint32{prepared.Supersedes[0].EntityID, prepared.Supersedes[1].EntityID})
+
+	third := submitPrepared(t, engine, user, ownerKey, prepared)
+	runOperationUnderGrant(t, engine, user, *runner)
+
+	// A mined batch is not evidence. Read the modules back.
+	requireEntityClear(t, client, *runner, first.EntityID, true)
+	requireEntityClear(t, client, *runner, second.EntityID, true)
+	requireEntityClear(t, client, *runner, third.EntityID, false)
+	t.Logf("✅ entities %d and %d cleared in one batch; %d holds the replacement",
+		first.EntityID, second.EntityID, third.EntityID)
+
+	usable := usableOn(t, db, owner, *runner)
+	require.Len(t, usable, 1, "a replace leaves exactly one usable grant")
+	require.Equal(t, third.ID, usable[0].ID)
+
+	// ── 3. An entity that is already clear must be DROPPED, not batched.
+	//
+	// Clearing the mark reproduces the state after an owner runs the
+	// onChainCleanup payload in their own wallet: the entity is gone from the
+	// chain and storage never found out. Batching its uninstall reverts the
+	// whole deferred action, so the next grant would fail — and keep failing,
+	// because only a successful replace marks TornDownAt.
+	clearTornDownMark(t, db, chainID.Int64(), owner, *runner, first.EntityID)
+
+	afterCleanup := firstPrepared(t, engine, user)
+	for _, s := range afterCleanup.Supersedes {
+		require.NotEqual(t, first.EntityID, s.EntityID,
+			"entity %d is already clear on chain; batching its uninstall reverts the whole grant",
+			first.EntityID)
+	}
+	require.True(t, tornDownOnRecord(t, db, chainID.Int64(), owner, *runner, first.EntityID),
+		"a candidate found clear on chain must be recorded torn down, or every later grant re-reads it")
+
+	fourth := submitPrepared(t, engine, user, ownerKey, afterCleanup)
+	runOperationUnderGrant(t, engine, user, *runner)
+	requireEntityClear(t, client, *runner, fourth.EntityID, false)
+	t.Logf("✅ stale candidate %d dropped; grant %d still landed", first.EntityID, fourth.EntityID)
+}
+
+// clearTornDownMark removes the TornDownAt marker from whichever policy holds
+// entity on runner, putting storage back to believing the entity is installed.
+//
+// Used to stage two situations that arise for real but cannot be produced
+// through the API: a wallet that stacked before on-chain replace shipped, and
+// one whose owner ran the explicit onChainCleanup payload without the gateway
+// ever learning it happened.
+func clearTornDownMark(t *testing.T, db storage.Storage, chainID int64, owner, runner common.Address, entity uint32) {
+	t.Helper()
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	require.NoError(t, err)
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != runner || p.EntityID != entity || p.Grant == nil {
+			continue
+		}
+		p.Grant.TornDownAt = 0
+		require.NoError(t, StoreSessionPolicy(db, p))
+		return
+	}
+	t.Fatalf("no stored policy holds entity %d on %s", entity, runner.Hex())
+}
+
+func tornDownOnRecord(t *testing.T, db storage.Storage, chainID int64, owner, runner common.Address, entity uint32) bool {
+	t.Helper()
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	require.NoError(t, err)
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != runner || p.EntityID != entity || p.Grant == nil {
+			continue
+		}
+		return p.Grant.TornDown()
+	}
+	t.Fatalf("no stored policy holds entity %d on %s", entity, runner.Hex())
+	return false
+}

--- a/core/taskengine/session_grant_replace_live_test.go
+++ b/core/taskengine/session_grant_replace_live_test.go
@@ -300,8 +300,22 @@ func seedEntitiesConsumedOnChain(
 ) {
 	t.Helper()
 
-	highest := uint32(0)
-	for entity := uint32(1); entity <= 32; entity++ {
+	// Walk until the wallet is clearly exhausted rather than to a fixed bound.
+	//
+	// A constant here is a trap, and it sprang: the bound was 32, the fixture's
+	// used range grew past it, and the scan then reported a highest that was too
+	// low. The allocator handed out entity 33 — clear on every module, deferred
+	// nonce sequence already 1 — and every grant AA23'd during validation with
+	// nothing on chain to say why. The bound has to track the wallet.
+	//
+	// Stopping needs a RUN of free entities, not the first one: a torn-down
+	// entity sitting between two live ones is normal after a replace, and a
+	// single-gap stop would end the walk in the middle of the used range.
+	const freeRunToStop = 8
+	const scanCeiling = 512
+
+	highest, freeRun := uint32(0), 0
+	for entity := uint32(1); entity <= scanCeiling && freeRun < freeRunToStop; entity++ {
 		sequence, err := aa.EntityDeferredNonceSequence(context.Background(), client, runner, entity)
 		require.NoError(t, err, "reading the deferred nonce sequence of entity %d", entity)
 
@@ -309,9 +323,15 @@ func seedEntitiesConsumedOnChain(
 		require.NoError(t, err)
 
 		if sequence != 0 || signer != (common.Address{}) {
-			highest = entity
+			highest, freeRun = entity, 0
+			continue
 		}
+		freeRun++
 	}
+	require.Less(t, highest, uint32(scanCeiling),
+		"runner %s has consumed %d+ entities; rotate this fixture to a fresh salt "+
+			"(scripts/fixture_wallet -salt N -deploy -fund 0.02) — entity ids are never reusable",
+		runner.Hex(), scanCeiling)
 	if highest == 0 {
 		return
 	}

--- a/core/taskengine/session_grant_replace_live_test.go
+++ b/core/taskengine/session_grant_replace_live_test.go
@@ -318,11 +318,21 @@ func seedEntitiesConsumedOnChain(
 	for entity := uint32(1); entity <= scanCeiling && freeRun < freeRunToStop; entity++ {
 		sequence, err := aa.EntityDeferredNonceSequence(context.Background(), client, runner, entity)
 		require.NoError(t, err, "reading the deferred nonce sequence of entity %d", entity)
+		if sequence != 0 {
+			// Spent, and unusable forever. Who signs it changes nothing, so
+			// skip that read — this walk is two calls per entity over a range
+			// that grows with the fixture.
+			highest, freeRun = entity, 0
+			continue
+		}
 
+		// A zero sequence is not the same as free. An entity installed by
+		// anything other than a deferred action — an owner calling
+		// installValidation directly, as the explicit-cleanup flow's inverse —
+		// holds a signer while its deferred nonce key is untouched.
 		signer, err := aa.EntitySignerOnChain(context.Background(), client, runner, entity)
 		require.NoError(t, err)
-
-		if sequence != 0 || signer != (common.Address{}) {
+		if signer != (common.Address{}) {
 			highest, freeRun = entity, 0
 			continue
 		}

--- a/core/taskengine/session_grant_replace_live_test.go
+++ b/core/taskengine/session_grant_replace_live_test.go
@@ -236,9 +236,25 @@ func livePermissions() SessionPermissions {
 		SpendCap: &model.ERC20SpendCap{
 			Token: &token, Amount: "1000000000000", GrantedCap: "1000000000000",
 		},
-		ValidUntilMs: time.Now().Add(7 * 24 * time.Hour).UnixMilli(),
+		ValidUntilMs: liveGrantValidUntilMs,
 	}
 }
+
+// liveGrantValidUntilMs is fixed for the process, and has to be.
+//
+// Submit does not trust the payload it is handed: it re-runs
+// PrepareSessionGrant and verifies the owner's signature against the digest it
+// rebuilds. So every input that reaches the deferred call must be identical at
+// prepare and at submit. ValidUntil reaches the TimeRange hook, which stores
+// unix SECONDS, so recomputing it from time.Now() at submit is invisible until
+// the two calls land either side of a second boundary — and then the rebuilt
+// digest differs and the signature recovers to a stranger.
+//
+// That went from theoretical to routine when #731 added a per-candidate chain
+// read to prepare (teardownVerifier dials per check), pushing prepare into the
+// hundreds of milliseconds. A real client sends the same validUntil it prepared
+// with; a test that regenerates it is the one telling the lie.
+var liveGrantValidUntilMs = time.Now().Add(7 * 24 * time.Hour).UnixMilli()
 
 func approveABIForReplace() []interface{} {
 	return []interface{}{


### PR DESCRIPTION
Live Sepolia coverage for the two behaviours #731 shipped that had never run against a chain.

#731 generalised the replace batch from one prior entity to N, and added a chain read that drops candidates already clear. Neither had live coverage — `TestGrantReplaceClearsThePriorEntity_Sepolia` asserts exactly one supersede, so it passes unchanged whether or not N-way works.

Both failures are invisible offline:

- A misrouted uninstall **mines with `success = true` and clears nothing** — the account catches `onUninstall` reverts and strands the module state.
- An uninstall aimed at an **already-clear** entity **reverts**, taking the whole deferred batch with it, so the new grant never installs.

The second is what `dropClearedTeardownTargets` exists for. Storage keeps believing an entity is installed long after the owner cleared it through the `onChainCleanup` payload, because nothing tells the gateway it happened — and only a *successful* replace sets `TornDownAt`, so without the drop the wallet cannot recover by itself.

## What the test does

Stacks two entities through the production path, so both `InstallCall`s are the bytes the owner actually signed rather than reconstructions — teardown is derived from those, and a rebuilt payload would mine and clear nothing. Then:

1. one grant tears down both, and the modules are read back;
2. the post-cleanup state is reproduced (entity clear on chain, storage still believing it installed) and the stale candidate must be **dropped**, recorded `TornDownAt`, and the grant must still land.

```
stacked: entities 25 and 26 both installed
✅ entities 25 and 26 cleared in one batch; 27 holds the replacement
✅ stale candidate 25 dropped; grant 28 still landed
```

## Verified to catch what it is for

| control | result |
| --- | --- |
| `dropClearedTeardownTargets` disabled | fails on the stale candidate — *"entity 11 is already clear on chain; batching its uninstall reverts the whole grant"* |
| `maxOnChainTeardowns` forced to 1 | fails on the supersede count — *"both installed entities must ride this batch"* |

## Also fixes a latent flake in the existing live test

`ValidUntil` was recomputed from `time.Now()` on the way into submit. Submit does not trust the payload it is handed — it re-runs `PrepareSessionGrant` and verifies the owner's signature against the digest it rebuilds — and `ValidUntil` reaches the TimeRange hook as unix **seconds**. A prepare and submit landing either side of a second boundary therefore rebuild a different digest, and the signature recovers to a stranger:

```
grant was signed by the wrong key: signed by 0x0609448b…, not the wallet owner 0x804e49e8…
```

Harmless until #731 added a per-candidate chain read to prepare (`teardownVerifier` dials per check), which pushed prepare into the hundreds of milliseconds and made the crossing routine — it cost two runs here before I stopped blaming the product. Now pinned for the process.

Worth noting for its own sake: that error message sends you to key management when the actual cause is an input that drifted between prepare and submit. A real client sends the same `validUntil` it prepared with, so this is not a live defect, but the diagnostic would be misleading if one ever did drift.

## Notes

- Behind the `integration` build tag; unit CI is unaffected.
- Runs on the salt-13 fixture and consumes four validation entities per run, which can never be recycled (#719) — on-demand, not per-PR.
- `scripts/fixture_wallet -salt 13` reports the wallet's per-entity state and funds it.

Refs #717
