### PR TITLE
feat: centralize REST auth in permission map

### DIFF
--- a/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
+++ b/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
@@ -1,16 +1,19 @@
 # Gateway change required: partner-gated reads & permission levels
 
-**Status:** Required change — not yet implemented  
+**Status:** **Implemented (gateway)** — `permission.go` / `ensurePermission` +  
+OpenAPI security overrides on PR #739.  
+**Remaining (external):** Studio + ava-sdk-js e2e mint/send partner `scope: read`  
+for token metadata; deploy configs with `scopes: [read]`; **per-partner rate  
+limits deferred** (see §4.4 — still JWT-subject / shared `anonymous` today).  
 **Repo:** EigenLayer-AVS (gateway / aggregator REST)  
 **Date:** 2026-08-08  
 **Related (Studio):** deposit / fund_wallet UX; `getTokenMetadataAction` fails with  
 `No valid auth key … wallet must sign in again` when the user has a live wallet  
 socket (AutoConnect) but no fresh **AVS user JWT** for the connected chain  
 (Position D).  
-**Related (existing):** `PLAN_PARTNER_PAYMENTS.md` (partner assertion — Phase 1  
-either/or simulate is **superseded** for auth policy below),  
-`aggregator/rest/partner.go`, `aggregator/rest/handlers_tokens.go`,  
-`aggregator/rest/handlers_wallets.go`
+**Related (code):** `aggregator/rest/permission.go`, `aggregator/rest/partner.go`,  
+`api/openapi.yaml`, `PLAN_PARTNER_PAYMENTS.md` (Phase 1 partner-only simulate  
+**superseded**).
 
 ---
 
@@ -272,15 +275,19 @@ user, err := s.requireUser(ctx) // not requireSimulateAuth
 
 ### 4.4 Rate limiting
 
-| Layer | Suggestion |
-|-------|------------|
-| Per partner | QPS / daily on partner-sufficient routes (`/tokens/*`, preview wallets) |
-| Per subject | When JWT present, or partner `sub` when set |
-| Global | Existing gateway limits |
+| Layer | Suggestion | Status |
+|-------|------------|--------|
+| Per partner | QPS / daily on partner-sufficient routes (`/tokens/*`, preview wallets) | **Deferred** (follow-up) |
+| Per subject | When JWT present, or partner `sub` when set | Partial (JWT subject only) |
+| Global | Existing gateway limits | Live |
 
