### PR TITLE
test(taskengine): give each writing live fixture its own wallet (#719)

### DIFF
--- a/core/taskengine/execute_sequential_contract_writes_test.go
+++ b/core/taskengine/execute_sequential_contract_writes_test.go
@@ -82,7 +82,7 @@ func TestExecuteTask_SequentialContractWrites_Sepolia(t *testing.T) {
 	})
 
 	// Register smart wallet in database
-	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(11155111), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddr,
 		Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/session_fixture_permissions_decode_test.go
+++ b/core/taskengine/session_fixture_permissions_decode_test.go
@@ -53,7 +53,10 @@ func TestDecodeValidationDataFromSepolia(t *testing.T) {
 // and nothing else, so it adopted this entity for a test that needed a bare
 // grant. The signer does match. Everything that decides whether the account
 // accepts the operation does not.
-func TestBareGrantFixtureRejectsTheStaleHookedEntity(t *testing.T) {
+// fixtureEntity is the entity the captured validation data above describes.
+const fixtureEntity = uint32(1)
+
+func TestFixtureGrantRejectsTheStaleHookedEntity(t *testing.T) {
 	state, err := decodeValidationData(common.FromHex(sepoliaEntity1ValidationData))
 	require.NoError(t, err)
 	state.Installed = true
@@ -62,8 +65,8 @@ func TestBareGrantFixtureRejectsTheStaleHookedEntity(t *testing.T) {
 	require.Equal(t, fixtureController, state.Signer,
 		"precondition: the signer matches, which is all the old check looked at")
 
-	want := bareGlobalGrant(fixtureController)
-	require.False(t, want.matches(state), "a bare-grant fixture must not adopt a hooked entity")
+	want := timeBoxedGlobalGrant(fixtureController, fixtureEntity)
+	require.False(t, want.matches(state), "a fixture grant must not adopt an entity carrying a different hook set")
 
 	diff := want.diff(state)
 	require.Contains(t, diff, "validation hooks")
@@ -97,7 +100,7 @@ func TestHookedGrantFixtureDoesNotAdoptOnAShapeMatch(t *testing.T) {
 // The bare fixture is the one shape that may be adopted: no hooks means no
 // module state hiding behind the comparison.
 func TestBareGrantFixtureIsTheOnlyReusableShape(t *testing.T) {
-	require.True(t, bareGlobalGrant(fixtureController).Reusable)
+	require.True(t, timeBoxedGlobalGrant(fixtureController, fixtureEntity).Reusable)
 	require.False(t, hookedGlobalGrant(fixtureController, 1).Reusable)
 }
 
@@ -111,7 +114,7 @@ func TestFixturePermissionDiffs(t *testing.T) {
 	}
 
 	t.Run("a free entity is reported as free, not as a mismatch", func(t *testing.T) {
-		want := bareGlobalGrant(fixtureController)
+		want := timeBoxedGlobalGrant(fixtureController, fixtureEntity)
 		require.Equal(t, "entity is free (no signer installed)", want.diff(validationState{Installed: false}))
 	})
 

--- a/core/taskengine/session_fixture_permissions_test.go
+++ b/core/taskengine/session_fixture_permissions_test.go
@@ -368,18 +368,11 @@ const maxFixtureEntityScan = 16
 //	go run ./scripts/fixture_wallet -salt N -deploy -fund 0.02
 //
 // which also prints each entity's signer and deferred nonce sequence.
-// KNOWN RED, and deliberately so: the two fixtures below grant BARE global
-// authority (grantControllerAuthority), and a bare grant's deferred install
-// AA23s on a wallet where its entity is actually free. They passed on shared
-// salt 0 only by ADOPTING a bare grant some earlier run had already installed
-// — "entity 3 already grants exactly what this test needs; reusing it" — so
-// they never ran the install path at all. Isolating them made that visible,
-// which is the point: #719 asks that a live test pass from a COLD fixture.
 //
-// Not the gas seed (raising seedVerificationGasDeferredBare to the hooked
-// value changes nothing), and not the isolation: the batch-swap fixture below
-// takes a HOOKED grant and installs cleanly on its own cold wallet. Tracked
-// separately; do not re-point these at salt 0 to make them green.
+// A swap fixture needs a token balance too, or the router reverts with STF —
+// which reads like a permissions failure and is not one:
+//
+//	go run ./scripts/fixture_wallet -salt N -fund-usdc 2
 const (
 	fixtureSaltWithdrawal       = 21
 	fixtureSaltSequentialWrites = 22

--- a/core/taskengine/session_fixture_permissions_test.go
+++ b/core/taskengine/session_fixture_permissions_test.go
@@ -107,17 +107,39 @@ type expectedPermissions struct {
 	Reusable bool
 }
 
-// bareGlobalGrant is the fixture shape grantControllerAuthority installs: a
-// global grant with no hooks at all.
+// fixtureGrantValidUntil bounds every fixture grant's TimeRange hook.
 //
-// Reusable, and it is the only shape that safely can be: "no hooks" is a
-// complete description. There is no module holding configuration behind it, so
-// a match here is a match on everything that decides whether an operation
-// validates.
-func bareGlobalGrant(controller common.Address) expectedPermissions {
+// Fixed rather than time.Now()-relative, and that is deliberate: submit re-runs
+// PrepareSessionGrant and verifies the owner's signature against the digest it
+// rebuilds, so any input that drifts between prepare and submit changes the
+// digest and the signature recovers to a stranger. TimeRange stores unix
+// SECONDS, so a relative value only misbehaves when the two calls land either
+// side of a second boundary — rare enough to look like a flake.
+//
+// 2030-01-01. Far enough out to outlive the fixtures, near enough to be a
+// plausible grant rather than a permanent one.
+const fixtureGrantValidUntil = uint64(1893456000)
+
+// timeBoxedGlobalGrant is the fixture shape grantControllerAuthority installs:
+// globally authorized — no target or selector scoping, so a fixture can move
+// ETH or call anything — carrying a single TimeRange validation hook.
+//
+// The hook is not decoration. A global validation installed with an EMPTY hooks
+// array is refused when it arrives as a DEFERRED action: measured on Sepolia
+// (#734), the same wallet accepts that identical installValidation as a direct
+// self-call and rejects it deferred, as an opaque AA23. Any hook is enough, and
+// TimeRange is the one that restricts nothing about what the grant may call.
+//
+// Reusable: TimeRange holds a validUntil per entity, but every fixture asks for
+// the same far-future window, so a match on the HookConfig is a match on what
+// decides validation. That is not true of the allowlist — see Reusable.
+func timeBoxedGlobalGrant(controller common.Address, entity uint32) expectedPermissions {
 	return expectedPermissions{
-		Signer:   controller,
-		Flags:    aa.ValidationFlagUserOp | aa.ValidationFlagGlobal,
+		Signer: controller,
+		Flags:  aa.ValidationFlagUserOp | aa.ValidationFlagGlobal,
+		ValidationHooks: []hookRef{
+			{Module: aa.TimeRangeModuleAddress(), Entity: entity, Flags: aa.HookFlagValidation},
+		},
 		Global:   true,
 		Reusable: true,
 	}

--- a/core/taskengine/session_fixture_permissions_test.go
+++ b/core/taskengine/session_fixture_permissions_test.go
@@ -326,31 +326,62 @@ func readValidationState(
 // investigate, not to keep piling onto.
 const maxFixtureEntityScan = 16
 
-// Fixture runner salts.
+// Fixture runner salts — one wallet per test that writes (#719).
 //
-// Every live fixture derives its runner from salt 0 today, which is why one
-// test's leftover validation entities become another test's problem: the wallet
-// is shared, and the entity layout on it belongs to whichever test installed
-// first. Verifying permissions (above) removes the failure mode; separate salts
-// would remove the coupling.
+// Sharing salt 0 meant the entity layout on the wallet belonged to whichever
+// test installed first, so one test's leftovers decided another's outcome.
+// Verifying permissions (above) removed the failure mode; separate salts remove
+// the coupling that caused it.
 //
-// They are all still 0 because a new salt is an undeployed, unfunded
-// counterfactual wallet. Flipping one without funding its runner turns a
-// passing live test into a failing one, so the salt and the funding have to
-// move together: pick a fresh value here, run the test once to have
-// requireFundedRunner print the runner address and the shortfall, fund it, and
-// it stays isolated from then on.
+// Only the tests that SEND get their own salt. The Uniswap simulation grants a
+// policy but never sends an operation, so its install never reaches the chain
+// and it installs nothing: it reads the wallet, it does not write it. Leaving it
+// on salt 0 makes that wallet exclusively its own — including the real USDC
+// balance it needs, which a fresh counterfactual would not have.
+//
+// A salt and its funding move together. A new value is an undeployed, unfunded
+// counterfactual, and flipping one alone turns a passing live test into a
+// failing one:
+//
+//	go run ./scripts/fixture_wallet -salt N -deploy -fund 0.02
+//
+// which also prints each entity's signer and deferred nonce sequence.
+// KNOWN RED, and deliberately so: the two fixtures below grant BARE global
+// authority (grantControllerAuthority), and a bare grant's deferred install
+// AA23s on a wallet where its entity is actually free. They passed on shared
+// salt 0 only by ADOPTING a bare grant some earlier run had already installed
+// — "entity 3 already grants exactly what this test needs; reusing it" — so
+// they never ran the install path at all. Isolating them made that visible,
+// which is the point: #719 asks that a live test pass from a COLD fixture.
+//
+// Not the gas seed (raising seedVerificationGasDeferredBare to the hooked
+// value changes nothing), and not the isolation: the batch-swap fixture below
+// takes a HOOKED grant and installs cleanly on its own cold wallet. Tracked
+// separately; do not re-point these at salt 0 to make them green.
 const (
-	fixtureSaltWithdrawal        = 0
-	fixtureSaltSequentialWrites  = 0
+	fixtureSaltWithdrawal       = 21
+	fixtureSaltSequentialWrites = 22
+	fixtureSaltBatchSwap        = 23
+	// The one non-writer: salt 0 is now its private wallet, USDC balance and all.
 	fixtureSaltUniswapSimulation = 0
-	fixtureSaltBatchSwap         = 0
-	// Salt 13 is funded and its entity space is clean, so unlike the fixtures
-	// above this one is genuinely isolated. The replace check installs and
-	// removes entities; doing that on a shared runner would churn another
-	// test's entity layout.
+	// The replace checks install and remove entities several at a time, which
+	// would churn any layout they shared.
 	fixtureSaltGrantReplace = 13
 )
+
+// Entities are consumed, never recycled — by design, not by neglect.
+//
+// A torn-down entity reads clear on every module while its EntryPoint deferred
+// nonce sequence keeps its value forever, and a grant signs a carrier nonce at
+// sequence 0. So reissuing an id signs a nonce the EntryPoint has already
+// consumed, and the operation AA23s during validation with nothing on chain to
+// explain why. NextSessionEntityID allocating max+1 over retained records is
+// what prevents that (see aa.EntryPointNonce), which means every run on a
+// fixture moves its entity ids up and none of them ever come back.
+//
+// The remedy is a fresh salt, not reuse. When a fixture's entity space gets
+// crowded, `scripts/fixture_wallet -salt N` shows how far it has walked and
+// which ids are spent; pick a new salt, deploy and fund it, and move on.
 
 // resetInitialPermissions brings the fixture's runner to the permission state
 // the test declares, and returns the stored grant to run under.

--- a/core/taskengine/session_grant_testhelper_test.go
+++ b/core/taskengine/session_grant_testhelper_test.go
@@ -60,17 +60,28 @@ func grantControllerAuthority(
 	// controller, so a signer-only check adopts it and then builds operations
 	// the account rejects — see session_fixture_permissions_test.go.
 	resetInitialPermissions(t, db, swCfg, wallet,
-		func(uint32) expectedPermissions { return bareGlobalGrant(controller) },
+		func(entity uint32) expectedPermissions { return timeBoxedGlobalGrant(controller, entity) },
 		func(policyID string) (*PreparedSessionGrant, error) {
 			return PrepareSessionGrant(db, swCfg.ChainID, controller, policyID, SessionGrantRequest{
 				Owner:  owner,
 				Wallet: wallet,
-				// Global with no hooks: a fixture grant, and the API makes that
-				// deliberate rather than accidental. Production grants carry hooks.
+				// Globally authorized, so a fixture can move ETH or call
+				// anything — but NOT hookless. A global validation with an
+				// empty hooks array is refused as a deferred action (#734), so
+				// a hookless fixture only ever worked by adopting an entity a
+				// previous run had installed. TimeRange is the hook that adds
+				// no restriction on what may be called.
 				Selectors: nil,
-				Hooks:     nil,
-				// A bare global grant is refused unless acknowledged. Fixtures may be
-				// self-administering; production grants carry hooks or scoping.
+				HooksFor: func(entity uint32) ([][]byte, error) {
+					hook, err := aa.TimeRangeValidationHook(entity, fixtureGrantValidUntil, 0)
+					if err != nil {
+						return nil, fmt.Errorf("time-range hook for entity %d: %w", entity, err)
+					}
+					return [][]byte{hook}, nil
+				},
+				ValidUntil: int64(fixtureGrantValidUntil) * 1000,
+				// Global with no selector scoping still counts as
+				// self-administering, and for a fixture that is deliberate.
 				AllowSelfAdministration: true,
 			})
 		})

--- a/core/taskengine/simulate_uniswap_workflow_test.go
+++ b/core/taskengine/simulate_uniswap_workflow_test.go
@@ -88,7 +88,7 @@ func TestSimulateTask_StopLossWorkflow_Sepolia(t *testing.T) {
 		SmartAccountAddress: smartWalletAddr,
 	}
 	require.NoError(t,
-		StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
+		StoreWallet(db, int64(11155111), ownerAddress, &model.SmartWallet{
 			Owner:   &ownerAddress,
 			Address: smartWalletAddr,
 			Factory: &cfg.SmartWallet.FactoryAddress,

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -67,7 +67,7 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 	require.NoError(t, err, "Failed to derive smart wallet address")
 
 	t.Logf("🔑 Owner EOA: %s", ownerAddress.Hex())
-	t.Logf("💼 Smart Wallet (salt:0): %s", smartWalletAddress.Hex())
+	t.Logf("💼 Smart Wallet (salt:%d): %s", fixtureSaltWithdrawal, smartWalletAddress.Hex())
 	t.Logf("💰 Destination: %s", destinationAddress.Hex())
 
 	// Create engine for RunNodeImmediately execution
@@ -94,7 +94,7 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(11155111), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(fixtureSaltWithdrawal),
@@ -464,7 +464,7 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 	require.NoError(t, err, "Failed to derive smart wallet address")
 
 	t.Logf("🔑 Owner EOA: %s", ownerAddress.Hex())
-	t.Logf("💼 Smart Wallet (salt:0): %s", smartWalletAddress.Hex())
+	t.Logf("💼 Smart Wallet (salt:%d): %s", fixtureSaltWithdrawal, smartWalletAddress.Hex())
 	t.Logf("💰 Destination: %s", destinationAddress.Hex())
 
 	// Check if wallet is deployed, and deploy it if needed
@@ -521,7 +521,7 @@ func TestUserOpETHWithdrawal_Sepolia(t *testing.T) {
 	}
 
 	// Register the smart wallet in the database
-	err = StoreWallet(db, int64(1), ownerAddress, &model.SmartWallet{
+	err = StoreWallet(db, int64(11155111), ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(fixtureSaltWithdrawal),

--- a/core/taskengine/userops_withdraw_test.go
+++ b/core/taskengine/userops_withdraw_test.go
@@ -93,8 +93,12 @@ func setupUserOpWithdrawalTest(t *testing.T) (*config.Config, common.Address, *c
 		SmartAccountAddress: smartWalletAddress,
 	}
 
-	// Register the smart wallet in the database
-	err = StoreWallet(db, int64(11155111), ownerAddress, &model.SmartWallet{
+	// Chain-scoped, and this helper is the BASE one — it loads
+	// aggregator-base.yaml. Take the chain from the config rather than naming
+	// one: a wallet stored under the wrong chain is invisible to ListWallets,
+	// and runner validation then falls back to deriving salts 0-4, which
+	// silently worked only while every fixture was salt 0.
+	err = StoreWallet(db, cfg.SmartWallet.ChainID, ownerAddress, &model.SmartWallet{
 		Owner:   &ownerAddress,
 		Address: smartWalletAddress,
 		Salt:    big.NewInt(fixtureSaltWithdrawal),

--- a/scripts/fixture_wallet/main.go
+++ b/scripts/fixture_wallet/main.go
@@ -48,6 +48,7 @@ func run() error {
 	saltArg := flag.String("salt", "", "fixture salt (see fixtureSalt* in session_fixture_permissions_test.go)")
 	doDeploy := flag.Bool("deploy", false, "deploy the account if it has no code")
 	fundEth := flag.String("fund", "", "top the runner up by this many ETH")
+	fundUsdc := flag.String("fund-usdc", "", "send this many Sepolia USDC from the owner EOA to the runner")
 	flag.Parse()
 
 	if *saltArg == "" {
@@ -105,6 +106,11 @@ func run() error {
 
 	if *fundEth != "" {
 		if err := fund(ctx, client, key, *sender, *fundEth); err != nil {
+			return err
+		}
+	}
+	if *fundUsdc != "" {
+		if err := fundToken(ctx, client, key, *sender, *fundUsdc); err != nil {
 			return err
 		}
 	}
@@ -273,5 +279,71 @@ func reportEntities(ctx context.Context, client *ethclient.Client, account commo
 		}
 		fmt.Printf("%-7d %-44s %d%s\n", entity, signer.Hex(), sequence, state)
 	}
+	return nil
+}
+
+// sepoliaUSDC is the test token the live swap fixtures trade. Not Circle's.
+const sepoliaUSDC = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
+
+// fundToken sends USDC from the owner EOA to the runner.
+//
+// A swap fixture needs a token balance as well as gas: without it the router
+// reverts with STF (its safeTransferFrom of the input token fails), which reads
+// like a permissions problem and is not one.
+func fundToken(ctx context.Context, client *ethclient.Client, key *ecdsa.PrivateKey, to common.Address, amount string) error {
+	f, ok := new(big.Float).SetString(amount)
+	if !ok {
+		return fmt.Errorf("-fund-usdc %q is not a number", amount)
+	}
+	units, _ := new(big.Float).Mul(f, big.NewFloat(1e6)).Int(nil) // 6 decimals
+	token := common.HexToAddress(sepoliaUSDC)
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	// transfer(address,uint256)
+	data := crypto.Keccak256([]byte("transfer(address,uint256)"))[:4]
+	data = append(data, common.LeftPadBytes(to.Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(units.Bytes(), 32)...)
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+	nonce, err := client.PendingNonceAt(ctx, from)
+	if err != nil {
+		return err
+	}
+	tip, err := client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+	head, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return err
+	}
+	gas, err := client.EstimateGas(ctx, ethereum.CallMsg{From: from, To: &token, Data: data})
+	if err != nil {
+		return fmt.Errorf("estimating USDC transfer (owner balance too low?): %w", err)
+	}
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID: chainID, Nonce: nonce, To: &token, Gas: gas * 12 / 10,
+		GasFeeCap: new(big.Int).Add(tip, new(big.Int).Mul(head.BaseFee, big.NewInt(2))),
+		GasTipCap: tip, Data: data,
+	})
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	if err != nil {
+		return err
+	}
+	if err := client.SendTransaction(ctx, signed); err != nil {
+		return err
+	}
+	fmt.Printf("\nsending %s USDC to %s\nhttps://sepolia.etherscan.io/tx/%s\n", amount, to.Hex(), signed.Hash().Hex())
+	receipt, err := waitMined(ctx, client, signed.Hash())
+	if err != nil {
+		return err
+	}
+	if receipt.Status != 1 {
+		return fmt.Errorf("USDC transfer reverted")
+	}
+	fmt.Printf("✅ %s now holds %s USDC units\n", to.Hex(), units)
 	return nil
 }


### PR DESCRIPTION
Each live test that **sends** now has its own deployed, funded runner, so one test's leftover validation entities can no longer decide another's outcome (#719).

| fixture | salt | runner |
| --- | --- | --- |
| withdrawal | 21 | `0xc0F536127b7447A374767c1A86Aa2A859E41568F` |
| sequential writes | 22 | `0xe251e2FB82134dC3CBc7b31C421d8cF834C43A20` |
| batch swap | 23 | `0x7c8C3092FBd63A5Cc256F1848b3792fFcF97b899` |

The Uniswap **simulation** keeps salt 0. It grants a policy but never sends, so its install never reaches the chain and it installs nothing — it reads the wallet rather than writing it. That makes salt 0 exclusively its own, including the real USDC balance it needs and a fresh counterfactual would not have.

**All five writing fixtures pass on their own cold wallets.** Getting there meant fixing what isolation exposed.

## What the shared wallet was hiding

**Bare grants cannot be installed by a deferred action.** The withdrawal and sequential-write fixtures granted *bare global* authority — no hooks at all — and that shape AA23s when its entity is genuinely free. On salt 0 they passed by **adopting** a grant an earlier run had left behind:

```
fixture: entity 3 already grants exactly what this test needs; reusing it
✅ Withdrawal request successful
```

so the install path never ran. Narrowed on Sepolia, on one wallet, one variable at a time:

| | result |
| --- | --- |
| bare global, direct self-call (`eth_call` from the account) | succeeds |
| hooked global, deferred install on the same cold wallet | succeeds |
| bare global, deferred install | **AA23** |
| bare global **+ a TimeRange hook**, deferred install | succeeds |

So it is not the wallet, not gas (raising `seedVerificationGasDeferredBare` to the hooked value changes nothing), and not `executeUserOp` wrapping (forcing it changes nothing). It is an **empty hooks array on a global validation** — refused when it arrives deferred, accepted as a direct self-call. That is consistent with the account declining to install a self-administering validation unattended, which is the same risk `aa.SessionGrant.Validate` already refuses in our own code.

Fixtures now carry a TimeRange validation hook. It restricts nothing about what may be called, so a fixture can still move ETH or call anything, and it is not an execution hook so `RequiresExecuteUserOp` stays false. `bareGlobalGrant` → `timeBoxedGlobalGrant`.

Its `validUntil` is a constant rather than `time.Now()`-relative, deliberately: submit re-runs `PrepareSessionGrant` and verifies the owner's signature against the digest it rebuilds, so an input that drifts between prepare and submit makes the signature recover to a stranger. TimeRange stores seconds, so a relative value misbehaves only across a second boundary — which looks like a flake.

**Three fixtures stored their wallet under chain 1 while running on Sepolia.** The key is chain-scoped, so `ListWallets` missed it and runner validation fell back to deriving salts 0–4 — which happened to succeed while every fixture *was* salt 0, and rejects anything above it.

## Review feedback

- **The Base helper** (`setupUserOpWithdrawalTest`, which loads `aggregator-base.yaml`) took its chain from a hardcoded Sepolia id after a find-and-replace of mine. Now reads `cfg.SmartWallet.ChainID`. Thanks — that was a real bug, and exactly the failure the chain-scoping fix above is about.
- **The two knowingly-red tests** are no longer red. Rather than land them failing or re-point them at salt 0, the underlying defect is fixed, so the objection is moot.

## Fixture tooling

```
go run ./scripts/fixture_wallet -salt N -deploy -fund 0.02
go run ./scripts/fixture_wallet -salt N -fund-usdc 2
```

`-fund-usdc` is new: a swap fixture needs a token balance as well as gas, and without one the router reverts with `STF`, which reads like a permissions failure and is not one. The tool also prints each entity's signer and deferred nonce sequence, flagging ids that are spent and can never be reissued.

Refs #719, #734
