### PR TITLE
docs: point operators at the gateway that actually answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,15 @@ per-chain internally, so there is no longer a separate testnet and mainnet
 address — Ethereum, Sepolia, Base, Base Sepolia and BNB all arrive over the
 same gRPC connection.
 
-The port is not a typo. `aggregator.avaprotocol.org` is a CNAME onto the
-gateway's TCP proxy, and the proxy chooses the public port; DNS cannot carry a
-port, so it has to be written out here.
+The port is not a typo, and it is not ours to choose. The name is a CNAME onto
+the gateway's Railway TCP proxy, which maps a public port Railway assigns onto
+the gateway's own `2206`. Railway's API takes no port argument when a proxy is
+created, so `57376` is what that proxy was given — stable for the life of the
+proxy, and different if one is ever recreated. DNS cannot carry a port, so it
+has to be written out here.
+
+Port `2206` is the gateway's internal listen address and is not reachable from
+outside; operators inside Railway's private network use `gateway.railway.internal:2206`.
 
 The REST API for workflows lives at `https://api.avaprotocol.org/api/v1`, and
 the operator dashboard at

--- a/README.md
+++ b/README.md
@@ -70,19 +70,21 @@ run.
 
 ### Aggregator Address
 
-The aggregator is currently run and managed by the Ava Protocol team. Depend on
-testnet or mainnet, you would need to point your operator to the right address
-in the operator config file.
+The aggregator is run and managed by the Ava Protocol team. Point your operator
+at it in the operator config file:
 
-#### Sepolia Testnet
+```yaml
+aggregator_server_ip_port_address: "zephyr.proxy.rlwy.net:57376"
+```
 
