### PR TITLE
feat: REST permission map, chainlink feed freshness validation

### DIFF
--- a/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
+++ b/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
@@ -1,0 +1,402 @@
+# Gateway change required: partner-gated reads & permission levels
+
+**Status:** **Implemented (gateway)** — `permission.go` / `ensurePermission` +  
+OpenAPI security overrides on PR #739.  
+**Remaining (external):** Studio + ava-sdk-js e2e mint/send partner `scope: read`  
+for token metadata; deploy configs with `scopes: [read]`; **per-partner rate  
+limits deferred** (see §4.4 — still JWT-subject / shared `anonymous` today).  
+**Repo:** EigenLayer-AVS (gateway / aggregator REST)  
+**Date:** 2026-08-08  
+**Related (Studio):** deposit / fund_wallet UX; `getTokenMetadataAction` fails with  
+`No valid auth key … wallet must sign in again` when the user has a live wallet  
+socket (AutoConnect) but no fresh **AVS user JWT** for the connected chain  
+(Position D).  
+**Related (code):** `aggregator/rest/permission.go`, `aggregator/rest/partner.go`,  
+`api/openapi.yaml`, `PLAN_PARTNER_PAYMENTS.md` (Phase 1 partner-only simulate  
+**superseded**).
+
+---
+
+## 1. Problem
+
+### What Studio needs
+
+Studio’s Deposit modal and token picker need **public-ish on-chain facts**:
+
+| Data | Today’s Studio path | Auth today |
+|------|---------------------|------------|
+| Token balances | Moralis (`getWalletTokenBalancesAction`) | NextAuth `userId` only — **no AVS JWT** |
+| Token metadata (name / symbol / decimals) | Gateway `GET /api/v1/tokens/{address}` via `getAuthedClient` | **Requires wallet-signed AVS user JWT** |
+
+Balances already work without an AVS JWT. Metadata does not:  
+`executionController.getTokenMetadata` → `getAuthedClient` → gateway  
+`GetToken` → `requireUser`.
+
+So after refresh, AutoConnect can restore Rabby while the modal still errors on  
+metadata because **AVS JWT is missing/expired for that EOA + chain**. The data  
+itself is not user-private (whitelist + `eth_call` name/symbol/decimals).
+
+The same cold-JWT gap hits **preview wallet resolve** (list + derive/create for  
+`$SMART_WALLET$`) if those paths ever required a user JWT without a partner  
+path — today they already allow partner OR JWT via `requireWalletDeriveAuth`;  
+this doc **keeps** that class partner-sufficient and groups list + create  
+together.
+
+### What we must not do
+
+**Do not open true public (anonymous) endpoints.**
+
+Unauthenticated `GET /tokens/*`, wallet list, etc. would:
+
+- Invite DDoS / scraper load against gateway + RPC
+- Bypass the tenant model (any client could hammer enrichment)
+- Diverge from “gateway is not a full public service”
+
+---
+
+## 2. Auth model (required)
+
+### Principle: minimal permission per operation
+
+The gateway is **not** intended as a fully public service. Most product traffic  
+sits behind a gate. Each operation gets the **weakest** permission that still  
+makes it safe and attributable — not “stack every gate by default.”
+
+**Two gates, different jobs. Applied by stakes, not always AND.**
+
+| Gate | Who | Purpose |
+|------|-----|---------|
+| **1. Partner app** | Registered partner in gateway config (`partners[]`; Studio only for now) | Outer door: only known apps may call. Attribution, per-partner rate limits, kill switch. **Sufficient alone** for low-stake read / preview-resolve. |
+| **2. User JWT** | End user’s wallet-signed gateway JWT (`Authorization: Bearer` via `auth:exchange`) | Binds the call to a concrete wallet subject and authority. **Required** for simulate / runNode and all user-owned or fund-moving ops. |
+
+There is **no anonymous / fully open** product API for these surfaces.
+
+```
+  Request
+      │
+      │  almost never anonymous
+      ▼
+  ┌─────────────────────────────┐
+  │ Gate 1: Partner             │  registered app (config whitelist)
+  │ (when op needs tenancy /    │
+  │  partner-sufficient class)  │
+  └─────────────┬───────────────┘
+                │
+     partner-sufficient ops          JWT-required ops
+     (read, preview wallet)          (simulate, execute, …)
+                │                              │
+                ▼                              ▼
+         handler                         Gate 2: User JWT
+                                         then handler
+```
+
+Gates do **not** fight each other: partner answers “which app,” JWT answers  
+“which wallet / with what authority.” Conflict only appears if a low-stake  
+read is forced through Gate 2 when Gate 1 alone is enough.
+
+### Partner registration (ops only)
+
+- Registration is **manual** (gateway YAML `partners[]` + public keys + scopes).
+- **Only Studio** is registered for now; design for N, operate with one.
+- **No partner registration / management API** in this change (or near term).
+- Suspend / rotate keys = config change + redeploy/reload as ops practice.
+
+### Target permission matrix
+
+| Operation class | Endpoints (today) | Minimal auth | Partner alone? | User JWT? |
+|-----------------|-------------------|--------------|----------------|-----------|
+| **Token / public chain reads** | `GET /api/v1/tokens/{address}` | Partner `scope: read` | **Yes** | No |
+| **Preview wallet resolve** | `GET /api/v1/wallets` (list), `POST /api/v1/wallets` (create/derive) | Partner (assertion `sub` = owner EOA) | **Yes** | No |
+| **Simulate / runNode / runTrigger** | `POST …/workflows:simulate`, `/nodes:run`, `/triggers:run` | **User JWT** | **No** | **Yes** |
+| **User-owned / fund authority** | workflows CRUD, executions, secrets, policies, withdraw, etc. | User JWT | **No** (policies already refuse partner) | **Yes** |
+
+**Preview wallet resolve** is one class: **list + create (derive)** share the same  
+partner-sufficient gate. Both are no-fund (CREATE2 / owner-scoped list).  
+Update / withdraw / nonce remain JWT-only.
+
+Optional later: require partner **in addition** on JWT routes (outer tenancy  
+AND). That is product lockdown, not the **minimal** requirement for those ops.  
+Minimal for simulate is JWT; minimal for token metadata and preview wallet  
+resolve is partner.
+
+### Relation to today’s code / `PLAN_PARTNER_PAYMENTS.md`
+
+| Surface | Today | This contract |
+|---------|--------|----------------|
+| Token metadata | `requireUser` only | **Partner `read` only** (JWT not required) |
+| List / create wallet | `requireWalletDeriveAuth` = partner **or** JWT | **Partner-sufficient** (JWT still accepted if present); keep `sub` = EOA for partner path |
+| Simulate / runNode / runTrigger | `requireSimulateAuth` = partner **or** JWT | **User JWT required** — partner alone **rejected** |
+| Fund / policies | User JWT; partner refused on policies | Unchanged |
+
+Phase 1 “partner-delegated simulate” (partner alone for no-fund run) is  
+**superseded** for policy: partner does **not** authorize simulate/runNode.  
+Partner remains for **reads + preview wallet resolve**.
+
+---
+
+## 3. Scope of APIs
+
+### In scope (must change)
+
+| Method | Path | Today | Required |
+|--------|------|-------|----------|
+| `GET` | `/api/v1/tokens/{address}` | `requireUser` | **Partner `read`** (no user JWT) |
+| `GET` | `/api/v1/wallets` | `requireWalletDeriveAuth` (partner **or** JWT) | **Preview wallet resolve** — partner OK without JWT; JWT OK if present |
+| `POST` | `/api/v1/wallets` | same | same class as list (derive/ensure) |
+| `POST` | `/api/v1/workflows:simulate` | `requireSimulateAuth` (partner **or** JWT) | **`requireUser` (JWT only)** — drop partner-only path |
+| `POST` | `/api/v1/nodes:run` | same | **JWT only** |
+| `POST` | `/api/v1/triggers:run` | same | **JWT only** |
+
+Handlers:
+
+- Tokens: `handlers_tokens.go` → `GetToken`
+- Wallets: `handlers_wallets.go` → `ListWallets`, `CreateWallet` (`requireWalletDeriveAuth`)
+- Simulate family: `handlers_workflows.go` / `handlers_nodes.go` / `handlers_triggers.go`
+
+Engine paths (whitelist, CREATE2, simulate) can stay; **auth helpers and  
+OpenAPI security** change.
+
+### Explicitly out of scope
+
+| Concern | Notes |
+|---------|--------|
+| Wallet **balances** for Deposit UI | Stay on Studio → Moralis + NextAuth until a gateway portfolio read is productized (then partner `read`, same as metadata). |
+| Partner registration API | Manual config only. |
+| Fund-moving / policies via partner | Never. |
+| Long-lived `X-Partner-API-Key` | Optional later; v1 reuses Ed25519 `X-Partner-Assertion`. |
+
+### “Public APIs” (product language)
+
+In Studio discussion, “public” meant **non-secret chain / resolve data**, not  
+unauthenticated HTTP:
+
+1. **Token metadata** — partner-gated.  
+2. **Preview wallet resolve** (list + create/derive) — partner-gated.  
+3. **Future gateway balances** — same partner `read` class if introduced.
+
+---
+
+## 4. Implementation sketch
+
+### 4.1 Partner verification (Gate 1)
+
+Reuse config registry (`partners[]`, `partner_assertion_audience`), Ed25519  
+`X-Partner-Assertion`:
+
+```json
+{
+  "iss": "studio",
+  "sub": "<owner EOA for wallet resolve; optional/empty for pure metadata>",
+  "scope": "read",
+  "aud": "<partner_assertion_audience>",
+  "exp": ...,
+  "iat": ...,
+  "jti": "..."
+}
+```
+
+Suggested scopes (config `scopes: [...]`):
+
+| Scope | Authorizes |
+|-------|------------|
+| `read` | Token metadata (and later portfolio reads). May also cover preview wallet resolve if product prefers one scope. |
+| `wallet_preview` (optional split) | List + create/derive only — use if `read` should not include wallet endpoints. |
+
+**v1 recommendation:** one scope `read` covering token metadata **and** preview  
+wallet resolve (list + create), to keep Studio minting simple. Split later if  
+a partner needs metadata without wallet resolve.
+
+- **Token metadata:** partner `read`; `sub` optional (logging / rate-limit key).  
+- **Preview wallet resolve:** partner `read` (or `wallet_preview`); **`sub` must  
+  be a real 0x EOA** (same rule as today’s `requireWalletDeriveAuth`).  
+- **`scope: simulate` on partner:** no longer authorizes simulate/runNode;  
+  remove from Studio mints for those calls; config may drop `simulate` or leave  
+  unused.
+
+Partner registration remains YAML only, e.g.:
+
+```yaml
+partners:
+  - id: studio
+    public_keys: ["ed25519:..."]
+    scopes: ["read"]
+    status: active
+partner_assertion_audience: avs-gateway-staging   # env-specific
+```
+
+### 4.2 Auth helpers
+
+```text
+requirePartner(ctx, requiredScope) → partnerPrincipal
+  - verify X-Partner-Assertion (or absent → 401 for partner-only routes)
+  - check registry scope + token scope
+  - return partner_id + sub
+
+requirePartnerRead(ctx):
+  - requirePartner(ctx, "read")
+  - for GetToken: build *model.User from sub if hex address, else zero / omit
+  - engine.GetTokenMetadata only uses user for logs today
+
+requirePreviewWalletResolve(ctx) → *model.User
+  - if user JWT present → requireUser (existing path)
+  - else requirePartner(ctx, "read") with sub = concrete EOA
+  - same shape as today’s requireWalletDeriveAuth, scopes updated
+
+requireUser(ctx) for simulate / runNode / runTrigger
+  - JWT required
+  - if X-Partner-Assertion present: either ignore for auth (JWT wins) or
+    refuse partner on these routes — prefer clear error if partner-only
+    credentials are sent without JWT so Studio fails loudly
+```
+
+`GetToken` becomes partner-only (no `requireUser`):
+
+```go
+_, err := s.requirePartner(ctx, scopeRead) // or requirePartnerRead
+// ... unchanged GetTokenMetadata; pass a User for logging if useful
+```
+
+Simulate family:
+
+```go
+user, err := s.requireUser(ctx) // not requireSimulateAuth
+```
+
+### 4.3 OpenAPI / SDK
+
+- Token metadata: security = partner assertion (`X-Partner-Assertion`), not  
+  bearer-only.  
+- Preview wallets: partner **or** bearer (document both).  
+- Simulate / runNode / runTrigger: bearer JWT **required**; document that  
+  partner alone is insufficient.  
+- SDK-js / Studio: mint `scope: "read"` for metadata + wallet resolve; stop  
+  relying on partner for simulate (send user JWT).  
+- Error codes: keep `PARTNER_*` vs `AUTH_REQUIRED` distinct.
+
+### 4.4 Rate limiting
+
+| Layer | Suggestion | Status |
+|-------|------------|--------|
+| Per partner | QPS / daily on partner-sufficient routes (`/tokens/*`, preview wallets) | **Deferred** (follow-up) |
+| Per subject | When JWT present, or partner `sub` when set | Partial (JWT subject only) |
+| Global | Existing gateway limits | Live |
+
+**Deferred note (PR #739 / Copilot):** rate-limit middleware still runs  
+*before* `ensurePermission` and keys only on JWT subject or the shared  
+`anonymous` bucket. Partner-only token/wallet traffic therefore shares  
+`anonymous` with unauthenticated noise. Fix requires verifying (or  
+peeking) partner identity before the limiter — separate change; not  
+blocking the permission-map merge. Partner Gate 1 still rejects unknown  
+apps at the handler.
+
+### 4.5 Studio follow-up
+
+1. Mint partner assertion `scope: "read"` for token metadata and preview  
+   wallet list/create.  
+2. Call those APIs with **partner only** when AVS JWT is cold (AutoConnect  
+   without re-exchange).  
+3. **Catalog-first** metadata fallback for known tokens (USDC/WETH) as extra  
+   UX hardening.  
+4. Simulate / runNode: **always** user JWT after auth exchange; do not send  
+   partner-only for those.  
+5. Deposit / preview resolve should not map “missing AVS JWT” to “wallet not  
+   connected” when only partner-gated reads were needed.
+
+---
+
+## 5. Security properties
+
+| Threat | Mitigation |
+|--------|------------|
+| Open internet scrapes `/tokens` or lists wallets | Gate 1: unknown partners rejected |
+| Leaked partner private key | Short TTL assertions; key rotation; scope limited to `read` / preview resolve — **not** simulate, execute, or policies |
+| Partner-only scrape of metadata | Per-partner rate limits + TTL (accepted blast radius: RPC cost, not funds) |
+| Partner-only simulate abuse | **Rejected** — JWT required for simulate/runNode |
+| Partner used for fund moves / policies | Existing refuse / requireUser; unchanged |
+| Leaked user JWT | Same as today for JWT routes; partner-sufficient routes do not need JWT |
+
+**Blast radius of partner `read` + preview wallet resolve:** metadata RPC,  
+owner-scoped wallet list/derive for assertion `sub` — not transfers, not  
+task create, not full simulate.
+
+---
+
+## 6. Acceptance criteria
+
+### Token metadata
+
+- [ ] `GET /api/v1/tokens/{address}` with valid partner `read` assertion,  
+      **no** user JWT → **200** (same body shape: `found`, symbol, decimals, …).  
+- [ ] Same without partner credential → **401** (even with valid user JWT,  
+      if product requires partner on this route; if JWT-only is still allowed  
+      as transition, document it — **target is partner-gated**).  
+- [ ] Partner without `read` scope → scope error.
+
+### Preview wallet resolve (list + create/derive)
+
+- [ ] `GET /api/v1/wallets` and `POST /api/v1/wallets` with partner assertion  
+      + `sub` = owner EOA, **no** user JWT → success (list / derived wallet).  
+- [ ] Partner with empty/non-address `sub` → **400** `PARTNER_SUBJECT_REQUIRED`  
+      (or equivalent).  
+- [ ] User JWT alone still works (optional compatibility).  
+- [ ] Update/withdraw/nonce still **JWT only**.
+
+### Simulate / runNode / runTrigger
+
+- [ ] Valid partner assertion alone (any scope) → **401** (JWT required).  
+- [ ] Valid user JWT → existing success behavior.  
+- [ ] Partner assertion cannot authorize createTask / execute / policies.
+
+### Ops / docs / Studio
+
+- [ ] Config example: Studio `scopes: ["read"]` (no registration API).  
+- [ ] OpenAPI + tests updated for the matrix.  
+- [ ] Studio: metadata + wallet resolve with partner when JWT cold;  
+      simulate only with JWT; catalog-first optional.
+
+---
+
+## 7. Non-goals
+
+- Fully public unauthenticated token, balance, or wallet HTTP APIs.  
+- Partner registration / multi-tenant admin API.  
+- Replacing Moralis balances in Studio in this change.  
+- Partner-only simulate / runNode (explicitly **not** allowed).  
+- Expanding partner scope to fund-moving operations.  
+- Dual-gate **AND** (partner + JWT) as the default for cheap reads.
+
+---
+
+## 8. Suggested implementation order
+
+1. Add `scopeRead` (+ helpers `requirePartner` / partner-only read path) in  
+   `aggregator/rest/partner.go`.  
+2. Switch `GetToken` to partner `read`; tests for partner-only success.  
+3. Keep/adjust `requireWalletDeriveAuth` as **preview wallet resolve** under  
+   `read` (list + create); confirm create stays partner-ok.  
+4. Switch simulate / runNode / runTrigger from `requireSimulateAuth` to  
+   `requireUser`; tests that partner-only is rejected.  
+5. Config examples: Studio `scopes: [read]`; deprecate partner `simulate` for  
+   auth.  
+6. SDK + Studio: `read` assertion for metadata + wallets; JWT for simulate;  
+   catalog-first as UX polish.
+
+---
+
+## 9. Summary
+
+| Question | Answer |
+|----------|--------|
+| Is token metadata user-secret? | No |
+| True public HTTP API? | **No** — partner gate |
+| Minimal gate for reads / preview wallet? | **Partner only** |
+| List + create (derive) one class? | **Yes** — preview wallet resolve under partner |
+| Simulate / runNode partner-only? | **No** — **user JWT required** |
+| Partner registration API? | **No** — manual config; Studio only for now |
+| Dual-gate AND on metadata? | **No** — that over-gates cold JWT UX |
+| Balances today | Moralis + NextAuth; partner `read` if moved to gateway later |
+
+This file is the **gateway-side auth contract**: partner as outer/minimal gate  
+for read + preview resolve; user JWT for simulate and restrictive ops; no  
+anonymous product APIs. Studio catalog/Moralis fallbacks remain complementary  
+UX, not a substitute for partner-bound gateway traffic.

--- a/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
+++ b/GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md
@@ -310,7 +310,7 @@ apps at the handler.
 |--------|------------|
 | Open internet scrapes `/tokens` or lists wallets | Gate 1: unknown partners rejected |
 | Leaked partner private key | Short TTL assertions; key rotation; scope limited to `read` / preview resolve — **not** simulate, execute, or policies |
-| Partner-only scrape of metadata | Per-partner rate limits + TTL (accepted blast radius: RPC cost, not funds) |
+| Partner-only scrape of metadata | Short-lived assertions, scoped access, and the existing shared global rate limit; per-partner limits are deferred (see §4.4). |
 | Partner-only simulate abuse | **Rejected** — JWT required for simulate/runNode |
 | Partner used for fund moves / policies | Existing refuse / requireUser; unchanged |
 | Leaked user JWT | Same as today for JWT routes; partner-sufficient routes do not need JWT |

--- a/PLAN_PARTNER_PAYMENTS.md
+++ b/PLAN_PARTNER_PAYMENTS.md
@@ -174,19 +174,72 @@ controller-signed authKey path. **Seam to preserve now:** the execute authorizat
 single, swappable check (today: "controller can sign for this wallet"; tomorrow: "Calibur permission
 exists") so dropping Calibur in does not touch the partner/scope layer.
 
-**Why Calibur, and not a 4337-routed EIP-7702 account: no EntryPoint migration.** We run **EntryPoint
-v0.6** today ([client.go:25](pkg/erc4337/bundler/client.go#L25), `EntryPointV06Address`), while every
-EIP-7702 delegation candidate surveyed in
-[discussion #658](https://github.com/AvaProtocol/EigenLayer-AVS/discussions/658) targets EntryPoint v0.7+.
-Forcing 7702 accounts through our 4337/bundler rails would drag in a v0.6→v0.7 migration we have not
-scoped. Calibur's relayer-native / direct-transaction model instead lets the aggregator EOA sign and
-submit the call directly — **no bundler, no EntryPoint upgrade** — which is the decisive reason it is the
-pick over a bundler-routed 7702 account. This reinforces the seam above: only the swappable authority
-check changes; the execution transport stays put and forces no infra migration. **De-risking next step
-(small + verifiable, not a full build):** a minimal Sepolia PoC of a Calibur-delegated EOA executing a
-single scoped call directly from the aggregator EOA (no bundler) and then revoking that authority — tx
-hashes proving the direct-transaction path works, no EntryPoint migration is needed, and revocation
-behaves — before any production code lands.
+**Why Calibur: it automates a different wallet than MA v2 does.** MA v2 operates the **smart wallet we
+derive from the user's EOA** — a separate contract at a factory address, which the user must fund before
+we can automate anything in it. Calibur automates the **user's EOA itself**, via EIP-7702 delegation: the
+account is the address the user already has, holding the assets they already hold, with no second address
+and no funding step. These are complementary products, not competing implementations of one product. The
+seam above stays the same either way — only the authority check swaps.
+
+**Superseded rationale — the EntryPoint v0.6 argument no longer applies.** An earlier revision of this
+section argued for Calibur on the grounds that we ran EntryPoint v0.6 while every 7702 candidate targeted
+v0.7+, making a bundler-routed 7702 account a forced migration. **We have since completed that cutover.**
+MA v2 on EntryPoint v0.7 is the only account provider we allow
+([config.go:58](core/config/config.go#L58) pins `EntryPointV07AddressHex`,
+[config.go:385](core/config/config.go#L385) returns v0.7 for MA v2 chains,
+[config.go:407](core/config/config.go#L407) rejects anything but `modular_account_v2`); see
+[docs/changes/20260807-retire-v06-send-path.md](docs/changes/20260807-retire-v06-send-path.md). The `EntryPointV06Address` constant survives only as legacy in [bundler/client.go:25](pkg/erc4337/bundler/client.go#L25). Do not
+cite the migration cost as a reason for anything.
+
+**The comparison that does remain: Calibur vs MA v2's own 7702 mode.** MA v2 also ships a 7702 flavor
+that delegates the user's EOA to the MA v2 implementation — same wallet type Calibur targets, so the
+choice is genuine and lives entirely in the EOA lane. **This was already surfaced in
+[discussion #658](https://github.com/AvaProtocol/EigenLayer-AVS/discussions/658) §4.4** — "In Alchemy's
+Account Kit, 7702 is the default mode for new accounts", with "session keys with allowlists, ERC-20 and
+native spend limits, expiries", which that survey itself called "precisely the scoped-controller shape we
+need" — but MA v2 was ranked *credible third* rather than finalist on three counterweights: smaller
+ERC-6900 module ecosystem, a 4337-first design that makes direct transactions less natural, and tooling
+gravity toward Alchemy's stack. **Two of those three have since evaporated:** the EntryPoint migration
+cost is gone (above), and we now run Alchemy's bundler and Gas Manager by default, so "gravity toward
+Alchemy's stack" describes where we already are.
+
+What survives is the one real trade-off: Calibur's relayer-native model lets the aggregator sign and
+submit `execute()` directly (**no bundler, no EntryPoint** — verified at 128,296 gas), while MA v2 7702
+routes every op as a UserOp through EntryPoint v0.7 and a bundler. Against that, MA v2 keeps us on **one
+account system whose permission layer is already audited** (ChainLight 2024-12-03, Quantstamp 2024-12-11)
+rather than a second, parallel one **whose scoping we author and audit ourselves** — and the three
+findings below are concrete evidence that the DIY path is easy to get wrong in ways that fail open. That
+re-weighting postdates #658 and warrants a re-score rather than inheriting its finalist. Verify MA v2 7702
+module semantics and the exact account↔EntryPoint pairing against current Alchemy docs before deciding —
+that is the least-settled input.
+
+**De-risking step: DONE.** The Sepolia PoC landed and was independently verified —
+[calibur-7702-poc](https://github.com/Antrikshgwal/calibur-7702-poc), verification branch and write-up at
+[chrisli30/calibur-7702-poc @ verify/ava-protocol-standalone](https://github.com/chrisli30/calibur-7702-poc/tree/verify/ava-protocol-standalone).
+Direct-transaction path works (aggregator-relayed scoped `execute()`, 128,296 gas, no bundler); revocation
+and expiry are total. **Three findings that must shape any production build:**
+
+1. **Scoping does not cover the signature path.** The policy hook is address-flag dispatched, and the
+   execution flags (`0x18`) leave `AFTER_IS_VALID_SIGNATURE_FLAG` (`1 << 2`) clear. Calibur's
+   `isValidSignature` admits any registered, unexpired key with no target or value scoping, so a
+   "scoped" key can mint arbitrary ERC-1271 account signatures — Permit2 approvals, Seaport orders — a
+   token drain that never reaches `beforeExecute`. **This is worse here than it would be on a derived
+   smart wallet**, precisely because of the wallet-type distinction above: the EOA is the user's primary
+   asset store, not a purpose-funded automation wallet. That is exactly the hazard #658 named as its
+   second hard constraint — "on a delegated EOA the blast radius is *everything the user owns* … the
+   controller must hold a scoped, expiring, user-revocable key — never root-equivalent access. This is
+   non-negotiable" — so the PoC as built does not yet clear the bar the survey set for it. A production
+   hook must mine for `0x1f` and explicitly deny the validation callbacks.
+2. **Hook scoping is fail-open.** `KeyManagement.update` accepts any hook with code and any nonzero flag
+   bit, so a mis-flagged hook is accepted, *looks* attached in `getKeySettings`, and silently enforces
+   nothing. Assert the hook's address bits at registration, not just at deploy.
+3. **Sponsored delegation fails silently on forge ≥ 1.2.** `vm.signAndAttachDelegation` signs
+   `accountNonce + 1`, valid only for a self-send; with the aggregator as sender the authorization is
+   *skipped* rather than rejected, the type-4 tx lands status 1, and nothing is delegated. Sponsored
+   relay is exactly our model — confirm delegation by reading `code(account)`, never by tx status.
+
+Common shape across all three: the bound is absent and the system reports success. Any Calibur
+integration needs positive assertions that each bound is live.
 
 **4.2 Partner attribution on tasks.** Add `string partner_id = NN [json_name="partnerId"]` to
 `protobuf/avs.proto` (additive/`omitempty`; old tasks load via the existing `DiscardUnknown` path,

--- a/PLAN_PARTNER_PAYMENTS.md
+++ b/PLAN_PARTNER_PAYMENTS.md
@@ -231,9 +231,14 @@ the canonical deployed contracts ([chrisli30/mav2-7702-poc](https://github.com/c
   `aa.SessionGrant.Validate()` ([ma_v2_install.go](core/chainio/aa/ma_v2_install.go)) refuses to pack a
   global grant carrying no execution hook, and `PackSessionSignerInstall` calls it on every path.
 
-Still open: whether Alchemy's **managed** session-key API leaves `isSignatureValidation` unset — its eight
-documented permission types are all execution-scoped and none mentions signing, so the flag is not exposed
-there. The contract enforces it; the managed default is unverified. Resolve before using that path.
+- **Alchemy's managed session-key path never grants signing either — not even `root`.** aa-sdk's
+  `PermissionBuilder` (`packages/smart-accounts/src/ma-v2/permissionBuilder.ts`) hardcodes
+  `isSignatureValidation: false` in both places it appears — the default config and the per-permission
+  config — and no branch mutates it. The `root` permission, which its own docs call "very dangerous",
+  sets `isGlobal = true` **and nothing else**. So even a root-scoped Alchemy session key can execute
+  anything yet still cannot answer `isValidSignature` as the user. Signature authority is reachable only
+  through the low-level `installValidation` decorator, where the caller supplies the flag byte
+  explicitly — a deliberate act, never a default. This closes the last open input in the re-score.
 
 The EOA-side consent flow this would require of Studio (two approvals, component ownership, re-consent) is
 out of scope here and documented privately in avs-infra, `EOA_7702_Delegation_Consent_Model.md`.

--- a/PLAN_PARTNER_PAYMENTS.md
+++ b/PLAN_PARTNER_PAYMENTS.md
@@ -209,9 +209,34 @@ routes every op as a UserOp through EntryPoint v0.7 and a bundler. Against that,
 account system whose permission layer is already audited** (ChainLight 2024-12-03, Quantstamp 2024-12-11)
 rather than a second, parallel one **whose scoping we author and audit ourselves** — and the three
 findings below are concrete evidence that the DIY path is easy to get wrong in ways that fail open. That
-re-weighting postdates #658 and warrants a re-score rather than inheriting its finalist. Verify MA v2 7702
-module semantics and the exact account↔EntryPoint pairing against current Alchemy docs before deciding —
-that is the least-settled input.
+re-weighting postdates #658 and warrants a re-score rather than inheriting its finalist.
+
+**MA v2 7702 semantics — VERIFIED 2026-08-10, no longer the open input.** An earlier revision of this
+paragraph called this the least-settled question. It has since been answered on a Sepolia fork against
+the canonical deployed contracts ([chrisli30/mav2-7702-poc](https://github.com/chrisli30/mav2-7702-poc)):
+
+- **`SemiModularAccount7702`** at `0x69007702764179f14F51cdce752f4f775d74E139` (`alchemy.sma-7702.1.0.0`);
+  its `entryPoint()` returns `0x0000000071727De22E5E9d8BAf0edAc6f37da032` — **byte-identical to the v0.7
+  EntryPoint we already run** ([config.go:58](core/config/config.go#L58)). The account↔EntryPoint pairing
+  question is closed: no migration, no new infra. Delegate only to this variant — Alchemy warns the other
+  MA v2 variants have unprotected initializers.
+- **Signing authority is opt-in and account-enforced.** ERC-6900 makes it a per-validation flag and
+  requires the account to honour it; MA v2 implements that in `ModularAccountBase._exec1271Validation`.
+  A session key installed without `isSignatureValidation` reverts `SignatureValidationInvalid` when used
+  to sign. **This is the exact inverse of finding 1 below** — where Calibur admits any registered key by
+  default, MA v2 refuses by default, so on the property #658 called non-negotiable MA v2 is correct by
+  construction and Calibur requires us to build it.
+- **A grant is upgradeable but never self-upgradeable.** The owner can widen scope later; a scoped key
+  cannot install another validation. Consistent with the guardrail already enforced in our own code —
+  `aa.SessionGrant.Validate()` ([ma_v2_install.go](core/chainio/aa/ma_v2_install.go)) refuses to pack a
+  global grant carrying no execution hook, and `PackSessionSignerInstall` calls it on every path.
+
+Still open: whether Alchemy's **managed** session-key API leaves `isSignatureValidation` unset — its eight
+documented permission types are all execution-scoped and none mentions signing, so the flag is not exposed
+there. The contract enforces it; the managed default is unverified. Resolve before using that path.
+
+The EOA-side consent flow this would require of Studio (two approvals, component ownership, re-consent) is
+out of scope here and documented privately in avs-infra, `EOA_7702_Delegation_Consent_Model.md`.
 
 **De-risking step: DONE.** The Sepolia PoC landed and was independently verified —
 [calibur-7702-poc](https://github.com/Antrikshgwal/calibur-7702-poc), verification branch and write-up at

--- a/README.md
+++ b/README.md
@@ -70,19 +70,21 @@ run.
 
 ### Aggregator Address
 
-The aggregator is currently run and managed by the Ava Protocol team. Depend on
-testnet or mainnet, you would need to point your operator to the right address
-in the operator config file.
+The aggregator is run and managed by the Ava Protocol team. Point your operator
+at it in the operator config file:
 
-#### Sepolia Testnet
+```yaml
+aggregator_server_ip_port_address: "aggregator.avaprotocol.org:57376"
+```
 
-- aggregator-sepolia.avaprotocol.org:2206
-- [https://api-explorer-sepolia.avaprotocol.org/](https://api-explorer-sepolia.avaprotocol.org/)
+One endpoint serves every chain. The gateway is a single deployment that routes
+per-chain internally, so there is no longer a separate testnet and mainnet
+address — Ethereum, Sepolia, Base, Base Sepolia and BNB all arrive over the
+same gRPC connection.
 
-#### Mainnet
-
-- aggregator.avaprotocol.org:2206
-- [https://api-explorer.avaprotocol.org/](https://api-explorer.avaprotocol.org/)
+The REST API for workflows lives at `https://api.avaprotocol.org/api/v1`, and
+the operator dashboard at
+[https://api.avaprotocol.org/telemetry](https://api.avaprotocol.org/telemetry).
 
 ## Operators
 
@@ -105,16 +107,14 @@ Currently, Ava Protocol has deployed our operator on the testnet. Community memb
 
 ## Telemetry Dashboard
 
-Operator that is connected to Ava Protocol aggregator can also check their
-operator on our telemetry dashboard as below
+An operator connected to the Ava Protocol gateway can see itself on the
+telemetry dashboard:
 
-### Testnet
+https://api.avaprotocol.org/telemetry
 
-https://aggregator-sepolia.avaprotocol.org/telemetry
-
-### Mainnet
-
-https://aggregator.avaprotocol.org/telemetry
+One dashboard covers every chain. The gateway is unified — a single deployment
+serves all chains and routes per-chain internally — so the previous per-chain
+`aggregator-*.avaprotocol.org/telemetry` hosts no longer exist.
 
 ## Branching Strategy
 

--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -364,8 +364,6 @@ func (w *ServerInterfaceWrapper) RunNode(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) ListOperators(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(BearerAuthScopes, []string{})
-
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.ListOperators(ctx)
 	return err
@@ -482,7 +480,7 @@ func (w *ServerInterfaceWrapper) GetToken(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter address: %s", err))
 	}
 
-	ctx.Set(BearerAuthScopes, []string{})
+	ctx.Set(PartnerAssertionScopes, []string{})
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetTokenParams
@@ -515,6 +513,8 @@ func (w *ServerInterfaceWrapper) ListWallets(ctx echo.Context) error {
 
 	ctx.Set(BearerAuthScopes, []string{})
 
+	ctx.Set(PartnerAssertionScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.ListWallets(ctx)
 	return err
@@ -525,6 +525,8 @@ func (w *ServerInterfaceWrapper) CreateWallet(ctx echo.Context) error {
 	var err error
 
 	ctx.Set(BearerAuthScopes, []string{})
+
+	ctx.Set(PartnerAssertionScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.CreateWallet(ctx)
@@ -1452,17 +1454,6 @@ type ListOperators200JSONResponse OperatorList
 func (response ListOperators200JSONResponse) VisitListOperatorsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type ListOperators401ApplicationProblemPlusJSONResponse struct {
-	UnauthorizedApplicationProblemPlusJSONResponse
-}
-
-func (response ListOperators401ApplicationProblemPlusJSONResponse) VisitListOperatorsResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	BearerAuthScopes = "bearerAuth.Scopes"
+	BearerAuthScopes       = "bearerAuth.Scopes"
+	PartnerAssertionScopes = "partnerAssertion.Scopes"
 )
 
 // Defines values for AwaitNodeType.

--- a/aggregator/rest/handlers_auth.go
+++ b/aggregator/rest/handlers_auth.go
@@ -37,6 +37,9 @@ const authMessageRequired = 8
 // the EigenLayer registration chain id (chain-agnostic auth). SDKs
 // construct the message locally; there is no GetSignatureFormat endpoint.
 func (s *Server) AuthExchange(ctx echo.Context) error {
+	if _, err := s.ensurePermission(ctx, OpAuthExchange); err != nil {
+		return err
+	}
 	var body generated.AuthExchangeRequest
 	if err := ctx.Bind(&body); err != nil {
 		return &restmw.HTTPError{

--- a/aggregator/rest/handlers_executions.go
+++ b/aggregator/rest/handlers_executions.go
@@ -40,10 +40,11 @@ const streamMinInterval = 250 * time.Millisecond
 // scan. Without workflowId we return 400 pointing the caller at the
 // nested route that does the same thing more explicitly.
 func (s *Server) ListExecutions(ctx echo.Context, params generated.ListExecutionsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListExecutions)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	if params.WorkflowId == nil || len(*params.WorkflowId) == 0 {
 		return badRequest("EXECUTIONS_WORKFLOW_REQUIRED",
 			"workflowId filter required",
@@ -63,10 +64,11 @@ func (s *Server) ListExecutions(ctx echo.Context, params generated.ListExecution
 // Nested convenience route. The path parameter `id` pins the workflowId
 // so the handler can hand the engine a single TaskIds entry.
 func (s *Server) ListExecutionsForWorkflow(ctx echo.Context, id generated.Ulid, params generated.ListExecutionsForWorkflowParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListExecutionsForWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := buildListExecutionsReq([]generated.Ulid{id}, params.After, params.Before, params.Limit)
 	resp, err := s.engine.ListExecutions(user, req)
@@ -83,10 +85,11 @@ func (s *Server) ListExecutionsForWorkflow(ctx echo.Context, id generated.Ulid, 
 // global index. Callers that already know the workflow can use the
 // nested form (`GET /workflows/{id}/executions`) too.
 func (s *Server) GetExecution(ctx echo.Context, id generated.Ulid, params generated.GetExecutionParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetExecution)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	workflowID := string(params.WorkflowId)
 	exec, err := s.engine.GetExecution(user, &avsproto.ExecutionReq{
 		TaskId:      workflowID,
@@ -108,10 +111,11 @@ func (s *Server) GetExecution(ctx echo.Context, id generated.Ulid, params genera
 // The caller must own the workflow; the engine's gate (DeliverSignal) rejects a
 // signal with no pending wait, a mismatched kind, or one that has timed out.
 func (s *Server) SignalExecution(ctx echo.Context, id generated.Ulid, params generated.SignalExecutionParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpSignalExecution)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	var body generated.SignalExecutionRequest
 	if err := ctx.Bind(&body); err != nil {
 		return badRequest("SIGNAL_BAD_REQUEST", "Invalid request body", err.Error())
@@ -145,10 +149,11 @@ func (s *Server) SignalExecution(ctx echo.Context, id generated.Ulid, params gen
 // clients polling for terminal state without paying the cost of
 // fetching the full execution record.
 func (s *Server) GetExecutionStatus(ctx echo.Context, id generated.Ulid, params generated.GetExecutionStatusParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetExecutionStatus)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	workflowID := string(params.WorkflowId)
 	statusResp, err := s.engine.GetExecutionStatus(user, &avsproto.ExecutionReq{
 		TaskId:      workflowID,
@@ -177,10 +182,11 @@ func (s *Server) GetExecutionStatus(ctx echo.Context, id generated.Ulid, params 
 // when the status changes. Closes on terminal status, after
 // streamMaxDuration, or when the client disconnects.
 func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params generated.StreamExecutionParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpStreamExecution)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	workflowID := string(params.WorkflowId)
 
 	interval := time.Second
@@ -302,10 +308,11 @@ func (s *Server) StreamExecution(ctx echo.Context, id generated.Ulid, params gen
 
 // CountExecutions — GET /api/v1/executions:count
 func (s *Server) CountExecutions(ctx echo.Context, params generated.CountExecutionsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCountExecutions)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetExecutionCountReq{}
 	if params.WorkflowId != nil {
@@ -322,10 +329,11 @@ func (s *Server) CountExecutions(ctx echo.Context, params generated.CountExecuti
 
 // ExecutionStats — GET /api/v1/executions:stats
 func (s *Server) ExecutionStats(ctx echo.Context, params generated.ExecutionStatsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpExecutionStats)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetExecutionStatsReq{}
 	if params.WorkflowId != nil {

--- a/aggregator/rest/handlers_health.go
+++ b/aggregator/rest/handlers_health.go
@@ -16,6 +16,9 @@ import (
 // authentication absence (security: []) so monitoring tools can probe
 // without credentials.
 func (s *Server) GetHealth(ctx echo.Context) error {
+	if _, err := s.ensurePermission(ctx, OpGetHealth); err != nil {
+		return err
+	}
 	status := generated.Ok
 	httpStatus := http.StatusOK
 

--- a/aggregator/rest/handlers_nodes.go
+++ b/aggregator/rest/handlers_nodes.go
@@ -21,11 +21,12 @@ import (
 // without persisting a workflow. Used by SDK testing flows and the
 // agent-CLI verify command.
 func (s *Server) RunNode(ctx echo.Context) error {
-	// No-fund operation: a user JWT or a partner assertion both authorize it.
-	user, err := s.requireSimulateAuth(ctx)
+	// User JWT required (LevelUser). Partner assertion alone does not authorize.
+	p, err := s.ensurePermission(ctx, OpRunNode)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.RunNodeRequest
 	if err := ctx.Bind(&body); err != nil {

--- a/aggregator/rest/handlers_nodes_nil_config_test.go
+++ b/aggregator/rest/handlers_nodes_nil_config_test.go
@@ -34,7 +34,7 @@ func runNodeCtx(body string) echo.Context {
 // the Config pointer directly; the rest already errored cleanly.
 func TestRunNodeRejectsNilConfigWithoutPanicking(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 
 	cases := []struct {
 		name string

--- a/aggregator/rest/handlers_operators.go
+++ b/aggregator/rest/handlers_operators.go
@@ -23,6 +23,9 @@ import (
 // work still in flight) — it returns as an empty array until that
 // lands. Clients should treat empty as "unknown", not "none".
 func (s *Server) ListOperators(ctx echo.Context) error {
+	if _, err := s.ensurePermission(ctx, OpListOperators); err != nil {
+		return err
+	}
 	if s.operators == nil {
 		return ctx.JSON(http.StatusOK, generated.OperatorList{Data: []generated.OperatorInfo{}})
 	}

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -26,11 +26,8 @@ import (
 // submit trusts nothing — the grant is recomputed from the echoed fields and
 // the signature is the only authority.
 //
-// Every handler leads with refusePartnerAssertion: a policy is fund
-// authority, and the refusal must be explicit rather than a handler that
-// silently never consults the header.
-
-const policyCapability = "Session-policy management"
+// Every handler authorizes via ensurePermission (LevelUserRefusePartner):
+// partner assertions are refused; user JWT is required.
 
 // policyChainID resolves the chain: explicit value wins, then the JWT's
 // audience chain. Zero means unresolvable (single-chain deployments have an
@@ -45,13 +42,10 @@ func policyChainID(ctx echo.Context, explicit *int64) int64 {
 	return 0
 }
 
-// policyAuth is the shared preamble: partner refusal, then user auth, then
-// path-address validation.
-func (s *Server) policyAuth(ctx echo.Context, address generated.EthereumAddress) (*model.User, common.Address, error) {
-	if err := refusePartnerAssertion(ctx, policyCapability); err != nil {
-		return nil, common.Address{}, err
-	}
-	user, err := s.requireUser(ctx)
+// policyAuth is the shared preamble: permission level for the operation,
+// then path-address validation.
+func (s *Server) policyAuth(ctx echo.Context, op string, address generated.EthereumAddress) (*model.User, common.Address, error) {
+	p, err := s.ensurePermission(ctx, op)
 	if err != nil {
 		return nil, common.Address{}, err
 	}
@@ -59,12 +53,12 @@ func (s *Server) policyAuth(ctx echo.Context, address generated.EthereumAddress)
 		return nil, common.Address{}, badRequest("POLICIES_BAD_ADDRESS", "Invalid wallet address",
 			"The {address} path parameter must be a valid 0x-prefixed hex address.")
 	}
-	return user, common.HexToAddress(string(address)), nil
+	return p.User, common.HexToAddress(string(address)), nil
 }
 
 // PrepareWalletPolicy allocates a grant and returns the payload to sign.
 func (s *Server) PrepareWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpPrepareWalletPolicy, address)
 	if err != nil {
 		return err
 	}
@@ -112,7 +106,7 @@ func (s *Server) PrepareWalletPolicy(ctx echo.Context, address generated.Ethereu
 
 // SubmitWalletPolicy verifies the owner's signature and stores the grant.
 func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.EthereumAddress) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpSubmitWalletPolicy, address)
 	if err != nil {
 		return err
 	}
@@ -151,7 +145,7 @@ func (s *Server) SubmitWalletPolicy(ctx echo.Context, address generated.Ethereum
 
 // ListWalletPolicies lists the wallet's grants, newest first.
 func (s *Server) ListWalletPolicies(ctx echo.Context, address generated.EthereumAddress, params generated.ListWalletPoliciesParams) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpListWalletPolicies, address)
 	if err != nil {
 		return err
 	}
@@ -173,7 +167,7 @@ func (s *Server) ListWalletPolicies(ctx echo.Context, address generated.Ethereum
 
 // GetWalletPolicy returns one grant.
 func (s *Server) GetWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.GetWalletPolicyParams) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpGetWalletPolicy, address)
 	if err != nil {
 		return err
 	}
@@ -204,7 +198,7 @@ func onChainCleanupAPI(c *taskengine.OnChainRevokeCleanup) *generated.OnChainRev
 
 // RevokeWalletPolicy revokes one grant.
 func (s *Server) RevokeWalletPolicy(ctx echo.Context, address generated.EthereumAddress, policyID generated.Ulid, params generated.RevokeWalletPolicyParams) error {
-	user, wallet, err := s.policyAuth(ctx, address)
+	user, wallet, err := s.policyAuth(ctx, OpRevokeWalletPolicy, address)
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_secrets.go
+++ b/aggregator/rest/handlers_secrets.go
@@ -15,10 +15,11 @@ import (
 
 // ListSecrets — GET /api/v1/secrets
 func (s *Server) ListSecrets(ctx echo.Context, params generated.ListSecretsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListSecrets)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.ListSecretsReq{IncludeTimestamps: true}
 	if params.WorkflowId != nil {
@@ -55,10 +56,11 @@ func (s *Server) ListSecrets(ctx echo.Context, params generated.ListSecretsParam
 // if a secret with the same (name, scope) already exists; in that case
 // we fall through to UpdateSecret so PUT semantics hold.
 func (s *Server) PutSecret(ctx echo.Context, name string) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpPutSecret)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.PutSecretRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -96,10 +98,11 @@ func (s *Server) PutSecret(ctx echo.Context, name string) error {
 
 // DeleteSecret — DELETE /api/v1/secrets/{name}
 func (s *Server) DeleteSecret(ctx echo.Context, name string, params generated.DeleteSecretParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpDeleteSecret)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.DeleteSecretReq{Name: name}
 	if params.WorkflowId != nil {

--- a/aggregator/rest/handlers_tokens.go
+++ b/aggregator/rest/handlers_tokens.go
@@ -20,10 +20,11 @@ import (
 // fallback succeeded — there's no 404 here because partial information
 // (just the address) is still useful to the caller.
 func (s *Server) GetToken(ctx echo.Context, address generated.EthereumAddress, params generated.GetTokenParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetToken)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetTokenMetadataReq{Address: string(address)}
 	if params.ChainId != nil {

--- a/aggregator/rest/handlers_triggers.go
+++ b/aggregator/rest/handlers_triggers.go
@@ -20,11 +20,12 @@ import (
 // use this to confirm a trigger config parses and returns the expected
 // shape before committing it to a workflow.
 func (s *Server) RunTrigger(ctx echo.Context) error {
-	// No-fund operation: a user JWT or a partner assertion both authorize it.
-	user, err := s.requireSimulateAuth(ctx)
+	// User JWT required (LevelUser). Partner assertion alone does not authorize.
+	p, err := s.ensurePermission(ctx, OpRunTrigger)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.RunTriggerRequest
 	if err := ctx.Bind(&body); err != nil {

--- a/aggregator/rest/handlers_wallets.go
+++ b/aggregator/rest/handlers_wallets.go
@@ -28,12 +28,13 @@ import (
 // No-fund: lists the smart wallets derived/owned by the authenticated owner
 // (the JWT subject, or a partner assertion's `sub`). Scoped to that owner, so
 // it never exposes another user's wallets. Partner-delegatable to resolve a
-// preview's runner — see requireWalletDeriveAuth.
+// preview's runner — see ensurePermission (partner_wallet_preview).
 func (s *Server) ListWallets(ctx echo.Context) error {
-	user, err := s.requireWalletDeriveAuth(ctx)
+	p, err := s.ensurePermission(ctx, OpListWallets)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	resp, err := s.engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
 	if err != nil {
@@ -70,11 +71,12 @@ func (s *Server) CreateWallet(ctx echo.Context) error {
 	// No-fund: derives the counterfactual CREATE2 address from (owner, salt,
 	// factory) and records it. Partner-delegatable so a preview can resolve a
 	// social user's runner before any wallet is deployed — see
-	// requireWalletDeriveAuth.
-	user, err := s.requireWalletDeriveAuth(ctx)
+	// ensurePermission (partner_wallet_preview).
+	p, err := s.ensurePermission(ctx, OpCreateWallet)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.CreateWalletRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -109,10 +111,11 @@ func (s *Server) CreateWallet(ctx echo.Context) error {
 // is identified by (salt, factory) — we re-resolve those from the
 // address via GetWallet and then SetWallet with the new isHidden.
 func (s *Server) UpdateWallet(ctx echo.Context, address generated.EthereumAddress) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpUpdateWallet)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body struct {
 		IsHidden *bool `json:"isHidden"`
@@ -156,10 +159,11 @@ func (s *Server) UpdateWallet(ctx echo.Context, address generated.EthereumAddres
 // in at startup. The full UserOp + paymaster + balance-checking
 // pipeline lives in aggregator package — REST is a thin adapter.
 func (s *Server) WithdrawWallet(ctx echo.Context, address generated.EthereumAddress) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpWithdrawWallet)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	if s.withdraws == nil {
 		return &restmw.HTTPError{
 			Status: http.StatusServiceUnavailable,
@@ -273,10 +277,11 @@ func (s *Server) WithdrawWallet(ctx echo.Context, address generated.EthereumAddr
 // Chain routing precedence: ?chainId= override → JWT aud → gateway
 // default. Same pattern as CreateWallet / WithdrawWallet.
 func (s *Server) GetWalletNonce(ctx echo.Context, address generated.EthereumAddress, params generated.GetWalletNonceParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetWalletNonce)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	if !common.IsHexAddress(string(address)) {
 		return badRequest("WALLETS_BAD_ADDRESS", "Invalid wallet address", "The {address} path parameter must be a valid 0x-prefixed hex address.")
 	}

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -18,7 +18,7 @@ import (
 //
 // Every handler is the same shape:
 //
-//	1. requireUser — pull the JWT subject from echo context.
+//	1. ensurePermission(op) — authorize via permissionMap.
 //	2. (for writes) decode the request body and translate via mapping/.
 //	3. Call the engine method.
 //	4. Translate the response back via mapping/ (or shape a tiny envelope).
@@ -28,10 +28,11 @@ import (
 
 // CreateWorkflow — POST /api/v1/workflows
 func (s *Server) CreateWorkflow(ctx echo.Context) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCreateWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.CreateWorkflowRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -61,10 +62,11 @@ func (s *Server) CreateWorkflow(ctx echo.Context) error {
 
 // ListWorkflows — GET /api/v1/workflows
 func (s *Server) ListWorkflows(ctx echo.Context, params generated.ListWorkflowsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpListWorkflows)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.ListTasksReq{
 		IncludeNodes: true,
@@ -108,10 +110,11 @@ func (s *Server) ListWorkflows(ctx echo.Context, params generated.ListWorkflowsP
 
 // GetWorkflow — GET /api/v1/workflows/{id}
 func (s *Server) GetWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpGetWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	workflow, err := s.engine.GetWorkflow(user, string(id))
 	if err != nil {
@@ -130,10 +133,11 @@ func (s *Server) GetWorkflow(ctx echo.Context, id generated.Ulid) error {
 // caller's perspective (idempotent, returns 204) but the engine removes
 // the underlying record so the operator stops monitoring.
 func (s *Server) CancelWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCancelWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	if _, err := s.engine.DeleteWorkflowByUser(user, string(id)); err != nil {
 		return notFoundOrError(err)
@@ -143,10 +147,11 @@ func (s *Server) CancelWorkflow(ctx echo.Context, id generated.Ulid) error {
 
 // PauseWorkflow — POST /api/v1/workflows/{id}:pause
 func (s *Server) PauseWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpPauseWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	if _, err := s.engine.SetWorkflowEnabledByUser(user, string(id), false); err != nil {
 		return notFoundOrError(err)
@@ -166,10 +171,11 @@ func (s *Server) PauseWorkflow(ctx echo.Context, id generated.Ulid) error {
 
 // ResumeWorkflow — POST /api/v1/workflows/{id}:resume
 func (s *Server) ResumeWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpResumeWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	if _, err := s.engine.SetWorkflowEnabledByUser(user, string(id), true); err != nil {
 		return notFoundOrError(err)
@@ -193,10 +199,11 @@ func (s *Server) ResumeWorkflow(ctx echo.Context, id generated.Ulid) error {
 // what the operator would have reported; if omitted, the engine fills
 // it with placeholder values.
 func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpTriggerWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.TriggerWorkflowRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -276,11 +283,12 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 // by the Studio UI's "Run once" affordance. The result is a transient
 // Execution echoing what an operator-driven run would have produced.
 func (s *Server) SimulateWorkflow(ctx echo.Context) error {
-	// No-fund operation: a user JWT or a partner assertion both authorize it.
-	user, err := s.requireSimulateAuth(ctx)
+	// User JWT required (LevelUser). Partner assertion alone does not authorize.
+	p, err := s.ensurePermission(ctx, OpSimulateWorkflow)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	var body generated.SimulateWorkflowRequest
 	if err := ctx.Bind(&body); err != nil {
@@ -347,10 +355,11 @@ func (s *Server) SimulateWorkflow(ctx echo.Context) error {
 // platform fee + per-node COGS + value-capture fee + any active
 // discount.
 func (s *Server) EstimateWorkflowFees(ctx echo.Context) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpEstimateWorkflowFees)
 	if err != nil {
 		return err
 	}
+	user := p.User
 	var body generated.EstimateFeesRequest
 	if err := ctx.Bind(&body); err != nil {
 		return badRequest("FEES_BAD_REQUEST", "Invalid request body", err.Error())
@@ -475,10 +484,11 @@ func openAPIInputVarsOrNil(in *generated.InputVariables) (map[string]*structpb.V
 // Returns the total number of workflows owned by the authenticated user,
 // optionally narrowed by smartWalletAddress.
 func (s *Server) CountWorkflows(ctx echo.Context, params generated.CountWorkflowsParams) error {
-	user, err := s.requireUser(ctx)
+	p, err := s.ensurePermission(ctx, OpCountWorkflows)
 	if err != nil {
 		return err
 	}
+	user := p.User
 
 	req := &avsproto.GetWorkflowCountReq{}
 	if params.SmartWalletAddress != nil {

--- a/aggregator/rest/partner.go
+++ b/aggregator/rest/partner.go
@@ -9,44 +9,35 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 
 	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
-	"github.com/AvaProtocol/EigenLayer-AVS/model"
 )
 
-// Partner-delegated auth for the no-fund "simulate" family.
+// Partner assertion verification for tenant-gated REST routes.
 //
-// A partner (tenant) such as Studio authenticates its own end users in its
-// own system and then vouches for them to the AVS for operations that move
-// no funds — workflows:simulate, nodes:run, triggers:run. Because simulate
-// skips wallet-ownership (engine.SimulateTask) and the authKey chain is
-// cosmetic, the partner does NOT need a per-user wallet signature for these.
+// A partner (tenant) such as Studio authenticates with a short-lived
+// Ed25519-signed assertion in X-Partner-Assertion (private_key_jwt style),
+// kept separate from Authorization: Bearer user JWTs.
 //
-// The partner proves its identity with a short-lived Ed25519-signed
-// assertion (private_key_jwt style) sent in the X-Partner-Assertion header,
-// kept deliberately separate from the user `Authorization: Bearer` path so
-// the existing user-JWT flow is untouched. The assertion's claims are the
-// stable contract that a future RFC 8693 token-exchange endpoint will reuse:
+// Which operations accept partner credentials is defined in permission.go
+// (permissionMap + ensurePermission), not by calling these helpers from
+// handlers directly. Partner-sufficient classes today:
 //
-//	{ "iss": "<partner_id>",        // selects the registered partner + keys
-//	  "sub": "<end-user address>",   // attribution; may be empty/opaque
-//	  "scope": "simulate",           // required scope for the call
-//	  "exp": <unix>, "iat": <unix> } // short-lived
+//   - scope "read": token metadata (partner only) and preview wallet
+//     list/create (partner with EOA sub, or user JWT)
 //
-// Fund-moving operations (createTask/execute) are NEVER authorized by a
-// partner assertion — those require real on-chain fund authority (the
-// controller-signed path today, Uniswap Calibur later). See
-// PLAN_PARTNER_PAYMENTS.md.
+// Simulate / runNode / runTrigger require a user JWT (LevelUser) — partner
+// alone is not enough. Fund-moving and session policies never accept
+// partner. See GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md.
 const (
 	// partnerAssertionHeader carries the partner's Ed25519-signed JWT.
 	partnerAssertionHeader = "X-Partner-Assertion"
 
-	// scopeSimulate is the only delegation scope honored today.
-	scopeSimulate = "simulate"
+	// scopeRead is the partner scope for non-fund reads and preview wallet resolve.
+	scopeRead = "read"
 
 	// maxPartnerAssertionTTL bounds how far in the future an assertion's
 	// `exp` may sit. Assertions are meant to be minted per session/call and
@@ -66,75 +57,6 @@ type partnerPrincipal struct {
 	subject   string
 }
 
-// requireSimulateAuth authorizes a simulate-family request via EITHER an
-// end-user JWT (the existing path) OR a partner assertion (the delegated
-// path). It returns the *model.User the engine expects.
-//
-//   - User JWT present  → behaves exactly like requireUser.
-//   - Else partner assertion present and valid → a User keyed on the
-//     assertion's `sub` (zero address when `sub` is empty/non-address;
-//     simulate tolerates this since it skips ownership).
-//   - Else → 401.
-func (s *Server) requireSimulateAuth(ctx echo.Context) (*model.User, error) {
-	// Any presented end-user JWT goes through the user path. requireUser
-	// rejects a missing/invalid subject — we must NOT silently fall through to
-	// the partner path for a structurally-valid-but-empty-subject token.
-	if authed := restmw.UserFromContext(ctx); authed != nil {
-		return s.requireUser(ctx)
-	}
-
-	principal, err := s.verifyPartnerAssertion(ctx, scopeSimulate)
-	if err != nil {
-		return nil, err
-	}
-	if principal != nil {
-		user := &model.User{}
-		// `sub` is attribution only. Use it as the acting address when it's
-		// a real EOA; otherwise leave the zero address — simulate runs
-		// against any address and never checks ownership.
-		if common.IsHexAddress(principal.subject) {
-			user.Address = common.HexToAddress(principal.subject)
-		}
-		s.logger.Info("partner-delegated simulate call",
-			"partner_id", principal.partnerID,
-			"subject", principal.subject,
-		)
-		return user, nil
-	}
-
-	// Neither credential present.
-	return nil, &restmw.HTTPError{
-		Status: http.StatusUnauthorized,
-		Code:   "AUTH_REQUIRED",
-		Title:  "Authentication required",
-		Detail: "This endpoint requires a Bearer JWT (POST /api/v1/auth:exchange) or a partner assertion (X-Partner-Assertion).",
-	}
-}
-
-// requireWalletDeriveAuth authorizes the no-fund wallet derivation/list step
-// (runner resolution during a preview) via the same either/or path as
-// requireSimulateAuth, but additionally requires a concrete owner EOA: a smart
-// wallet is derived deterministically from its owner, so an empty/opaque
-// subject cannot be served. Partner assertions used here must carry a real
-// `sub` address. This unblocks Studio's `$SMART_WALLET$` placeholder
-// resolution (getWallets) for partner-delegated previews; it stays no-fund and
-// needs no ownership check — derivation only reads (owner, salt, factory).
-func (s *Server) requireWalletDeriveAuth(ctx echo.Context) (*model.User, error) {
-	user, err := s.requireSimulateAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if user.Address == (common.Address{}) {
-		return nil, &restmw.HTTPError{
-			Status: http.StatusBadRequest,
-			Code:   "PARTNER_SUBJECT_REQUIRED",
-			Title:  "Owner address required",
-			Detail: "Wallet derivation requires the assertion `sub` to be the end-user's 0x EOA address.",
-		}
-	}
-	return user, nil
-}
-
 // refusePartnerAssertion explicitly rejects a request that presents
 // X-Partner-Assertion on an endpoint partner delegation may never reach.
 //
@@ -152,9 +74,8 @@ func (s *Server) requireWalletDeriveAuth(ctx echo.Context) (*model.User, error) 
 // validity-dependent response would make this endpoint an oracle for
 // assertion validity.
 //
-// MUST be the first line of every /policies handler (avs-infra master doc
-// §7.4a; the decision predates the routes). Returns nil when no assertion is
-// present — user-JWT requests pass through untouched.
+// Invoked via ensurePermission for LevelUserRefusePartner routes. Returns
+// nil when no assertion is present — user-JWT requests pass through.
 func refusePartnerAssertion(ctx echo.Context, capability string) error {
 	if strings.TrimSpace(ctx.Request().Header.Get(partnerAssertionHeader)) == "" {
 		return nil
@@ -162,8 +83,7 @@ func refusePartnerAssertion(ctx echo.Context, capability string) error {
 	return partnerError(http.StatusForbidden, "PARTNER_DELEGATION_UNSUPPORTED",
 		"Partner delegation not supported here",
 		fmt.Sprintf("%s is fund authority and cannot be exercised through a partner assertion. "+
-			"Partner delegation covers the no-fund simulate family only; use the end-user's "+
-			"Bearer JWT (POST /api/v1/auth:exchange) for this endpoint.", capability))
+			"Use the end-user's Bearer JWT (POST /api/v1/auth:exchange) for this endpoint.", capability))
 }
 
 // verifyPartnerAssertion validates the X-Partner-Assertion header against the

--- a/aggregator/rest/partner_test.go
+++ b/aggregator/rest/partner_test.go
@@ -74,31 +74,10 @@ func validClaims() jwt.MapClaims {
 	return jwt.MapClaims{
 		"iss":   "studio",
 		"sub":   testPartnerSubject,
-		"scope": "simulate",
+		"scope": "read",
 		"iat":   time.Now().Unix(),
 		"exp":   time.Now().Add(5 * time.Minute).Unix(),
 	}
-}
-
-func TestRequireSimulateAuth_PartnerHappyPath(t *testing.T) {
-	pub, priv, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
-
-	user, err := s.requireSimulateAuth(ctxWithAssertion(signAssertion(t, priv, validClaims())))
-	if err != nil {
-		t.Fatalf("expected success, got error: %v", err)
-	}
-	if got := user.Address.Hex(); got != testPartnerSubject {
-		t.Fatalf("expected acting address %s, got %s", testPartnerSubject, got)
-	}
-}
-
-func TestRequireSimulateAuth_NoCredential(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
-
-	_, err := s.requireSimulateAuth(ctxWithAssertion(""))
-	assertHTTPStatus(t, err, http.StatusUnauthorized)
 }
 
 // ctxWithUser builds an Echo context as the JWT middleware would leave it —
@@ -109,25 +88,6 @@ func ctxWithUser(subject string) echo.Context {
 	c := e.NewContext(req, httptest.NewRecorder())
 	c.Set("auth.user", &restmw.AuthenticatedUser{Subject: subject})
 	return c
-}
-
-func TestRequireSimulateAuth_PrefersUserJWT(t *testing.T) {
-	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
-
-	const subject = "0x2222222222222222222222222222222222222222"
-	user, err := s.requireSimulateAuth(ctxWithUser(subject))
-	if err != nil {
-		t.Fatalf("valid user JWT should succeed, got: %v", err)
-	}
-	if user.Address.Hex() != subject {
-		t.Fatalf("expected user %s, got %s", subject, user.Address.Hex())
-	}
-
-	// A present-but-empty-subject JWT must be rejected, NOT silently fall
-	// through to the partner path.
-	_, err = s.requireSimulateAuth(ctxWithUser(""))
-	assertHTTPStatus(t, err, http.StatusUnauthorized)
 }
 
 func TestDecodeEd25519Keys_TolerantAndMultiEncoding(t *testing.T) {
@@ -171,7 +131,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "wrong signing key",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			// Signed by a key the registry doesn't know.
 			assertion:  func(t *testing.T) string { return signAssertion(t, otherPriv, validClaims()) },
@@ -180,7 +140,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "unknown issuer",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -191,7 +151,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		},
 		{
 			name:       "suspended partner",
-			server:     func(t *testing.T) *Server { return newPartnerServer(t, pub, []string{scopeSimulate}, "suspended") },
+			server:     func(t *testing.T) *Server { return newPartnerServer(t, pub, []string{scopeRead}, "suspended") },
 			assertion:  func(t *testing.T) string { return signAssertion(t, priv, validClaims()) },
 			wantStatus: http.StatusForbidden,
 		},
@@ -204,7 +164,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "scope not declared in token",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -216,7 +176,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "expired assertion",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -228,7 +188,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "ttl too long",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -240,7 +200,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 		{
 			name: "missing expiry",
 			server: func(t *testing.T) *Server {
-				return newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+				return newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 			},
 			assertion: func(t *testing.T) string {
 				c := validClaims()
@@ -254,7 +214,7 @@ func TestVerifyPartnerAssertion_Rejections(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := tc.server(t)
-			_, err := s.verifyPartnerAssertion(ctxWithAssertion(tc.assertion(t)), scopeSimulate)
+			_, err := s.verifyPartnerAssertion(ctxWithAssertion(tc.assertion(t)), scopeRead)
 			assertHTTPStatus(t, err, tc.wantStatus)
 		})
 	}
@@ -264,10 +224,10 @@ func TestVerifyPartnerAssertion_Audience(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 
 	t.Run("matching audience accepted", func(t *testing.T) {
-		s := newPartnerServerAud(t, pub, []string{scopeSimulate}, partnerStatusActive, "avs-gateway-staging")
+		s := newPartnerServerAud(t, pub, []string{scopeRead}, partnerStatusActive, "avs-gateway-staging")
 		c := validClaims()
 		c["aud"] = "avs-gateway-staging"
-		principal, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeSimulate)
+		principal, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeRead)
 		if err != nil {
 			t.Fatalf("expected success, got: %v", err)
 		}
@@ -277,41 +237,46 @@ func TestVerifyPartnerAssertion_Audience(t *testing.T) {
 	})
 
 	t.Run("missing/mismatched audience rejected", func(t *testing.T) {
-		s := newPartnerServerAud(t, pub, []string{scopeSimulate}, partnerStatusActive, "avs-gateway-staging")
+		s := newPartnerServerAud(t, pub, []string{scopeRead}, partnerStatusActive, "avs-gateway-staging")
 		// Assertion targets prod, gateway expects staging.
 		c := validClaims()
 		c["aud"] = "avs-gateway-prod"
-		_, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeSimulate)
+		_, err := s.verifyPartnerAssertion(ctxWithAssertion(signAssertion(t, priv, c)), scopeRead)
 		assertHTTPStatus(t, err, http.StatusUnauthorized)
 	})
 }
 
-// requireWalletDeriveAuth must reject a partner assertion whose `sub` is not a
-// concrete EOA — a smart wallet can't be derived without an owner.
-func TestRequireWalletDeriveAuth_OpaqueSubjectRejected(t *testing.T) {
+// Preview wallet resolve must reject a partner assertion whose `sub` is not a
+// concrete non-zero EOA — a smart wallet can't be derived without an owner.
+func TestEnsurePermission_WalletPreview_OpaqueSubjectRejected(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 
 	c := validClaims()
 	c["sub"] = "studio-user-42" // not an address
-	_, err := s.requireWalletDeriveAuth(ctxWithAssertion(signAssertion(t, priv, c)))
+	_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpListWallets)
+	assertHTTPStatus(t, err, http.StatusBadRequest)
+
+	c = validClaims()
+	c["sub"] = "0x0000000000000000000000000000000000000000"
+	_, err = s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpListWallets)
 	assertHTTPStatus(t, err, http.StatusBadRequest)
 
 	// With a real EOA sub it resolves to that owner.
-	user, err := s.requireWalletDeriveAuth(ctxWithAssertion(signAssertion(t, priv, validClaims())))
+	p, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpListWallets)
 	if err != nil {
 		t.Fatalf("expected success with address sub, got: %v", err)
 	}
-	if user.Address.Hex() != testPartnerSubject {
-		t.Fatalf("expected owner %s, got %s", testPartnerSubject, user.Address.Hex())
+	if p.User.Address.Hex() != testPartnerSubject {
+		t.Fatalf("expected owner %s, got %s", testPartnerSubject, p.User.Address.Hex())
 	}
 }
 
 func TestVerifyPartnerAssertion_AbsentHeaderFallsThrough(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
-	s := newPartnerServer(t, pub, []string{scopeSimulate}, partnerStatusActive)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
 
-	principal, err := s.verifyPartnerAssertion(ctxWithAssertion(""), scopeSimulate)
+	principal, err := s.verifyPartnerAssertion(ctxWithAssertion(""), scopeRead)
 	if err != nil {
 		t.Fatalf("absent header must not error, got: %v", err)
 	}

--- a/aggregator/rest/permission.go
+++ b/aggregator/rest/permission.go
@@ -1,0 +1,277 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/labstack/echo/v4"
+
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+)
+
+// Permission levels are the minimal credential class an operation needs.
+// Handlers call ensurePermission(op); they do not pick requireUser vs
+// partner helpers ad hoc. See GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md.
+type Level string
+
+const (
+	// LevelPublic — no credentials (health, auth exchange).
+	LevelPublic Level = "public"
+
+	// LevelPartnerRead — registered partner with scope "read" only.
+	// Token metadata and similar non-secret chain reads. No user JWT.
+	LevelPartnerRead Level = "partner_read"
+
+	// LevelPartnerWalletPreview — partner assertion (scope "read") with a
+	// concrete EOA `sub`, OR a user JWT. List + create/derive wallets for
+	// preview runner resolution.
+	LevelPartnerWalletPreview Level = "partner_wallet_preview"
+
+	// LevelUser — wallet-signed Bearer JWT required.
+	// Simulate/runNode, workflows, secrets, fund-adjacent wallet ops, etc.
+	LevelUser Level = "user"
+
+	// LevelUserRefusePartner — user JWT required; partner assertion header
+	// is categorically rejected (session policies / fund authority).
+	LevelUserRefusePartner Level = "user_refuse_partner"
+)
+
+// OpenAPI operationId constants — keys in permissionMap.
+const (
+	OpGetHealth    = "getHealth"
+	OpAuthExchange = "authExchange"
+
+	OpCreateWorkflow       = "createWorkflow"
+	OpListWorkflows        = "listWorkflows"
+	OpGetWorkflow          = "getWorkflow"
+	OpCancelWorkflow       = "cancelWorkflow"
+	OpPauseWorkflow        = "pauseWorkflow"
+	OpResumeWorkflow       = "resumeWorkflow"
+	OpTriggerWorkflow      = "triggerWorkflow"
+	OpSimulateWorkflow     = "simulateWorkflow"
+	OpEstimateWorkflowFees = "estimateWorkflowFees"
+	OpCountWorkflows       = "countWorkflows"
+
+	OpListExecutions            = "listExecutions"
+	OpListExecutionsForWorkflow = "listExecutionsForWorkflow"
+	OpGetExecution              = "getExecution"
+	OpGetExecutionStatus        = "getExecutionStatus"
+	OpSignalExecution           = "signalExecution"
+	OpStreamExecution           = "streamExecution"
+	OpCountExecutions           = "countExecutions"
+	OpExecutionStats            = "executionStats"
+
+	OpListWallets    = "listWallets"
+	OpCreateWallet   = "createWallet"
+	OpUpdateWallet   = "updateWallet"
+	OpWithdrawWallet = "withdrawWallet"
+	OpGetWalletNonce = "getWalletNonce"
+
+	OpPrepareWalletPolicy = "prepareWalletPolicy"
+	OpSubmitWalletPolicy  = "submitWalletPolicy"
+	OpListWalletPolicies  = "listWalletPolicies"
+	OpGetWalletPolicy     = "getWalletPolicy"
+	OpRevokeWalletPolicy  = "revokeWalletPolicy"
+
+	OpListSecrets  = "listSecrets"
+	OpPutSecret    = "putSecret"
+	OpDeleteSecret = "deleteSecret"
+
+	OpGetToken = "getToken"
+
+	OpRunNode    = "runNode"
+	OpRunTrigger = "runTrigger"
+
+	OpListOperators = "listOperators"
+)
+
+// permissionMap is the single source of truth: operationId → minimal level.
+// Fail closed: ensurePermission rejects unknown ops.
+var permissionMap = map[string]Level{
+	OpGetHealth:    LevelPublic,
+	OpAuthExchange: LevelPublic,
+
+	// Partner-gated public-ish reads (no user JWT).
+	OpGetToken: LevelPartnerRead,
+
+	// Preview wallet resolve: list + create/derive under partner (or JWT).
+	OpListWallets:  LevelPartnerWalletPreview,
+	OpCreateWallet: LevelPartnerWalletPreview,
+
+	// Simulate family: user JWT only (partner alone insufficient).
+	OpSimulateWorkflow: LevelUser,
+	OpRunNode:          LevelUser,
+	OpRunTrigger:       LevelUser,
+
+	// User-owned workflows / executions / secrets / wallet fund surface.
+	OpCreateWorkflow:            LevelUser,
+	OpListWorkflows:             LevelUser,
+	OpGetWorkflow:               LevelUser,
+	OpCancelWorkflow:            LevelUser,
+	OpPauseWorkflow:             LevelUser,
+	OpResumeWorkflow:            LevelUser,
+	OpTriggerWorkflow:           LevelUser,
+	OpEstimateWorkflowFees:      LevelUser,
+	OpCountWorkflows:            LevelUser,
+	OpListExecutions:            LevelUser,
+	OpListExecutionsForWorkflow: LevelUser,
+	OpGetExecution:              LevelUser,
+	OpGetExecutionStatus:        LevelUser,
+	OpSignalExecution:           LevelUser,
+	OpStreamExecution:           LevelUser,
+	OpCountExecutions:           LevelUser,
+	OpExecutionStats:            LevelUser,
+	OpListSecrets:               LevelUser,
+	OpPutSecret:                 LevelUser,
+	OpDeleteSecret:              LevelUser,
+	OpUpdateWallet:              LevelUser,
+	OpWithdrawWallet:            LevelUser,
+	OpGetWalletNonce:            LevelUser,
+
+	// Fund authority: user JWT + explicit partner refusal.
+	OpPrepareWalletPolicy: LevelUserRefusePartner,
+	OpSubmitWalletPolicy:  LevelUserRefusePartner,
+	OpListWalletPolicies:  LevelUserRefusePartner,
+	OpGetWalletPolicy:     LevelUserRefusePartner,
+	OpRevokeWalletPolicy:  LevelUserRefusePartner,
+
+	// Monitoring: remains open (matches today's handler; product may lock later).
+	OpListOperators: LevelPublic,
+}
+
+// Principal is the result of ensurePermission: who may act and at which level.
+type Principal struct {
+	// User is the engine-facing subject. Non-nil for every level except
+	// LevelPublic (and may be a zero-address User for partner-only metadata
+	// when assertion `sub` is empty).
+	User *model.User
+	// PartnerID is set when a partner assertion authorized the call.
+	PartnerID string
+	Level     Level
+}
+
+// ensurePermission authorizes the request for the given OpenAPI operationId
+// using permissionMap. Handlers should call this first and use Principal.User
+// for engine calls.
+func (s *Server) ensurePermission(ctx echo.Context, op string) (*Principal, error) {
+	level, ok := permissionMap[op]
+	if !ok {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusInternalServerError,
+			Code:   "AUTHZ_UNMAPPED",
+			Title:  "Operation not in permission map",
+			Detail: fmt.Sprintf("operation %q has no permission level; add it to permissionMap", op),
+		}
+	}
+
+	switch level {
+	case LevelPublic:
+		return &Principal{Level: level}, nil
+
+	case LevelPartnerRead:
+		return s.authPartnerRead(ctx, level)
+
+	case LevelPartnerWalletPreview:
+		return s.authPartnerWalletPreview(ctx, level)
+
+	case LevelUser:
+		user, err := s.requireUser(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &Principal{User: user, Level: level}, nil
+
+	case LevelUserRefusePartner:
+		if err := refusePartnerAssertion(ctx, op); err != nil {
+			return nil, err
+		}
+		user, err := s.requireUser(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &Principal{User: user, Level: level}, nil
+
+	default:
+		return nil, &restmw.HTTPError{
+			Status: http.StatusInternalServerError,
+			Code:   "AUTHZ_UNKNOWN_LEVEL",
+			Title:  "Unknown permission level",
+			Detail: fmt.Sprintf("level %q is not implemented", level),
+		}
+	}
+}
+
+// authPartnerRead requires a valid partner assertion with scope "read".
+// User JWT alone is not enough (partner-gated gateway traffic).
+func (s *Server) authPartnerRead(ctx echo.Context, level Level) (*Principal, error) {
+	pp, err := s.verifyPartnerAssertion(ctx, scopeRead)
+	if err != nil {
+		return nil, err
+	}
+	if pp == nil {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusUnauthorized,
+			Code:   "PARTNER_REQUIRED",
+			Title:  "Partner assertion required",
+			Detail: "This endpoint requires a partner assertion (X-Partner-Assertion) with scope \"read\".",
+		}
+	}
+	user := userFromPartnerSubject(pp.subject)
+	s.logger.Info("partner-gated read call",
+		"partner_id", pp.partnerID,
+		"subject", pp.subject,
+		"level", string(level),
+	)
+	return &Principal{User: user, PartnerID: pp.partnerID, Level: level}, nil
+}
+
+// authPartnerWalletPreview: user JWT if present, else partner read + EOA sub.
+func (s *Server) authPartnerWalletPreview(ctx echo.Context, level Level) (*Principal, error) {
+	if authed := restmw.UserFromContext(ctx); authed != nil {
+		user, err := s.requireUser(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return &Principal{User: user, Level: level}, nil
+	}
+
+	pp, err := s.verifyPartnerAssertion(ctx, scopeRead)
+	if err != nil {
+		return nil, err
+	}
+	if pp == nil {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusUnauthorized,
+			Code:   "AUTH_REQUIRED",
+			Title:  "Authentication required",
+			Detail: "This endpoint requires a Bearer JWT (POST /api/v1/auth:exchange) or a partner assertion (X-Partner-Assertion) with scope \"read\" and sub set to the owner EOA.",
+		}
+	}
+	// Concrete owner EOA required: opaque ids and the zero address are
+	// rejected (zero would collapse every misconfigured partner call onto
+	// one shared non-user owner). Mirrors the pre-permission-map check.
+	if !common.IsHexAddress(pp.subject) || common.HexToAddress(pp.subject) == (common.Address{}) {
+		return nil, &restmw.HTTPError{
+			Status: http.StatusBadRequest,
+			Code:   "PARTNER_SUBJECT_REQUIRED",
+			Title:  "Owner address required",
+			Detail: "Wallet derivation requires the assertion `sub` to be the end-user's non-zero 0x EOA address.",
+		}
+	}
+	user := userFromPartnerSubject(pp.subject)
+	s.logger.Info("partner-delegated wallet preview call",
+		"partner_id", pp.partnerID,
+		"subject", pp.subject,
+	)
+	return &Principal{User: user, PartnerID: pp.partnerID, Level: level}, nil
+}
+
+func userFromPartnerSubject(subject string) *model.User {
+	user := &model.User{}
+	if common.IsHexAddress(subject) {
+		user.Address = common.HexToAddress(subject)
+	}
+	return user
+}

--- a/aggregator/rest/permission_test.go
+++ b/aggregator/rest/permission_test.go
@@ -1,0 +1,209 @@
+package rest
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"testing"
+)
+
+// expectedPermissionLevels is the authorization policy matrix. Keep in sync
+// with permissionMap and api/openapi.yaml security overrides.
+var expectedPermissionLevels = map[string]Level{
+	OpGetHealth:     LevelPublic,
+	OpAuthExchange:  LevelPublic,
+	OpListOperators: LevelPublic,
+
+	OpGetToken: LevelPartnerRead,
+
+	OpListWallets:  LevelPartnerWalletPreview,
+	OpCreateWallet: LevelPartnerWalletPreview,
+
+	OpSimulateWorkflow: LevelUser,
+	OpRunNode:          LevelUser,
+	OpRunTrigger:       LevelUser,
+
+	OpCreateWorkflow:            LevelUser,
+	OpListWorkflows:             LevelUser,
+	OpGetWorkflow:               LevelUser,
+	OpCancelWorkflow:            LevelUser,
+	OpPauseWorkflow:             LevelUser,
+	OpResumeWorkflow:            LevelUser,
+	OpTriggerWorkflow:           LevelUser,
+	OpEstimateWorkflowFees:      LevelUser,
+	OpCountWorkflows:            LevelUser,
+	OpListExecutions:            LevelUser,
+	OpListExecutionsForWorkflow: LevelUser,
+	OpGetExecution:              LevelUser,
+	OpGetExecutionStatus:        LevelUser,
+	OpSignalExecution:           LevelUser,
+	OpStreamExecution:           LevelUser,
+	OpCountExecutions:           LevelUser,
+	OpExecutionStats:            LevelUser,
+	OpListSecrets:               LevelUser,
+	OpPutSecret:                 LevelUser,
+	OpDeleteSecret:              LevelUser,
+	OpUpdateWallet:              LevelUser,
+	OpWithdrawWallet:            LevelUser,
+	OpGetWalletNonce:            LevelUser,
+
+	OpPrepareWalletPolicy: LevelUserRefusePartner,
+	OpSubmitWalletPolicy:  LevelUserRefusePartner,
+	OpListWalletPolicies:  LevelUserRefusePartner,
+	OpGetWalletPolicy:     LevelUserRefusePartner,
+	OpRevokeWalletPolicy:  LevelUserRefusePartner,
+}
+
+func TestPermissionMap_CoversAllOperationsAndLevels(t *testing.T) {
+	for op, want := range expectedPermissionLevels {
+		got, ok := permissionMap[op]
+		if !ok {
+			t.Errorf("permissionMap missing operation %q", op)
+			continue
+		}
+		if got != want {
+			t.Errorf("permissionMap[%q] = %q, want %q", op, got, want)
+		}
+	}
+	if len(permissionMap) != len(expectedPermissionLevels) {
+		t.Errorf("permissionMap has %d entries, expected %d", len(permissionMap), len(expectedPermissionLevels))
+		for op := range permissionMap {
+			if _, ok := expectedPermissionLevels[op]; !ok {
+				t.Errorf("permissionMap has unexpected key %q", op)
+			}
+		}
+	}
+}
+
+func TestEnsurePermission_UnmappedOp(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+	_, err := s.ensurePermission(ctxWithAssertion(""), "notARealOperation")
+	assertHTTPStatus(t, err, http.StatusInternalServerError)
+}
+
+func TestEnsurePermission_PartnerRead(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	t.Run("partner ok without user JWT", func(t *testing.T) {
+		p, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpGetToken)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.Level != LevelPartnerRead || p.PartnerID != "studio" {
+			t.Fatalf("unexpected principal: %+v", p)
+		}
+		if p.User == nil || p.User.Address.Hex() != testPartnerSubject {
+			t.Fatalf("expected user from sub, got %+v", p.User)
+		}
+	})
+
+	t.Run("user JWT alone rejected", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithUser(testPartnerSubject), OpGetToken)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("no credential rejected", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithAssertion(""), OpGetToken)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("simulate scope not enough for read", func(t *testing.T) {
+		sSim := newPartnerServer(t, pub, []string{"simulate"}, partnerStatusActive)
+		c := validClaims()
+		c["scope"] = "simulate"
+		_, err := sSim.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpGetToken)
+		assertHTTPStatus(t, err, http.StatusForbidden)
+	})
+}
+
+func TestEnsurePermission_SimulateRequiresUserJWT(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	t.Run("partner alone rejected", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpSimulateWorkflow)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+		_, err = s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpRunNode)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("user JWT ok", func(t *testing.T) {
+		p, err := s.ensurePermission(ctxWithUser(testPartnerSubject), OpSimulateWorkflow)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.User.Address.Hex() != testPartnerSubject {
+			t.Fatalf("got user %s", p.User.Address.Hex())
+		}
+	})
+}
+
+func TestEnsurePermission_WalletPreview(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	t.Run("partner with EOA sub", func(t *testing.T) {
+		p, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpCreateWallet)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.PartnerID != "studio" {
+			t.Fatalf("expected partner id, got %q", p.PartnerID)
+		}
+	})
+
+	t.Run("user JWT", func(t *testing.T) {
+		const subject = "0x2222222222222222222222222222222222222222"
+		p, err := s.ensurePermission(ctxWithUser(subject), OpListWallets)
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		if p.User.Address.Hex() != subject {
+			t.Fatalf("got %s", p.User.Address.Hex())
+		}
+	})
+
+	t.Run("empty JWT subject not partner fallthrough", func(t *testing.T) {
+		_, err := s.ensurePermission(ctxWithUser(""), OpListWallets)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("zero address sub rejected", func(t *testing.T) {
+		c := validClaims()
+		c["sub"] = "0x0000000000000000000000000000000000000000"
+		_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, c)), OpListWallets)
+		assertHTTPStatus(t, err, http.StatusBadRequest)
+	})
+}
+
+func TestEnsurePermission_UserRefusePartner(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+
+	// Partner header + user JWT still refused (categorical).
+	ctx := ctxWithUser(testPartnerSubject)
+	ctx.Request().Header.Set(partnerAssertionHeader, signAssertion(t, priv, validClaims()))
+	_, err := s.ensurePermission(ctx, OpPrepareWalletPolicy)
+	assertHTTPStatus(t, err, http.StatusForbidden)
+
+	p, err := s.ensurePermission(ctxWithUser(testPartnerSubject), OpPrepareWalletPolicy)
+	if err != nil {
+		t.Fatalf("user-only should succeed: %v", err)
+	}
+	if p.Level != LevelUserRefusePartner {
+		t.Fatalf("level %s", p.Level)
+	}
+}
+
+func TestEnsurePermission_Public(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	s := newPartnerServer(t, pub, []string{scopeRead}, partnerStatusActive)
+	p, err := s.ensurePermission(ctxWithAssertion(""), OpGetHealth)
+	if err != nil {
+		t.Fatalf("public must succeed: %v", err)
+	}
+	if p.Level != LevelPublic || p.User != nil {
+		t.Fatalf("unexpected principal %+v", p)
+	}
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -61,6 +61,9 @@ tags:
   - name: Operators
     description: Connected operator status (read-only)
 
+# Default: end-user JWT. Operations that accept partner assertions (or
+# require them exclusively) override `security` per path. See
+# aggregator/rest/permission.go and GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md.
 security:
   - bearerAuth: []
 
@@ -75,6 +78,16 @@ components:
         signature flow) or via the operator-run `create-api-key` CLI
         (long-lived, server-to-server). Send on every request as
         `Authorization: Bearer <jwt>`.
+    partnerAssertion:
+      type: apiKey
+      in: header
+      name: X-Partner-Assertion
+      description: |
+        Short-lived Ed25519-signed partner assertion (JWT). `iss` must
+        match a registered partner id; `scope` must include the required
+        scope for the route (typically `read`); short-lived `exp` is
+        required. For preview wallet list/create, `sub` must be the
+        end-user's non-zero 0x EOA. See partners[] in gateway config.
 
   parameters:
     PageBefore:
@@ -2179,8 +2192,11 @@ paths:
       description: |
         Run a workflow definition end-to-end against the engine (Tenderly
         simulation for chain-writing nodes) and return the full Execution.
-        Nothing is persisted.
+        Nothing is persisted. Requires a user Bearer JWT; partner assertion
+        alone is not sufficient.
       operationId: simulateWorkflow
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -2468,7 +2484,13 @@ paths:
     get:
       tags: [Wallets]
       summary: List the authenticated user's smart wallets
+      description: |
+        Preview wallet resolve. Authorize with a user Bearer JWT **or** a
+        partner assertion (`scope: read`) whose `sub` is the owner EOA.
       operationId: listWallets
+      security:
+        - bearerAuth: []
+        - partnerAssertion: []
       responses:
         '200':
           description: All wallets for the authenticated user.
@@ -2482,8 +2504,12 @@ paths:
       description: |
         Idempotent "ensure exists". Returns the deterministic CREATE2-derived
         address. POST (not GET) because it persists a wallet record server-side
-        as a side effect of the derivation.
+        as a side effect of the derivation. Authorize with a user Bearer JWT
+        **or** a partner assertion (`scope: read`) whose `sub` is the owner EOA.
       operationId: createWallet
+      security:
+        - bearerAuth: []
+        - partnerAssertion: []
       requestBody:
         required: true
         content:
@@ -2828,7 +2854,13 @@ paths:
     get:
       tags: [Tokens]
       summary: Retrieve ERC-20 token metadata
+      description: |
+        Partner-gated public-ish chain data. Requires a partner assertion
+        with `scope: read` (`X-Partner-Assertion`). A user Bearer JWT alone
+        is not sufficient.
       operationId: getToken
+      security:
+        - partnerAssertion: []
       parameters:
         - $ref: '#/components/parameters/ChainIdQuery'
       responses:
@@ -2850,8 +2882,11 @@ paths:
       description: |
         Useful for SDK testing flows — run a node definition against
         provided input variables without persisting a workflow. Honors
-        `node.config.chainId` (overrides body `chainId`).
+        `node.config.chainId` (overrides body `chainId`). Requires a user
+        Bearer JWT; partner assertion alone is not sufficient.
       operationId: runNode
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -2870,7 +2905,11 @@ paths:
     post:
       tags: [Triggers]
       summary: Evaluate a trigger definition with inline input
+      description: |
+        Requires a user Bearer JWT; partner assertion alone is not sufficient.
       operationId: runTrigger
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -2897,11 +2936,12 @@ paths:
         Read-only monitoring endpoint. Returns each operator's
         `supportedChainIds`, `capabilities`, `lastSeen`, and `version`.
         Useful for dashboards and debugging multi-chain task routing.
+        Currently unauthenticated (public monitoring).
       operationId: listOperators
+      security: []
       responses:
         '200':
           description: Connected operators.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/OperatorList' }
-        '401': { $ref: '#/components/responses/Unauthorized' }

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -112,8 +112,8 @@ smart_wallet:
   paymaster_address:
 
 # Chain worker registry — gateway routes tasks to workers by chain_id.
-# In production (Railway): worker-sepolia.railway.internal:50051
-# Locally: workers run on different localhost ports.
+# Locally, workers run on different localhost ports. A hosted deployment puts
+# them on a private network and sets worker_addr accordingly.
 chains:
   - chain_id: 11155111
     name: sepolia

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -139,24 +139,22 @@ chains:
       paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
       max_wallets_per_owner:  3
 
-# Optional: delegated partners (tenants). A partner authenticates its own
-# end users in its own system and may call the no-fund simulate family
-# (workflows:simulate / nodes:run / triggers:run) AND no-fund wallet
-# derivation (GET /wallets, POST /wallets) on their behalf WITHOUT a per-user
-# wallet signature, by sending a short-lived Ed25519-signed assertion in the
-# `X-Partner-Assertion` header. The assertion's `iss` must equal `id`, its
-# signature must verify against one of `public_keys`, it must declare a `scope`
-# granted below, carry a short-lived `exp`, and (if partner_assertion_audience
-# is set) an `aud` matching it. For wallet derivation `sub` must be the end
-# user's 0x EOA. Fund-moving operations are never authorized this way.
-# See PLAN_PARTNER_PAYMENTS.md. Omit this block to disable partner delegation.
+# Optional: delegated partners (tenants). Manual registration only (no API).
+# A partner sends a short-lived Ed25519 assertion in `X-Partner-Assertion`.
+# Scope "read" authorizes partner-gated reads (GET /tokens/{address}) and
+# preview wallet resolve (GET/POST /wallets; assertion `sub` must be the
+# owner EOA). Simulate / runNode / runTrigger require a user JWT — partner
+# alone is not enough. Fund-moving and session policies never accept partner.
+# Assertion `iss` must equal `id`; signature must verify against `public_keys`;
+# short-lived `exp` required; `aud` must match partner_assertion_audience when set.
+# See GATEWAY_CHANGE_REQUIRED_PARTNER_GATED_READS.md. Omit to disable partner auth.
 partners:
   - id: studio
     # Base64-encoded Ed25519 public key(s); list several to rotate.
     public_keys:
       - "${STUDIO_PARTNER_PUBLIC_KEY_BASE64}"
     scopes:
-      - simulate
+      - read
     status: active
 # Bind partner assertions to this gateway/environment so a captured assertion
 # can't be replayed elsewhere; assertions must carry a matching `aud`.

--- a/config/worker-base-sepolia.example.yaml
+++ b/config/worker-base-sepolia.example.yaml
@@ -14,7 +14,8 @@ chain_id:   84532
 chain_name: base-sepolia
 
 # Internal gRPC listen address (gateway connects here).
-# In production (Railway): worker-base-sepolia.railway.internal:50051
+# In a hosted deployment this is reached over the platform's private network;
+# the gateway's chain registry holds the address.
 listen_address: "0.0.0.0:50052"
 
 # Health check endpoint (Railway requires HTTP health checks).

--- a/config/worker-sepolia.example.yaml
+++ b/config/worker-sepolia.example.yaml
@@ -14,7 +14,8 @@ chain_id:   11155111
 chain_name: sepolia
 
 # Internal gRPC listen address (gateway connects here).
-# In production (Railway): worker-sepolia.railway.internal:50051
+# In a hosted deployment this is reached over the platform's private network;
+# the gateway's chain registry holds the address.
 listen_address: "0.0.0.0:50051"
 
 # Health check endpoint (Railway requires HTTP health checks).

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -541,17 +541,15 @@ type ChainConfigRaw struct {
 	SmartWallet SmartWalletConfigRaw `yaml:"smart_wallet"`
 }
 
-// PartnerConfig is a registered partner (tenant) permitted to call
-// delegated, no-fund operations — currently the simulate family
-// (workflows:simulate / nodes:run / triggers:run) — on behalf of its own
-// authenticated end users, without those users producing a wallet
-// signature. Partners authenticate with a short-lived Ed25519-signed
-// assertion (private_key_jwt style) whose `iss` claim equals ID and whose
+// PartnerConfig is a registered partner (tenant). Registration is manual
+// (YAML only). Partners authenticate with a short-lived Ed25519-signed
+// assertion (private_key_jwt style) whose `iss` equals ID and whose
 // signature verifies against one of PublicKeys.
 //
-// Simulate moves no funds and skips wallet-ownership, so partner trust is
-// sufficient for it; fund-moving operations (createTask/execute) are never
-// authorized by a partner assertion alone. See PLAN_PARTNER_PAYMENTS.md.
+// Scope "read" covers partner-gated token metadata and preview wallet
+// list/create. Simulate/runNode require a user JWT; fund-moving and
+// session policies never accept partner. Which REST ops accept partner
+// credentials is defined in aggregator/rest/permission.go.
 type PartnerConfig struct {
 	// ID is the partner identifier; it must equal the `iss` claim of the
 	// partner's assertions (e.g. "studio").
@@ -560,9 +558,8 @@ type PartnerConfig struct {
 	// "ed25519:"-prefixed). Multiple entries allow key rotation — any
 	// listed key may verify an assertion.
 	PublicKeys []string `yaml:"public_keys"`
-	// Scopes are the delegation scopes granted to this partner, e.g.
-	// ["simulate"]. A request is allowed only if its required scope is
-	// present here.
+	// Scopes are the scopes granted to this partner, e.g. ["read"].
+	// A request is allowed only if its required scope is present here.
 	Scopes []string `yaml:"scopes"`
 	// Status gates the partner; only "active" partners are honored.
 	Status string `yaml:"status"`

--- a/core/taskengine/macros/chainlink_test.go
+++ b/core/taskengine/macros/chainlink_test.go
@@ -1,0 +1,58 @@
+package macros
+
+import (
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestValidateChainlinkRound(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	maxAge := time.Hour
+	tenMinAgo := big.NewInt(now.Add(-10 * time.Minute).Unix())
+	twoHoursAgo := big.NewInt(now.Add(-2 * time.Hour).Unix())
+	price := big.NewInt(262199000000)
+
+	// Fresh, complete round: the answer passes through unchanged.
+	got, err := validateChainlinkRound(chainlinkRound{
+		roundID: big.NewInt(100), answer: price, updatedAt: tenMinAgo, answeredInRound: big.NewInt(100),
+	}, maxAge, now)
+	if err != nil {
+		t.Fatalf("fresh round: unexpected error: %v", err)
+	}
+	if got.Cmp(price) != 0 {
+		t.Fatalf("fresh round: answer = %s, want %s", got, price)
+	}
+
+	// Each unhealthy round must be rejected; the answer must never leak through.
+	bad := []struct {
+		name  string
+		round chainlinkRound
+	}{
+		{"stale: updated 2h ago, max 1h", chainlinkRound{big.NewInt(100), price, twoHoursAgo, big.NewInt(100)}},
+		{"negative price", chainlinkRound{big.NewInt(100), big.NewInt(-1), tenMinAgo, big.NewInt(100)}},
+		{"zero price", chainlinkRound{big.NewInt(100), big.NewInt(0), tenMinAgo, big.NewInt(100)}},
+		{"round not complete (updatedAt 0)", chainlinkRound{big.NewInt(100), price, big.NewInt(0), big.NewInt(100)}},
+		{"carried-over answer (answeredInRound < roundId)", chainlinkRound{big.NewInt(100), price, tenMinAgo, big.NewInt(99)}},
+		{"nil answer", chainlinkRound{big.NewInt(100), nil, tenMinAgo, big.NewInt(100)}},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := validateChainlinkRound(tt.round, maxAge, now); err == nil {
+				t.Fatalf("expected error, got answer %s", got)
+			}
+		})
+	}
+}
+
+func TestChainlinkMaxAge(t *testing.T) {
+	if d := chainlinkMaxAge(nil); d != chainlinkDefaultMaxAge {
+		t.Fatalf("no arg: got %s, want default %s", d, chainlinkDefaultMaxAge)
+	}
+	if d := chainlinkMaxAge([]int{0}); d != chainlinkDefaultMaxAge {
+		t.Fatalf("zero arg: got %s, want default %s", d, chainlinkDefaultMaxAge)
+	}
+	if d := chainlinkMaxAge([]int{3600}); d != time.Hour {
+		t.Fatalf("explicit arg: got %s, want 1h", d)
+	}
+}

--- a/core/taskengine/macros/chainlink_test.go
+++ b/core/taskengine/macros/chainlink_test.go
@@ -2,6 +2,7 @@ package macros
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 )
@@ -11,35 +12,57 @@ func TestValidateChainlinkRound(t *testing.T) {
 	maxAge := time.Hour
 	tenMinAgo := big.NewInt(now.Add(-10 * time.Minute).Unix())
 	twoHoursAgo := big.NewInt(now.Add(-2 * time.Hour).Unix())
+	// age == maxAge must still pass (staleness uses age > maxAge, not >=).
+	exactlyMaxAge := big.NewInt(now.Add(-maxAge).Unix())
+	// one second past maxAge must fail.
+	oneSecOver := big.NewInt(now.Add(-(maxAge + time.Second)).Unix())
 	price := big.NewInt(262199000000)
 
-	// Fresh, complete round: the answer passes through unchanged.
-	got, err := validateChainlinkRound(chainlinkRound{
-		roundID: big.NewInt(100), answer: price, updatedAt: tenMinAgo, answeredInRound: big.NewInt(100),
-	}, maxAge, now)
-	if err != nil {
-		t.Fatalf("fresh round: unexpected error: %v", err)
+	// Healthy rounds: the answer passes through unchanged.
+	good := []struct {
+		name  string
+		round chainlinkRound
+	}{
+		{"fresh equal round ids", chainlinkRound{big.NewInt(100), price, tenMinAgo, big.NewInt(100)}},
+		// Chainlink allows answeredInRound >= roundId (answer may land in a later round).
+		{"answeredInRound > roundId", chainlinkRound{big.NewInt(100), price, tenMinAgo, big.NewInt(101)}},
+		{"age exactly maxAge", chainlinkRound{big.NewInt(100), price, exactlyMaxAge, big.NewInt(100)}},
 	}
-	if got.Cmp(price) != 0 {
-		t.Fatalf("fresh round: answer = %s, want %s", got, price)
+	for _, tt := range good {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateChainlinkRound(tt.round, maxAge, now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Cmp(price) != 0 {
+				t.Fatalf("answer = %s, want %s", got, price)
+			}
+		})
 	}
 
 	// Each unhealthy round must be rejected; the answer must never leak through.
 	bad := []struct {
-		name  string
-		round chainlinkRound
+		name       string
+		round      chainlinkRound
+		errContain string
 	}{
-		{"stale: updated 2h ago, max 1h", chainlinkRound{big.NewInt(100), price, twoHoursAgo, big.NewInt(100)}},
-		{"negative price", chainlinkRound{big.NewInt(100), big.NewInt(-1), tenMinAgo, big.NewInt(100)}},
-		{"zero price", chainlinkRound{big.NewInt(100), big.NewInt(0), tenMinAgo, big.NewInt(100)}},
-		{"round not complete (updatedAt 0)", chainlinkRound{big.NewInt(100), price, big.NewInt(0), big.NewInt(100)}},
-		{"carried-over answer (answeredInRound < roundId)", chainlinkRound{big.NewInt(100), price, tenMinAgo, big.NewInt(99)}},
-		{"nil answer", chainlinkRound{big.NewInt(100), nil, tenMinAgo, big.NewInt(100)}},
+		{"stale: updated 2h ago, max 1h", chainlinkRound{big.NewInt(100), price, twoHoursAgo, big.NewInt(100)}, "stale price"},
+		{"stale: one second over maxAge", chainlinkRound{big.NewInt(100), price, oneSecOver, big.NewInt(100)}, "stale price"},
+		{"negative price", chainlinkRound{big.NewInt(100), big.NewInt(-1), tenMinAgo, big.NewInt(100)}, "invalid price"},
+		{"zero price", chainlinkRound{big.NewInt(100), big.NewInt(0), tenMinAgo, big.NewInt(100)}, "invalid price"},
+		{"round not complete (updatedAt 0)", chainlinkRound{big.NewInt(100), price, big.NewInt(0), big.NewInt(100)}, "round not complete"},
+		{"carried-over answer (answeredInRound < roundId)", chainlinkRound{big.NewInt(100), price, tenMinAgo, big.NewInt(99)}, "stale round"},
+		{"nil answer", chainlinkRound{big.NewInt(100), nil, tenMinAgo, big.NewInt(100)}, "incomplete"},
+		{"nil updatedAt", chainlinkRound{big.NewInt(100), price, nil, big.NewInt(100)}, "incomplete"},
 	}
 	for _, tt := range bad {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, err := validateChainlinkRound(tt.round, maxAge, now); err == nil {
+			got, err := validateChainlinkRound(tt.round, maxAge, now)
+			if err == nil {
 				t.Fatalf("expected error, got answer %s", got)
+			}
+			if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.errContain)
 			}
 		})
 	}
@@ -49,10 +72,33 @@ func TestChainlinkMaxAge(t *testing.T) {
 	if d := chainlinkMaxAge(nil); d != chainlinkDefaultMaxAge {
 		t.Fatalf("no arg: got %s, want default %s", d, chainlinkDefaultMaxAge)
 	}
+	if d := chainlinkMaxAge([]int{}); d != chainlinkDefaultMaxAge {
+		t.Fatalf("empty slice: got %s, want default %s", d, chainlinkDefaultMaxAge)
+	}
 	if d := chainlinkMaxAge([]int{0}); d != chainlinkDefaultMaxAge {
 		t.Fatalf("zero arg: got %s, want default %s", d, chainlinkDefaultMaxAge)
 	}
+	if d := chainlinkMaxAge([]int{-1}); d != chainlinkDefaultMaxAge {
+		t.Fatalf("negative arg: got %s, want default %s", d, chainlinkDefaultMaxAge)
+	}
 	if d := chainlinkMaxAge([]int{3600}); d != time.Hour {
 		t.Fatalf("explicit arg: got %s, want 1h", d)
+	}
+	// Only the first override is used when multiple are supplied.
+	if d := chainlinkMaxAge([]int{60, 3600}); d != time.Minute {
+		t.Fatalf("multi arg: got %s, want 1m (first wins)", d)
+	}
+}
+
+func TestBigFromABI(t *testing.T) {
+	want := big.NewInt(42)
+	if got := bigFromABI(want); got.Cmp(want) != 0 {
+		t.Fatalf("big.Int: got %v, want %v", got, want)
+	}
+	if got := bigFromABI(nil); got != nil {
+		t.Fatalf("nil: got %v, want nil", got)
+	}
+	if got := bigFromABI("not-a-bigint"); got != nil {
+		t.Fatalf("wrong type: got %v, want nil", got)
 	}
 }

--- a/core/taskengine/macros/contract_test.go
+++ b/core/taskengine/macros/contract_test.go
@@ -1,6 +1,7 @@
 package macros
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -45,7 +46,12 @@ func TestExpression(t *testing.T) {
 	rpc := testutil.GetTestRPCURL()
 	SetRpc(rpc)
 
-	p, e := CompileExpression(`priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306")`)
+	// Pass the max-age override so these live-feed assertions don't flake when the
+	// Sepolia feed is stale (the case guarded against in the staleness logic). This
+	// also exercises the optional maxAgeSeconds argument through the expr path.
+	price := fmt.Sprintf(`priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306", %d)`, testNoStaleBound)
+
+	p, e := CompileExpression(price)
 	if e != nil {
 		t.Errorf("Compile expression error: %v", e)
 	}
@@ -61,12 +67,7 @@ func TestExpression(t *testing.T) {
 
 	t.Logf("Exp Run Result: %v", r.(*big.Int))
 
-	match, e := RunExpressionQuery(`
-		bigCmp(
-		  priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306"),
-		  toBigInt("2000")
-		) > 0
-	`)
+	match, e := RunExpressionQuery(fmt.Sprintf(`bigCmp(%s, toBigInt("2000")) > 0`, price))
 	if e != nil {
 		t.Errorf("Run expr error: %v %v", e, r)
 	}
@@ -74,12 +75,7 @@ func TestExpression(t *testing.T) {
 		t.Error("Evaluate error. Expected: true, received: false")
 	}
 
-	match, e = RunExpressionQuery(`
-		bigCmp(
-		  priceChainlink("0x694AA1769357215DE4FAC081bf1f309aDC325306"),
-		  toBigInt("9262391230023")
-		) > 0
-	`)
+	match, e = RunExpressionQuery(fmt.Sprintf(`bigCmp(%s, toBigInt("9262391230023")) > 0`, price))
 	if e != nil {
 		t.Errorf("Run expr error: %v %v", e, r)
 	}

--- a/core/taskengine/macros/exp.go
+++ b/core/taskengine/macros/exp.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -62,46 +63,92 @@ func readContractData(contractAddress string, data string, method string, contra
 // QueryContract
 //const taskCondition = `cmp(chainlinkPrice("0x694AA1769357215DE4FAC081bf1f309aDC325306"), parseUnit("2621.99", 8)) > 1`
 
-func chainlinkLatestRoundData(tokenPair string) *big.Int {
+// chainlinkDefaultMaxAge bounds how stale a feed's updatedAt may be before its
+// answer is rejected. Chainlink heartbeats vary by feed (ETH/USD ~1h, some feeds
+// up to 24h), so the default is deliberately loose to avoid rejecting a healthy
+// slow feed. Callers on a faster feed should pass an explicit max age in seconds.
+const chainlinkDefaultMaxAge = 24 * time.Hour
+
+// chainlinkRound is the decoded latestRoundData tuple:
+// (roundId, answer, startedAt, updatedAt, answeredInRound).
+type chainlinkRound struct {
+	roundID         *big.Int
+	answer          *big.Int
+	updatedAt       *big.Int
+	answeredInRound *big.Int
+}
+
+// validateChainlinkRound returns the round's answer, or an error if the round is
+// incomplete, reports a non-positive price, or is older than maxAge relative to
+// now. Keeping the checks separate from the RPC call makes them unit-testable
+// without a live feed. See https://docs.chain.link/data-feeds/api-reference.
+func validateChainlinkRound(r chainlinkRound, maxAge time.Duration, now time.Time) (*big.Int, error) {
+	if r.answer == nil || r.updatedAt == nil {
+		return nil, fmt.Errorf("incomplete round data")
+	}
+	if r.answer.Sign() <= 0 {
+		return nil, fmt.Errorf("invalid price %s: must be > 0", r.answer)
+	}
+	// updatedAt == 0 means the round has not been answered yet.
+	if r.updatedAt.Sign() == 0 {
+		return nil, fmt.Errorf("round not complete: updatedAt is 0")
+	}
+	// answeredInRound < roundId means the answer was carried over from an earlier
+	// round — a stalled feed on legacy aggregators.
+	if r.answeredInRound != nil && r.roundID != nil && r.answeredInRound.Cmp(r.roundID) < 0 {
+		return nil, fmt.Errorf("stale round: answeredInRound %s < roundId %s", r.answeredInRound, r.roundID)
+	}
+	updatedAt := time.Unix(r.updatedAt.Int64(), 0)
+	if age := now.Sub(updatedAt); age > maxAge {
+		return nil, fmt.Errorf("stale price: last updated %s ago, exceeds max age %s", age.Truncate(time.Second), maxAge)
+	}
+	return r.answer, nil
+}
+
+// chainlinkMaxAge resolves an optional caller-supplied max age (seconds) to a
+// duration, falling back to chainlinkDefaultMaxAge.
+func chainlinkMaxAge(maxAgeSeconds []int) time.Duration {
+	if len(maxAgeSeconds) > 0 && maxAgeSeconds[0] > 0 {
+		return time.Duration(maxAgeSeconds[0]) * time.Second
+	}
+	return chainlinkDefaultMaxAge
+}
+
+// bigFromABI safely extracts a *big.Int from an ABI-decoded value.
+func bigFromABI(v any) *big.Int {
+	b, _ := v.(*big.Int)
+	return b
+}
+
+// chainlinkLatestRoundData reads a Chainlink feed's latest round and returns its
+// price, panicking if the feed is unreachable or the round is stale or invalid.
+// The expr VM recovers the panic, so a bad feed fails the task loudly instead of
+// silently evaluating a condition against outdated or zero data. An optional
+// second argument overrides the staleness window (in seconds).
+func chainlinkLatestRoundData(tokenPair string, maxAgeSeconds ...int) *big.Int {
 	output, err := QueryContract(
 		rpcConn,
-		// https://docs.chain.link/data-feeds/price-feeds/addresses?network=ethereum&page=1&search=et#sepolia-testnet
-		// ETH-USD pair on sepolia
 		common.HexToAddress(tokenPair),
 		chainlinkABI,
 		"latestRoundData",
 	)
-
 	if err != nil {
 		panic(fmt.Errorf("Error when querying contract through rpc. contract: %s. error: %w", tokenPair, err))
 	}
-
-	// TODO: Check round and answer to prevent the case where chainlink down we
-	// may got outdated data
-	if len(output) < 2 || output[1] == nil {
-		return big.NewInt(0)
+	if len(output) < 5 {
+		panic(fmt.Errorf("chainlink feed %s: unexpected latestRoundData output (%d fields)", tokenPair, len(output)))
 	}
-	return output[1].(*big.Int)
-}
 
-func chainlinkLatestAnswer(tokenPair string) *big.Int {
-	output, err := QueryContract(
-		rpcConn,
-		// https://docs.chain.link/data-feeds/price-feeds/addresses?network=ethereum&page=1&search=et#sepolia-testnet
-		// ETH-USD pair on sepolia
-		common.HexToAddress(tokenPair),
-		chainlinkABI,
-		"latestAnswer",
-	)
-
+	answer, err := validateChainlinkRound(chainlinkRound{
+		roundID:         bigFromABI(output[0]),
+		answer:          bigFromABI(output[1]),
+		updatedAt:       bigFromABI(output[3]),
+		answeredInRound: bigFromABI(output[4]),
+	}, chainlinkMaxAge(maxAgeSeconds), time.Now())
 	if err != nil {
-		panic(fmt.Errorf("Error when querying contract through rpc. contract: %s. error: %w", tokenPair, err))
+		panic(fmt.Errorf("chainlink feed %s: %w", tokenPair, err))
 	}
-
-	if len(output) == 0 || output[0] == nil {
-		return big.NewInt(0)
-	}
-	return output[0].(*big.Int)
+	return answer
 }
 
 func BigCmp(a *big.Int, b *big.Int) (r int) {
@@ -176,11 +223,8 @@ func (bi *Builtin) ToBigInt(val string) *big.Int {
 	return ToBigInt(val)
 }
 
-func (bi *Builtin) ChainlinkLatestRoundData(tokenPair string) *big.Int {
-	return chainlinkLatestRoundData(tokenPair)
-}
-func (bi *Builtin) ChainlinkLatestAnswer(tokenPair string) *big.Int {
-	return chainlinkLatestAnswer(tokenPair)
+func (bi *Builtin) ChainlinkLatestRoundData(tokenPair string, maxAgeSeconds ...int) *big.Int {
+	return chainlinkLatestRoundData(tokenPair, maxAgeSeconds...)
 }
 
 func (bi *Builtin) BigCmp(a *big.Int, b *big.Int) (r int) {
@@ -207,8 +251,11 @@ var (
 		// macro to do IO from JS
 		"readContractData": readContractData,
 
-		"priceChainlink":           chainlinkLatestAnswer,
-		"chainlinkPrice":           chainlinkLatestAnswer,
+		// priceChainlink / chainlinkPrice historically used the deprecated
+		// latestAnswer (no round or timestamp, so staleness was undetectable).
+		// They now route through latestRoundData, which validates freshness.
+		"priceChainlink":           chainlinkLatestRoundData,
+		"chainlinkPrice":           chainlinkLatestRoundData,
 		"latestRoundDataChainlink": chainlinkLatestRoundData,
 
 		"bigCmp":    BigCmp,

--- a/core/taskengine/macros/exp_test.go
+++ b/core/taskengine/macros/exp_test.go
@@ -6,11 +6,18 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 )
 
-func TestChainlinkLatestAnswer(t *testing.T) {
+// testNoStaleBound is a max-age override (seconds) large enough that a live
+// testnet feed never reads as stale, so RPC-gated smoke tests don't flake on
+// Sepolia freshness. ~50 years, and kept under math.MaxInt32 so the untyped
+// constant is safe on 32-bit builds. Staleness logic itself is unit-tested in
+// chainlink_test.go.
+const testNoStaleBound = 50 * 365 * 24 * 3600
+
+func TestChainlinkLatestRoundData(t *testing.T) {
 	SetRpc(testutil.GetTestRPCURL())
 
-	// https://sepolia.etherscan.io/address/0x9aCb42Ac07C72cFc29Cd95d9DEaC807E93ada1F6#code
-	value := chainlinkLatestAnswer("0x694AA1769357215DE4FAC081bf1f309aDC325306")
+	// https://sepolia.etherscan.io/address/0x694AA1769357215DE4FAC081bf1f309aDC325306
+	value := chainlinkLatestRoundData("0x694AA1769357215DE4FAC081bf1f309aDC325306", testNoStaleBound)
 	if value == nil {
 		t.Errorf("fail to query chainlink answer. expect a value, got nil")
 	}

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -32,9 +32,10 @@ eth_rpc_url: <your_ethereum_mainnet_rpc_url>
 ecdsa_private_key_store_path: <path_to_operator_ecdsa_key_json>
 bls_private_key_store_path: <path_to_operator_bls_key_json>
 
-# Unified aggregator endpoint — serves all mainnet chains (Ethereum, Base, ...)
-# from a single gRPC connection. The gateway routes per-chain internally.
-aggregator_server_ip_port_address: "aggregator.avaprotocol.org:2206"
+# One endpoint, and it is the mainnet one — see the note below on third-party
+# operators. The gateway routes per-chain internally, so there is no separate
+# address to switch to.
+aggregator_server_ip_port_address: "aggregator.avaprotocol.org:57376"
 
 # avs node spec compliance https://eigen.nethermind.io/docs/spec/intro
 eigen_metrics_ip_port_address: <operator_public_ip>:9090

--- a/docs/changes/20260612-delegate-chain-rpc-to-workers.md
+++ b/docs/changes/20260612-delegate-chain-rpc-to-workers.md
@@ -76,7 +76,7 @@ Two implementations:
    the `ChainRegistry` already maintained at `aggregator/chain_registry.go`,
    calls `ChainWorker.GetTokenMetadata` over the existing gRPC
    connection. The registry already knows the mapping
-   (`worker-bnb-mainnet.railway.internal:50051` → chain 56 etc.) —
+   (one worker address per chain_id, e.g. chain 56) —
    we'd just expose a getter.
 2. **Local-fallback** (single-binary, integration tests): falls back
    to the existing `TokenEnrichmentService` for callers that don't
@@ -104,7 +104,7 @@ Once Phase 2 is live and confirmed in production:
 
 1. Remove the per-chain RPC + bundler entries from
    `gateway-railway.yaml`'s `chains:` block. Each entry collapses to
-   just `worker_addr: worker-X.railway.internal:50051` + the static
+   just `worker_addr: <worker-host>:50051` + the static
    AVS contract addresses.
 2. Delete `SEPOLIA_RPC`, `BASE_RPC`, `ETHEREUM_RPC`, `BASE_SEPOLIA_RPC`,
    `BNB_RPC` env vars from the **gateway** Railway service. (The
@@ -137,7 +137,7 @@ ripping out the gateway's RPC config.
 ## Risks & rollback
 
 - **Worker-routed lookup latency**: adds 1 gRPC round-trip per token
-  lookup. Workers are on Railway's private network (`<svc>.railway.internal`),
+  lookup. Workers sit on the deployment's private network,
   so single-digit milliseconds. The local
   `TokenEnrichmentService` cache lives on the worker side now —
   consider whether the gateway also needs a thin LRU in front to


### PR DESCRIPTION
## Summary

Release PR: `staging` → `main` for a **minor** bump (`4.11.0` → `4.12.0`).

Highest-impact change is `feat:`; `fix` / `docs` / `test` ride along.

### Included changes

- **feat: centralize REST auth in permission map (#739)** — single permission map for REST auth; OpenAPI/config/handler wiring; partner-gated reads reworked
- **fix: validate chainlink feed freshness in price macros (#668)** — `priceChainlink` / `chainlinkPrice` / `latestRoundDataChainlink` reject stale, incomplete, or non-positive rounds (panic instead of silent `0` / frozen price); optional `maxAgeSeconds` (default 24h)
- **test: expand chainlink round validation edge cases (#743)** — pure unit coverage for age boundary, `answeredInRound > roundId`, nil `updatedAt`, `chainlinkMaxAge` / `bigFromABI` edges
- **docs: point operators at the gateway that actually answers (#738)**
- **docs: correct Calibur rationale for the EntryPoint v0.7 cutover (#740)**
- **docs: record the MA v2 7702 verification (#741)**
- **docs: Alchemy managed session-key path never grants signing (#742)**

### User-visible notes

- **REST auth (#739):** permission evaluation centralized; partner-gated read behavior follows the new map — check OpenAPI / gateway config if you rely on partner keys.
- **Chainlink macros (#668):** tasks using `priceChainlink` / `chainlinkPrice` on a feed stale beyond the max age (default 24h) now **fail loudly** instead of evaluating against a frozen price. Pass `priceChainlink(feed, maxAgeSeconds)` to tune the window.

## Pre-merge checks

- [x] `make storage-check` vs `origin/main` — no breaking storage changes
- [x] `main` synced into `staging` (picks up `version.go` `v4.11.0` bump)

## Test plan

- [ ] CI green on this PR
- [ ] Confirm semantic-release / release workflow tags `v4.12.0` after squash merge
- [ ] Smoke: price-condition task with a fresh feed still evaluates; stale feed fails the task
- [ ] Smoke: partner-key REST paths still match expected allow/deny after permission map