### PR TITLE
feat: Wave B Optimism + Unichain maps (staging → main)

### DIFF
--- a/config/worker-optimism.example.yaml
+++ b/config/worker-optimism.example.yaml
@@ -1,0 +1,35 @@
+# Worker configuration TEMPLATE for OP Mainnet (chain 10).
+#
+# This is a checked-in template. The real file is gitignored — copy it
+# and fill in the placeholder values:
+#
+#   cp config/worker-optimism.example.yaml config/worker-optimism.yaml
+#   $EDITOR config/worker-optimism.yaml
+#
+# Handles chain-specific execution: UserOps, contract writes, token
+# enrichment. Stateless — no local DB (gateway owns storage).
+#
+# Production config lives in avs-infra/railway/configs/worker-optimism-railway.yaml.
+environment: development
+
+chain_id:   10
+chain_name: optimism
+
+listen_address: "0.0.0.0:50056"
+health_address: "0.0.0.0:8095"
+gateway_address: "127.0.0.1:2206"
+
+# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# endpoint — they rate-limit under load.
+eth_rpc_url: ${OPTIMISM_RPC_URL}
+eth_ws_url:  ${OPTIMISM_WS_URL}
+
+# alchemy derives the endpoint from alchemy_api_key + opt-mainnet.
+bundler_provider: alchemy
+alchemy_api_key:  ${ALCHEMY_API_KEY}
+
+# Local workers must not draw on the production Gas Manager policy.
+disable_gas_sponsorship: true
+
+smart_wallet:
+  controller_private_key: ${MAINNET_CONTROLLER_PRIVATE_KEY}

--- a/config/worker-unichain.example.yaml
+++ b/config/worker-unichain.example.yaml
@@ -1,0 +1,35 @@
+# Worker configuration TEMPLATE for Unichain (chain 130).
+#
+# This is a checked-in template. The real file is gitignored — copy it
+# and fill in the placeholder values:
+#
+#   cp config/worker-unichain.example.yaml config/worker-unichain.yaml
+#   $EDITOR config/worker-unichain.yaml
+#
+# Handles chain-specific execution: UserOps, contract writes, token
+# enrichment. Stateless — no local DB (gateway owns storage).
+#
+# Production config lives in avs-infra/railway/configs/worker-unichain-railway.yaml.
+environment: development
+
+chain_id:   130
+chain_name: unichain
+
+listen_address: "0.0.0.0:50057"
+health_address: "0.0.0.0:8096"
+gateway_address: "127.0.0.1:2206"
+
+# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# endpoint — they rate-limit under load.
+eth_rpc_url: ${UNICHAIN_RPC_URL}
+eth_ws_url:  ${UNICHAIN_WS_URL}
+
+# alchemy derives the endpoint from alchemy_api_key + unichain-mainnet.
+bundler_provider: alchemy
+alchemy_api_key:  ${ALCHEMY_API_KEY}
+
+# Local workers must not draw on the production Gas Manager policy.
+disable_gas_sponsorship: true
+
+smart_wallet:
+  controller_private_key: ${MAINNET_CONTROLLER_PRIVATE_KEY}

