### PR TITLE
fix(worker): stack traces at Error, not Warn; restore CI for 12 skipped packages

### DIFF
--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -6,11 +6,20 @@ on:
     branches:
       - main
       - staging
+    # Every directory holding production Go code belongs here. A package left
+    # off does not fail — it runs no tests at all and the PR reports green,
+    # which is worse. This PR is an example: it changes worker/ and, before
+    # worker/** was added, ran no unit tests and no lint.
     paths:
       - "core/**"
       - "pkg/**"
       - "aggregator/**"
       - "operator/**"
+      - "worker/**"
+      - "storage/**"
+      - "migrations/**"
+      - "protobuf/**"
+      - "metrics/**"
       - "model/**"
       - "cmd/**"
       - "version/**"

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -141,17 +141,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # An allowlist, so a package missing from it is silently untested rather
+      # than red. Everything with a _test.go file belongs here; check with
+      #   go list ./... | while read p; do ls ${p#*AVS/}/*_test.go; done
       matrix:
         test:
           - aggregator
+          - aggregator/rest
+          - aggregator/rest/mapping
+          - aggregator/rest/middleware
+          - cmd
+          - core/apqueue
+          - core/chainio/aa
+          - core/config
           - core/taskengine
           - core/taskengine/trigger
           - core/taskengine/macros
+          - model
+          - pkg/bigint
           - pkg/timekeeper
           - pkg/graphql
           - pkg/byte4
           - pkg/erc4337/preset
           - pkg/erc4337/bundler
+          - pkg/erc4337/userop
+          - pkg/logger
+          - worker
           - core/backup
           - core/migrator
           - migrations

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -11,6 +11,7 @@ import (
 
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
@@ -43,11 +44,24 @@ func RunWithConfig(configPath string) error {
 }
 
 func New(cfg *WorkerConfig) (*Worker, error) {
-	logLevel := sdklogging.Development
+	// Stack traces at Error, never at Warn.
+	//
+	// sdklogging.NewZapLogger builds zap's DEVELOPMENT config outside
+	// production, and zap attaches a stack trace to every Warn when
+	// Development is set. So a boot notice that is merely informative — a
+	// worker running unsponsored, say — prints a dozen frames and reads like a
+	// crash, which is exactly how it was read. The gateway already pins this
+	// to Error (core/config/config.go); the worker had been left on the
+	// default because nothing warned at boot until it did.
+	//
+	// AddCallerSkip(1) is what NewZapLogger passes, and is kept so log lines
+	// still name their real call site rather than this constructor.
+	zapConfig := zap.NewDevelopmentConfig()
 	if cfg.Environment == "production" {
-		logLevel = sdklogging.Production
+		zapConfig = zap.NewProductionConfig()
 	}
-	logger, err := sdklogging.NewZapLogger(logLevel)
+	logger, err := sdklogging.NewZapLoggerByConfig(zapConfig,
+		zap.AddCallerSkip(1), zap.AddStacktrace(zap.ErrorLevel))
 	if err != nil {
 		return nil, fmt.Errorf("creating logger: %w", err)
 	}


### PR DESCRIPTION
Three related changes: a worker logging fix, and the CI that should have been verifying it.

## 1. Worker stack traces at Error, not Warn

A worker boot notice was printing a full stack trace and reading like a crash:

```
WARN worker/worker.go:91  Chain worker will send unsponsored operations
github.com/AvaProtocol/EigenLayer-AVS/worker.(*Worker).Start
        /Users/…/worker/worker.go:91
github.com/AvaProtocol/EigenLayer-AVS/worker.RunWithConfig
        /Users/…/worker/worker.go:42
…
```

The worker started fine — health endpoint and gRPC server both came up right after it.

`sdklogging.NewZapLogger` builds zap's **development** config outside production, and zap attaches a stack trace to every `Warn` when `Development` is set. True since #538; nothing warned at worker boot until #730 added the unsponsored-operations notice, which finally gave it something to attach one to.

The gateway already pins this to Error (`core/config/config.go`). The worker now does too, keeping the `AddCallerSkip(1)` that `NewZapLogger` passes so log lines still name their real call site.

Measured on the same config, only the option differing:

| | stack frames |
| --- | --- |
| Warn, before | 4 |
| Warn, after | 0 |
| Error, after | 4 |

## 2. The worker had no CI

Investigating why this PR had almost no checks: `run-test-on-pr.yml`'s path filter listed `core`, `pkg`, `aggregator`, `operator`, `model`, `cmd`, `version`, `config` — and nothing else. **A PR touching only `worker/` never triggered the workflow**, so it reported green having run no tests and no lint. `storage/` (the BadgerDB layer) and `migrations/` were in the same position.

## 3. The matrix was a second allowlist with the same hole

Even once triggered, the job only runs the packages the matrix names — and **twelve packages with `_test.go` files were missing**:

`aggregator/rest`, `aggregator/rest/mapping`, `aggregator/rest/middleware`, `cmd`, `core/apqueue`, **`core/chainio/aa`**, `core/config`, `model`, `pkg/bigint`, `pkg/erc4337/userop`, `pkg/logger`, `worker`

`core/chainio/aa` is the one that matters: 11 test files, including where the #717 teardown payloads are pinned — the assertions standing between us and an uninstall that mines with `success = true` and clears nothing. Those had never run in CI. `pkg/erc4337/userop` (nonce encoding) and `aggregator/rest` (the REST surface) were also absent.

All twelve verified locally with the command CI uses (`go test . -short`) before being added. Both lists now carry a note that they are allowlists — the property that made this invisible.

## Result

This PR went from 5 checks to 31. Green: 30 pass, 0 fail.
