### PR TITLE
fix: Wave A review — BNB price fallback, Arb block time, whitelist skip

### DIFF
--- a/core/services/moralis_service.go
+++ b/core/services/moralis_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"time"
 
@@ -165,8 +166,9 @@ func getChainTokenMapping() map[int64]ChainToken {
 // hardcoded fallback price directly.
 //
 // Add a chain here ONLY when Moralis's /erc20/.../price endpoint is
-// verified to return data for it. Mainnet chains where ETH is the
-// native token reuse Ethereum's price under the same fallback.
+// verified to return data for it. ETH-native mainnets (Ethereum, Base,
+// Arbitrum) may reuse the ETH hardcoded fallback if Moralis is down.
+// BNB must not — see getFallbackPrice.
 var nativePricingSupportedChains = map[int64]bool{
 	1:     true, // Ethereum mainnet
 	8453:  true, // Base mainnet
@@ -202,7 +204,10 @@ func (ms *MoralisService) GetNativeTokenPriceUSD(chainID int64) (*big.Float, err
 	// trip of latency or a Sentry capture. Cache the fallback so subsequent
 	// calls within the cache window hit the warm path.
 	if !nativePricingSupportedChains[chainID] {
-		fallback := ms.getFallbackPrice(chainToken.Symbol)
+		fallback, fbErr := ms.getFallbackPrice(chainToken.Symbol)
+		if fbErr != nil {
+			return nil, fbErr
+		}
 		ms.setCachedPrice(cacheKey, fallback, chainToken.Symbol)
 		return fallback, nil
 	}
@@ -215,8 +220,11 @@ func (ms *MoralisService) GetNativeTokenPriceUSD(chainID int64) (*big.Float, err
 			"symbol", chainToken.Symbol,
 			"error", err)
 
-		// Return fallback price based on token type
-		return ms.getFallbackPrice(chainToken.Symbol), nil
+		fallback, fbErr := ms.getFallbackPrice(chainToken.Symbol)
+		if fbErr != nil {
+			return nil, fmt.Errorf("moralis price fetch failed and no safe fallback for %s: %w", chainToken.Symbol, err)
+		}
+		return fallback, nil
 	}
 
 	// Cache the result
@@ -395,15 +403,19 @@ func (ms *MoralisService) getETHPrice() (*big.Float, error) {
 	return ms.GetNativeTokenPriceUSD(1) // Ethereum mainnet
 }
 
-// getFallbackPrice returns hardcoded fallback prices for supported tokens
-// Only includes ETH since aggregator only supports Ethereum and Base chains
-func (ms *MoralisService) getFallbackPrice(symbol string) *big.Float {
-	// Only ETH is supported across all chains (Ethereum and Base)
-	if symbol == "ETH" {
-		return big.NewFloat(2500.0)
+// getFallbackPrice returns a hardcoded USD price when Moralis is unavailable.
+// Only ETH has a fallback: it is the native on Ethereum / Base / Arbitrum, and
+// the existing testnet skip path depends on it. Non-ETH natives (BNB) must
+// not inherit $2500 — ConvertUSDToWei divides by this number, so an ETH-shaped
+// BNB price would silently undercharge. Callers treat a non-nil error as
+// "no price", not "use ETH anyway".
+func (ms *MoralisService) getFallbackPrice(symbol string) (*big.Float, error) {
+	switch strings.ToUpper(strings.TrimSpace(symbol)) {
+	case "ETH":
+		return big.NewFloat(2500.0), nil
+	default:
+		return nil, fmt.Errorf("no hardcoded fallback price for native token %q", symbol)
 	}
-
-	return big.NewFloat(2500.0) // Default to ETH price
 }
 
 // CleanupCache removes expired cache entries (called periodically)

--- a/core/services/moralis_service_test.go
+++ b/core/services/moralis_service_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChainIDToMoralisChain(t *testing.T) {
+	ms := &MoralisService{}
+	cases := []struct {
+		chainID int64
+		want    string
+	}{
+		{1, "eth"},
+		{11155111, "sepolia"},
+		{8453, "base"},
+		{84532, "base-sepolia"},
+		{56, "bsc"},
+		{42161, "arbitrum"},
+		{10, ""},
+	}
+	for _, tc := range cases {
+		if got := ms.chainIDToMoralisChain(tc.chainID); got != tc.want {
+			t.Errorf("chainIDToMoralisChain(%d) = %q, want %q", tc.chainID, got, tc.want)
+		}
+	}
+}
+
+func TestGetChainTokenMappingWaveA(t *testing.T) {
+	m := getChainTokenMapping()
+
+	bnb, ok := m[56]
+	if !ok {
+		t.Fatal("missing chain 56")
+	}
+	if bnb.Symbol != "BNB" || bnb.Decimals != 18 {
+		t.Errorf("BNB token = %+v", bnb)
+	}
+	if !strings.EqualFold(bnb.ContractAddr, "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c") {
+		t.Errorf("WBNB address = %s", bnb.ContractAddr)
+	}
+
+	arb, ok := m[42161]
+	if !ok {
+		t.Fatal("missing chain 42161")
+	}
+	if arb.Symbol != "ETH" || arb.Decimals != 18 {
+		t.Errorf("Arb native = %+v", arb)
+	}
+	if !strings.EqualFold(arb.ContractAddr, "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1") {
+		t.Errorf("Arb WETH address = %s", arb.ContractAddr)
+	}
+
+	if !nativePricingSupportedChains[56] || !nativePricingSupportedChains[42161] {
+		t.Error("Wave A mainnets must be in nativePricingSupportedChains")
+	}
+}
+
+func TestGetFallbackPriceRefusesNonETH(t *testing.T) {
+	ms := &MoralisService{}
+	got, err := ms.getFallbackPrice("ETH")
+	if err != nil || got == nil {
+		t.Fatalf("ETH fallback: %v %v", got, err)
+	}
+	if f, _ := got.Float64(); f != 2500 {
+		t.Errorf("ETH fallback = %v, want 2500", f)
+	}
+
+	if _, err := ms.getFallbackPrice("BNB"); err == nil {
+		t.Fatal("BNB must not inherit the $2500 ETH fallback")
+	}
+	if _, err := ms.getFallbackPrice("bnb"); err == nil {
+		t.Fatal("bnb (lowercase) must not inherit the ETH fallback")
+	}
+}

--- a/core/taskengine/limits.go
+++ b/core/taskengine/limits.go
@@ -130,6 +130,7 @@ var chainBlockTime = map[int64]time.Duration{
 	8453:     2 * time.Second,        // Base
 	84532:    2 * time.Second,        // Base Sepolia
 	56:       750 * time.Millisecond, // BNB Smart Chain (post-Maxwell sub-second blocks)
+	42161:    250 * time.Millisecond, // Arbitrum One (~250ms; under-estimate vs typical 200–300ms)
 }
 
 // defaultBlockTime is used for a chain absent from the table. Deliberately

--- a/core/taskengine/limits_test.go
+++ b/core/taskengine/limits_test.go
@@ -295,6 +295,12 @@ func TestBlockTimeForChain(t *testing.T) {
 	if got := blockTimeForChain(1); got != 12*time.Second {
 		t.Errorf("Ethereum block time = %v, want 12s", got)
 	}
+	if got := blockTimeForChain(42161); got != 250*time.Millisecond {
+		t.Errorf("Arbitrum block time = %v, want 250ms (must under-estimate, not use the 1s default)", got)
+	}
+	if got := blockTimeForChain(56); got != 750*time.Millisecond {
+		t.Errorf("BNB block time = %v, want 750ms", got)
+	}
 	// An unlisted chain must fall back to the *strict* default, never a
 	// permissive one — overestimating block time would open a hole.
 	if got := blockTimeForChain(424242); got != defaultBlockTime {

--- a/core/taskengine/token_metadata.go
+++ b/core/taskengine/token_metadata.go
@@ -214,23 +214,37 @@ func newTokenEnrichmentService(
 	return service, nil
 }
 
+// whitelistFileForChain returns the embedded token-list filename for chainID.
+// skip=true means this chain has no sidecar yet — do not load another chain's
+// list (CREATE2-shared addresses would be attributed to the wrong chain).
+func whitelistFileForChain(chainID uint64) (filename string, skip bool) {
+	switch chainID {
+	case ChainIDEthereum:
+		return "ethereum.json", false
+	case ChainIDSepolia:
+		return "sepolia.json", false
+	case ChainIDBase:
+		return "base.json", false
+	case ChainIDBaseSepolia:
+		return "base-sepolia.json", false
+	case ChainIDBNBMainnet:
+		return "bnb-mainnet.json", false
+	case ChainIDArbitrumOne:
+		return "", true
+	default:
+		return "ethereum.json", false
+	}
+}
+
 // LoadWhitelist loads token metadata from whitelist files
 func (t *TokenEnrichmentService) LoadWhitelist() error {
-	var filename string
-	switch t.chainID {
-	case ChainIDEthereum:
-		filename = "ethereum.json"
-	case ChainIDSepolia:
-		filename = "sepolia.json"
-	case ChainIDBase:
-		filename = "base.json"
-	case ChainIDBaseSepolia:
-		filename = "base-sepolia.json"
-	case ChainIDBNBMainnet:
-		filename = "bnb-mainnet.json"
-	default:
-		// For unknown chains, try ethereum.json as fallback
-		filename = "ethereum.json"
+	filename, skip := whitelistFileForChain(t.chainID)
+	if skip {
+		if t.logger != nil {
+			t.logger.Info("No token whitelist sidecar for chain; metadata will come from RPC",
+				"chainID", t.chainID)
+		}
+		return nil
 	}
 
 	// Read from the embedded FS — see core/taskengine/tokenwhitelist for

--- a/core/taskengine/token_metadata_test.go
+++ b/core/taskengine/token_metadata_test.go
@@ -73,6 +73,21 @@ func BenchmarkGetTokenMetadata(b *testing.B) {
 	b.Skip("Skipping metadata benchmark - requires RPC client in new implementation")
 }
 
+func TestWhitelistFileForChain(t *testing.T) {
+	filename, skip := whitelistFileForChain(ChainIDArbitrumOne)
+	if !skip || filename != "" {
+		t.Errorf("Arbitrum must skip the Ethereum whitelist, got file=%q skip=%v", filename, skip)
+	}
+	filename, skip = whitelistFileForChain(ChainIDBNBMainnet)
+	if skip || filename != "bnb-mainnet.json" {
+		t.Errorf("BNB must use bnb-mainnet.json, got file=%q skip=%v", filename, skip)
+	}
+	filename, skip = whitelistFileForChain(ChainIDEthereum)
+	if skip || filename != "ethereum.json" {
+		t.Errorf("Ethereum must use ethereum.json, got file=%q skip=%v", filename, skip)
+	}
+}
+
 func TestIsNativeToken(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/docs/changes/20260812-arbitrum-bnb-chain-maps.md
+++ b/docs/changes/20260812-arbitrum-bnb-chain-maps.md
@@ -20,9 +20,10 @@ Production is adding Arbitrum One (42161) as a chain worker and graduating BNB (
 
 - Add `ChainIDArbitrumOne = 42161`.
 - Map Moralis slugs `56 → bsc`, `42161 → arbitrum`. Enable native pricing for both mainnets.
-- Do **not** hand-seed `tokenwhitelist/arbitrum.json`. The drift gate (`make sync-tokens`) requires that directory to match `@avaprotocol/protocols@$PROTOCOLS_VERSION`, and 0.10.0 has no Arb tokens sidecar. Enrichment on 42161 falls back to RPC until a sidecar lands.
+- Do **not** hand-seed `tokenwhitelist/arbitrum.json`. The drift gate (`make sync-tokens`) requires that directory to match `@avaprotocol/protocols@$PROTOCOLS_VERSION`, and 0.10.0 has no Arb tokens sidecar. `LoadWhitelist` **skips** 42161 (empty cache, RPC fetch) instead of loading `ethereum.json`.
 - Add Arbitrum aliases to the balance-node chain map.
 - Add `config/worker-arbitrum.example.yaml` for local-dev.
+- Review follow-ups (#749 comment): `getFallbackPrice` no longer returns $2500 for BNB; `chainBlockTime[42161]=250ms`; Moralis mapping tests.
 
 Production Railway YAML stays in avs-infra.
 


### PR DESCRIPTION
Follow-up to #748 addressing the review on the mis-targeted #749.

## Why this is against staging

#749 cherry-picked #748 onto `main`. That skipped the usual `feature → staging → main` path and would have raced a version.go downgrade (staging still at 4.12.0). Closing #749; this lands the review fixes on staging first. After merge, cut staging → main.

## Review items

1. **BNB fallback price** — `getFallbackPrice` no longer returns $2500 for non-ETH natives. A Moralis miss on BNB errors instead of undercharging via `ConvertUSDToWei`. ETH-native chains (Eth / Base / Arb) keep the existing $2500 fallback.
2. **Arbitrum `chainBlockTime`** — `42161: 250ms` so the block-trigger floor does not use the 1s default (an overestimate vs ~250ms blocks).
3. **Whitelist** — `whitelistFileForChain(42161)` skips; does not load `ethereum.json`.
4. **Tests** — `moralis_service_test.go` covers slugs, WBNB/WETH addresses, and the BNB fallback refusal. `limits_test.go` / `token_metadata_test.go` cover (2) and (3).

## Test plan

- [x] `go test ./core/services ./core/taskengine`
- [ ] CI