--- a/core/config/bundler_provider_test.go
+++ b/core/config/bundler_provider_test.go
@@ -130,6 +130,8 @@ func TestExpansionChainsHaveAlchemySubdomains(t *testing.T) {
 	}{
 		{56, "https://bnb-mainnet.g.alchemy.com/v2/K"},
 		{42161, "https://arb-mainnet.g.alchemy.com/v2/K"},
+		{10, "https://opt-mainnet.g.alchemy.com/v2/K"},
+		{130, "https://unichain-mainnet.g.alchemy.com/v2/K"},
 		{999, "https://hyperliquid-mainnet.g.alchemy.com/v2/K"},
 		{4663, "https://robinhood-mainnet.g.alchemy.com/v2/K"},
 	} {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -433,6 +433,8 @@ var alchemyNetworkSubdomain = map[int64]string{
 	// standard addresses — byte-identical to Sepolia, where operations have
 	// actually landed.
 	42161: "arb-mainnet",
+	10:    "opt-mainnet",
+	130:   "unichain-mainnet",
 	999:   "hyperliquid-mainnet",
 	4663:  "robinhood-mainnet",
 }

--- a/core/services/moralis_service.go
+++ b/core/services/moralis_service.go
@@ -150,6 +150,17 @@ func getChainTokenMapping() map[int64]ChainToken {
 			Decimals:     18,
 			ContractAddr: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
 		},
+
+		// OP Mainnet — native is ETH; price via OP-stack WETH predeploy.
+		10: {
+			Symbol:       "ETH",
+			Decimals:     18,
+			ContractAddr: "0x4200000000000000000000000000000000000006",
+		},
+		// Unichain (130) is deliberately absent: Moralis Data API does not
+		// list it. GetNativeTokenPriceUSD then uses getETHPrice() (live ETH
+		// on chain 1) — correct because Unichain gas is ETH. Do not add it
+		// here just to hit the $2500 hardcoded fallback.
 	}
 }
 
@@ -174,6 +185,8 @@ var nativePricingSupportedChains = map[int64]bool{
 	8453:  true, // Base mainnet
 	56:    true, // BNB Smart Chain
 	42161: true, // Arbitrum One
+	10:    true, // OP Mainnet
+	// Unichain (130) intentionally absent — Moralis Data API does not list it.
 	// Testnets intentionally absent: 11155111 (Sepolia), 84532 (Base-Sepolia).
 }
 
@@ -367,6 +380,8 @@ func (ms *MoralisService) chainIDToMoralisChain(chainID int64) string {
 		return "bsc"
 	case 42161:
 		return "arbitrum"
+	case 10:
+		return "optimism"
 	default:
 		return ""
 	}

