### PR TITLE
fix: skip token whitelist for unmapped chains

### DIFF
--- a/core/taskengine/token_metadata.go
+++ b/core/taskengine/token_metadata.go
@@ -232,7 +232,9 @@ func whitelistFileForChain(chainID uint64) (filename string, skip bool) {
 	case ChainIDArbitrumOne:
 		return "", true
 	default:
-		return "ethereum.json", false
+		// Unknown chain: skip, don't inherit Ethereum's list. A CREATE2
+		// address that exists on both would otherwise get ETH metadata.
+		return "", true
 	}
 }
 

--- a/core/taskengine/token_metadata_test.go
+++ b/core/taskengine/token_metadata_test.go
@@ -86,6 +86,10 @@ func TestWhitelistFileForChain(t *testing.T) {
 	if skip || filename != "ethereum.json" {
 		t.Errorf("Ethereum must use ethereum.json, got file=%q skip=%v", filename, skip)
 	}
+	filename, skip = whitelistFileForChain(10) // Optimism — no sidecar yet
+	if !skip || filename != "" {
+		t.Errorf("unmapped chain must skip, not inherit ethereum.json; got file=%q skip=%v", filename, skip)
+	}
 }
 
 func TestIsNativeToken(t *testing.T) {

--- a/docs/changes/20260812-arbitrum-bnb-chain-maps.md
+++ b/docs/changes/20260812-arbitrum-bnb-chain-maps.md
@@ -20,7 +20,7 @@ Production is adding Arbitrum One (42161) as a chain worker and graduating BNB (
 
 - Add `ChainIDArbitrumOne = 42161`.
 - Map Moralis slugs `56 → bsc`, `42161 → arbitrum`. Enable native pricing for both mainnets.
-- Do **not** hand-seed `tokenwhitelist/arbitrum.json`. The drift gate (`make sync-tokens`) requires that directory to match `@avaprotocol/protocols@$PROTOCOLS_VERSION`, and 0.10.0 has no Arb tokens sidecar. `LoadWhitelist` **skips** 42161 (empty cache, RPC fetch) instead of loading `ethereum.json`.
+- Do **not** hand-seed `tokenwhitelist/arbitrum.json`. The drift gate (`make sync-tokens`) requires that directory to match `@avaprotocol/protocols@$PROTOCOLS_VERSION`, and 0.10.0 has no Arb tokens sidecar. `LoadWhitelist` **skips** any chain without a sidecar (42161 and the default for the next unmapped chain) instead of loading `ethereum.json`.
 - Add Arbitrum aliases to the balance-node chain map.
 - Add `config/worker-arbitrum.example.yaml` for local-dev.
 - Review follow-ups (#749 comment): `getFallbackPrice` no longer returns $2500 for BNB; `chainBlockTime[42161]=250ms`; Moralis mapping tests.


### PR DESCRIPTION
Nit from #751: `whitelistFileForChain` default no longer loads `ethereum.json`. Unmapped chains skip (RPC metadata) so Wave B does not repeat the Arbitrum CREATE2 mix-up.

The health-deep mutex-across-fan-out note is left as-is — that tradeoff is intentional and already commented.

## Test plan

- [x] `go test ./core/taskengine -run TestWhitelistFileForChain`