### PR TITLE
feat: map Arbitrum and BNB in Moralis, balances, and token catalog

### DIFF
--- a/config/worker-arbitrum.example.yaml
+++ b/config/worker-arbitrum.example.yaml
@@ -1,0 +1,35 @@
+# Worker configuration TEMPLATE for Arbitrum One (chain 42161).
+#
+# This is a checked-in template. The real file is gitignored — copy it
+# and fill in the placeholder values:
+#
+#   cp config/worker-arbitrum.example.yaml config/worker-arbitrum.yaml
+#   $EDITOR config/worker-arbitrum.yaml
+#
+# Handles chain-specific execution: UserOps, contract writes, token
+# enrichment. Stateless — no local DB (gateway owns storage).
+#
+# Production config lives in avs-infra/railway/configs/worker-arbitrum-railway.yaml.
+environment: development
+
+chain_id:   42161
+chain_name: arbitrum
+
+listen_address: "0.0.0.0:50055"
+health_address: "0.0.0.0:8094"
+gateway_address: "127.0.0.1:2206"
+
+# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# endpoint — they rate-limit under load.
+eth_rpc_url: ${ARBITRUM_RPC_URL}
+eth_ws_url:  ${ARBITRUM_WS_URL}
+
+# alchemy derives the endpoint from alchemy_api_key + arb-mainnet.
+bundler_provider: alchemy
+alchemy_api_key:  ${ALCHEMY_API_KEY}
+
+# Local workers must not draw on the production Gas Manager policy.
+disable_gas_sponsorship: true
+
+smart_wallet:
+  controller_private_key: ${MAINNET_CONTROLLER_PRIVATE_KEY}

--- a/core/services/moralis_service.go
+++ b/core/services/moralis_service.go
@@ -108,8 +108,8 @@ func GetMoralisService(apiKey string, logger sdklogging.Logger) *MoralisService 
 // CONFIGURATION AND INITIALIZATION
 // =============================================================================
 
-// getChainTokenMapping returns native token information for supported chains
-// Only includes chains that the aggregator actually supports: Ethereum and Base
+// getChainTokenMapping returns native token information for supported chains.
+// Keep in lockstep with chainIDToMoralisChain.
 func getChainTokenMapping() map[int64]ChainToken {
 	return map[int64]ChainToken{
 		// Ethereum Mainnet and Testnet
@@ -135,6 +135,20 @@ func getChainTokenMapping() map[int64]ChainToken {
 			Decimals:     18,
 			ContractAddr: "0x4200000000000000000000000000000000000006", // WETH on Base Sepolia
 		},
+
+		// BNB Smart Chain — native is BNB; Moralis prices via WBNB.
+		56: {
+			Symbol:       "BNB",
+			Decimals:     18,
+			ContractAddr: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+		},
+
+		// Arbitrum One — native is ETH; price via WETH.
+		42161: {
+			Symbol:       "ETH",
+			Decimals:     18,
+			ContractAddr: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+		},
 	}
 }
 
@@ -154,11 +168,11 @@ func getChainTokenMapping() map[int64]ChainToken {
 // verified to return data for it. Mainnet chains where ETH is the
 // native token reuse Ethereum's price under the same fallback.
 var nativePricingSupportedChains = map[int64]bool{
-	1:    true, // Ethereum mainnet
-	8453: true, // Base mainnet
+	1:     true, // Ethereum mainnet
+	8453:  true, // Base mainnet
+	56:    true, // BNB Smart Chain
+	42161: true, // Arbitrum One
 	// Testnets intentionally absent: 11155111 (Sepolia), 84532 (Base-Sepolia).
-	// BNB Smart Chain (56) is also absent until its allowlist entry in
-	// chainIDToMoralisChain lands and is verified to return data.
 }
 
 // GetNativeTokenPriceUSD implements PriceService interface
@@ -330,8 +344,7 @@ func (ms *MoralisService) fetchTokenPrice(chainID int64, chainToken ChainToken) 
 	return big.NewFloat(result.UsdPrice), nil
 }
 
