### PR TITLE
docs: Alchemy's managed session-key path never grants signing, not even root

### DIFF
--- a/PLAN_PARTNER_PAYMENTS.md
+++ b/PLAN_PARTNER_PAYMENTS.md
@@ -231,9 +231,14 @@ the canonical deployed contracts ([chrisli30/mav2-7702-poc](https://github.com/c
   `aa.SessionGrant.Validate()` ([ma_v2_install.go](core/chainio/aa/ma_v2_install.go)) refuses to pack a
   global grant carrying no execution hook, and `PackSessionSignerInstall` calls it on every path.
 
-Still open: whether Alchemy's **managed** session-key API leaves `isSignatureValidation` unset — its eight
-documented permission types are all execution-scoped and none mentions signing, so the flag is not exposed
-there. The contract enforces it; the managed default is unverified. Resolve before using that path.
+- **Alchemy's managed session-key path never grants signing either — not even `root`.** aa-sdk's
+  `PermissionBuilder` (`packages/smart-accounts/src/ma-v2/permissionBuilder.ts`) hardcodes
+  `isSignatureValidation: false` in both places it appears — the default config and the per-permission
+  config — and no branch mutates it. The `root` permission, which its own docs call "very dangerous",
+  sets `isGlobal = true` **and nothing else**. So even a root-scoped Alchemy session key can execute
+  anything yet still cannot answer `isValidSignature` as the user. Signature authority is reachable only
+  through the low-level `installValidation` decorator, where the caller supplies the flag byte
+  explicitly — a deliberate act, never a default. This closes the last open input in the re-score.
 
 The EOA-side consent flow this would require of Studio (two approvals, component ownership, re-consent) is
 out of scope here and documented privately in avs-infra, `EOA_7702_Delegation_Consent_Model.md`.


### PR DESCRIPTION
Follow-up to #741, which merged before this commit reached its branch — so `staging` still carries a line that is now wrong.

`PLAN_PARTNER_PAYMENTS.md` §4.1 currently ends with:

> Still open: whether Alchemy's **managed** session-key API leaves `isSignatureValidation` unset … The contract enforces it; the managed default is unverified. Resolve before using that path.

That has been resolved. Docs-only, one paragraph.

## The result

**Alchemy's managed session-key path never grants signing authority — and `root` is not an exception.**

aa-sdk's `PermissionBuilder` (`packages/smart-accounts/src/ma-v2/permissionBuilder.ts`, 811 lines) contains exactly two occurrences of `isSignatureValidation`, both hardcoded `false` — the builder's default `ValidationConfig` and the per-permission config. No branch mutates it.

`PermissionType.ROOT`, which Alchemy's own docs call *"full access to everything. This is a very dangerous permission to grant"*, sets `isGlobal = true` and nothing else:

```ts
if (permission.type === PermissionType.ROOT) {
  ...
  this.validationConfig.isGlobal = true;
  return this;
}
```

So even a root-scoped Alchemy session key can execute anything and still cannot answer `isValidSignature` as the user. Signature authority is reachable only through the low-level `installValidation` decorator, where the caller supplies the flag byte explicitly — a deliberate act, never a default.

This explains something the docs alone did not: the eight documented permission types are all execution-scoped because **execution and signing are separate axes** in that model, and the managed API only exposes the first.

Practical upshot — withholding the flag is not something we would have to remember on the managed path. It is what that path already does, and our own `aa.SessionGrant.AllowSignatureValidation` default agrees with it independently.

## Method

Verified by downloading and grepping the files, not by code search. `gh search code` for `"isSignatureValidation: true"` returned *no results* while a previous query from the same tool had returned a hit in `account.test.ts` — GitHub code search is unreliable for punctuated phrases and cannot support a negative claim. Noted in the avs-infra companion doc so this is not later "confirmed" by a method that cannot establish it.

Closes the last open input in the Calibur vs MA v2 7702 re-score. Decides nothing; the remaining trade is Calibur's no-bundler execution path against a second account system whose scoping we would own.