-Partner-first is what makes anonymous scrapers fail at Gate 1; implement  
-per-partner limits with the auth change (today’s limiter is mostly per JWT  
-subject / shared anonymous).
+**Deferred note (PR #739 / Copilot):** rate-limit middleware still runs  
+*before* `ensurePermission` and keys only on JWT subject or the shared  
+`anonymous` bucket. Partner-only token/wallet traffic therefore shares  
+`anonymous` with unauthenticated noise. Fix requires verifying (or  
+peeking) partner identity before the limiter — separate change; not  
+blocking the permission-map merge. Partner Gate 1 still rejects unknown  
+apps at the handler.
 
 ### 4.5 Studio follow-up
 

--- a/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
+++ b/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
@@ -1,0 +1,395 @@
+# Gateway change required: partner-gated reads & permission levels
+
+**Status:** Required change — not yet implemented  
+**Repo:** EigenLayer-AVS (gateway / aggregator REST)  
+**Date:** 2026-08-08  
+**Related (Studio):** deposit / fund_wallet UX; `getTokenMetadataAction` fails with  
+`No valid auth key … wallet must sign in again` when the user has a live wallet  
+socket (AutoConnect) but no fresh **AVS user JWT** for the connected chain  
+(Position D).  
+**Related (existing):** `PLAN_PARTNER_PAYMENTS.md` (partner assertion — Phase 1  
+either/or simulate is **superseded** for auth policy below),  
+`aggregator/rest/partner.go`, `aggregator/rest/handlers_tokens.go`,  
+`aggregator/rest/handlers_wallets.go`
+
+---
+
+## 1. Problem
+
+### What Studio needs
+
+Studio’s Deposit modal and token picker need **public-ish on-chain facts**:
+
+| Data | Today’s Studio path | Auth today |
+|------|---------------------|------------|
+| Token balances | Moralis (`getWalletTokenBalancesAction`) | NextAuth `userId` only — **no AVS JWT** |
+| Token metadata (name / symbol / decimals) | Gateway `GET /api/v1/tokens/{address}` via `getAuthedClient` | **Requires wallet-signed AVS user JWT** |
+
+Balances already work without an AVS JWT. Metadata does not:  
+`executionController.getTokenMetadata` → `getAuthedClient` → gateway  
+`GetToken` → `requireUser`.
+
+So after refresh, AutoConnect can restore Rabby while the modal still errors on  
+metadata because **AVS JWT is missing/expired for that EOA + chain**. The data  
+itself is not user-private (whitelist + `eth_call` name/symbol/decimals).
+
+The same cold-JWT gap hits **preview wallet resolve** (list + derive/create for  
+`$SMART_WALLET$`) if those paths ever required a user JWT without a partner  
+path — today they already allow partner OR JWT via `requireWalletDeriveAuth`;  
+this doc **keeps** that class partner-sufficient and groups list + create  
+together.
+
+### What we must not do
+
+**Do not open true public (anonymous) endpoints.**
+
+Unauthenticated `GET /tokens/*`, wallet list, etc. would:
+
+- Invite DDoS / scraper load against gateway + RPC
+- Bypass the tenant model (any client could hammer enrichment)
+- Diverge from “gateway is not a full public service”
+
+---
+
+## 2. Auth model (required)
+
+### Principle: minimal permission per operation
+
+The gateway is **not** intended as a fully public service. Most product traffic  
+sits behind a gate. Each operation gets the **weakest** permission that still  
+makes it safe and attributable — not “stack every gate by default.”
+
+**Two gates, different jobs. Applied by stakes, not always AND.**
+
+| Gate | Who | Purpose |
+|------|-----|---------|
+| **1. Partner app** | Registered partner in gateway config (`partners[]`; Studio only for now) | Outer door: only known apps may call. Attribution, per-partner rate limits, kill switch. **Sufficient alone** for low-stake read / preview-resolve. |
+| **2. User JWT** | End user’s wallet-signed gateway JWT (`Authorization: Bearer` via `auth:exchange`) | Binds the call to a concrete wallet subject and authority. **Required** for simulate / runNode and all user-owned or fund-moving ops. |
+
+There is **no anonymous / fully open** product API for these surfaces.
+
+```
+  Request
+      │
+      │  almost never anonymous
+      ▼
+  ┌─────────────────────────────┐
+  │ Gate 1: Partner             │  registered app (config whitelist)
+  │ (when op needs tenancy /    │
+  │  partner-sufficient class)  │
+  └─────────────┬───────────────┘
+                │
+     partner-sufficient ops          JWT-required ops
+     (read, preview wallet)          (simulate, execute, …)
+                │                              │
+                ▼                              ▼
+         handler                         Gate 2: User JWT
+                                         then handler
+```
+
+Gates do **not** fight each other: partner answers “which app,” JWT answers  
+“which wallet / with what authority.” Conflict only appears if a low-stake  
+read is forced through Gate 2 when Gate 1 alone is enough.
+
+### Partner registration (ops only)
+
+- Registration is **manual** (gateway YAML `partners[]` + public keys + scopes).
+- **Only Studio** is registered for now; design for N, operate with one.
+- **No partner registration / management API** in this change (or near term).
+- Suspend / rotate keys = config change + redeploy/reload as ops practice.
+
+### Target permission matrix
+
+| Operation class | Endpoints (today) | Minimal auth | Partner alone? | User JWT? |
+|-----------------|-------------------|--------------|----------------|-----------|
+| **Token / public chain reads** | `GET /api/v1/tokens/{address}` | Partner `scope: read` | **Yes** | No |
+| **Preview wallet resolve** | `GET /api/v1/wallets` (list), `POST /api/v1/wallets` (create/derive) | Partner (assertion `sub` = owner EOA) | **Yes** | No |
+| **Simulate / runNode / runTrigger** | `POST …/workflows:simulate`, `/nodes:run`, `/triggers:run` | **User JWT** | **No** | **Yes** |
+| **User-owned / fund authority** | workflows CRUD, executions, secrets, policies, withdraw, etc. | User JWT | **No** (policies already refuse partner) | **Yes** |
+
+**Preview wallet resolve** is one class: **list + create (derive)** share the same  
+partner-sufficient gate. Both are no-fund (CREATE2 / owner-scoped list).  
+Update / withdraw / nonce remain JWT-only.
+
+Optional later: require partner **in addition** on JWT routes (outer tenancy  
+AND). That is product lockdown, not the **minimal** requirement for those ops.  
+Minimal for simulate is JWT; minimal for token metadata and preview wallet  
+resolve is partner.
+
+### Relation to today’s code / `PLAN_PARTNER_PAYMENTS.md`
+
+| Surface | Today | This contract |
+|---------|--------|----------------|
+| Token metadata | `requireUser` only | **Partner `read` only** (JWT not required) |
+| List / create wallet | `requireWalletDeriveAuth` = partner **or** JWT | **Partner-sufficient** (JWT still accepted if present); keep `sub` = EOA for partner path |
+| Simulate / runNode / runTrigger | `requireSimulateAuth` = partner **or** JWT | **User JWT required** — partner alone **rejected** |
+| Fund / policies | User JWT; partner refused on policies | Unchanged |
+
+Phase 1 “partner-delegated simulate” (partner alone for no-fund run) is  
+**superseded** for policy: partner does **not** authorize simulate/runNode.  
+Partner remains for **reads + preview wallet resolve**.
+
+---
+
+## 3. Scope of APIs
+
+### In scope (must change)
+
+| Method | Path | Today | Required |
+|--------|------|-------|----------|
+| `GET` | `/api/v1/tokens/{address}` | `requireUser` | **Partner `read`** (no user JWT) |
+| `GET` | `/api/v1/wallets` | `requireWalletDeriveAuth` (partner **or** JWT) | **Preview wallet resolve** — partner OK without JWT; JWT OK if present |
+| `POST` | `/api/v1/wallets` | same | same class as list (derive/ensure) |
+| `POST` | `/api/v1/workflows:simulate` | `requireSimulateAuth` (partner **or** JWT) | **`requireUser` (JWT only)** — drop partner-only path |
+| `POST` | `/api/v1/nodes:run` | same | **JWT only** |
+| `POST` | `/api/v1/triggers:run` | same | **JWT only** |
+
+Handlers:
+
+- Tokens: `handlers_tokens.go` → `GetToken`
+- Wallets: `handlers_wallets.go` → `ListWallets`, `CreateWallet` (`requireWalletDeriveAuth`)
+- Simulate family: `handlers_workflows.go` / `handlers_nodes.go` / `handlers_triggers.go`
+
+Engine paths (whitelist, CREATE2, simulate) can stay; **auth helpers and  
+OpenAPI security** change.
+
+### Explicitly out of scope
+
+| Concern | Notes |
+|---------|--------|
+| Wallet **balances** for Deposit UI | Stay on Studio → Moralis + NextAuth until a gateway portfolio read is productized (then partner `read`, same as metadata). |
+| Partner registration API | Manual config only. |
+| Fund-moving / policies via partner | Never. |
+| Long-lived `X-Partner-API-Key` | Optional later; v1 reuses Ed25519 `X-Partner-Assertion`. |
+
+### “Public APIs” (product language)
+
+In Studio discussion, “public” meant **non-secret chain / resolve data**, not  
+unauthenticated HTTP:
+
+1. **Token metadata** — partner-gated.  
+2. **Preview wallet resolve** (list + create/derive) — partner-gated.  
+3. **Future gateway balances** — same partner `read` class if introduced.
+
+---
+
+## 4. Implementation sketch
+
+### 4.1 Partner verification (Gate 1)
+
+Reuse config registry (`partners[]`, `partner_assertion_audience`), Ed25519  
+`X-Partner-Assertion`:
+
+```json
+{
+  "iss": "studio",
+  "sub": "<owner EOA for wallet resolve; optional/empty for pure metadata>",
+  "scope": "read",
+  "aud": "<partner_assertion_audience>",
+  "exp": ...,
+  "iat": ...,
+  "jti": "..."
+}
+```
+
+Suggested scopes (config `scopes: [...]`):
+
+| Scope | Authorizes |
+|-------|------------|
+| `read` | Token metadata (and later portfolio reads). May also cover preview wallet resolve if product prefers one scope. |
+| `wallet_preview` (optional split) | List + create/derive only — use if `read` should not include wallet endpoints. |
+
+**v1 recommendation:** one scope `read` covering token metadata **and** preview  
+wallet resolve (list + create), to keep Studio minting simple. Split later if  
+a partner needs metadata without wallet resolve.
+
+- **Token metadata:** partner `read`; `sub` optional (logging / rate-limit key).  
+- **Preview wallet resolve:** partner `read` (or `wallet_preview`); **`sub` must  
+  be a real 0x EOA** (same rule as today’s `requireWalletDeriveAuth`).  
+- **`scope: simulate` on partner:** no longer authorizes simulate/runNode;  
+  remove from Studio mints for those calls; config may drop `simulate` or leave  
+  unused.
+
+Partner registration remains YAML only, e.g.:
+
+```yaml
+partners:
+  - id: studio
+    public_keys: ["ed25519:..."]
+    scopes: ["read"]
+    status: active
+partner_assertion_audience: avs-gateway-staging   # env-specific
+```
+
+### 4.2 Auth helpers
+
+```text
+requirePartner(ctx, requiredScope) → partnerPrincipal
+  - verify X-Partner-Assertion (or absent → 401 for partner-only routes)
+  - check registry scope + token scope
+  - return partner_id + sub
+
+requirePartnerRead(ctx):
+  - requirePartner(ctx, "read")
+  - for GetToken: build *model.User from sub if hex address, else zero / omit
+  - engine.GetTokenMetadata only uses user for logs today
+
+requirePreviewWalletResolve(ctx) → *model.User
+  - if user JWT present → requireUser (existing path)
+  - else requirePartner(ctx, "read") with sub = concrete EOA
+  - same shape as today’s requireWalletDeriveAuth, scopes updated
+
+requireUser(ctx) for simulate / runNode / runTrigger
+  - JWT required
+  - if X-Partner-Assertion present: either ignore for auth (JWT wins) or
+    refuse partner on these routes — prefer clear error if partner-only
+    credentials are sent without JWT so Studio fails loudly
+```
+
+`GetToken` becomes partner-only (no `requireUser`):
+
+```go
+_, err := s.requirePartner(ctx, scopeRead) // or requirePartnerRead
+// ... unchanged GetTokenMetadata; pass a User for logging if useful
+```
+
+Simulate family:
+
+```go
+user, err := s.requireUser(ctx) // not requireSimulateAuth
+```
+
+### 4.3 OpenAPI / SDK
+
+- Token metadata: security = partner assertion (`X-Partner-Assertion`), not  
+  bearer-only.  
+- Preview wallets: partner **or** bearer (document both).  
+- Simulate / runNode / runTrigger: bearer JWT **required**; document that  
+  partner alone is insufficient.  
+- SDK-js / Studio: mint `scope: "read"` for metadata + wallet resolve; stop  
+  relying on partner for simulate (send user JWT).  
+- Error codes: keep `PARTNER_*` vs `AUTH_REQUIRED` distinct.
+
+### 4.4 Rate limiting
+
+| Layer | Suggestion |
+|-------|------------|
+| Per partner | QPS / daily on partner-sufficient routes (`/tokens/*`, preview wallets) |
+| Per subject | When JWT present, or partner `sub` when set |
+| Global | Existing gateway limits |
+
+Partner-first is what makes anonymous scrapers fail at Gate 1; implement  
+per-partner limits with the auth change (today’s limiter is mostly per JWT  
+subject / shared anonymous).
+
+### 4.5 Studio follow-up
+
+1. Mint partner assertion `scope: "read"` for token metadata and preview  
+   wallet list/create.  
+2. Call those APIs with **partner only** when AVS JWT is cold (AutoConnect  
+   without re-exchange).  
+3. **Catalog-first** metadata fallback for known tokens (USDC/WETH) as extra  
+   UX hardening.  
+4. Simulate / runNode: **always** user JWT after auth exchange; do not send  
+   partner-only for those.  
+5. Deposit / preview resolve should not map “missing AVS JWT” to “wallet not  
+   connected” when only partner-gated reads were needed.
+
+---
+
+## 5. Security properties
+
+| Threat | Mitigation |
+|--------|------------|
+| Open internet scrapes `/tokens` or lists wallets | Gate 1: unknown partners rejected |
+| Leaked partner private key | Short TTL assertions; key rotation; scope limited to `read` / preview resolve — **not** simulate, execute, or policies |
+| Partner-only scrape of metadata | Per-partner rate limits + TTL (accepted blast radius: RPC cost, not funds) |
+| Partner-only simulate abuse | **Rejected** — JWT required for simulate/runNode |
+| Partner used for fund moves / policies | Existing refuse / requireUser; unchanged |
+| Leaked user JWT | Same as today for JWT routes; partner-sufficient routes do not need JWT |
+
+**Blast radius of partner `read` + preview wallet resolve:** metadata RPC,  
+owner-scoped wallet list/derive for assertion `sub` — not transfers, not  
+task create, not full simulate.
+
+---
+
+## 6. Acceptance criteria
+
+### Token metadata
+
+- [ ] `GET /api/v1/tokens/{address}` with valid partner `read` assertion,  
+      **no** user JWT → **200** (same body shape: `found`, symbol, decimals, …).  
+- [ ] Same without partner credential → **401** (even with valid user JWT,  
+      if product requires partner on this route; if JWT-only is still allowed  
+      as transition, document it — **target is partner-gated**).  
+- [ ] Partner without `read` scope → scope error.
+
+### Preview wallet resolve (list + create/derive)
+
+- [ ] `GET /api/v1/wallets` and `POST /api/v1/wallets` with partner assertion  
+      + `sub` = owner EOA, **no** user JWT → success (list / derived wallet).  
+- [ ] Partner with empty/non-address `sub` → **400** `PARTNER_SUBJECT_REQUIRED`  
+      (or equivalent).  
+- [ ] User JWT alone still works (optional compatibility).  
+- [ ] Update/withdraw/nonce still **JWT only**.
+
+### Simulate / runNode / runTrigger
+
+- [ ] Valid partner assertion alone (any scope) → **401** (JWT required).  
+- [ ] Valid user JWT → existing success behavior.  
+- [ ] Partner assertion cannot authorize createTask / execute / policies.
+
+### Ops / docs / Studio
+
+- [ ] Config example: Studio `scopes: ["read"]` (no registration API).  
+- [ ] OpenAPI + tests updated for the matrix.  
+- [ ] Studio: metadata + wallet resolve with partner when JWT cold;  
+      simulate only with JWT; catalog-first optional.
+
+---
+
+## 7. Non-goals
+
+- Fully public unauthenticated token, balance, or wallet HTTP APIs.  
+- Partner registration / multi-tenant admin API.  
+- Replacing Moralis balances in Studio in this change.  
+- Partner-only simulate / runNode (explicitly **not** allowed).  
+- Expanding partner scope to fund-moving operations.  
+- Dual-gate **AND** (partner + JWT) as the default for cheap reads.
+
+---
+
+## 8. Suggested implementation order
+
+1. Add `scopeRead` (+ helpers `requirePartner` / partner-only read path) in  
+   `aggregator/rest/partner.go`.  
+2. Switch `GetToken` to partner `read`; tests for partner-only success.  
+3. Keep/adjust `requireWalletDeriveAuth` as **preview wallet resolve** under  
+   `read` (list + create); confirm create stays partner-ok.  
+4. Switch simulate / runNode / runTrigger from `requireSimulateAuth` to  
+   `requireUser`; tests that partner-only is rejected.  
+5. Config examples: Studio `scopes: [read]`; deprecate partner `simulate` for  
+   auth.  
+6. SDK + Studio: `read` assertion for metadata + wallets; JWT for simulate;  
+   catalog-first as UX polish.
+
+---
+
+## 9. Summary
+
+| Question | Answer |
+|----------|--------|
+| Is token metadata user-secret? | No |
+| True public HTTP API? | **No** — partner gate |
+| Minimal gate for reads / preview wallet? | **Partner only** |
+| List + create (derive) one class? | **Yes** — preview wallet resolve under partner |
+| Simulate / runNode partner-only? | **No** — **user JWT required** |
+| Partner registration API? | **No** — manual config; Studio only for now |
+| Dual-gate AND on metadata? | **No** — that over-gates cold JWT UX |
+| Balances today | Moralis + NextAuth; partner `read` if moved to gateway later |
+
+This file is the **gateway-side auth contract**: partner as outer/minimal gate  
+for read + preview resolve; user JWT for simulate and restrictive ops; no  
+anonymous product APIs. Studio catalog/Moralis fallbacks remain complementary  
+UX, not a substitute for partner-bound gateway traffic.

--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -364,8 +364,6 @@ func (w *ServerInterfaceWrapper) RunNode(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) ListOperators(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(BearerAuthScopes, []string{})
-
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.ListOperators(ctx)
 	return err
@@ -482,7 +480,7 @@ func (w *ServerInterfaceWrapper) GetToken(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
 	}
 
-	ctx.Set(BearerAuthScopes, []string{})
+	ctx.Set(PartnerAssertionScopes, []string{})
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetTokenParams
@@ -515,6 +513,8 @@ func (w *ServerInterfaceWrapper) ListWallets(ctx echo.Context) error {
 
 	ctx.Set(BearerAuthScopes, []string{})
 
+	ctx.Set(PartnerAssertionScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.ListWallets(ctx)
 	return err
@@ -525,6 +525,8 @@ func (w *ServerInterfaceWrapper) CreateWallet(ctx echo.Context) error {
 	var err error
 
 	ctx.Set(BearerAuthScopes, []string{})
+
+	ctx.Set(PartnerAssertionScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.CreateWallet(ctx)
@@ -1452,17 +1454,6 @@ type ListOperators200JSONResponse OperatorList
 func (response ListOperators200JSONResponse) VisitListOperatorsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type ListOperators401ApplicationProblemPlusJSONResponse struct {
-	UnauthorizedApplicationProblemPlusJSONResponse
-}
-
-func (response ListOperators401ApplicationProblemPlusJSONResponse) VisitListOperatorsResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	BearerAuthScopes = "bearerAuth.Scopes"
+	BearerAuthScopes       = "bearerAuth.Scopes"
+	PartnerAssertionScopes = "partnerAssertion.Scopes"
 )
 
 // Defines values for AwaitNodeType.

--- a/aggregator/rest/handlers_auth.go
+++ b/aggregator/rest/handlers_auth.go
@@ -37,6 +37,9 @@ const authMessageRequired = 8
 // the EigenLayer registration chain id (chain-agnostic auth). SDKs
 // construct the message locally; there is no GetSignatureFormat endpoint.
 func (s *Server) AuthExchange(ctx echo.Context) error {
+	if _, err := s.ensurePermission(ctx, OpAuthExchange); err != nil {
+		return err
+	}
 	var body generated.AuthExchangeRequest
 	if err := ctx.Bind(&body); err != nil {
 		return &restmw.HTTPError{

--- a/aggregator/rest/handlers_executions.go
+++ b/aggregator/rest/handlers_executions.go
@@ -40,10 +40,11 @@ const streamMinInterval = 250 * time.Millisecond
 // scan. Without workflowId we return 400 pointing the caller at the
 // nested route that does the same thing more explicitly.
 func (s *Server) ListExecutions(ctx echo.Context, params generated.ListExecutionsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListExecutions)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	if params.WorkflowId == nil || len(*params.WorkflowId) == 0 {
 		return badRequest("EXECUTIONS_WORKFLOW_REQUIRED",
 			"workflowId filter required",
@@ -63,10 +64,11 @@ func (s *Server) ListExecutions(ctx echo.Context, params generated.ListExecution
 // Nested convenience route. The path parameter `id` pins the workflowId
 // so the handler can hand the engine a single TaskIds entry.
 func (s *Server) ListExecutionsForWorkflow(ctx echo.Context, id generated.Ulid, params generated.ListExecutionsForWorkflowParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListExecutionsForWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := buildListExecutionsReq([]generated.Ulid{id}, params.After, params.Before, params.Limit)
 	resp, err := s.engine.ListExecutions(user, req)
@@ -83,10 +85,11 @@ func (s *Server) ListExecutionsForWorkflow(ctx echo.Context, id generated.Ulid, 
 // global index. Callers that already know the workflow can use the
 // nested form (`GET /workflows/{id}/executions`) too.
 func (s *Server) GetExecution(ctx echo.Context, id generated.Ulid, params generated.GetExecutionParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetExecution)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	workflowID := string(params.WorkflowId)
 	exec, err := s.engine.GetExecution(user, &avsproto.ExecutionReq{
 		TaskId:      workflowID,
@@ -108,10 +111,11 @@ func (s *Server) GetExecution(ctx echo.Context, id generated.Ulid, params genera
 // The caller must own the workflow; the engine's gate (DeliverSignal) rejects a
 // signal with no pending wait, a mismatched kind, or one that has timed out.
 func (s *Server) SignalExecution(ctx echo.Context, id generated.Ulid, params generated.SignalExecutionParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpSignalExecution)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	var body generated.SignalExecutionRequest
 	if err := ctx.Bind(&body); err != nil {
 		return badRequest("SIGNAL_BAD_REQUEST", "Invalid request body", err.Error())
@@ -145,10 +149,11 @@ func (s *Server) SignalExecution(ctx echo.Context, id generated.Ulid, params gen
 // clients polling for terminal state without paying the cost of
 // fetching the full execution record.
 func (s *Server) GetExecutionStatus(ctx echo.Context, id generated.Ulid, params generated.GetExecutionStatusParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetExecutionStatus)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	workflowID := string(params.WorkflowId)
 	statusResp, err := s.engine.GetExecutionStatus(user, &avsproto.ExecutionReq{
 		TaskId:      workflowID,
@@ -177,10 +182,11 @@ func (s *Server) GetExecutionStatus(ctx echo.Context, id generated.Ulid, params 
 // when the status changes. Closes on terminal status, after
 // streamMaxDuration, or when the client disconnects.
 func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params generated.StreamExecutionParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpStreamExecution)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	workflowID := string(params.WorkflowId)
 
 	interval := time.Second
@@ -302,10 +308,11 @@ func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params gen
 
 // CountExecutions — GET /api/v1/executions:count
 func (s *Server) CountExecutions(ctx echo.Context, params generated.CountExecutionsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCountExecutions)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetExecutionCountReq{}
 	if params.WorkflowId != nil {
@@ -322,10 +329,11 @@ func (s *Server) CountExecutions(ctx echo.Context, params generated.CountExecuti
 
 // ExecutionStats — GET /api/v1/executions:stats
 func (s *Server) ExecutionStats(ctx echo.Context, params generated.ExecutionStatsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpExecutionStats)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetExecutionStatsReq{}
 	if params.WorkflowId != nil {

--- a/aggregator/rest/handlers_health.go
+++ b/aggregator/rest/handlers_health.go
@@ -16,6 +16,9 @@ import (
 // authentication absence (security: []) so monitoring tools can probe
 // without credentials.
 func (s *Server) GetHealth(ctx echo.Context) error {
+	if _, err := s.ensurePermission(ctx, OpGetHealth); err != nil {
+		return err
+	}
 	status := generated.Ok
 	httpStatus := http.StatusOK
 

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -21,7 +21,7 @@ import (
 // without persisting a workflow. Used by SDK testing flows and the
 // agent-CLI verify command.
 func (s *Server) RunNode(ctx echo.Context) error {
-	// No-fund operation: a user JWT or a partner assertion both authorize it.
+	// User JWT required (LevelUser). Partner assertion alone does not authorize.
 	p, err := s.ensurePermission(ctx, OpRunNode)
 	if err != nil {
 		return err

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -22,10 +22,11 @@ import (
 // agent-CLI verify command.
 func (s *Server) RunNode(ctx echo.Context) error {
 	// No-fund operation: a user JWT or a partner assertion both authorize it.
-	user, err := s.requireSimulateAuth(ctx)
+	p, err := s.ensurePermission(ctx, OpRunNode)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.RunNodeRequest
 	if err := ctx.Bind(&body); err != nil {

--- a/aggregator/rest/handlers_nodes_nil_config_test.go
+++ b/aggregator/rest/handlers_nodes_nil_config_test.go
@@ -34,7 +34,7 @@ func runNodeCtx(body string) echo.Context {
 // the Config pointer directly; the rest already errored cleanly.
 func TestRunNodeRejectsNilConfigWithoutPanicking(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 
 	cases := []struct {
 		name string

--- a/aggregator/rest/handlers_operators.go
+++ b/aggregator/rest/handlers_operators.go
@@ -23,6 +23,9 @@ import (
 // work still in flight) — it returns as an empty array until that
 // lands. Clients should treat empty as "unknown", not "none".
 func (s *Server) ListOperators(ctx echo.Context) error {
+	if _, err := s.ensurePermission(ctx, OpListOperators); err != nil {
+		return err
+	}
 	if s.operators == nil {
 		return ctx.JSON(http.StatusOK, generated.OperatorList{Data: []generated.OperatorInfo{}})
 	}

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -26,11 +26,8 @@ import (
 // submit trusts nothing — the grant is recomputed from the echoed fields and
 // the signature is the only authority.
 //
-// Every handler leads with refusePartnerAssertion: a policy is fund
-// authority, and the refusal must be explicit rather than a handler that
-// silently never consults the header.
-
-const policyCapability = "Session-policy management"
+// Every handler authorizes via ensurePermission (LevelUserRefusePartner):
+// partner assertions are refused; user JWT is required.
 
 // policyChainID resolves the chain: explicit value wins, then the JWT's
 // audience chain. Zero means unresolvable (single-chain deployments have an
@@ -45,13 +42,10 @@ func policyChainID(ctx echo.Context, explicit *int64) int64 {
 	return 0
 }
 
-// policyAuth is the shared preamble: partner refusal, then user auth, then
-// path-address validation.
-func (s *Server) policyAuth(ctx echo.Context, address generated.EthereumAddress) (*model.User, common.Address, error) {
-	if err := refusePartnerAssertion(ctx, policyCapability); err != nil {
-		return nil, common.Address{}, err
-	}
-	user, err := s.requireUser(ctx)
+// policyAuth is the shared preamble: permission level for the operation,
+// then path-address validation.
+func (s *Server) policyAuth(ctx echo.Context, op string, address generated.EthereumAddress) (*model.User, common.Address, error) {
+	p, err := s.ensurePermission(ctx, op)
 	if err != nil {
 		return nil, common.Address{}, err
 	}
@@ -59,12 +53,12 @@ func (s *Server) policyAuth(ctx echo.Context, address generated.EthereumAddress)
 		return nil, common.Address{}, badRequest("POLICIES_BAD_ADDRESS", "Invalid wallet address",
 			"The {address} path parameter must be a valid 0x-prefixed hex address.")
 	}
-	return user, common.HexToAddress(string(address)), nil
+	return p.User, common.HexToAddress(string(address)), nil
 }
 
 // PrepareWalletPolicy allocates a grant and returns the payload to sign.
 func (s *Server) PrepareWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpPrepareWalletPolicy, address)
 	if err != nil {
 		return err
 	}
@@ -112,7 +106,7 @@ func (s *Server) PrepareWalletPolicy(ctx echo.Context, address generated.Ethereu
 
 // SubmitWalletPolicy verifies the owner's signature and stores the grant.
 func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpSubmitWalletPolicy, address)
 	if err != nil {
 		return err
 	}
@@ -151,7 +145,7 @@ func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.Ethereum
 
 // ListWalletPolicies lists the wallet's grants, newest first.
 func (s *Server) ListWalletPolicies(ctx echo.Context, address generated.EthereumAddress, params generated.ListWalletPoliciesParams) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpListWalletPolicies, address)
 	if err != nil {
 		return err
 	}
@@ -173,7 +167,7 @@ func (s *Server) ListWalletPolicies(ctx echo.Context, address generated.Ethereum
 
 // GetWalletPolicy returns one grant.
 func (s *Server) GetWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.GetWalletPolicyParams) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpGetWalletPolicy, address)
 	if err != nil {
 		return err
 	}
@@ -204,7 +198,7 @@ func onChainCleanupAPI(c *taskengine.OnChainRevokeCleanup) *generated.OnChainRev
 
 // RevokeWalletPolicy revokes one grant.
 func (s *Server) RevokeWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.RevokeWalletPolicyParams) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpRevokeWalletPolicy, address)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_secrets.go
+++ b/aggregator/rest/handlers_secrets.go
@@ -15,10 +15,11 @@ import (
 
 // ListSecrets — GET /api/v1/secrets
 func (s *Server) ListSecrets(ctx echo.Context, params generated.ListSecretsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListSecrets)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.ListSecretsReq{IncludeTimestamps: true}
 	if params.WorkflowId != nil {
@@ -55,10 +56,11 @@ func (s *Server) ListSecrets(ctx echo.Context, params generated.ListSecretsParam
 // if a secret with the same (name, scope) already exists; in that case
 // we fall through to UpdateSecret so PUT semantics hold.
 func (s *Server) PutSecret(ctx echo.Context, name string) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpPutSecret)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.PutSecretRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -96,10 +98,11 @@ func (s *Server) PutSecret(ctx echo.Context, name string) error {
 
 // DeleteSecret — DELETE /api/v1/secrets/{name}
 func (s *Server) DeleteSecret(ctx echo.Context, name string, params generated.DeleteSecretParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpDeleteSecret)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.DeleteSecretReq{Name: name}
 	if params.WorkflowId != nil {

--- a/aggregator/rest/handlers_tokens.go
+++ b/aggregator/rest/handlers_tokens.go
@@ -20,10 +20,11 @@ import (
 // fallback succeeded — there's no 404 here because partial information
 // (just the address) is still useful to the caller.
 func (s *Server) GetToken(ctx echo.Context, address generated.EthereumAddress, params generated.GetTokenParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetToken)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetTokenMetadataReq{Address: string(address)}
 	if params.ChainId != nil {

--- a/aggregator/rest/handlers_triggers.go
+++ b/aggregator/rest/handlers_triggers.go
@@ -20,7 +20,7 @@ import (
 // use this to confirm a trigger config parses and returns the expected
 // shape before committing it to a workflow.
 func (s *Server) RunTrigger(ctx echo.Context) error {
-	// No-fund operation: a user JWT or a partner assertion both authorize it.
+	// User JWT required (LevelUser). Partner assertion alone does not authorize.
 	p, err := s.ensurePermission(ctx, OpRunTrigger)
 	if err != nil {
 		return err

--- a/aggregator/rest/handlers_triggers.go
+++ b/aggregator/rest/handlers_triggers.go
@@ -21,10 +21,11 @@ import (
 // shape before committing it to a workflow.
 func (s *Server) RunTrigger(ctx echo.Context) error {
 	// No-fund operation: a user JWT or a partner assertion both authorize it.
-	user, err := s.requireSimulateAuth(ctx)
+	p, err := s.ensurePermission(ctx, OpRunTrigger)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.RunTriggerRequest
 	if err := ctx.Bind(&body); err != nil {

--- a/aggregator/rest/handlers_wallets.go
+++ b/aggregator/rest/handlers_wallets.go
@@ -28,12 +28,13 @@ import (
 // No-fund: lists the smart wallets derived/owned by the authenticated owner
 // (the JWT subject, or a partner assertion's `sub`). Scoped to that owner, so
 // it never exposes another user's wallets. Partner-delegatable to resolve a
-// preview's runner — see requireWalletDeriveAuth.
+// preview's runner — see ensurePermission (partner_wallet_preview).
 func (s *Server) ListWallets(ctx echo.Context) error {
-	user, err := s.requireWalletDeriveAuth(ctx)
+	p, err := s.ensurePermission(ctx, OpListWallets)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	resp, err := s.engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
 	if err != nil {
@@ -70,11 +71,12 @@ func (s *Server) CreateWallet(ctx echo.Context) error {
 	// No-fund: derives the counterfactual CREATE2 address from (owner, salt,
 	// factory) and records it. Partner-delegatable so a preview can resolve a
 	// social user's runner before any wallet is deployed — see
-	// requireWalletDeriveAuth.
-	user, err := s.requireWalletDeriveAuth(ctx)
+	// ensurePermission (partner_wallet_preview).
+	p, err := s.ensurePermission(ctx, OpCreateWallet)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.CreateWalletRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -109,10 +111,11 @@ func (s *Server) CreateWallet(ctx echo.Context) error {
 // is identified by (salt, factory) — we re-resolve those from the
 // address via GetWallet and then SetWallet with the new isHidden.
 func (s *Server) UpdateWallet(ctx echo.Context, address generated.EthereumAddress) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpUpdateWallet)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body struct {
 		IsHidden *bool `json:"isHidden"`
@@ -156,10 +159,11 @@ func (s *Server) UpdateWallet(ctx echo.Context, address generated.EthereumAddres
 // in at startup. The full UserOp + paymaster + balance-checking
 // pipeline lives in aggregator package — REST is a thin adapter.
 func (s *Server) WithdrawWallet(ctx echo.Context, address generated.EthereumAddress) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpWithdrawWallet)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	if s.withdraws == nil {
 		return &restmw.HTTPError{
 			Status: http.StatusServiceUnavailable,
@@ -273,10 +277,11 @@ func (s *Server) WithdrawWallet(ctx echo.Context, address generated.EthereumAddr
 // Chain routing precedence: ?chainId= override → JWT aud → gateway
 // default. Same pattern as CreateWallet / WithdrawWallet.
 func (s *Server) GetWalletNonce(ctx echo.Context, address generated.EthereumAddress, params generated.GetWalletNonceParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetWalletNonce)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	if !common.IsHexAddress(string(address)) {
 		return badRequest("WALLETS_BAD_ADDRESS", "Invalid wallet address", "The {address} path parameter must be a valid 0x-prefixed hex address.")
 	}

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -18,7 +18,7 @@ import (
 //
 // Every handler is the same shape:
 //
-//	1. requireUser — pull the JWT subject from echo context.
+//	1. ensurePermission(op) — authorize via permissionMap.
 //	2. (for writes) decode the request body and translate via mapping/.
 //	3. Call the engine method.
 //	4. Translate the response back via mapping/ (or shape a tiny envelope).
@@ -28,10 +28,11 @@ import (
 
 // CreateWorkflow — POST /api/v1/workflows
 func (s *Server) CreateWorkflow(ctx echo.Context) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCreateWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.CreateWorkflowRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -61,10 +62,11 @@ func (s *Server) CreateWorkflow(ctx echo.Context) error {
 
 // ListWorkflows — GET /api/v1/workflows
 func (s *Server) ListWorkflows(ctx echo.Context, params generated.ListWorkflowsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListWorkflows)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.ListTasksReq{
 		IncludeNodes: true,
@@ -108,10 +110,11 @@ func (s *Server) ListWorkflows(ctx echo.Context, params generated.ListWorkflowsP
 
 // GetWorkflow — GET /api/v1/workflows/{id}
 func (s *Server) GetWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	workflow, err := s.engine.GetWorkflow(user, string(id))
 	if err != nil {
@@ -130,10 +133,11 @@ func (s *Server) GetWorkflow(ctx echo.Context, id generated.Ulid) error {
 // caller's perspective (idempotent, returns 204) but the engine removes
 // the underlying record so the operator stops monitoring.
 func (s *Server) CancelWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCancelWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	if _, err := s.engine.DeleteWorkflowByUser(user, string(id)); err != nil {
 		return notFoundOrError(err)
@@ -143,10 +147,11 @@ func (s *Server) CancelWorkflow(ctx echo.Context, id generated.Ulid) error {
 
 // PauseWorkflow — POST /api/v1/workflows/{id}:pause
 func (s *Server) PauseWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpPauseWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	if _, err := s.engine.SetWorkflowEnabledByUser(user, string(id), false); err != nil {
 		return notFoundOrError(err)
@@ -166,10 +171,11 @@ func (s *Server) PauseWorkflow(ctx echo.Context, id generated.Ulid) error {
 
 // ResumeWorkflow — POST /api/v1/workflows/{id}:resume
 func (s *Server) ResumeWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpResumeWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	if _, err := s.engine.SetWorkflowEnabledByUser(user, string(id), true); err != nil {
 		return notFoundOrError(err)
@@ -193,10 +199,11 @@ func (s *Server) ResumeWorkflow(ctx echo.Context, id generated.Ulid) error {
 // what the operator would have reported; if omitted, the engine fills
 // it with placeholder values.
 func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpTriggerWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.TriggerWorkflowRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -277,10 +284,11 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 // Execution echoing what an operator-driven run would have produced.
 func (s *Server) SimulateWorkflow(ctx echo.Context) error {
 	// No-fund operation: a user JWT or a partner assertion both authorize it.
-	user, err := s.requireSimulateAuth(ctx)
+	p, err := s.ensurePermission(ctx, OpSimulateWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.SimulateWorkflowRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -347,10 +355,11 @@ func (s *Server) SimulateWorkflow(ctx echo.Context) error {
 // platform fee + per-node COGS + value-capture fee + any active
 // discount.
 func (s *Server) EstimateWorkflowFees(ctx echo.Context) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpEstimateWorkflowFees)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	var body generated.EstimateFeesRequest
 	if err := ctx.Bind(&body); err != nil {
 		return badRequest("FEES_BAD_REQUEST", "Invalid request body", err.Error())
@@ -475,10 +484,11 @@ func openAPIInputVarsOrNil(in *generated.InputVariables) (map[string]*structpb.V
 // Returns the total number of workflows owned by the authenticated user,
 // optionally narrowed by smartWalletAddress.
 func (s *Server) CountWorkflows(ctx echo.Context, params generated.CountWorkflowsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCountWorkflows)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetWorkflowCountReq{}
 	if params.SmartWalletAddress != nil {

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -283,7 +283,7 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 // by the Studio UI's "Run once" affordance. The result is a transient
 // Execution echoing what an operator-driven run would have produced.
 func (s *Server) SimulateWorkflow(ctx echo.Context) error {
-	// No-fund operation: a user JWT or a partner assertion both authorize it.
+	// User JWT required (LevelUser). Partner assertion alone does not authorize.
 	p, err := s.ensurePermission(ctx, OpSimulateWorkflow)
 	if err != nil {
 		return err

--- a/aggregator/rest/partner.go
+++ b/aggregator/rest/partner.go
@@ -9,44 +9,35 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 
 	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
-	"github.com/AvaProtocol/EigenLayer-AVS/model"
 )
 
-// Partner-delegated auth for the no-fund "simulate" family.
+// Partner assertion verification for tenant-gated REST routes.
 //
-// A partner (tenant) such as Studio authenticates its own end users in its
-// own system and then vouches for them to the AVS for operations that move
-// no funds — workflows:simulate, nodes:run, triggers:run. Because simulate
-// skips wallet-ownership (engine.SimulateTask) and the authKey chain is
-// cosmetic, the partner does NOT need a per-user wallet signature for these.
+// A partner (tenant) such as Studio authenticates with a short-lived
+// Ed25519-signed assertion in X-Partner-Assertion (private_key_jwt style),
+// kept separate from Authorization: Bearer user JWTs.
 //
-// The partner proves its identity with a short-lived Ed25519-signed
-// assertion (private_key_jwt style) sent in the X-Partner-Assertion header,
-// kept deliberately separate from the user `Authorization: Bearer` path so
-// the existing user-JWT flow is untouched. The assertion's claims are the
-// stable contract that a future RFC 8693 token-exchange endpoint will reuse:
+// Which operations accept partner credentials is defined in permission.go
+// (permissionMap + ensurePermission), not by calling these helpers from
+// handlers directly. Partner-sufficient classes today:
 //
-//	{ "iss": "<partner_id>",        // selects the registered partner + keys
-//	  "sub": "<end-user address>",   // attribution; may be empty/opaque
-//	  "scope": "simulate",           // required scope for the call
-//	  "exp": <unix>, "iat": <unix> } // short-lived
+//   - scope "read": token metadata (partner only) and preview wallet
+//     list/create (partner with EOA sub, or user JWT)
 //
-// Fund-moving operations (createTask/execute) are NEVER authorized by a
-// partner assertion — those require real on-chain fund authority (the
-// controller-signed path today, Uniswap Calibur later). See
-// PLAN_PARTNER_PAYMENTS.md.
+// Simulate / runNode / runTrigger require a user JWT (LevelUser) — partner
+// alone is not enough. Fund-moving and session policies never accept
+// partner. See GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md.
 const (
 	// partnerAssertionHeader carries the partner's Ed25519-signed JWT.
 	partnerAssertionHeader = "X-Partner-Assertion"
 
-	// scopeSimulate is the only delegation scope honored today.
-	scopeSimulate = "simulate"
+	// scopeRead is the partner scope for non-fund reads and preview wallet resolve.
+	scopeRead = "read"
 
 	// maxPartnerAssertionTTL bounds how far in the future an assertion's
 	// `exp` may sit. Assertions are meant to be minted per session/call and
@@ -66,75 +57,6 @@ type partnerPrincipal struct {
 	subject   string
 }
 
-// requireSimulateAuth authorizes a simulate-family request via EITHER an
-// end-user JWT (the existing path) OR a partner assertion (the delegated
-// path). It returns the *model.User the engine expects.
-//
-//   - User JWT present  → behaves exactly like requireUser.
-//   - Else partner assertion present and valid → a User keyed on the
-//     assertion's `sub` (zero address when `sub` is empty/non-address;
-//     simulate tolerates this since it skips ownership).
-//   - Else → 401.
-func (s *Server) requireSimulateAuth(ctx echo.Context) (*model.User, error) {
-	// Any presented end-user JWT goes through the user path. requireUser
-	// rejects a missing/invalid subject — we must NOT silently fall through to
-	// the partner path for a structurally-valid-but-empty-subject token.
-	if authed := restmw.UserFromContext(ctx); authed != nil {
-		return s.requireUser(ctx)
-	}
-
-	principal, err := s.verifyPartnerAssertion(ctx, scopeSimulate)
-	if err != nil {
-		return nil, err
-	}
-	if principal != nil {
-		user := &model.User{}
-		// `sub` is attribution only. Use it as the acting address when it's
-		// a real EOA; otherwise leave the zero address — simulate runs
-		// against any address and never checks ownership.
-		if common.IsHexAddress(principal.subject) {
-			user.Address = common.HexToAddress(principal.subject)
-		}
-		s.logger.Info("partner-delegated simulate call",
-			"partner_id", principal.partnerID,
-			"subject", principal.subject,
-		)
-		return user, nil
-	}
-
-	// Neither credential present.
-	return nil, &restmw.HTTPError{
-		Status: http.StatusUnauthorized,
-		Code:   "AUTH_REQUIRED",
-		Title:  "Authentication required",
-		Detail: "This endpoint requires a Bearer JWT (POST /api/v1/auth:exchange) or a partner assertion (X-Partner-Assertion).",
-	}
-}
-
-// requireWalletDeriveAuth authorizes the no-fund wallet derivation/list step
-// (runner resolution during a preview) via the same either/or path as
-// requireSimulateAuth, but additionally requires a concrete owner EOA: a smart
-// wallet is derived deterministically from its owner, so an empty/opaque
-// subject cannot be served. Partner assertions used here must carry a real
-// `sub` address. This unblocks Studio's `$SMART_WALLET$` placeholder
-// resolution (getWallets) for partner-delegated previews; it stays no-fund and
-// needs no ownership check — derivation only reads (owner, salt, factory).
-func (s *Server) requireWalletDeriveAuth(ctx echo.Context) (*model.User, error) {
-	user, err := s.requireSimulateAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if user.Address == (common.Address{}) {
-		return nil, &restmw.HTTPError{
-			Status: http.StatusBadRequest,
-			Code:   "PARTNER_SUBJECT_REQUIRED",
-			Title:  "Owner address required",
-			Detail: "Wallet derivation requires the assertion `sub` to be the end-user's 0x EOA address.",
-		}
-	}
-	return user, nil
-}
-
 // refusePartnerAssertion explicitly rejects a request that presents
 // X-Partner-Assertion on an endpoint partner delegation may never reach.
 //
@@ -152,9 +74,8 @@ func (s *Server) requireWalletDeriveAuth(ctx echo.Context) (*model.User, error) 
 // validity-dependent response would make this endpoint an oracle for
 // assertion validity.
 //
-// MUST be the first line of every /policies handler (avs-infra master doc
-// §7.4a; the decision predates the routes). Returns nil when no assertion is
-// present — user-JWT requests pass through untouched.
+// Invoked via ensurePermission for LevelUserRefusePartner routes. Returns
+// nil when no assertion is present — user-JWT requests pass through.
 func refusePartnerAssertion(ctx echo.Context, capability string) error {
 	if strings.TrimSpace(ctx.Request().Header.Get(partnerAssertionHeader)) == "" {
 		return nil
@@ -162,8 +83,7 @@ func refusePartnerAssertion(ctx echo.Context, capability string) error {
 	return partnerError(http.StatusForbidden, "PARTNER_DELEGATION_UNSUPPORTED",
 		"Partner delegation not supported here",
 		fmt.Sprintf("%s is fund authority and cannot be exercised through a partner assertion. "+
-			"Partner delegation covers the no-fund simulate family only; use the end-user's "+
-			"Bearer JWT (POST /api/v1/auth:exchange) for this endpoint.", capability))
+			"Use the end-user's Bearer JWT (POST /api/v1/auth:exchange) for this endpoint.", capability))
 }
 
 // verifyPartnerAssertion validates the X-Partner-Assertion header against the

--- a/aggregator/rest/partner_test.go
+++ b/aggregator/rest/partner_test.go
@@ -74,31 +74,10 @@ func validClaims() jwt.MapClaims {
 	return jwt.MapClaims{
 		"iss":   "studio",
 		"sub":   testPartnerSubject,
-		"scope": "simulate",
+		"scope": "read",
 		"iat":   time.Now().Unix(),
 		"exp":   time.Now().Add(5 * time.Minute).Unix(),
 	}
-}
-
-func TestRequireSimulateAuth_PartnerHappyPath(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
-
-	user, err := s.requireSimulateAuth(ctxWithAssertion(signAssertion(t, priv, validClaims())))
-	if err != nil {
-		t.Fatalf("expected success, got error: %v", err)
-	}
-	if got := user.Address.Hex(); got != testPartnerSubject {
-		t.Fatalf("expected acting address %s, got %s", testPartnerSubject, got)
-	}
-}
-
-func TestRequireSimulateAuth_NoCredential(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
-
-	_, err := s.requireSimulateAuth(ctxWithAssertion(""))
-	assertHTTPStatus(t, err, http.StatusUnauthorized)
 }
 
 // ctxWithUser builds an Echo context as the JWT middleware would leave it —
@@ -109,25 +88,6 @@ func ctxWithUser(subject string) echo.Context {
 	c := e.NewContext(req, httptest.NewRecorder())
 	c.Set("auth.user", &restmw.AuthenticatedUser{Subject: subject})
 	return c
-}
-
-func TestRequireSimulateAuth_PrefersUserJWT(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
-
-	const subject = "0x2222222222222222222222222222222222222222"
-	user, err := s.requireSimulateAuth(ctxWithUser(subject))
-	if err != nil {
-		t.Fatalf("valid user JWT should succeed, got: %v", err)
-	}
-	if user.Address.Hex() != subject {
-		t.Fatalf("expected user %s, got %s", subject, user.Address.Hex())
-	}
-
-	// A present-but-empty-subject JWT must be rejected, NOT silently fall
-	// through to the partner path.
-	_, err = s.requireSimulateAuth(ctxWithUser(""))
-	assertHTTPStatus(t, err, http.StatusUnauthorized)
 }
 
 func TestDecodeEd25519Keys_TolerantAndMultiEncoding(t *testing.T) {
@@ -171,7 +131,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "wrong signing key",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			// Signed by a key the registry doesn't know.
 			assertion:  func(t *testing.T) string { return signAssertion(t, otherPriv, validClaims()) },
@@ -180,7 +140,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "unknown issuer",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -191,7 +151,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		},
 		{
 			name:       "suspended partner",
-			server:     func(t *testing.T) *Server { return newPartnerServer(t, pub, []string{scopeSimulate}, "suspended") },
+			server:     func(t *testing.T) *Server { return newPartnerServer(t, pub, []string{scopeRead}, "suspended") },
 			assertion:  func(t *testing.T) string { return signAssertion(t, priv, validClaims()) },
 			wantStatus: http.StatusForbidden,
 		},
@@ -204,7 +164,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "scope not declared in token",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -216,7 +176,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "expired assertion",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -228,7 +188,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "ttl too long",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -240,7 +200,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "missing expiry",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -254,7 +214,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := tc.server(t)
-			_, err := s.verifyPartnerAssertion(ctxWithAssertion(tc.assertion(t)), scopeSimulate)
+			_, err := s.verifyPartnerAssertion(ctxWithAssertion(tc.assertion(t)), scopeRead)
 			assertHTTPStatus(t, err, tc.wantStatus)
 		})
 	}
@@ -264,10 +224,10 @@ func TestVerifyPartnerAssertion_Audience(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 
 	t.Run("matching audience accepted", func(t *testing.T) {
-		s := newPartnerServerAud(t, pub, []string{scopeSimulate}, partnerStatusActive, "avs-gateway-staging")
+		s := newPartnerServerAud(t, pub, []string{scopeRead}, partnerStatusActive, "avs-gateway-staging")
 		c := validClaims()
 		c["aud"] = "avs-gateway-staging"
-		principal, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeSimulate)
+		principal, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeRead)
 		if err != nil {
 			t.Fatalf("expected success, got: %v", err)
 		}
@@ -277,41 +237,41 @@ func TestVerifyPartnerAssertion_Audience(t *testing.T) {
 	})
 
 	t.Run("missing/mismatched audience rejected", func(t *testing.T) {
-		s := newPartnerServerAud(t, pub, []string{scopeSimulate}, partnerStatusActive, "avs-gateway-staging")
+		s := newPartnerServerAud(t, pub, []string{scopeRead}, partnerStatusActive, "avs-gateway-staging")
 		// Assertion targets prod, gateway expects staging.
 		c := validClaims()
 		c["aud"] = "avs-gateway-prod"
-		_, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeSimulate)
+		_, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeRead)
 		assertHTTPStatus(t, err, http.StatusUnauthorized)
 	})
 }
 
-// requireWalletDeriveAuth must reject a partner assertion whose `sub` is not a
+// Preview wallet resolve must reject a partner assertion whose `sub` is not a
 // concrete EOA — a smart wallet can't be derived without an owner.
-func TestRequireWalletDeriveAuth_OpaqueSubjectRejected(t *testing.T) {
+func TestEnsurePermission_WalletPreview_OpaqueSubjectRejected(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 
 	c := validClaims()
 	c["sub"] = "studio-user-42" // not an address
-	_, err := s.requireWalletDeriveAuth(ctxWithAssertion(signAssertion(t, priv, c)))
+	_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpListWallets)
 	assertHTTPStatus(t, err, http.StatusBadRequest)
 
 	// With a real EOA sub it resolves to that owner.
-	user, err := s.requireWalletDeriveAuth(ctxWithAssertion(signAssertion(t, priv, validClaims())))
+	p, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpListWallets)
 	if err != nil {
 		t.Fatalf("expected success with address sub, got: %v", err)
 	}
-	if user.Address.Hex() != testPartnerSubject {
-		t.Fatalf("expected owner %s, got %s", testPartnerSubject, user.Address.Hex())
+	if p.User.Address.Hex() != testPartnerSubject {
+		t.Fatalf("expected owner %s, got %s", testPartnerSubject, p.User.Address.Hex())
 	}
 }
 
 func TestVerifyPartnerAssertion_AbsentHeaderFallsThrough(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 
-	principal, err := s.verifyPartnerAssertion(ctxWithAssertion(""), scopeSimulate)
+	principal, err := s.verifyPartnerAssertion(ctxWithAssertion(""), scopeRead)
 	if err != nil {
 		t.Fatalf("absent header must not error, got: %v", err)
 	}

--- a/aggregator/rest/partner_test.go
+++ b/aggregator/rest/partner_test.go
@@ -247,7 +247,7 @@ func TestVerifyPartnerAssertion_Audience(t *testing.T) {
 }
 
 // Preview wallet resolve must reject a partner assertion whose `sub` is not a
-// concrete EOA — a smart wallet can't be derived without an owner.
+// concrete non-zero EOA — a smart wallet can't be derived without an owner.
 func TestEnsurePermission_WalletPreview_OpaqueSubjectRejected(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
@@ -255,6 +255,11 @@ func TestEnsurePermission_WalletPreview_OpaqueSubjectRejected(t *testing.T) {
 	c := validClaims()
 	c["sub"] = "studio-user-42" // not an address
 	_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpListWallets)
+	assertHTTPStatus(t, err, http.StatusBadRequest)
+
+	c = validClaims()
+	c["sub"] = "0x0000000000000000000000000000000000000000"
+	_, err = s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpListWallets)
 	assertHTTPStatus(t, err, http.StatusBadRequest)
 
 	// With a real EOA sub it resolves to that owner.

--- a/aggregator/rest/permission.go
+++ b/aggregator/rest/permission.go
@@ -249,12 +249,15 @@ func (s *Server) authPartnerWalletPreview(ctx echo.Context, level Level) (*Princ
 			Detail: "This endpoint requires a Bearer JWT (POST /api/v1/auth:exchange) or a partner assertion (X-Partner-Assertion) with scope \"read\" and sub set to the owner EOA.",
 		}
 	}
-	if !common.IsHexAddress(pp.subject) {
+	// Concrete owner EOA required: opaque ids and the zero address are
+	// rejected (zero would collapse every misconfigured partner call onto
+	// one shared non-user owner). Mirrors the pre-permission-map check.
+	if !common.IsHexAddress(pp.subject) || common.HexToAddress(pp.subject) == (common.Address{}) {
 		return nil, &restmw.HTTPError{
 			Status: http.StatusBadRequest,
 			Code:   "PARTNER_SUBJECT_REQUIRED",
 			Title:  "Owner address required",
-			Detail: "Wallet derivation requires the assertion `sub` to be the end-user's 0x EOA address.",
+			Detail: "Wallet derivation requires the assertion `sub` to be the end-user's non-zero 0x EOA address.",
 		}
 	}
 	user := userFromPartnerSubject(pp.subject)

--- a/aggregator/rest/permission.go
+++ b/aggregator/rest/permission.go
@@ -1,0 +1,274 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// Permission levels are the minimal credential class an operation needs.
+// Handlers call ensurePermission(op); they do not pick requireUser vs
+// partner helpers ad hoc. See GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md.
+type Level string
+
+const (
+	// LevelPublic — no credentials (health, auth exchange).
+	LevelPublic Level = "public"
+
+	// LevelPartnerRead — registered partner with scope "read" only.
+	// Token metadata and similar non-secret chain reads. No user JWT.
+	LevelPartnerRead Level = "partner_read"
+
+	// LevelPartnerWalletPreview — partner assertion (scope "read") with a
+	// concrete EOA `sub`, OR a user JWT. List + create/derive wallets for
+	// preview runner resolution.
+	LevelPartnerWalletPreview Level = "partner_wallet_preview"
+
+	// LevelUser — wallet-signed Bearer JWT required.
+	// Simulate/runNode, workflows, secrets, fund-adjacent wallet ops, etc.
+	LevelUser Level = "user"
+
+	// LevelUserRefusePartner — user JWT required; partner assertion header
+	// is categorically rejected (session policies / fund authority).
+	LevelUserRefusePartner Level = "user_refuse_partner"
+)
+
+// OpenAPI operationId constants — keys in permissionMap.
+const (
+	OpGetHealth    = "getHealth"
+	OpAuthExchange = "authExchange"
+
+	OpCreateWorkflow       = "createWorkflow"
+	OpListWorkflows        = "listWorkflows"
+	OpGetWorkflow          = "getWorkflow"
+	OpCancelWorkflow       = "cancelWorkflow"
+	OpPauseWorkflow        = "pauseWorkflow"
+	OpResumeWorkflow       = "resumeWorkflow"
+	OpTriggerWorkflow      = "triggerWorkflow"
+	OpSimulateWorkflow     = "simulateWorkflow"
+	OpEstimateWorkflowFees = "estimateWorkflowFees"
+	OpCountWorkflows       = "countWorkflows"
+
+	OpListExecutions            = "listExecutions"
+	OpListExecutionsForWorkflow = "listExecutionsForWorkflow"
+	OpGetExecution              = "getExecution"
+	OpGetExecutionStatus        = "getExecutionStatus"
+	OpSignalExecution           = "signalExecution"
+	OpStreamExecution           = "streamExecution"
+	OpCountExecutions           = "countExecutions"
+	OpExecutionStats            = "executionStats"
+
+	OpListWallets    = "listWallets"
+	OpCreateWallet   = "createWallet"
+	OpUpdateWallet   = "updateWallet"
+	OpWithdrawWallet = "withdrawWallet"
+	OpGetWalletNonce = "getWalletNonce"
+
+	OpPrepareWalletPolicy = "prepareWalletPolicy"
+	OpSubmitWalletPolicy  = "submitWalletPolicy"
+	OpListWalletPolicies  = "listWalletPolicies"
+	OpGetWalletPolicy     = "getWalletPolicy"
+	OpRevokeWalletPolicy  = "revokeWalletPolicy"
+
+	OpListSecrets  = "listSecrets"
+	OpPutSecret    = "putSecret"
+	OpDeleteSecret = "deleteSecret"
+
+	OpGetToken = "getToken"
+
+	OpRunNode    = "runNode"
+	OpRunTrigger = "runTrigger"
+
+	OpListOperators = "listOperators"
+)
+
+// permissionMap is the single source of truth: operationId → minimal level.
+// Fail closed: ensurePermission rejects unknown ops.
+var permissionMap = map[string]Level{
+	OpGetHealth:    LevelPublic,
+	OpAuthExchange: LevelPublic,
+
+	// Partner-gated public-ish reads (no user JWT).
+	OpGetToken: LevelPartnerRead,
+
+	// Preview wallet resolve: list + create/derive under partner (or JWT).
+	OpListWallets:  LevelPartnerWalletPreview,
+	OpCreateWallet: LevelPartnerWalletPreview,
+
+	// Simulate family: user JWT only (partner alone insufficient).
+	OpSimulateWorkflow: LevelUser,
+	OpRunNode:          LevelUser,
+	OpRunTrigger:       LevelUser,
+
+	// User-owned workflows / executions / secrets / wallet fund surface.
+	OpCreateWorkflow:            LevelUser,
+	OpListWorkflows:             LevelUser,
+	OpGetWorkflow:               LevelUser,
+	OpCancelWorkflow:            LevelUser,
+	OpPauseWorkflow:             LevelUser,
+	OpResumeWorkflow:            LevelUser,
+	OpTriggerWorkflow:           LevelUser,
+	OpEstimateWorkflowFees:      LevelUser,
+	OpCountWorkflows:            LevelUser,
+	OpListExecutions:            LevelUser,
+	OpListExecutionsForWorkflow: LevelUser,
+	OpGetExecution:              LevelUser,
+	OpGetExecutionStatus:        LevelUser,
+	OpSignalExecution:           LevelUser,
+	OpStreamExecution:           LevelUser,
+	OpCountExecutions:           LevelUser,
+	OpExecutionStats:            LevelUser,
+	OpListSecrets:               LevelUser,
+	OpPutSecret:                 LevelUser,
+	OpDeleteSecret:              LevelUser,
+	OpUpdateWallet:              LevelUser,
+	OpWithdrawWallet:            LevelUser,
+	OpGetWalletNonce:            LevelUser,
+
+	// Fund authority: user JWT + explicit partner refusal.
+	OpPrepareWalletPolicy: LevelUserRefusePartner,
+	OpSubmitWalletPolicy:  LevelUserRefusePartner,
+	OpListWalletPolicies:  LevelUserRefusePartner,
+	OpGetWalletPolicy:     LevelUserRefusePartner,
+	OpRevokeWalletPolicy:  LevelUserRefusePartner,
+
+	// Monitoring: remains open (matches today's handler; product may lock later).
+	OpListOperators: LevelPublic,
+}
+
+// Principal is the result of ensurePermission: who may act and at which level.
+type Principal struct {
+	// User is the engine-facing subject. Non-nil for every level except
+	// LevelPublic (and may be a zero-address User for partner-only metadata
+	// when assertion `sub` is empty).
+	User *model.User
+	// PartnerID is set when a partner assertion authorized the call.
+	PartnerID string
+	Level     Level
+}
+
+// ensurePermission authorizes the request for the given OpenAPI operationId
+// using permissionMap. Handlers should call this first and use Principal.User
+// for engine calls.
+func (s *Server) ensurePermission(ctx echo.Context, op string) (*Principal, error) {
+	level, ok := permissionMap[op]
+	if !ok {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusInternalServerError,
+			Code:   "AUTHZ_UNMAPPED",
+			Title:  "Operation not in permission map",
+			Detail: fmt.Sprintf("operation %q has no permission level; add it to permissionMap", op),
+		}
+	}
+
+	switch level {
+	case LevelPublic:
+		return &Principal{Level: level}, nil
+
+	case LevelPartnerRead:
+		return s.authPartnerRead(ctx, level)
+
+	case LevelPartnerWalletPreview:
+		return s.authPartnerWalletPreview(ctx, level)
+
+	case LevelUser:
+		user, err := s.requireUser(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &Principal{User: user, Level: level}, nil
+
+	case LevelUserRefusePartner:
+		if err := refusePartnerAssertion(ctx, op); err != nil {
+			return nil, err
+		}
+		user, err := s.requireUser(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &Principal{User: user, Level: level}, nil
+
+	default:
+		return nil, &restmw.HTTPError{
+			Status: http.StatusInternalServerError,
+			Code:   "AUTHZ_UNKNOWN_LEVEL",
+			Title:  "Unknown permission level",
+			Detail: fmt.Sprintf("level %q is not implemented", level),
+		}
+	}
+}
+
+// authPartnerRead requires a valid partner assertion with scope "read".
+// User JWT alone is not enough (partner-gated gateway traffic).
+func (s *Server) authPartnerRead(ctx echo.Context, level Level) (*Principal, error) {
+	pp, err := s.verifyPartnerAssertion(ctx, scopeRead)
+	if err != nil {
+		return nil, err
+	}
+	if pp == nil {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusUnauthorized,
+			Code:   "PARTNER_REQUIRED",
+			Title:  "Partner assertion required",
+			Detail: "This endpoint requires a partner assertion (X-Partner-Assertion) with scope \"read\".",
+		}
+	}
+	user := userFromPartnerSubject(pp.subject)
+	s.logger.Info("partner-gated read call",
+		"partner_id", pp.partnerID,
+		"subject", pp.subject,
+		"level", string(level),
+	)
+	return &Principal{User: user, PartnerID: pp.partnerID, Level: level}, nil
+}
+
+// authPartnerWalletPreview: user JWT if present, else partner read + EOA sub.
+func (s *Server) authPartnerWalletPreview(ctx echo.Context, level Level) (*Principal, error) {
+	if authed := restmw.UserFromContext(ctx); authed != nil {
+		user, err := s.requireUser(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &Principal{User: user, Level: level}, nil
+	}
+
+	pp, err := s.verifyPartnerAssertion(ctx, scopeRead)
+	if err != nil {
+		return nil, err
+	}
+	if pp == nil {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusUnauthorized,
+			Code:   "AUTH_REQUIRED",
+			Title:  "Authentication required",
+			Detail: "This endpoint requires a Bearer JWT (POST /api/v1/auth:exchange) or a partner assertion (X-Partner-Assertion) with scope \"read\" and sub set to the owner EOA.",
+		}
+	}
+	if !common.IsHexAddress(pp.subject) {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusBadRequest,
+			Code:   "PARTNER_SUBJECT_REQUIRED",
+			Title:  "Owner address required",
+			Detail: "Wallet derivation requires the assertion `sub` to be the end-user's 0x EOA address.",
+		}
+	}
+	user := userFromPartnerSubject(pp.subject)
+	s.logger.Info("partner-delegated wallet preview call",
+		"partner_id", pp.partnerID,
+		"subject", pp.subject,
+	)
+	return &Principal{User: user, PartnerID: pp.partnerID, Level: level}, nil
+}
+
+func userFromPartnerSubject(subject string) *model.User {
+	user := &model.User{}
+	if common.IsHexAddress(subject) {
+		user.Address = common.HexToAddress(subject)
+	}
+	return user
+}

--- a/aggregator/rest/permission_test.go
+++ b/aggregator/rest/permission_test.go
@@ -6,65 +6,68 @@ import (
 	"testing"
 )
 
-// allOperationIDs is the exhaustive list of OpenAPI operationIds the REST
-// server implements. Keep in sync with permissionMap / api/openapi.yaml.
-var allOperationIDs = []string{
-	OpGetHealth,
-	OpAuthExchange,
-	OpCreateWorkflow,
-	OpListWorkflows,
-	OpGetWorkflow,
-	OpCancelWorkflow,
-	OpPauseWorkflow,
-	OpResumeWorkflow,
-	OpTriggerWorkflow,
-	OpSimulateWorkflow,
-	OpEstimateWorkflowFees,
-	OpCountWorkflows,
-	OpListExecutions,
-	OpListExecutionsForWorkflow,
-	OpGetExecution,
-	OpGetExecutionStatus,
-	OpSignalExecution,
-	OpStreamExecution,
-	OpCountExecutions,
-	OpExecutionStats,
-	OpListWallets,
-	OpCreateWallet,
-	OpUpdateWallet,
-	OpWithdrawWallet,
-	OpGetWalletNonce,
-	OpPrepareWalletPolicy,
-	OpSubmitWalletPolicy,
-	OpListWalletPolicies,
-	OpGetWalletPolicy,
-	OpRevokeWalletPolicy,
-	OpListSecrets,
-	OpPutSecret,
-	OpDeleteSecret,
-	OpGetToken,
-	OpRunNode,
-	OpRunTrigger,
-	OpListOperators,
+// expectedPermissionLevels is the authorization policy matrix. Keep in sync
+// with permissionMap and api/openapi.yaml security overrides.
+var expectedPermissionLevels = map[string]Level{
+	OpGetHealth:     LevelPublic,
+	OpAuthExchange:  LevelPublic,
+	OpListOperators: LevelPublic,
+
+	OpGetToken: LevelPartnerRead,
+
+	OpListWallets:  LevelPartnerWalletPreview,
+	OpCreateWallet: LevelPartnerWalletPreview,
+
+	OpSimulateWorkflow: LevelUser,
+	OpRunNode:          LevelUser,
+	OpRunTrigger:       LevelUser,
+
+	OpCreateWorkflow:            LevelUser,
+	OpListWorkflows:             LevelUser,
+	OpGetWorkflow:               LevelUser,
+	OpCancelWorkflow:            LevelUser,
+	OpPauseWorkflow:             LevelUser,
+	OpResumeWorkflow:            LevelUser,
+	OpTriggerWorkflow:           LevelUser,
+	OpEstimateWorkflowFees:      LevelUser,
+	OpCountWorkflows:            LevelUser,
+	OpListExecutions:            LevelUser,
+	OpListExecutionsForWorkflow: LevelUser,
+	OpGetExecution:              LevelUser,
+	OpGetExecutionStatus:        LevelUser,
+	OpSignalExecution:           LevelUser,
+	OpStreamExecution:           LevelUser,
+	OpCountExecutions:           LevelUser,
+	OpExecutionStats:            LevelUser,
+	OpListSecrets:               LevelUser,
+	OpPutSecret:                 LevelUser,
+	OpDeleteSecret:              LevelUser,
+	OpUpdateWallet:              LevelUser,
+	OpWithdrawWallet:            LevelUser,
+	OpGetWalletNonce:            LevelUser,
+
+	OpPrepareWalletPolicy: LevelUserRefusePartner,
+	OpSubmitWalletPolicy:  LevelUserRefusePartner,
+	OpListWalletPolicies:  LevelUserRefusePartner,
+	OpGetWalletPolicy:     LevelUserRefusePartner,
+	OpRevokeWalletPolicy:  LevelUserRefusePartner,
 }
 
-func TestPermissionMap_CoversAllOperations(t *testing.T) {
-	for _, op := range allOperationIDs {
-		if _, ok := permissionMap[op]; !ok {
+func TestPermissionMap_CoversAllOperationsAndLevels(t *testing.T) {
+	for op, want := range expectedPermissionLevels {
+		got, ok := permissionMap[op]
+		if !ok {
 			t.Errorf("permissionMap missing operation %q", op)
+			continue
+		}
+		if got != want {
+			t.Errorf("permissionMap[%q] = %q, want %q", op, got, want)
 		}
 	}
-	if len(permissionMap) != len(allOperationIDs) {
-		t.Errorf("permissionMap has %d entries, expected %d — extra keys?", len(permissionMap), len(allOperationIDs))
+	if len(permissionMap) != len(expectedPermissionLevels) {
+		t.Errorf("permissionMap has %d entries, expected %d", len(permissionMap), len(expectedPermissionLevels))
 		for op := range permissionMap {
-			found := false
-			for _, want := range allOperationIDs {
-				if op == want {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if _, ok := expectedPermissionLevels[op]; !ok {
 				t.Errorf("permissionMap has unexpected key %q", op)
 			}
 		}
@@ -164,6 +167,13 @@ func TestEnsurePermission_WalletPreview(t *testing.T) {
 	t.Run("empty JWT subject not partner fallthrough", func(t *testing.T) {
 		_, err := s.ensurePermission(ctxWithUser(""), OpListWallets)
 		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("zero address sub rejected", func(t *testing.T) {
+		c := validClaims()
+		c["sub"] = "0x0000000000000000000000000000000000000000"
+		_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpListWallets)
+		assertHTTPStatus(t, err, http.StatusBadRequest)
 	})
 }
 

--- a/aggregator/rest/permission_test.go
+++ b/aggregator/rest/permission_test.go
@@ -1,0 +1,199 @@
+package rest
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"testing"
+)
+
+// allOperationIDs is the exhaustive list of OpenAPI operationIds the REST
+// server implements. Keep in sync with permissionMap / api/openapi.yaml.
+var allOperationIDs = []string{
+	OpGetHealth,
+	OpAuthExchange,
+	OpCreateWorkflow,
+	OpListWorkflows,
+	OpGetWorkflow,
+	OpCancelWorkflow,
+	OpPauseWorkflow,
+	OpResumeWorkflow,
+	OpTriggerWorkflow,
+	OpSimulateWorkflow,
+	OpEstimateWorkflowFees,
+	OpCountWorkflows,
+	OpListExecutions,
+	OpListExecutionsForWorkflow,
+	OpGetExecution,
+	OpGetExecutionStatus,
+	OpSignalExecution,
+	OpStreamExecution,
+	OpCountExecutions,
+	OpExecutionStats,
+	OpListWallets,
+	OpCreateWallet,
+	OpUpdateWallet,
+	OpWithdrawWallet,
+	OpGetWalletNonce,
+	OpPrepareWalletPolicy,
+	OpSubmitWalletPolicy,
+	OpListWalletPolicies,
+	OpGetWalletPolicy,
+	OpRevokeWalletPolicy,
+	OpListSecrets,
+	OpPutSecret,
+	OpDeleteSecret,
+	OpGetToken,
+	OpRunNode,
+	OpRunTrigger,
+	OpListOperators,
+}
+
+func TestPermissionMap_CoversAllOperations(t *testing.T) {
+	for _, op := range allOperationIDs {
+		if _, ok := permissionMap[op]; !ok {
+			t.Errorf("permissionMap missing operation %q", op)
+		}
+	}
+	if len(permissionMap) != len(allOperationIDs) {
+		t.Errorf("permissionMap has %d entries, expected %d — extra keys?", len(permissionMap), len(allOperationIDs))
+		for op := range permissionMap {
+			found := false
+			for _, want := range allOperationIDs {
+				if op == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("permissionMap has unexpected key %q", op)
+			}
+		}
+	}
+}
+
+func TestEnsurePermission_UnmappedOp(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+	_, err := s.ensurePermission(ctxWithAssertion(""), "notARealOperation")
+	assertHTTPStatus(t, err, http.StatusInternalServerError)
+}
+
+func TestEnsurePermission_PartnerRead(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	t.Run("partner ok without user JWT", func(t *testing.T) {
+		p, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpGetToken)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.Level != LevelPartnerRead || p.PartnerID != "studio" {
+			t.Fatalf("unexpected principal: %+v", p)
+		}
+		if p.User == nil || p.User.Address.Hex() != testPartnerSubject {
+			t.Fatalf("expected user from sub, got %+v", p.User)
+		}
+	})
+
+	t.Run("user JWT alone rejected", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithUser(testPartnerSubject), OpGetToken)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("no credential rejected", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithAssertion(""), OpGetToken)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("simulate scope not enough for read", func(t *testing.T) {
+		sSim := newPartnerServer(t, pub, []string{"simulate"}, partnerStatusActive)
+		c := validClaims()
+		c["scope"] = "simulate"
+		_, err := sSim.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpGetToken)
+		assertHTTPStatus(t, err, http.StatusForbidden)
+	})
+}
+
+func TestEnsurePermission_SimulateRequiresUserJWT(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	t.Run("partner alone rejected", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpSimulateWorkflow)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+		_, err = s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpRunNode)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("user JWT ok", func(t *testing.T) {
+		p, err := s.ensurePermission(ctxWithUser(testPartnerSubject), OpSimulateWorkflow)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.User.Address.Hex() != testPartnerSubject {
+			t.Fatalf("got user %s", p.User.Address.Hex())
+		}
+	})
+}
+
+func TestEnsurePermission_WalletPreview(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	t.Run("partner with EOA sub", func(t *testing.T) {
+		p, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpCreateWallet)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.PartnerID != "studio" {
+			t.Fatalf("expected partner id, got %q", p.PartnerID)
+		}
+	})
+
+	t.Run("user JWT", func(t *testing.T) {
+		const subject = "0x2222222222222222222222222222222222222222"
+		p, err := s.ensurePermission(ctxWithUser(subject), OpListWallets)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.User.Address.Hex() != subject {
+			t.Fatalf("got %s", p.User.Address.Hex())
+		}
+	})
+
+	t.Run("empty JWT subject not partner fallthrough", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithUser(""), OpListWallets)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+}
+
+func TestEnsurePermission_UserRefusePartner(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	// Partner header + user JWT still refused (categorical).
+	ctx := ctxWithUser(testPartnerSubject)
+	ctx.Request().Header.Set(partnerAssertionHeader, signAssertion(t, priv, validClaims()))
+	_, err := s.ensurePermission(ctx, OpPrepareWalletPolicy)
+	assertHTTPStatus(t, err, http.StatusForbidden)
+
+	p, err := s.ensurePermission(ctxWithUser(testPartnerSubject), OpPrepareWalletPolicy)
+	if err != nil {
+		t.Fatalf("user-only should succeed: %v", err)
+	}
+	if p.Level != LevelUserRefusePartner {
+		t.Fatalf("level %s", p.Level)
+	}
+}
+
+func TestEnsurePermission_Public(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+	p, err := s.ensurePermission(ctxWithAssertion(""), OpGetHealth)
+	if err != nil {
+		t.Fatalf("public must succeed: %v", err)
+	}
+	if p.Level != LevelPublic || p.User != nil {
+		t.Fatalf("unexpected principal %+v", p)
+	}
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -61,6 +61,9 @@ tags:
   - name: Operators
     description: Connected operator status (read-only)
 
+# Default: end-user JWT. Operations that accept partner assertions (or
+# require them exclusively) override `security` per path. See
+# aggregator/rest/permission.go and GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md.
 security:
   - bearerAuth: []
 
@@ -75,6 +78,16 @@ components:
         signature flow) or via the operator-run `create-api-key` CLI
         (long-lived, server-to-server). Send on every request as
         `Authorization: Bearer <jwt>`.
+    partnerAssertion:
+      type: apiKey
+      in: header
+      name: X-Partner-Assertion
+      description: |
+        Short-lived Ed25519-signed partner assertion (JWT). `iss` must
+        match a registered partner id; `scope` must include the required
+        scope for the route (typically `read`); short-lived `exp` is
+        required. For preview wallet list/create, `sub` must be the
+        end-user's non-zero 0x EOA. See partners[] in gateway config.
 
   parameters:
     PageBefore:
@@ -2179,8 +2192,11 @@ paths:
       description: |
         Run a workflow definition end-to-end against the engine (Tenderly
         simulation for chain-writing nodes) and return the full Execution.
-        Nothing is persisted.
+        Nothing is persisted. Requires a user Bearer JWT; partner assertion
+        alone is not sufficient.
       operationId: simulateWorkflow
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -2468,7 +2484,13 @@ paths:
     get:
       tags: [Wallets]
       summary: List the authenticated user's smart wallets
+      description: |
+        Preview wallet resolve. Authorize with a user Bearer JWT **or** a
+        partner assertion (`scope: read`) whose `sub` is the owner EOA.
       operationId: listWallets
+      security:
+        - bearerAuth: []
+        - partnerAssertion: []
       responses:
         '200':
           description: All wallets for the authenticated user.
@@ -2482,8 +2504,12 @@ paths:
       description: |
         Idempotent "ensure exists". Returns the deterministic CREATE2-derived
         address. POST (not GET) because it persists a wallet record server-side
-        as a side effect of the derivation.
+        as a side effect of the derivation. Authorize with a user Bearer JWT
+        **or** a partner assertion (`scope: read`) whose `sub` is the owner EOA.
       operationId: createWallet
+      security:
+        - bearerAuth: []
+        - partnerAssertion: []
       requestBody:
         required: true
         content:
@@ -2828,7 +2854,13 @@ paths:
     get:
       tags: [Tokens]
       summary: Retrieve ERC-20 token metadata
+      description: |
+        Partner-gated public-ish chain data. Requires a partner assertion
+        with `scope: read` (`X-Partner-Assertion`). A user Bearer JWT alone
+        is not sufficient.
       operationId: getToken
+      security:
+        - partnerAssertion: []
       parameters:
         - $ref: '#/components/parameters/ChainIdQuery'
       responses:
@@ -2850,8 +2882,11 @@ paths:
       description: |
         Useful for SDK testing flows — run a node definition against
         provided input variables without persisting a workflow. Honors
-        `node.config.chainId` (overrides body `chainId`).
+        `node.config.chainId` (overrides body `chainId`). Requires a user
+        Bearer JWT; partner assertion alone is not sufficient.
       operationId: runNode
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -2870,7 +2905,11 @@ paths:
     post:
       tags: [Triggers]
       summary: Evaluate a trigger definition with inline input
+      description: |
+        Requires a user Bearer JWT; partner assertion alone is not sufficient.
       operationId: runTrigger
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -2897,11 +2936,12 @@ paths:
         Read-only monitoring endpoint. Returns each operator's
         `supportedChainIds`, `capabilities`, `lastSeen`, and `version`.
         Useful for dashboards and debugging multi-chain task routing.
+        Currently unauthenticated (public monitoring).
       operationId: listOperators
+      security: []
       responses:
         '200':
           description: Connected operators.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OperatorList' }
-        '401': { $ref: '#/components/responses/Unauthorized' }

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -139,24 +139,22 @@ chains:
       paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
       max_wallets_per_owner:  3
 
-# Optional: delegated partners (tenants). A partner authenticates its own
-# end users in its own system and may call the no-fund simulate family
-# (workflows:simulate / nodes:run / triggers:run) AND no-fund wallet
-# derivation (GET /wallets, POST /wallets) on their behalf WITHOUT a per-user
-# wallet signature, by sending a short-lived Ed25519-signed assertion in the
-# `X-Partner-Assertion` header. The assertion's `iss` must equal `id`, its
-# signature must verify against one of `public_keys`, it must declare a `scope`
-# granted below, carry a short-lived `exp`, and (if partner_assertion_audience
-# is set) an `aud` matching it. For wallet derivation `sub` must be the end
-# user's 0x EOA. Fund-moving operations are never authorized this way.
-# See PLAN_PARTNER_PAYMENTS.md. Omit this block to disable partner delegation.
+# Optional: delegated partners (tenants). Manual registration only (no API).
+# A partner sends a short-lived Ed25519 assertion in `X-Partner-Assertion`.
+# Scope "read" authorizes partner-gated reads (GET /tokens/{address}) and
+# preview wallet resolve (GET/POST /wallets; assertion `sub` must be the
+# owner EOA). Simulate / runNode / runTrigger require a user JWT — partner
+# alone is not enough. Fund-moving and session policies never accept partner.
+# Assertion `iss` must equal `id`; signature must verify against `public_keys`;
+# short-lived `exp` required; `aud` must match partner_assertion_audience when set.
+# See GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md. Omit to disable partner auth.
 partners:
   - id: studio
     # Base64-encoded Ed25519 public key(s); list several to rotate.
     public_keys:
       - "${STUDIO_PARTNER_PUBLIC_KEY_BASE64}"
     scopes:
-      - simulate
+      - read
     status: active
 # Bind partner assertions to this gateway/environment so a captured assertion
 # can't be replayed elsewhere; assertions must carry a matching `aud`.

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -541,17 +541,15 @@ type ChainConfigRaw struct {
 	SmartWallet SmartWalletConfigRaw `yaml:"smart_wallet"`
 }
 
-// PartnerConfig is a registered partner (tenant) permitted to call
-// delegated, no-fund operations — currently the simulate family
-// (workflows:simulate / nodes:run / triggers:run) — on behalf of its own
-// authenticated end users, without those users producing a wallet
-// signature. Partners authenticate with a short-lived Ed25519-signed
-// assertion (private_key_jwt style) whose `iss` claim equals ID and whose
+// PartnerConfig is a registered partner (tenant). Registration is manual
+// (YAML only). Partners authenticate with a short-lived Ed25519-signed
+// assertion (private_key_jwt style) whose `iss` equals ID and whose
 // signature verifies against one of PublicKeys.
 //
-// Simulate moves no funds and skips wallet-ownership, so partner trust is
-// sufficient for it; fund-moving operations (createTask/execute) are never
-// authorized by a partner assertion alone. See PLAN_PARTNER_PAYMENTS.md.
+// Scope "read" covers partner-gated token metadata and preview wallet
+// list/create. Simulate/runNode require a user JWT; fund-moving and
+// session policies never accept partner. Which REST ops accept partner
+// credentials is defined in aggregator/rest/permission.go.
 type PartnerConfig struct {
 	// ID is the partner identifier; it must equal the `iss` claim of the
 	// partner's assertions (e.g. "studio").
@@ -560,9 +558,8 @@ type PartnerConfig struct {
 	// "ed25519:"-prefixed). Multiple entries allow key rotation — any
 	// listed key may verify an assertion.
 	PublicKeys []string `yaml:"public_keys"`
-	// Scopes are the delegation scopes granted to this partner, e.g.
-	// ["simulate"]. A request is allowed only if its required scope is
-	// present here.
+	// Scopes are the scopes granted to this partner, e.g. ["read"].
+	// A request is allowed only if its required scope is present here.
 	Scopes []string `yaml:"scopes"`
 	// Status gates the partner; only "active" partners are honored.
 	Status string `yaml:"status"`


### PR DESCRIPTION
## Summary

- Add `aggregator/rest/permission.go` with a single **permission map** and `ensurePermission(op)` so every REST handler authorizes by OpenAPI operationId instead of ad-hoc `requireUser` / `requireSimulateAuth` helpers.
- Apply the layered minimal-auth model (see `GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md`):

| Level | Auth | Operations |
|-------|------|------------|
| `public` | none | health, auth:exchange, listOperators |
| `partner_read` | partner assertion `scope: read` | **GET /tokens/{address}** |
| `partner_wallet_preview` | partner `read` + EOA `sub`, **or** user JWT | **list + create** wallets |
| `user` | user JWT | workflows, executions, secrets, wallet fund ops, **simulate / runNode / runTrigger** |
| `user_refuse_partner` | user JWT; partner header refused | session policies |

- **Breaking auth policy:** partner-only simulate is removed; partner config example scope is `read` (not `simulate`).
- Partner registration remains manual YAML only.

## Follow-up (not in this PR)

- **ava-sdk-js e2e / Studio:** `client.tokens.retrieve` with JWT-only will get `PARTNER_REQUIRED` once this gateway ships. Tests that only `authenticateClient` (Bearer JWT) must also send `X-Partner-Assertion` with `scope: "read"` for token metadata. Simulate/runNode keep working with JWT-only. Partner-only simulate (if any client still does it) will fail — JWT required.
- Deployed gateway configs: set Studio partner `scopes: [read]`.
- Studio must mint `scope: read` for metadata + preview wallets.

## Test plan

- [x] `go test ./aggregator/rest/` (permission map coverage + level matrix)
- [ ] Deploy staging gateway with `scopes: [read]` for Studio
- [ ] Studio/SDK: mint partner `read` assertion; call `tokens.retrieve` without relying on JWT alone
- [ ] Confirm simulate/runNode still work with user JWT; partner alone returns 401
- [ ] Confirm GET/POST wallets work with partner+sub or JWT
- [ ] Confirm policies still refuse partner assertion