-// chainIDToMoralisChain converts chain ID to Moralis chain identifier
-// Only supports Ethereum and Base chains that the aggregator works with
+// chainIDToMoralisChain converts chain ID to Moralis chain identifier.
 func (ms *MoralisService) chainIDToMoralisChain(chainID int64) string {
 	switch chainID {
 	case 1:
@@ -342,6 +355,10 @@ func (ms *MoralisService) chainIDToMoralisChain(chainID int64) string {
 		return "base"
 	case 84532:
 		return "base-sepolia"
+	case 56:
+		return "bsc"
+	case 42161:
+		return "arbitrum"
 	default:
 		return ""
 	}

--- a/core/taskengine/execution_providers.go
+++ b/core/taskengine/execution_providers.go
@@ -29,6 +29,8 @@ func GetNetworkName(chainID int64) string {
 		return "base-sepolia"
 	case ChainIDBNBMainnet:
 		return "bnb-mainnet"
+	case ChainIDArbitrumOne:
+		return "arbitrum"
 	default:
 		return "unknown"
 	}

--- a/core/taskengine/token_metadata.go
+++ b/core/taskengine/token_metadata.go
@@ -95,6 +95,7 @@ const (
 	ChainIDBase        uint64 = 8453
 	ChainIDBaseSepolia uint64 = 84532
 	ChainIDBNBMainnet  uint64 = 56
+	ChainIDArbitrumOne uint64 = 42161
 )
 
 // Native token sentinel address used by Moralis and other services

--- a/core/taskengine/vm_runner_balance.go
+++ b/core/taskengine/vm_runner_balance.go
@@ -89,6 +89,14 @@ var chainIDMap = map[string]string{
 	"binance": "bsc",
 	"56":      "bsc",
 	"0x38":    "bsc",
+
+	// Arbitrum One
+	"arbitrum":     "arbitrum",
+	"arbitrum-one": "arbitrum",
+	"arbitrum one": "arbitrum",
+	"arb":          "arbitrum",
+	"42161":        "arbitrum",
+	"0xa4b1":       "arbitrum",
 }
 
 // normalizeChainID converts various chain identifier formats to Moralis chain name

--- a/core/taskengine/vm_runner_balance_test.go
+++ b/core/taskengine/vm_runner_balance_test.go
@@ -553,6 +553,24 @@ func TestBalanceNode_ChainNormalization(t *testing.T) {
 			shouldError:   false,
 		},
 		{
+			name:          "BNB by chain ID",
+			inputChain:    "56",
+			expectedChain: "bsc",
+			shouldError:   false,
+		},
+		{
+			name:          "Arbitrum by name",
+			inputChain:    "arbitrum",
+			expectedChain: "arbitrum",
+			shouldError:   false,
+		},
+		{
+			name:          "Arbitrum by chain ID",
+			inputChain:    "42161",
+			expectedChain: "arbitrum",
+			shouldError:   false,
+		},
+		{
 			name:        "Unsupported chain",
 			inputChain:  "unsupported-chain",
 			shouldError: true,

--- a/docs/changes/20260812-arbitrum-bnb-chain-maps.md
+++ b/docs/changes/20260812-arbitrum-bnb-chain-maps.md
@@ -1,0 +1,31 @@
+# Add Arbitrum (and finish BNB) to Moralis + token catalog maps
+
+- **Date**: 2026-08-12
+- **Status**: Implemented
+- **Branch**: feat/wave-a-arbitrum-chain-support
+- **Related**: avs-infra `docs/changes/20260812-chain-expansion-wave-a.md`, `@avaprotocol/protocols@0.10.0`
+
+## Problem
+
+Production is adding Arbitrum One (42161) as a chain worker and graduating BNB (56) past connectivity-only. The gateway already walks `config.Chains` and registers a `TokenEnrichmentService` per chain, but several Go maps still treated Eth/Base as the only priced/named networks:
+
+- Moralis `chainIDToMoralisChain` returned `""` for 56 and 42161, so fee USD lines and ERC-20 prices fell back or failed.
+- Balance-node `chainIDMap` knew BNB but not Arbitrum.
+- Token whitelist `LoadWhitelist` fell back to `ethereum.json` for any unknown chain — wrong addresses if an Arb worker asked for metadata.
+- `GetNetworkName(42161)` returned `"unknown"`.
+
+`alchemyNetworkSubdomain` already mapped `42161 → arb-mainnet`; no bundler change.
+
+## Decision
+
+- Add `ChainIDArbitrumOne = 42161`.
+- Map Moralis slugs `56 → bsc`, `42161 → arbitrum`. Enable native pricing for both mainnets.
+- Do **not** hand-seed `tokenwhitelist/arbitrum.json`. The drift gate (`make sync-tokens`) requires that directory to match `@avaprotocol/protocols@$PROTOCOLS_VERSION`, and 0.10.0 has no Arb tokens sidecar. Enrichment on 42161 falls back to RPC until a sidecar lands.
+- Add Arbitrum aliases to the balance-node chain map.
+- Add `config/worker-arbitrum.example.yaml` for local-dev.
+
+Production Railway YAML stays in avs-infra.
+
+## Verification
+
+- `go test ./core/taskengine ./core/services` — catalog + `normalizeChainID` cases for 56/42161.


### PR DESCRIPTION
Promote Wave A chain maps from staging (#748) onto main.

Cherry-picked 8ff3df89 onto current main instead of opening staging to main directly: staging still has version.go at 4.12.0, which would have downgraded main (4.13.0).

## What's in this PR

- Moralis: 56 to bsc, 42161 to arbitrum; native pricing on both mainnets
- Balance-node chain aliases for Arbitrum One
- ChainIDArbitrumOne + GetNetworkName(42161)
- Local config/worker-arbitrum.example.yaml

Production Railway already has worker-arbitrum connected (v4.13.0). This image change is what makes the new maps live after the next Docker publish.

## Test plan

- [x] Unit tests on #748
- [x] Auth probe chainId 42161 against Railway: JWT aud=42161 (SDK tests/v4/core/auth.test.ts)
- [ ] CI on this PR