--- a/core/services/moralis_service_test.go
+++ b/core/services/moralis_service_test.go
@@ -17,7 +17,8 @@ func TestChainIDToMoralisChain(t *testing.T) {
 		{84532, "base-sepolia"},
 		{56, "bsc"},
 		{42161, "arbitrum"},
-		{10, ""},
+		{10, "optimism"},
+		{130, ""},
 	}
 	for _, tc := range cases {
 		if got := ms.chainIDToMoralisChain(tc.chainID); got != tc.want {
@@ -53,6 +54,26 @@ func TestGetChainTokenMappingWaveA(t *testing.T) {
 
 	if !nativePricingSupportedChains[56] || !nativePricingSupportedChains[42161] {
 		t.Error("Wave A mainnets must be in nativePricingSupportedChains")
+	}
+
+	op, ok := m[10]
+	if !ok {
+		t.Fatal("missing chain 10")
+	}
+	if op.Symbol != "ETH" || op.Decimals != 18 {
+		t.Errorf("OP native = %+v", op)
+	}
+	if !strings.EqualFold(op.ContractAddr, "0x4200000000000000000000000000000000000006") {
+		t.Errorf("OP WETH address = %s", op.ContractAddr)
+	}
+	if !nativePricingSupportedChains[10] {
+		t.Error("OP Mainnet must be in nativePricingSupportedChains")
+	}
+	if _, ok := m[130]; ok {
+		t.Error("Unichain must not be in chainTokens — Moralis Data API does not list 130; leave it on getETHPrice()")
+	}
+	if nativePricingSupportedChains[130] {
+		t.Error("Unichain must not be in nativePricingSupportedChains")
 	}
 }
 

--- a/core/taskengine/execution_providers.go
+++ b/core/taskengine/execution_providers.go
@@ -31,6 +31,10 @@ func GetNetworkName(chainID int64) string {
 		return "bnb-mainnet"
 	case ChainIDArbitrumOne:
 		return "arbitrum"
+	case ChainIDOptimismMainnet:
+		return "optimism"
+	case ChainIDUnichainMainnet:
+		return "unichain"
 	default:
 		return "unknown"
 	}

--- a/core/taskengine/limits.go
+++ b/core/taskengine/limits.go
@@ -131,6 +131,8 @@ var chainBlockTime = map[int64]time.Duration{
 	84532:    2 * time.Second,        // Base Sepolia
 	56:       750 * time.Millisecond, // BNB Smart Chain (post-Maxwell sub-second blocks)
 	42161:    250 * time.Millisecond, // Arbitrum One (~250ms; under-estimate vs typical 200–300ms)
+	10:       2 * time.Second,        // OP Mainnet (OP-stack, same family as Base)
+	130:      200 * time.Millisecond, // Unichain flashblocks ~200ms; 1s sealed blocks. Under-estimate.
 }
 
 // defaultBlockTime is used for a chain absent from the table. Deliberately

--- a/core/taskengine/token_metadata.go
+++ b/core/taskengine/token_metadata.go
@@ -90,12 +90,14 @@ const (
 
 // Chain ID constants
 const (
-	ChainIDEthereum    uint64 = 1
-	ChainIDSepolia     uint64 = 11155111
-	ChainIDBase        uint64 = 8453
-	ChainIDBaseSepolia uint64 = 84532
-	ChainIDBNBMainnet  uint64 = 56
-	ChainIDArbitrumOne uint64 = 42161
+	ChainIDEthereum        uint64 = 1
+	ChainIDSepolia         uint64 = 11155111
+	ChainIDBase            uint64 = 8453
+	ChainIDBaseSepolia     uint64 = 84532
+	ChainIDBNBMainnet      uint64 = 56
+	ChainIDArbitrumOne     uint64 = 42161
+	ChainIDOptimismMainnet uint64 = 10
+	ChainIDUnichainMainnet uint64 = 130
 )
 
 // Native token sentinel address used by Moralis and other services
@@ -229,7 +231,7 @@ func whitelistFileForChain(chainID uint64) (filename string, skip bool) {
 		return "base-sepolia.json", false
 	case ChainIDBNBMainnet:
 		return "bnb-mainnet.json", false
-	case ChainIDArbitrumOne:
+	case ChainIDArbitrumOne, ChainIDOptimismMainnet, ChainIDUnichainMainnet:
 		return "", true
 	default:
 		// Unknown chain: skip, don't inherit Ethereum's list. A CREATE2

--- a/core/taskengine/token_metadata_test.go
+++ b/core/taskengine/token_metadata_test.go
@@ -86,7 +86,11 @@ func TestWhitelistFileForChain(t *testing.T) {
 	if skip || filename != "ethereum.json" {
 		t.Errorf("Ethereum must use ethereum.json, got file=%q skip=%v", filename, skip)
 	}
-	filename, skip = whitelistFileForChain(10) // Optimism — no sidecar yet
+	filename, skip = whitelistFileForChain(ChainIDOptimismMainnet)
+	if !skip || filename != "" {
+		t.Errorf("Optimism whitelist = (%q, skip=%v), want skip", filename, skip)
+	}
+	filename, skip = whitelistFileForChain(ChainIDUnichainMainnet)
 	if !skip || filename != "" {
 		t.Errorf("unmapped chain must skip, not inherit ethereum.json; got file=%q skip=%v", filename, skip)
 	}

--- a/core/taskengine/vm_runner_balance.go
+++ b/core/taskengine/vm_runner_balance.go
@@ -97,6 +97,15 @@ var chainIDMap = map[string]string{
 	"arb":          "arbitrum",
 	"42161":        "arbitrum",
 	"0xa4b1":       "arbitrum",
+
+	// OP Mainnet — Moralis slug "optimism"
+	"optimism":   "optimism",
+	"op":         "optimism",
+	"op-mainnet": "optimism",
+	"10":         "optimism",
+	"0xa":        "optimism",
+	// Unichain is not in Moralis Data API — do not add aliases that would
+	// send "unichain" to Moralis and 400.
 }
 
 // normalizeChainID converts various chain identifier formats to Moralis chain name

--- a/core/taskengine/vm_runner_balance_test.go
+++ b/core/taskengine/vm_runner_balance_test.go
@@ -571,6 +571,23 @@ func TestBalanceNode_ChainNormalization(t *testing.T) {
 			shouldError:   false,
 		},
 		{
+			name:          "Optimism by name",
+			inputChain:    "optimism",
+			expectedChain: "optimism",
+			shouldError:   false,
+		},
+		{
+			name:          "Optimism by chain ID",
+			inputChain:    "10",
+			expectedChain: "optimism",
+			shouldError:   false,
+		},
+		{
+			name:        "Unichain is not a Moralis Data API chain",
+			inputChain:  "130",
+			shouldError: true,
+		},
+		{
 			name:        "Unsupported chain",
 			inputChain:  "unsupported-chain",
 			shouldError: true,

--- a/docs/changes/20260813-wave-b-optimism-unichain-maps.md
+++ b/docs/changes/20260813-wave-b-optimism-unichain-maps.md
@@ -1,0 +1,25 @@
+# Wave B: Optimism + Unichain chain maps
+
+- **Date**: 2026-08-13
+- **Status**: Proposed
+- **Branch**: feat/wave-b-optimism-unichain
+- **Related**: avs-infra `docs/changes/20260813-chain-expansion-wave-b.md`, `@avaprotocol/protocols` Unichain catalog PR
+
+## Problem
+
+Wave B adds OP Mainnet (10) and Unichain (130) as product chains. Alchemy subdomains were documented but not mapped (`10` / `130` missing from `alchemyNetworkSubdomain`), so `ActiveBundlerURL` would hard-error at send time. Several Go maps still treated Eth/Base/BNB/Arb as the only named/priced networks.
+
+## Decision
+
+- Map `10 → opt-mainnet`, `130 → unichain-mainnet` in `alchemyNetworkSubdomain`.
+- Moralis: `10 → optimism`, native pricing via OP-stack WETH `0x4200…0006`. **Do not** map Unichain — Moralis Data API does not list 130. Unichain USD conversion uses live ETH (`getETHPrice()`), which is correct because gas is ETH.
+- `chainBlockTime`: OP `2s` (same family as Base); Unichain `200ms` (flashblock under-estimate vs 1s sealed blocks).
+- `GetNetworkName` + balance-node aliases for Optimism. No Unichain Moralis aliases (would 400).
+- Whitelist sidecars skip for both (no `optimism.json` / `unichain.json` until `make sync-tokens` can produce them).
+- Local-dev worker example YAML for both.
+
+Production Railway YAML stays in avs-infra.
+
+## Verification
+
+- `go test ./core/config ./core/services ./core/taskengine` — subdomain, Moralis slug, block-time, whitelist, `normalizeChainID`.


### PR DESCRIPTION
Wave B maps are on staging (#753). This is the staging→main cut so the next release image can bundle OP (10) and Unichain (130).

## Why merge main into staging first

`main` is at `version/version.go` **4.14.0**. Staging was still **4.13.0** + #753. A raw staging→main squash would have downgraded the version (same class of bug as #749). Staging now includes `origin/main`, so this PR keeps **4.14.0** and only adds the Wave B maps.

## In this PR

- `alchemyNetworkSubdomain`: `10 → opt-mainnet`, `130 → unichain-mainnet`
- Moralis OP only (Unichain stays on live ETH price)
- `chainBlockTime` 2s / 200ms
- Worker example YAML

Railway workers are already live on `v4.14.0` (handshake + auth probes green). UserOps on 10/130 need this tag.

## Merge

Squash (this repo rejects merge commits on main). After merge: `./scripts/release.sh` from avs-infra, then `/sync-main` in EigenLayer-AVS.

Related: avs-infra `docs/changes/20260813-chain-expansion-wave-b.md`, `@avaprotocol/protocols@0.11.0`