-- aggregator-sepolia.avaprotocol.org:2206
-- [https://api-explorer-sepolia.avaprotocol.org/](https://api-explorer-sepolia.avaprotocol.org/)
+One endpoint serves every chain. The gateway is a single deployment that routes
+per-chain internally, so there is no longer a separate testnet and mainnet
+address — Ethereum, Sepolia, Base, Base Sepolia and BNB all arrive over the
+same gRPC connection.
 
-#### Mainnet
-
-- aggregator.avaprotocol.org:2206
-- [https://api-explorer.avaprotocol.org/](https://api-explorer.avaprotocol.org/)
+The REST API for workflows lives at `https://api.avaprotocol.org/api/v1`, and
+the operator dashboard at
+[https://api.avaprotocol.org/telemetry](https://api.avaprotocol.org/telemetry).
 
 ## Operators
 
@@ -105,16 +107,14 @@ Currently, Ava Protocol has deployed our operator on the testnet. Community memb
 
 ## Telemetry Dashboard
 
-Operator that is connected to Ava Protocol aggregator can also check their
-operator on our telemetry dashboard as below
+An operator connected to the Ava Protocol gateway can see itself on the
+telemetry dashboard:
 
-### Testnet
+https://api.avaprotocol.org/telemetry
 
-https://aggregator-sepolia.avaprotocol.org/telemetry
-
-### Mainnet
-
-https://aggregator.avaprotocol.org/telemetry
+One dashboard covers every chain. The gateway is unified — a single deployment
+serves all chains and routes per-chain internally — so the previous per-chain
+`aggregator-*.avaprotocol.org/telemetry` hosts no longer exist.
 
 ## Branching Strategy
 

--- a/README.md
+++ b/README.md
@@ -82,16 +82,6 @@ per-chain internally, so there is no longer a separate testnet and mainnet
 address — Ethereum, Sepolia, Base, Base Sepolia and BNB all arrive over the
 same gRPC connection.
 
-The port is not a typo, and it is not ours to choose. The name is a CNAME onto
-the gateway's Railway TCP proxy, which maps a public port Railway assigns onto
-the gateway's own `2206`. Railway's API takes no port argument when a proxy is
-created, so `57376` is what that proxy was given — stable for the life of the
-proxy, and different if one is ever recreated. DNS cannot carry a port, so it
-has to be written out here.
-
-Port `2206` is the gateway's internal listen address and is not reachable from
-outside; operators inside Railway's private network use `gateway.railway.internal:2206`.
-
 The REST API for workflows lives at `https://api.avaprotocol.org/api/v1`, and
 the operator dashboard at
 [https://api.avaprotocol.org/telemetry](https://api.avaprotocol.org/telemetry).

--- a/README.md
+++ b/README.md
@@ -74,13 +74,17 @@ The aggregator is run and managed by the Ava Protocol team. Point your operator
 at it in the operator config file:
 
 ```yaml
-aggregator_server_ip_port_address: "zephyr.proxy.rlwy.net:57376"
+aggregator_server_ip_port_address: "aggregator.avaprotocol.org:57376"
 ```
 
 One endpoint serves every chain. The gateway is a single deployment that routes
 per-chain internally, so there is no longer a separate testnet and mainnet
 address — Ethereum, Sepolia, Base, Base Sepolia and BNB all arrive over the
 same gRPC connection.
+
+The port is not a typo. `aggregator.avaprotocol.org` is a CNAME onto the
+gateway's TCP proxy, and the proxy chooses the public port; DNS cannot carry a
+port, so it has to be written out here.
 
 The REST API for workflows lives at `https://api.avaprotocol.org/api/v1`, and
 the operator dashboard at

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -112,8 +112,8 @@ smart_wallet:
   paymaster_address:
 
 # Chain worker registry — gateway routes tasks to workers by chain_id.
-# In production (Railway): worker-sepolia.railway.internal:50051
-# Locally: workers run on different localhost ports.
+# Locally, workers run on different localhost ports. A hosted deployment puts
+# them on a private network and sets worker_addr accordingly.
 chains:
   - chain_id: 11155111
     name: sepolia

--- a/config/worker-base-sepolia.example.yaml
+++ b/config/worker-base-sepolia.example.yaml
@@ -14,7 +14,8 @@ chain_id:   84532
 chain_name: base-sepolia
 
 # Internal gRPC listen address (gateway connects here).
-# In production (Railway): worker-base-sepolia.railway.internal:50051
+# In a hosted deployment this is reached over the platform's private network;
+# the gateway's chain registry holds the address.
 listen_address: "0.0.0.0:50052"
 
 # Health check endpoint (Railway requires HTTP health checks).

--- a/config/worker-sepolia.example.yaml
+++ b/config/worker-sepolia.example.yaml
@@ -14,7 +14,8 @@ chain_id:   11155111
 chain_name: sepolia
 
 # Internal gRPC listen address (gateway connects here).
-# In production (Railway): worker-sepolia.railway.internal:50051
+# In a hosted deployment this is reached over the platform's private network;
+# the gateway's chain registry holds the address.
 listen_address: "0.0.0.0:50051"
 
 # Health check endpoint (Railway requires HTTP health checks).

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -35,7 +35,7 @@ bls_private_key_store_path: <path_to_operator_bls_key_json>
 # Unified aggregator endpoint — one gRPC connection serves every chain
 # (Ethereum, Sepolia, Base, Base Sepolia, BNB); the gateway routes per-chain
 # internally, so there is no separate testnet address.
-aggregator_server_ip_port_address: "zephyr.proxy.rlwy.net:57376"
+aggregator_server_ip_port_address: "aggregator.avaprotocol.org:57376"
 
 # avs node spec compliance https://eigen.nethermind.io/docs/spec/intro
 eigen_metrics_ip_port_address: <operator_public_ip>:9090

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -32,9 +32,9 @@ eth_rpc_url: <your_ethereum_mainnet_rpc_url>
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 
-# Unified aggregator endpoint — one gRPC connection serves every chain
-# (Ethereum, Sepolia, Base, Base Sepolia, BNB); the gateway routes per-chain
-# internally, so there is no separate testnet address.
+# One endpoint, and it is the mainnet one — see the note below on third-party
+# operators. The gateway routes per-chain internally, so there is no separate
+# address to switch to.
 aggregator_server_ip_port_address: "aggregator.avaprotocol.org:57376"
 
 # avs node spec compliance https://eigen.nethermind.io/docs/spec/intro

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -32,9 +32,10 @@ eth_rpc_url: <your_ethereum_mainnet_rpc_url>
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 
-# Unified aggregator endpoint — serves all mainnet chains (Ethereum, Base, ...)
-# from a single gRPC connection. The gateway routes per-chain internally.
-aggregator_server_ip_port_address: "aggregator.avaprotocol.org:2206"
+# Unified aggregator endpoint — one gRPC connection serves every chain
+# (Ethereum, Sepolia, Base, Base Sepolia, BNB); the gateway routes per-chain
+# internally, so there is no separate testnet address.
+aggregator_server_ip_port_address: "zephyr.proxy.rlwy.net:57376"
 
 # avs node spec compliance https://eigen.nethermind.io/docs/spec/intro
 eigen_metrics_ip_port_address: <operator_public_ip>:9090

--- a/docs/changes/20260612-delegate-chain-rpc-to-workers.md
+++ b/docs/changes/20260612-delegate-chain-rpc-to-workers.md
@@ -76,7 +76,7 @@ Two implementations:
    the `ChainRegistry` already maintained at `aggregator/chain_registry.go`,
    calls `ChainWorker.GetTokenMetadata` over the existing gRPC
    connection. The registry already knows the mapping
-   (`worker-bnb-mainnet.railway.internal:50051` → chain 56 etc.) —
+   (one worker address per chain_id, e.g. chain 56) —
    we'd just expose a getter.
 2. **Local-fallback** (single-binary, integration tests): falls back
    to the existing `TokenEnrichmentService` for callers that don't
@@ -104,7 +104,7 @@ Once Phase 2 is live and confirmed in production:
 
 1. Remove the per-chain RPC + bundler entries from
    `gateway-railway.yaml`'s `chains:` block. Each entry collapses to
-   just `worker_addr: worker-X.railway.internal:50051` + the static
+   just `worker_addr: <worker-host>:50051` + the static
    AVS contract addresses.
 2. Delete `SEPOLIA_RPC`, `BASE_RPC`, `ETHEREUM_RPC`, `BASE_SEPOLIA_RPC`,
    `BNB_RPC` env vars from the **gateway** Railway service. (The
@@ -137,7 +137,7 @@ ripping out the gateway's RPC config.
 ## Risks & rollback
 
 - **Worker-routed lookup latency**: adds 1 gRPC round-trip per token
-  lookup. Workers are on Railway's private network (`<svc>.railway.internal`),
+  lookup. Workers sit on the deployment's private network,
   so single-digit milliseconds. The local
   `TokenEnrichmentService` cache lives on the worker side now —
   consider whether the gateway also needs a thin LRU in front to


### PR DESCRIPTION
`README.md` and `docs/Operator.md` told community operators to dial `aggregator.avaprotocol.org:2206` (and `aggregator-sepolia` for testnet). Neither worked at the time this was opened:

| host | DNS | port 2206 |
| --- | --- | --- |
| `aggregator.avaprotocol.org` | `3.219.223.211` (AWS, per whois `AT-88-Z`) | closed |
| `aggregator-sepolia.avaprotocol.org` | none | — |

Anyone following those instructions got a connection timeout with nothing explaining why.

## The DNS has since been fixed

`aggregator.avaprotocol.org` is **no longer stale** — it is now a CNAME onto the gateway's Railway TCP proxy, applied and verified:

```
$ dig +short CNAME aggregator.avaprotocol.org
zephyr.proxy.rlwy.net.

$ grpcurl -plaintext aggregator.avaprotocol.org:57376 list
aggregator.Node
grpc.reflection.v1.ServerReflection
grpc.reflection.v1alpha.ServerReflection
```

So the address published here answers today. An earlier version of this description named the raw `zephyr.proxy.rlwy.net:57376`, which is what the diff used before the CNAME existed; that is what the branded name resolves to now, and the branded name is preferred because it survives Railway regenerating the proxy host.

## Collapsing the testnet/mainnet split

One gateway serves chains 1, 11155111, 56, 8453 and 84532 and routes per-chain internally, so there is a single operator endpoint rather than one per network.

`docs/Operator.md` states separately that **third-party operator support is mainnet-only**, with testnet coordination handled internally. The endpoint comment there is written accordingly and no longer enumerates the testnet chains the gateway happens to serve, which would have invited exactly the reading that note exists to prevent.

## Dead links removed

`api-explorer.avaprotocol.org` and `api-explorer-sepolia.avaprotocol.org` both fail to connect; the first was an alias onto the retired IP. Telemetry moved with the gateway to `https://api.avaprotocol.org/telemetry` (200), so the two per-chain links collapse into one.

## Route 53, in the same pass

Five dead records removed: four aliases dangling on the deleted `aggregator-holesky` / `aggregator-minato` names — including `api-explorer-minato.avaprotocol.org.avaprotocol.org`, whose doubled suffix meant it could never have resolved — plus `api-explorer`.

## On how long this was broken

I do not know, and an earlier version of this description said "for a while" without evidence. What is verified is the state at the time of checking, above. The only bound is circumstantial: the gateway's TCP proxy was created 2026-05-26. Route 53 keeps no history via its API.

## Note for whoever maintains the gateway service

The published port is Railway-assigned — `TCPProxyCreateInput` has no port argument, and `tcpProxyDelete` is the only related mutation. Deleting that proxy changes the port and breaks these instructions silently. Recorded in `avs-infra/RAILWAY_OPERATIONS.md`.
