### PR TITLE
feat: per-node retry policy for transient read/off-chain failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,3 @@ tmp/rehearsal-gateway-backup/
 
 # Local Claude Code agent state (session locks, project-local skills, etc.)
 .claude/
-
-# Editor-local settings
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ tmp/rehearsal-gateway-backup/
 
 # Local Claude Code agent state (session locks, project-local skills, etc.)
 .claude/
+
+# Editor-local settings
+.vscode/

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1771,6 +1771,13 @@ func (n *Engine) CreateWorkflow(user *model.User, taskPayload *avsproto.CreateTa
 		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
+	// Constant retry ceilings (limits.go). Retry is a per-execution multiplier on
+	// metered provider calls, so it is bounded like every other one; an over-limit
+	// policy is rejected here rather than silently clamped at execution time.
+	if err := validateRetryPolicies(task.Nodes); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
+	}
+
 	// Default chain_id to the aggregator's SmartWallet chain when not specified.
 	// In gateway mode the top-level SmartWallet is populated from chains[0]
 	// (mainnet by convention), so a missing chain_id silently routes the task

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -266,6 +266,10 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 	if x.engine != nil {
 		vm.WithChainConfigResolver(x.engine.ResolveSmartWalletConfig)
 	}
+	// Retry backoffs sleep against this context, so a cancelled request aborts a
+	// pending backoff instead of holding the execution open. The async queue path
+	// passes context.Background() and is bounded by the retry ceilings alone.
+	vm.WithContext(ctx)
 
 	// Merge input variables from trigger execution (overrides task-level input variables)
 	if queueData != nil && len(queueData.InputVariables) > 0 {

--- a/core/taskengine/limits.go
+++ b/core/taskengine/limits.go
@@ -101,6 +101,44 @@ const (
 	// quietly processed the first 100 of 5,000 addresses would report success
 	// while skipping most of its job.
 	MaxLoopIterations = 100
+
+	// MaxRetryAttempts bounds a node's RetryPolicy for the same reason
+	// MaxLoopIterations bounds a Loop: retry is a client-controlled multiplier
+	// on metered provider calls *inside* a single execution, which no trigger
+	// floor can reach. Unbounded, `{max_attempts: 100, backoff_ms: 60000}` is
+	// 1h39m of sleeping inside one node.
+	//
+	// 5 attempts is where retrying stops buying anything: with the default 1s
+	// backoff and 2x growth that is 15s of waiting, long enough to ride out a
+	// provider blip or a rate-limit window, and a failure still standing after
+	// four retries is not transient.
+	MaxRetryAttempts = 5
+
+	// DefaultRetryBackoff applies when a policy enables retries without setting
+	// backoff_ms. Without a default, `{max_attempts: 5}` — the most natural
+	// policy to write — retried with *zero* delay, turning one 429 into five
+	// immediate hits.
+	DefaultRetryBackoff = time.Second
+
+	// MaxRetryBackoff caps any single backoff, whether it came from backoff_ms,
+	// max_backoff_ms, or exponential growth. Capping the growing value itself
+	// (not a per-attempt copy) is also what keeps the multiplication from
+	// overflowing time.Duration.
+	MaxRetryBackoff = 30 * time.Second
+
+	// MaxTotalRetryDelay bounds one node's worst-case *total* time asleep, so
+	// the three retry knobs cannot be combined into a long stall that each knob
+	// individually passes. Checked at create time against the exact schedule the
+	// policy produces.
+	MaxTotalRetryDelay = 60 * time.Second
+
+	// MaxExecutionRetryDelay bounds retry sleeping across a whole execution.
+	// Per-node validation cannot see fan-out: a Loop runs its retryable runner
+	// once per element, so MaxLoopIterations nodes each within MaxTotalRetryDelay
+	// still multiply to 100 minutes. Enforced at runtime by retryBudget; once
+	// spent, later nodes fail on their first attempt instead of extending the
+	// execution.
+	MaxExecutionRetryDelay = 5 * time.Minute
 )
 
 // cronSamples is how many consecutive fire times to inspect when deriving a
@@ -273,4 +311,151 @@ func validateTriggerFrequency(trigger *avsproto.TaskTrigger, fallbackChainID int
 	}
 
 	return nil
+}
+
+// validateRetryPolicies rejects any node whose retry_policy exceeds the retry
+// ceilings, or that sets one where it can never apply.
+//
+// Following MaxLoopIterations' reasoning, an over-limit policy is an error
+// rather than a silent clamp: a task that quietly retried 5 times when it asked
+// for 100 would report success while doing something other than what it was
+// configured to do, and the caller would never learn the ceiling exists.
+func validateRetryPolicies(nodes []*avsproto.TaskNode) error {
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		label := node.GetName()
+		if label == "" {
+			label = node.GetId()
+		}
+		if err := validateRetryPolicy(label, node.GetRetryPolicy(), nodeSupportsRetry(node)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateRetryPolicy checks a single node's policy. supported reports whether
+// the node's runner is on the retry allowlist.
+func validateRetryPolicy(nodeLabel string, policy *avsproto.RetryPolicy, supported bool) error {
+	if policy == nil {
+		return nil
+	}
+
+	// A policy on a node that can never honor it is rejected rather than
+	// ignored. The allowlist is enforced structurally at execution time, so an
+	// accepted policy on (say) a ContractWrite would do nothing forever, with no
+	// error and no warning — the user would believe they had retries.
+	if !supported {
+		return fmt.Errorf(
+			"node %q sets retry_policy, but retries are only supported on idempotent read/off-chain nodes (REST, GraphQL, ContractRead, Balance, and Loops over those): re-invoking an on-chain write could submit the transaction twice",
+			nodeLabel)
+	}
+
+	if policy.GetMaxAttempts() <= 1 {
+		// 0 and 1 both mean "one attempt"; the other fields are inert.
+		return nil
+	}
+
+	if policy.GetMaxAttempts() > MaxRetryAttempts {
+		return fmt.Errorf(
+			"node %q sets retry_policy.max_attempts=%d, above the maximum of %d: each attempt spends metered provider quota, so retries are bounded like every other per-execution multiplier",
+			nodeLabel, policy.GetMaxAttempts(), MaxRetryAttempts)
+	}
+
+	if backoff := time.Duration(policy.GetBackoffMs()) * time.Millisecond; backoff > MaxRetryBackoff {
+		return fmt.Errorf(
+			"node %q sets retry_policy.backoff_ms=%d (%s), above the %s maximum for a single backoff",
+			nodeLabel, policy.GetBackoffMs(), backoff, MaxRetryBackoff)
+	}
+	if maxBackoff := time.Duration(policy.GetMaxBackoffMs()) * time.Millisecond; maxBackoff > MaxRetryBackoff {
+		return fmt.Errorf(
+			"node %q sets retry_policy.max_backoff_ms=%d (%s), above the %s maximum for a single backoff",
+			nodeLabel, policy.GetMaxBackoffMs(), maxBackoff, MaxRetryBackoff)
+	}
+	if multiplier := policy.GetBackoffMultiplier(); multiplier < 0 {
+		return fmt.Errorf(
+			"node %q sets retry_policy.backoff_multiplier=%v: must not be negative (omit it for the default of %v)",
+			nodeLabel, multiplier, defaultBackoffMultiplier)
+	}
+
+	for _, class := range policy.GetRetryOn() {
+		if !isKnownRetryClass(class) {
+			return fmt.Errorf(
+				"node %q sets an unknown retry_policy.retry_on class %q: valid classes are %s",
+				nodeLabel, class, strings.Join(defaultRetryClasses, ", "))
+		}
+	}
+
+	// The individual knobs can each pass while their combination stalls the
+	// execution, so bound the schedule the policy actually produces.
+	if total := worstCaseRetryDelay(policy); total > MaxTotalRetryDelay {
+		return fmt.Errorf(
+			"node %q has a retry_policy that can sleep %s in total (%d attempts starting at %s, x%v), above the %s maximum: lower max_attempts, backoff_ms, or set max_backoff_ms",
+			nodeLabel, total, policy.GetMaxAttempts(),
+			effectiveInitialBackoff(policy), effectiveMultiplier(policy), MaxTotalRetryDelay)
+	}
+
+	return nil
+}
+
+func isKnownRetryClass(class string) bool {
+	for _, c := range defaultRetryClasses {
+		if c == class {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveInitialBackoff / effectiveMultiplier resolve the defaults
+// executeWithRetry applies, so validation measures the same schedule that will
+// actually run.
+func effectiveInitialBackoff(policy *avsproto.RetryPolicy) time.Duration {
+	backoff := time.Duration(policy.GetBackoffMs()) * time.Millisecond
+	if backoff <= 0 {
+		backoff = DefaultRetryBackoff
+	}
+	if cap := effectiveMaxBackoff(policy); backoff > cap {
+		backoff = cap
+	}
+	return backoff
+}
+
+func effectiveMultiplier(policy *avsproto.RetryPolicy) float64 {
+	multiplier := policy.GetBackoffMultiplier()
+	if multiplier <= 0 {
+		multiplier = defaultBackoffMultiplier
+	}
+	return multiplier
+}
+
+func effectiveMaxBackoff(policy *avsproto.RetryPolicy) time.Duration {
+	maxBackoff := time.Duration(policy.GetMaxBackoffMs()) * time.Millisecond
+	if maxBackoff <= 0 || maxBackoff > MaxRetryBackoff {
+		maxBackoff = MaxRetryBackoff
+	}
+	return maxBackoff
+}
+
+// worstCaseRetryDelay sums every backoff a fully-exhausted policy would sleep:
+// max_attempts-1 gaps, growing by the multiplier and clamped by the per-backoff
+// cap. This is the worst case by construction — an attempt that succeeds, or
+// fails with a non-retryable error, sleeps less.
+func worstCaseRetryDelay(policy *avsproto.RetryPolicy) time.Duration {
+	attempts := int(policy.GetMaxAttempts())
+	if attempts > MaxRetryAttempts {
+		attempts = MaxRetryAttempts
+	}
+	backoff := effectiveInitialBackoff(policy)
+	multiplier := effectiveMultiplier(policy)
+	maxBackoff := effectiveMaxBackoff(policy)
+
+	total := time.Duration(0)
+	for i := 0; i < attempts-1; i++ {
+		total += backoff
+		backoff = nextBackoff(backoff, multiplier, maxBackoff)
+	}
+	return total
 }

--- a/core/taskengine/limits_test.go
+++ b/core/taskengine/limits_test.go
@@ -382,3 +382,166 @@ func TestCreateWorkflowDefaultsNonPositiveMaxExecution(t *testing.T) {
 		t.Errorf("explicit maxExecution 7 became %d", created.MaxExecution)
 	}
 }
+
+// retryTestNode names a minimal node of the given shape and attaches a policy.
+func retryTestNode(name string, policy *avsproto.RetryPolicy, node *avsproto.TaskNode) *avsproto.TaskNode {
+	node.Id = name
+	node.Name = name
+	node.RetryPolicy = policy
+	return node
+}
+
+func restTestNode() *avsproto.TaskNode {
+	return &avsproto.TaskNode{TaskType: &avsproto.TaskNode_RestApi{RestApi: &avsproto.RestAPINode{}}}
+}
+
+func writeTestNode() *avsproto.TaskNode {
+	return &avsproto.TaskNode{TaskType: &avsproto.TaskNode_ContractWrite{ContractWrite: &avsproto.ContractWriteNode{}}}
+}
+
+func transferTestNode() *avsproto.TaskNode {
+	return &avsproto.TaskNode{TaskType: &avsproto.TaskNode_EthTransfer{EthTransfer: &avsproto.ETHTransferNode{}}}
+}
+
+func customCodeTestNode() *avsproto.TaskNode {
+	return &avsproto.TaskNode{TaskType: &avsproto.TaskNode_CustomCode{CustomCode: &avsproto.CustomCodeNode{}}}
+}
+
+func loopOverRestTestNode() *avsproto.TaskNode {
+	return &avsproto.TaskNode{TaskType: &avsproto.TaskNode_Loop{Loop: &avsproto.LoopNode{
+		Runner: &avsproto.LoopNode_RestApi{RestApi: &avsproto.RestAPINode{}},
+	}}}
+}
+
+func loopOverWriteTestNode() *avsproto.TaskNode {
+	return &avsproto.TaskNode{TaskType: &avsproto.TaskNode_Loop{Loop: &avsproto.LoopNode{
+		Runner: &avsproto.LoopNode_ContractWrite{ContractWrite: &avsproto.ContractWriteNode{}},
+	}}}
+}
+
+func TestValidateRetryPolicies(t *testing.T) {
+	tests := []struct {
+		name    string
+		node    *avsproto.TaskNode
+		wantErr string // substring; empty means the policy must be accepted
+	}{
+		{
+			name: "no policy is always fine",
+			node: retryTestNode("write1", nil, writeTestNode()),
+		},
+		{
+			name: "modest policy on a read node",
+			node: retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: 3, BackoffMs: 500}, restTestNode()),
+		},
+		{
+			name: "bare max_attempts is accepted (backoff_ms is defaulted)",
+			node: retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: MaxRetryAttempts}, restTestNode()),
+		},
+		{
+			name: "policy on a loop over a read runner",
+			node: retryTestNode("loop1", &avsproto.RetryPolicy{MaxAttempts: 3, BackoffMs: 500}, loopOverRestTestNode()),
+		},
+		{
+			// The #676 exclusion, enforced at create time as well as structurally:
+			// a write node must never carry a policy that looks like it works.
+			name:    "policy on a contract write is rejected",
+			node:    retryTestNode("write1", &avsproto.RetryPolicy{MaxAttempts: 3}, writeTestNode()),
+			wantErr: "only supported on idempotent read/off-chain nodes",
+		},
+		{
+			name:    "policy on an eth transfer is rejected",
+			node:    retryTestNode("transfer1", &avsproto.RetryPolicy{MaxAttempts: 3}, transferTestNode()),
+			wantErr: "only supported on idempotent read/off-chain nodes",
+		},
+		{
+			name:    "policy on a loop over a write runner is rejected",
+			node:    retryTestNode("loop1", &avsproto.RetryPolicy{MaxAttempts: 3}, loopOverWriteTestNode()),
+			wantErr: "only supported on idempotent read/off-chain nodes",
+		},
+		{
+			name:    "policy on a node with no runner support is rejected",
+			node:    retryTestNode("code1", &avsproto.RetryPolicy{MaxAttempts: 2}, customCodeTestNode()),
+			wantErr: "only supported on idempotent read/off-chain nodes",
+		},
+		{
+			// The reviewed shape: 100 attempts x 60s backoff is 1h39m of sleeping
+			// inside one node, on the async path where nothing cancels it.
+			name:    "over-limit max_attempts is rejected, not clamped",
+			node:    retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: 100, BackoffMs: 60000}, restTestNode()),
+			wantErr: "above the maximum of 5",
+		},
+		{
+			name:    "over-limit backoff_ms is rejected",
+			node:    retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: 2, BackoffMs: 60000}, restTestNode()),
+			wantErr: "above the 30s maximum for a single backoff",
+		},
+		{
+			name:    "over-limit max_backoff_ms is rejected",
+			node:    retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: 2, BackoffMs: 100, MaxBackoffMs: 45000}, restTestNode()),
+			wantErr: "above the 30s maximum for a single backoff",
+		},
+		{
+			name:    "unknown retry_on class is rejected",
+			node:    retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: 2, RetryOn: []string{"http_500"}}, restTestNode()),
+			wantErr: `unknown retry_policy.retry_on class "http_500"`,
+		},
+		{
+			name:    "negative multiplier is rejected",
+			node:    retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: 2, BackoffMultiplier: -2}, restTestNode()),
+			wantErr: "must not be negative",
+		},
+		{
+			// Each knob passes on its own; the schedule they combine into does not.
+			name: "combined total delay above the cap is rejected",
+			node: retryTestNode("rest1", &avsproto.RetryPolicy{
+				MaxAttempts: 5, BackoffMs: 20000, BackoffMultiplier: 1,
+			}, restTestNode()),
+			wantErr: "above the 1m0s maximum",
+		},
+		{
+			// max_attempts <= 1 means the other fields never take effect.
+			name: "inert policy is not measured against the ceilings",
+			node: retryTestNode("rest1", &avsproto.RetryPolicy{MaxAttempts: 1, BackoffMs: 600000}, restTestNode()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRetryPolicies([]*avsproto.TaskNode{tt.node})
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected the policy to be accepted, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestWorstCaseRetryDelay checks that validation measures the schedule
+// executeWithRetry actually runs, defaults and caps included.
+func TestWorstCaseRetryDelay(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy *avsproto.RetryPolicy
+		want   time.Duration
+	}{
+		{"no retries", &avsproto.RetryPolicy{MaxAttempts: 1}, 0},
+		{"defaults: 1s, 2s, 4s, 8s", &avsproto.RetryPolicy{MaxAttempts: 5}, 15 * time.Second},
+		{"flat multiplier", &avsproto.RetryPolicy{MaxAttempts: 3, BackoffMs: 2000, BackoffMultiplier: 1}, 4 * time.Second},
+		{"capped by max_backoff_ms", &avsproto.RetryPolicy{MaxAttempts: 4, BackoffMs: 1000, BackoffMultiplier: 100, MaxBackoffMs: 3000}, 7 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := worstCaseRetryDelay(tt.policy); got != tt.want {
+				t.Fatalf("worstCaseRetryDelay() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/taskengine/retry.go
+++ b/core/taskengine/retry.go
@@ -1,13 +1,20 @@
 package taskengine
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"math"
 	"net"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // Retry error classes. A RetryPolicy.retry_on entry must match one of these to
@@ -26,49 +33,175 @@ var defaultRetryClasses = []string{retryClassTimeout, retryClassHTTP429, retryCl
 // defaultBackoffMultiplier applies when a policy enables retries without setting one.
 const defaultBackoffMultiplier = 2.0
 
-var http5xxRe = regexp.MustCompile(`\b5\d\d\b`)
+// urlRe strips URLs from an error message before any status-code sniffing.
+// Without this, an incidental number inside a URL is indistinguishable from a
+// response status: "GET https://api.example.com/tokens?limit=500 returned 404"
+// classified as http_5xx purely because of the query parameter.
+var urlRe = regexp.MustCompile(`https?://\S+`)
+
+// httpStatusRe matches a 3-digit status only in a status-like context ("HTTP
+// 503", "status code: 502", "returned status 500"). Anchoring to a keyword is
+// what keeps arbitrary 3-digit numbers in prose from being read as statuses.
+var httpStatusRe = regexp.MustCompile(`(?:status code|statuscode|status|http)[^0-9]{0,12}(\d{3})\b`)
+
+// eofRe word-bounds "eof" so it matches "unexpected EOF" but not a token that
+// merely contains those letters.
+var eofRe = regexp.MustCompile(`\beof\b`)
+
+// grpcProseRe matches a *stringified* gRPC status (an error that was rendered
+// to text somewhere upstream and so no longer satisfies status.FromError).
+// Only the codes that are genuinely transient are listed.
+var grpcProseRe = regexp.MustCompile(`rpc error: code = (unavailable|deadlineexceeded|resourceexhausted)`)
 
 // classifyRetryableError maps err to one of the retry classes, or "" if it is
-// not a recognizably transient failure. Classification is best-effort and
-// string-based: node runners surface upstream failures as wrapped errors rather
-// than typed status codes, so this errs toward not retrying when unsure.
+// not a recognizably transient failure.
+//
+// Order matters: structured signals (net.Error, context.DeadlineExceeded, gRPC
+// status codes) are consulted before any string matching, because they are the
+// only ones that cannot be spoofed by the shape of a message. String matching
+// is the fallback for runners that wrap upstream failures as plain errors, and
+// it deliberately errs toward *not* retrying when unsure — an unrecognized
+// error returns "".
 func classifyRetryableError(err error) string {
 	if err == nil {
 		return ""
 	}
 
-	// Structured network timeouts (and context deadlines) first — most reliable signal.
+	// Structured network timeouts — most reliable signal.
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return retryClassTimeout
 	}
-
-	msg := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+	if errors.Is(err, context.DeadlineExceeded) {
 		return retryClassTimeout
-	case strings.Contains(msg, "429") || strings.Contains(msg, "too many requests"):
+	}
+
+	// Typed gRPC status. Substring-matching "rpc" here was the old behavior and
+	// it classified every status.Errorf as retryable — including permanent
+	// InvalidArgument / NotFound / PermissionDenied, which this codebase returns
+	// widely. Read the code instead and allowlist the transient ones.
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.Unavailable:
+			return retryClassRPC
+		case codes.DeadlineExceeded:
+			return retryClassTimeout
+		case codes.ResourceExhausted:
+			// The canonical gRPC → HTTP mapping for a rate limit is 429, so a
+			// user who turns http_429 off gets no gRPC rate-limit retries either.
+			return retryClassHTTP429
+		default:
+			// Any other code is a definite answer from the server, not a blip.
+			return ""
+		}
+	}
+
+	msg := urlRe.ReplaceAllString(strings.ToLower(err.Error()), " ")
+
+	if strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded") {
+		return retryClassTimeout
+	}
+	if grpcProseRe.MatchString(msg) {
+		return retryClassRPC
+	}
+	if code := statusCodeFromMessage(msg); code > 0 {
+		if class := classifyHTTPStatus(code); class != "" {
+			return class
+		}
+	}
+	if strings.Contains(msg, "too many requests") || strings.Contains(msg, "rate limit") {
 		return retryClassHTTP429
-	case http5xxRe.MatchString(msg) ||
-		strings.Contains(msg, "internal server error") ||
+	}
+	if strings.Contains(msg, "internal server error") ||
 		strings.Contains(msg, "bad gateway") ||
 		strings.Contains(msg, "service unavailable") ||
-		strings.Contains(msg, "gateway timeout"):
+		strings.Contains(msg, "gateway timeout") {
 		return retryClassHTTP5xx
-	case strings.Contains(msg, "connection refused") ||
+	}
+	if strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "no such host") ||
-		strings.Contains(msg, "eof") ||
-		strings.Contains(msg, "rpc"):
+		eofRe.MatchString(msg) {
 		return retryClassRPC
 	}
 	return ""
 }
 
-// isRetryableError reports whether err is a transient failure whose class is
-// enabled by policy.
-func isRetryableError(err error, policy *avsproto.RetryPolicy) bool {
-	class := classifyRetryableError(err)
+// statusCodeFromMessage extracts an HTTP status code from a message that names
+// one in a status-like context. Returns 0 when the message carries no status.
+func statusCodeFromMessage(msg string) int {
+	m := httpStatusRe.FindStringSubmatch(msg)
+	if m == nil {
+		return 0
+	}
+	code := 0
+	for _, ch := range m[1] {
+		code = code*10 + int(ch-'0')
+	}
+	return code
+}
+
+// classifyHTTPStatus maps an HTTP status code to a retry class. Only 429 and
+// 5xx are transient; every other status is the server's final answer.
+func classifyHTTPStatus(code int) string {
+	switch {
+	case code == 429:
+		return retryClassHTTP429
+	case code >= 500 && code <= 599:
+		return retryClassHTTP5xx
+	}
+	return ""
+}
+
+// retryClassFor classifies the outcome of one attempt.
+//
+// A returned error is not the only way a node fails: the REST runner reports an
+// HTTP 4xx/5xx by returning (step, nil) with step.Success == false, so looking
+// only at err would make http_429 / http_5xx retries dead code for the node
+// they matter most for. When the step carries a structured status code, that
+// number is used directly — no prose sniffing.
+func retryClassFor(step *avsproto.Execution_Step, err error) string {
+	if err != nil {
+		return classifyRetryableError(err)
+	}
+	if step == nil || step.GetSuccess() {
+		return ""
+	}
+	if code := httpStatusFromStep(step); code > 0 {
+		return classifyHTTPStatus(code)
+	}
+	if stepErr := step.GetError(); stepErr != "" {
+		return classifyRetryableError(errors.New(stepErr))
+	}
+	return ""
+}
+
+// httpStatusFromStep reads the HTTP status the REST runner records in its
+// standard response envelope ({status, statusText, url, headers, data}).
+// Returns 0 for any step that carries no such envelope.
+func httpStatusFromStep(step *avsproto.Execution_Step) int {
+	restOut := step.GetRestApi()
+	if restOut == nil {
+		return 0
+	}
+	structVal, ok := restOut.GetData().GetKind().(*structpb.Value_StructValue)
+	if !ok || structVal.StructValue == nil {
+		return 0
+	}
+	statusVal, ok := structVal.StructValue.GetFields()["status"]
+	if !ok {
+		return 0
+	}
+	num, ok := statusVal.GetKind().(*structpb.Value_NumberValue)
+	if !ok {
+		return 0
+	}
+	return int(num.NumberValue)
+}
+
+// retryClassEnabled reports whether policy opts into retrying class.
+func retryClassEnabled(class string, policy *avsproto.RetryPolicy) bool {
 	if class == "" {
 		return false
 	}
@@ -84,51 +217,232 @@ func isRetryableError(err error, policy *avsproto.RetryPolicy) bool {
 	return false
 }
 
+// isRetryableError reports whether err is a transient failure whose class is
+// enabled by policy.
+func isRetryableError(err error, policy *avsproto.RetryPolicy) bool {
+	return retryClassEnabled(classifyRetryableError(err), policy)
+}
+
+// retryBudget bounds the total time one execution may spend sleeping between
+// retries, across every node it runs.
+//
+// Per-node validation (limits.go) bounds a single node's worst case, but a Loop
+// runs its retryable runner once per element — up to MaxLoopIterations times —
+// so the per-node bound alone still multiplies. This is the execution-wide
+// backstop: once the budget is spent, later nodes stop retrying and fail on
+// their first attempt rather than extending the execution further.
+type retryBudget struct {
+	mu   sync.Mutex
+	left time.Duration
+}
+
+func newRetryBudget(total time.Duration) *retryBudget {
+	return &retryBudget{left: total}
+}
+
+// reserve deducts d from the budget, reporting false (and deducting nothing)
+// when the remaining budget cannot cover it.
+func (b *retryBudget) reserve(d time.Duration) bool {
+	if b == nil {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if d > b.left {
+		return false
+	}
+	b.left -= d
+	return true
+}
+
+// remaining reports the unspent budget. Test/observability helper.
+func (b *retryBudget) remaining() time.Duration {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.left
+}
+
+// sleepFunc waits for d, returning ctx.Err() if the context is cancelled first.
+type sleepFunc func(ctx context.Context, d time.Duration) error
+
+// contextSleep is the production sleepFunc: an interruptible sleep, so a
+// cancelled request aborts a pending backoff instead of holding the execution
+// open for the full delay.
+func contextSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // executeWithRetry runs attempt up to policy.max_attempts times, sleeping with
 // exponential backoff between attempts that fail with a retryable error. It
 // returns the result of the final attempt. A nil policy, or max_attempts <= 1,
-// means exactly one attempt — identical to the pre-retry behavior. Only the
-// final attempt's step is returned, so the caller logs a single execution step.
+// means exactly one attempt — identical to the pre-retry behavior.
+//
+// Every bound here is also enforced at task creation (validateRetryPolicy), so
+// a stored task cannot carry a policy that exceeds them; the clamps below are
+// defense in depth for tasks created before validation existed and for internal
+// callers that bypass CreateTask.
 //
 // This is intended for idempotent read/off-chain nodes only; the caller is
 // responsible for restricting it to the retry allowlist. On-chain write nodes
 // must not be retried here (double-spend risk — see issue #676).
 func executeWithRetry(
+	ctx context.Context,
 	policy *avsproto.RetryPolicy,
-	sleep func(time.Duration),
+	budget *retryBudget,
+	sleep sleepFunc,
 	attempt func() (*avsproto.Execution_Step, error),
 ) (*avsproto.Execution_Step, error) {
 	maxAttempts := 1
 	if policy != nil && policy.GetMaxAttempts() > 1 {
 		maxAttempts = int(policy.GetMaxAttempts())
+		if maxAttempts > MaxRetryAttempts {
+			maxAttempts = MaxRetryAttempts
+		}
 	}
 
+	// max_backoff_ms is optional, but the ceiling is not: `backoff` itself is
+	// capped (not just the local wait), so repeated multiplication cannot run
+	// away. Uncapped it overflowed to a negative Duration at ~34 attempts and
+	// every later "sleep" silently became a no-op.
+	maxBackoff := time.Duration(policy.GetMaxBackoffMs()) * time.Millisecond
+	if maxBackoff <= 0 || maxBackoff > MaxRetryBackoff {
+		maxBackoff = MaxRetryBackoff
+	}
+
+	// backoff_ms has no documented default, and 0 meant "retry with no delay at
+	// all" — so the most natural policy a user writes, {max_attempts: 5}, turned
+	// one 429 into five immediate hits. Default it whenever retries are on.
 	backoff := time.Duration(policy.GetBackoffMs()) * time.Millisecond
+	if backoff <= 0 {
+		backoff = DefaultRetryBackoff
+	}
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+
 	multiplier := policy.GetBackoffMultiplier()
 	if multiplier <= 0 {
 		multiplier = defaultBackoffMultiplier
 	}
-	maxBackoff := time.Duration(policy.GetMaxBackoffMs()) * time.Millisecond
 
+	startedAt := time.Now()
 	var step *avsproto.Execution_Step
 	var err error
+	attempts := 0
+
 	for i := 0; i < maxAttempts; i++ {
 		step, err = attempt()
-		if err == nil {
-			return step, nil
+		attempts++
+
+		if i == maxAttempts-1 {
+			break
 		}
-		// Last attempt, or a failure we won't retry: return as-is.
-		if i == maxAttempts-1 || !isRetryableError(err, policy) {
-			return step, err
+		if !retryClassEnabled(retryClassFor(step, err), policy) {
+			break
 		}
-		if backoff > 0 {
-			wait := backoff
-			if maxBackoff > 0 && wait > maxBackoff {
-				wait = maxBackoff
-			}
-			sleep(wait)
-			backoff = time.Duration(float64(backoff) * multiplier)
+		// The execution-wide budget is spent: stop retrying rather than extend
+		// this execution any further.
+		if !budget.reserve(backoff) {
+			break
 		}
+		if sleepErr := sleep(ctx, backoff); sleepErr != nil {
+			// Cancelled or deadline-exceeded: return the last attempt's result
+			// instead of starting work the caller is no longer waiting for.
+			break
+		}
+		backoff = nextBackoff(backoff, multiplier, maxBackoff)
+	}
+
+	if attempts > 1 {
+		annotateRetriedStep(step, attempts, time.Since(startedAt))
 	}
 	return step, err
+}
+
+// nextBackoff grows cur by multiplier, saturating at max. Computed in float64
+// and bounds-checked before the conversion so an overflowing product clamps
+// instead of wrapping to a negative Duration.
+func nextBackoff(cur time.Duration, multiplier float64, max time.Duration) time.Duration {
+	next := float64(cur) * multiplier
+	if math.IsNaN(next) || next <= 0 || next >= float64(max) {
+		return max
+	}
+	return time.Duration(next)
+}
+
+// annotateRetriedStep records that a step took more than one attempt.
+//
+// Only the final attempt's step is returned, so without this a node that
+// retried four times over 30s would be indistinguishable from one fast success:
+// start_at is rewound to the first attempt so end_at - start_at is the true
+// elapsed time, and the attempt count goes in the step log.
+func annotateRetriedStep(step *avsproto.Execution_Step, attempts int, elapsed time.Duration) {
+	if step == nil {
+		return
+	}
+	endAt := step.GetEndAt()
+	if endAt == 0 {
+		endAt = time.Now().UnixMilli()
+		step.EndAt = endAt
+	}
+	step.StartAt = endAt - elapsed.Milliseconds()
+
+	note := fmt.Sprintf("Retry: %d attempts over %s (per-node retry_policy)", attempts, elapsed.Round(time.Millisecond))
+	if step.GetLog() == "" {
+		step.Log = note
+	} else {
+		step.Log = step.GetLog() + "\n" + note
+	}
+}
+
+// nodeSupportsRetry reports whether a node's runner is on the retry allowlist:
+// idempotent read/off-chain work that is safe to re-invoke.
+//
+// A Loop counts when — and only when — its own runner is one of those; a Loop
+// wrapping ContractWrite or EthTransfer is not retryable for the same
+// double-spend reason the top-level write nodes are not (#676).
+func nodeSupportsRetry(node *avsproto.TaskNode) bool {
+	if node == nil {
+		return false
+	}
+	if node.GetRestApi() != nil || node.GetGraphqlQuery() != nil ||
+		node.GetContractRead() != nil || node.GetBalance() != nil {
+		return true
+	}
+	if loop := node.GetLoop(); loop != nil {
+		return loop.GetRestApi() != nil || loop.GetGraphqlDataQuery() != nil || loop.GetContractRead() != nil
+	}
+	return false
+}
+
+// propagateRetryPolicyToIteration copies a Loop node's retry policy onto the
+// synthetic per-iteration node, for read runners only.
+//
+// A REST GET fanned out across a Loop is exactly where 429s show up, so the
+// loop path is the feature's strongest use case; before this the policy was
+// accepted on a Loop and silently did nothing there. The write runners are
+// skipped so the #676 exclusion holds inside loops too, and the execution-wide
+// retryBudget bounds the fan-out that per-node validation cannot see.
+func propagateRetryPolicyToIteration(parent *avsproto.TaskNode, nested *avsproto.TaskNode) {
+	if parent == nil || nested == nil {
+		return
+	}
+	policy := parent.GetRetryPolicy()
+	if policy == nil || !nodeSupportsRetry(nested) {
+		return
+	}
+	nested.RetryPolicy = policy
 }

--- a/core/taskengine/retry.go
+++ b/core/taskengine/retry.go
@@ -1,0 +1,134 @@
+package taskengine
+
+import (
+	"errors"
+	"net"
+	"regexp"
+	"strings"
+	"time"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// Retry error classes. A RetryPolicy.retry_on entry must match one of these to
+// enable retries for that class of failure.
+const (
+	retryClassTimeout = "timeout"
+	retryClassHTTP429 = "http_429"
+	retryClassHTTP5xx = "http_5xx"
+	retryClassRPC     = "rpc_error"
+)
+
+// defaultRetryClasses is used when a RetryPolicy sets max_attempts but leaves
+// retry_on empty: all transient classes are eligible.
+var defaultRetryClasses = []string{retryClassTimeout, retryClassHTTP429, retryClassHTTP5xx, retryClassRPC}
+
+// defaultBackoffMultiplier applies when a policy enables retries without setting one.
+const defaultBackoffMultiplier = 2.0
+
+var http5xxRe = regexp.MustCompile(`\b5\d\d\b`)
+
+// classifyRetryableError maps err to one of the retry classes, or "" if it is
+// not a recognizably transient failure. Classification is best-effort and
+// string-based: node runners surface upstream failures as wrapped errors rather
+// than typed status codes, so this errs toward not retrying when unsure.
+func classifyRetryableError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// Structured network timeouts (and context deadlines) first — most reliable signal.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return retryClassTimeout
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return retryClassTimeout
+	case strings.Contains(msg, "429") || strings.Contains(msg, "too many requests"):
+		return retryClassHTTP429
+	case http5xxRe.MatchString(msg) ||
+		strings.Contains(msg, "internal server error") ||
+		strings.Contains(msg, "bad gateway") ||
+		strings.Contains(msg, "service unavailable") ||
+		strings.Contains(msg, "gateway timeout"):
+		return retryClassHTTP5xx
+	case strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "eof") ||
+		strings.Contains(msg, "rpc"):
+		return retryClassRPC
+	}
+	return ""
+}
+
+// isRetryableError reports whether err is a transient failure whose class is
+// enabled by policy.
+func isRetryableError(err error, policy *avsproto.RetryPolicy) bool {
+	class := classifyRetryableError(err)
+	if class == "" {
+		return false
+	}
+	enabled := policy.GetRetryOn()
+	if len(enabled) == 0 {
+		enabled = defaultRetryClasses
+	}
+	for _, c := range enabled {
+		if c == class {
+			return true
+		}
+	}
+	return false
+}
+
+// executeWithRetry runs attempt up to policy.max_attempts times, sleeping with
+// exponential backoff between attempts that fail with a retryable error. It
+// returns the result of the final attempt. A nil policy, or max_attempts <= 1,
+// means exactly one attempt — identical to the pre-retry behavior. Only the
+// final attempt's step is returned, so the caller logs a single execution step.
+//
+// This is intended for idempotent read/off-chain nodes only; the caller is
+// responsible for restricting it to the retry allowlist. On-chain write nodes
+// must not be retried here (double-spend risk — see issue #676).
+func executeWithRetry(
+	policy *avsproto.RetryPolicy,
+	sleep func(time.Duration),
+	attempt func() (*avsproto.Execution_Step, error),
+) (*avsproto.Execution_Step, error) {
+	maxAttempts := 1
+	if policy != nil && policy.GetMaxAttempts() > 1 {
+		maxAttempts = int(policy.GetMaxAttempts())
+	}
+
+	backoff := time.Duration(policy.GetBackoffMs()) * time.Millisecond
+	multiplier := policy.GetBackoffMultiplier()
+	if multiplier <= 0 {
+		multiplier = defaultBackoffMultiplier
+	}
+	maxBackoff := time.Duration(policy.GetMaxBackoffMs()) * time.Millisecond
+
+	var step *avsproto.Execution_Step
+	var err error
+	for i := 0; i < maxAttempts; i++ {
+		step, err = attempt()
+		if err == nil {
+			return step, nil
+		}
+		// Last attempt, or a failure we won't retry: return as-is.
+		if i == maxAttempts-1 || !isRetryableError(err, policy) {
+			return step, err
+		}
+		if backoff > 0 {
+			wait := backoff
+			if maxBackoff > 0 && wait > maxBackoff {
+				wait = maxBackoff
+			}
+			sleep(wait)
+			backoff = time.Duration(float64(backoff) * multiplier)
+		}
+	}
+	return step, err
+}

--- a/core/taskengine/retry_allowlist_test.go
+++ b/core/taskengine/retry_allowlist_test.go
@@ -1,0 +1,198 @@
+package taskengine
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// retryAllowlistGuards is the complete set of node-type guards whose branch may
+// route its runner through executeNodeWithRetry: idempotent reads only.
+//
+// ContractWrite and EthTransfer are absent by design. Retry re-invokes the
+// runner, and an ambiguous confirmation on a write would resubmit the UserOp
+// (issue #676), so those branches must always call their runner directly.
+var retryAllowlistGuards = map[string]bool{
+	"GetRestApi":      true,
+	"GetGraphqlQuery": true,
+	"GetContractRead": true,
+	"GetBalance":      true,
+}
+
+// TestRetryAllowlist_WriteNodesRunExactlyOnce is the test the safety argument
+// rests on.
+//
+// The #676 guarantee is structural: retries exist only where a dispatch branch
+// opts into them, so a write node runs its runner exactly once no matter what
+// retry_policy it carries. Nothing about that is checked by the type system —
+// wiring `v.runContractWrite` through `executeNodeWithRetry` in a later
+// refactor would compile, pass every other test, and silently make double
+// submission possible. This reads the dispatchers' own source and fails if any
+// call to executeNodeWithRetry sits in a branch outside the allowlist.
+func TestRetryAllowlist_WriteNodesRunExactlyOnce(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "vm.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing vm.go: %v", err)
+	}
+
+	type site struct {
+		guard string
+		pos   token.Position
+	}
+	var sites []site
+
+	// Track the enclosing if-statements so each retry call can be attributed to
+	// the node-type guard that admits it. An else-if is its own IfStmt inside
+	// the parent's Else, so the *innermost* IfStmt whose Body (not Else)
+	// contains the call is the branch that runs it.
+	var stack []ast.Node
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			stack = stack[:len(stack)-1]
+			return false
+		}
+		stack = append(stack, n)
+
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "executeNodeWithRetry" {
+			return true
+		}
+
+		guard := ""
+		for i := len(stack) - 1; i >= 0; i-- {
+			ifStmt, ok := stack[i].(*ast.IfStmt)
+			if !ok {
+				continue
+			}
+			if call.Pos() < ifStmt.Body.Pos() || call.Pos() > ifStmt.Body.End() {
+				// The call is in this if's Else — an else-if we have already
+				// attributed, or will attribute, to its own IfStmt.
+				continue
+			}
+			guard = nodeTypeGuard(ifStmt.Cond)
+			break
+		}
+		sites = append(sites, site{guard: guard, pos: fset.Position(call.Pos())})
+		return true
+	})
+
+	if len(sites) == 0 {
+		t.Fatal("found no executeNodeWithRetry call sites in vm.go — either the helper was renamed or retry was removed; update this test deliberately")
+	}
+
+	covered := map[string]bool{}
+	for _, s := range sites {
+		if s.guard == "" {
+			t.Errorf("%s: executeNodeWithRetry is called outside any node-type branch, so the allowlist no longer bounds what can be retried", s.pos)
+			continue
+		}
+		if !retryAllowlistGuards[s.guard] {
+			t.Errorf("%s: node branch %s() routes its runner through executeNodeWithRetry, but only idempotent reads may be retried — re-invoking a write can resubmit a UserOp (#676)", s.pos, s.guard)
+			continue
+		}
+		covered[s.guard] = true
+	}
+
+	// The allowlist must not silently shrink either: a read branch that loses
+	// its retry wiring makes the feature a no-op there with no other signal.
+	var missing []string
+	for guard := range retryAllowlistGuards {
+		if !covered[guard] {
+			missing = append(missing, guard)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("no dispatch branch retries %s — the retry allowlist lost a read node type", strings.Join(missing, ", "))
+	}
+}
+
+// TestRetryAllowlist_WriteRunnersNeverWrapped is the same guarantee read from
+// the other direction: the write runners must only ever be called directly.
+func TestRetryAllowlist_WriteRunnersNeverWrapped(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "vm.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing vm.go: %v", err)
+	}
+
+	writeRunners := map[string]bool{"runContractWrite": true, "runEthTransfer": true}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "executeNodeWithRetry" {
+			return true
+		}
+		for _, arg := range call.Args {
+			argSel, ok := arg.(*ast.SelectorExpr)
+			if ok && writeRunners[argSel.Sel.Name] {
+				t.Errorf("%s: %s is passed to executeNodeWithRetry; on-chain writes must never be re-invoked (#676)",
+					fset.Position(call.Pos()), argSel.Sel.Name)
+			}
+		}
+		return true
+	})
+}
+
+// TestNodeSupportsRetry pins which node shapes may carry a policy at all. This
+// is what CreateTask validates against, so a write node cannot even be stored
+// with a policy that looks like it works.
+func TestNodeSupportsRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		node *avsproto.TaskNode
+		want bool
+	}{
+		{"nil node", nil, false},
+		{"rest", restTestNode(), true},
+		{"contract write", writeTestNode(), false},
+		{"eth transfer", transferTestNode(), false},
+		{"custom code", customCodeTestNode(), false},
+		{"loop over rest", loopOverRestTestNode(), true},
+		{"loop over contract write", loopOverWriteTestNode(), false},
+		{"graphql", &avsproto.TaskNode{TaskType: &avsproto.TaskNode_GraphqlQuery{GraphqlQuery: &avsproto.GraphQLQueryNode{}}}, true},
+		{"contract read", &avsproto.TaskNode{TaskType: &avsproto.TaskNode_ContractRead{ContractRead: &avsproto.ContractReadNode{}}}, true},
+		{"balance", &avsproto.TaskNode{TaskType: &avsproto.TaskNode_Balance{Balance: &avsproto.BalanceNode{}}}, true},
+		{"branch", &avsproto.TaskNode{TaskType: &avsproto.TaskNode_Branch{Branch: &avsproto.BranchNode{}}}, false},
+		{"filter", &avsproto.TaskNode{TaskType: &avsproto.TaskNode_Filter{Filter: &avsproto.FilterNode{}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nodeSupportsRetry(tt.node); got != tt.want {
+				t.Fatalf("nodeSupportsRetry(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// nodeTypeGuard extracts the "GetX" method name from a branch condition of the
+// form `node.GetX() != nil`, or "" when the condition is not of that shape.
+func nodeTypeGuard(cond ast.Expr) string {
+	bin, ok := cond.(*ast.BinaryExpr)
+	if !ok || bin.Op != token.NEQ {
+		return ""
+	}
+	call, ok := bin.X.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !strings.HasPrefix(sel.Sel.Name, "Get") {
+		return ""
+	}
+	return sel.Sel.Name
+}

--- a/core/taskengine/retry_test.go
+++ b/core/taskengine/retry_test.go
@@ -1,12 +1,17 @@
 package taskengine
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // fakeNetErr is a net.Error whose Timeout() we control, to exercise the
@@ -18,6 +23,15 @@ func (e fakeNetErr) Error() string   { return "dial tcp: something happened" }
 func (e fakeNetErr) Timeout() bool   { return e.timeout }
 func (e fakeNetErr) Temporary() bool { return false }
 
+// recordingSleep is a sleepFunc that records what it was asked to wait for and
+// returns immediately, so retry tests cost no wall time.
+func recordingSleep(waits *[]time.Duration) sleepFunc {
+	return func(_ context.Context, d time.Duration) error {
+		*waits = append(*waits, d)
+		return nil
+	}
+}
+
 func TestClassifyRetryableError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -27,26 +41,72 @@ func TestClassifyRetryableError(t *testing.T) {
 		{"nil", nil, ""},
 		{"structured net timeout", fakeNetErr{timeout: true}, retryClassTimeout},
 		{"non-timeout net error is not classified by string", fakeNetErr{timeout: false}, ""},
+		{"context deadline sentinel", context.DeadlineExceeded, retryClassTimeout},
 		{"timeout keyword", errors.New("request timeout after 30s"), retryClassTimeout},
-		{"context deadline", errors.New("context deadline exceeded"), retryClassTimeout},
-		{"http 429", errors.New("server returned 429"), retryClassHTTP429},
+		{"context deadline text", errors.New("context deadline exceeded"), retryClassTimeout},
+		{"http 429", errors.New("server returned status 429"), retryClassHTTP429},
 		{"too many requests phrase", errors.New("Too Many Requests"), retryClassHTTP429},
 		{"http 500", errors.New("unexpected status 500 from upstream"), retryClassHTTP5xx},
 		{"http 503", errors.New("HTTP 503"), retryClassHTTP5xx},
+		{"graphql non-200 status", errors.New("graphql: server returned a non-200 status code: 502"), retryClassHTTP5xx},
 		{"internal server error phrase", errors.New("Internal Server Error"), retryClassHTTP5xx},
-		{"bad gateway phrase", errors.New("502 Bad Gateway"), retryClassHTTP5xx},
+		{"bad gateway phrase", errors.New("Bad Gateway"), retryClassHTTP5xx},
 		{"connection refused", errors.New("dial: connection refused"), retryClassRPC},
 		{"connection reset", errors.New("read: connection reset by peer"), retryClassRPC},
 		{"no such host", errors.New("lookup foo: no such host"), retryClassRPC},
 		{"eof", errors.New("unexpected EOF"), retryClassRPC},
-		{"rpc keyword", errors.New("rpc call failed"), retryClassRPC},
+		{"stringified transient grpc status", errors.New("rpc error: code = Unavailable desc = connection closed"), retryClassRPC},
 		{"non-transient", errors.New("invalid ABI: field not found"), ""},
-		{"4xx that is not 429 is not retryable", errors.New("400 bad request"), ""},
+		{"4xx that is not 429 is not retryable", errors.New("status 400 bad request"), ""},
+
+		// Regressions: a bare substring match read these as transient.
+		{
+			"the word rpc alone is not a retry signal",
+			errors.New("rpc call failed: unsupported method"),
+			"",
+		},
+		{
+			"3-digit number in a URL is not a status code",
+			errors.New("GET https://api.example.com/v2/tokens?limit=500 returned status 404 not found"),
+			"",
+		},
+		{
+			"429 inside a URL is not a rate limit",
+			errors.New("GET https://api.example.com/pools/429 returned status 404"),
+			"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := classifyRetryableError(tt.err); got != tt.want {
 				t.Fatalf("classifyRetryableError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyGRPCStatus pins the typed-status path: permanent codes must not
+// burn the retry budget just because status.Errorf renders as "rpc error: ...".
+func TestClassifyGRPCStatus(t *testing.T) {
+	tests := []struct {
+		code codes.Code
+		want string
+	}{
+		{codes.InvalidArgument, ""},
+		{codes.NotFound, ""},
+		{codes.PermissionDenied, ""},
+		{codes.Unauthenticated, ""},
+		{codes.FailedPrecondition, ""},
+		{codes.Internal, ""},
+		{codes.Unavailable, retryClassRPC},
+		{codes.DeadlineExceeded, retryClassTimeout},
+		{codes.ResourceExhausted, retryClassHTTP429},
+	}
+	for _, tt := range tests {
+		t.Run(tt.code.String(), func(t *testing.T) {
+			err := status.Errorf(tt.code, "task id is malformed")
+			if got := classifyRetryableError(err); got != tt.want {
+				t.Fatalf("classifyRetryableError(%v) = %q, want %q", err, got, tt.want)
 			}
 		})
 	}
@@ -79,10 +139,57 @@ func TestIsRetryableError(t *testing.T) {
 	}
 }
 
+// TestRetryClassFor_FailedStepWithoutError covers the REST runner's shape: an
+// HTTP 4xx/5xx is reported as (step, nil) with success=false, so a classifier
+// that only looked at err would make http_5xx retries dead code.
+func TestRetryClassFor_FailedStepWithoutError(t *testing.T) {
+	restStep := func(statusCode int, success bool) *avsproto.Execution_Step {
+		data, err := structpb.NewValue(map[string]interface{}{
+			"status":     statusCode,
+			"statusText": "",
+			"url":        "https://api.example.com/v2/tokens?limit=500",
+			"data":       "",
+		})
+		if err != nil {
+			t.Fatalf("structpb.NewValue: %v", err)
+		}
+		return &avsproto.Execution_Step{
+			Id:      "rest1",
+			Success: success,
+			Error:   fmt.Sprintf("HTTP %d", statusCode),
+			OutputData: &avsproto.Execution_Step_RestApi{
+				RestApi: &avsproto.RestAPINode_Output{Data: data},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		step *avsproto.Execution_Step
+		err  error
+		want string
+	}{
+		{"successful step", restStep(200, true), nil, ""},
+		{"502 from the response envelope", restStep(502, false), nil, retryClassHTTP5xx},
+		{"429 from the response envelope", restStep(429, false), nil, retryClassHTTP429},
+		{"404 is not retryable despite the limit=500 url", restStep(404, false), nil, ""},
+		{"a returned error still wins", restStep(200, true), errors.New("i/o timeout"), retryClassTimeout},
+		{"failed step with only a message", &avsproto.Execution_Step{Success: false, Error: "connection refused"}, nil, retryClassRPC},
+		{"nil step, nil error", nil, nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryClassFor(tt.step, tt.err); got != tt.want {
+				t.Fatalf("retryClassFor() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // stepWithID builds a minimal execution step tagged with an id so tests can
 // assert which attempt's step is returned.
 func stepWithID(id string) *avsproto.Execution_Step {
-	return &avsproto.Execution_Step{Id: id}
+	return &avsproto.Execution_Step{Id: id, Success: false}
 }
 
 func TestExecuteWithRetry_SingleAttemptWhenNotConfigured(t *testing.T) {
@@ -96,17 +203,18 @@ func TestExecuteWithRetry_SingleAttemptWhenNotConfigured(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var calls, sleeps int
+			var calls int
+			var waits []time.Duration
 			retryErr := errors.New("i/o timeout") // retryable class, but policy forbids more than one attempt
-			step, err := executeWithRetry(tc.policy, func(time.Duration) { sleeps++ }, func() (*avsproto.Execution_Step, error) {
+			step, err := executeWithRetry(context.Background(), tc.policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
 				calls++
 				return stepWithID("s"), retryErr
 			})
 			if calls != 1 {
 				t.Fatalf("expected exactly 1 attempt, got %d", calls)
 			}
-			if sleeps != 0 {
-				t.Fatalf("expected no sleeps, got %d", sleeps)
+			if len(waits) != 0 {
+				t.Fatalf("expected no sleeps, got %v", waits)
 			}
 			if err != retryErr || step.GetId() != "s" {
 				t.Fatalf("expected the single attempt's step and error, got step=%v err=%v", step, err)
@@ -116,17 +224,21 @@ func TestExecuteWithRetry_SingleAttemptWhenNotConfigured(t *testing.T) {
 }
 
 func TestExecuteWithRetry_SuccessFirstTryDoesNotRetry(t *testing.T) {
-	var calls, sleeps int
+	var calls int
+	var waits []time.Duration
 	policy := &avsproto.RetryPolicy{MaxAttempts: 3, BackoffMs: 10}
-	step, err := executeWithRetry(policy, func(time.Duration) { sleeps++ }, func() (*avsproto.Execution_Step, error) {
+	step, err := executeWithRetry(context.Background(), policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
 		calls++
-		return stepWithID("ok"), nil
+		return &avsproto.Execution_Step{Id: "ok", Success: true}, nil
 	})
-	if calls != 1 || sleeps != 0 {
-		t.Fatalf("expected 1 call and 0 sleeps, got calls=%d sleeps=%d", calls, sleeps)
+	if calls != 1 || len(waits) != 0 {
+		t.Fatalf("expected 1 call and 0 sleeps, got calls=%d waits=%v", calls, waits)
 	}
 	if err != nil || step.GetId() != "ok" {
 		t.Fatalf("expected success step, got step=%v err=%v", step, err)
+	}
+	if step.GetLog() != "" {
+		t.Fatalf("a single-attempt step must not be annotated as retried, got log %q", step.GetLog())
 	}
 }
 
@@ -135,12 +247,12 @@ func TestExecuteWithRetry_RetriesThenSucceeds(t *testing.T) {
 	var waits []time.Duration
 	policy := &avsproto.RetryPolicy{MaxAttempts: 3, BackoffMs: 10, RetryOn: []string{retryClassTimeout}}
 
-	step, err := executeWithRetry(policy, func(d time.Duration) { waits = append(waits, d) }, func() (*avsproto.Execution_Step, error) {
+	step, err := executeWithRetry(context.Background(), policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
 		calls++
 		if calls < 3 {
 			return stepWithID(fmt.Sprintf("fail-%d", calls)), errors.New("i/o timeout")
 		}
-		return stepWithID("success"), nil
+		return &avsproto.Execution_Step{Id: "success", Success: true}, nil
 	})
 
 	if calls != 3 {
@@ -159,18 +271,45 @@ func TestExecuteWithRetry_RetriesThenSucceeds(t *testing.T) {
 			t.Fatalf("sleep[%d] = %v, want %v (all: %v)", i, waits[i], want[i], waits)
 		}
 	}
+	// Observability: a step that took 3 attempts must not read as one fast success.
+	if !strings.Contains(step.GetLog(), "Retry: 3 attempts") {
+		t.Fatalf("expected the step log to record the retries, got %q", step.GetLog())
+	}
+}
+
+// TestExecuteWithRetry_DefaultsBackoffWhenUnset covers the most natural policy a
+// user writes. With no default, backoff started at 0, the sleep was skipped
+// entirely, and one 429 became five immediate hits.
+func TestExecuteWithRetry_DefaultsBackoffWhenUnset(t *testing.T) {
+	var waits []time.Duration
+	policy := &avsproto.RetryPolicy{MaxAttempts: 4}
+
+	_, _ = executeWithRetry(context.Background(), policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
+		return stepWithID("x"), errors.New("i/o timeout")
+	})
+
+	want := []time.Duration{DefaultRetryBackoff, 2 * DefaultRetryBackoff, 4 * DefaultRetryBackoff}
+	if len(waits) != len(want) {
+		t.Fatalf("expected %d sleeps, got %d (%v)", len(want), len(waits), waits)
+	}
+	for i := range want {
+		if waits[i] != want[i] {
+			t.Fatalf("sleep[%d] = %v, want %v (all: %v)", i, waits[i], want[i], waits)
+		}
+	}
 }
 
 func TestExecuteWithRetry_NonRetryableFailsImmediately(t *testing.T) {
-	var calls, sleeps int
+	var calls int
+	var waits []time.Duration
 	policy := &avsproto.RetryPolicy{MaxAttempts: 5, BackoffMs: 10}
 	fatal := errors.New("invalid ABI: field not found")
-	step, err := executeWithRetry(policy, func(time.Duration) { sleeps++ }, func() (*avsproto.Execution_Step, error) {
+	step, err := executeWithRetry(context.Background(), policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
 		calls++
 		return stepWithID("boom"), fatal
 	})
-	if calls != 1 || sleeps != 0 {
-		t.Fatalf("expected 1 call and 0 sleeps for a non-retryable error, got calls=%d sleeps=%d", calls, sleeps)
+	if calls != 1 || len(waits) != 0 {
+		t.Fatalf("expected 1 call and 0 sleeps for a non-retryable error, got calls=%d waits=%v", calls, waits)
 	}
 	if err != fatal || step.GetId() != "boom" {
 		t.Fatalf("expected the failing step and error, got step=%v err=%v", step, err)
@@ -182,7 +321,7 @@ func TestExecuteWithRetry_ExhaustsAndReturnsLastFailure(t *testing.T) {
 	var waits []time.Duration
 	policy := &avsproto.RetryPolicy{MaxAttempts: 2, BackoffMs: 5, RetryOn: []string{retryClassTimeout}}
 
-	step, err := executeWithRetry(policy, func(d time.Duration) { waits = append(waits, d) }, func() (*avsproto.Execution_Step, error) {
+	step, err := executeWithRetry(context.Background(), policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
 		calls++
 		return stepWithID(fmt.Sprintf("attempt-%d", calls)), errors.New("i/o timeout")
 	})
@@ -207,7 +346,7 @@ func TestExecuteWithRetry_MaxBackoffCaps(t *testing.T) {
 		MaxBackoffMs:      150,
 		RetryOn:           []string{retryClassTimeout},
 	}
-	_, _ = executeWithRetry(policy, func(d time.Duration) { waits = append(waits, d) }, func() (*avsproto.Execution_Step, error) {
+	_, _ = executeWithRetry(context.Background(), policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
 		return stepWithID("x"), errors.New("i/o timeout")
 	})
 
@@ -221,5 +360,102 @@ func TestExecuteWithRetry_MaxBackoffCaps(t *testing.T) {
 		if waits[i] != want[i] {
 			t.Fatalf("sleep[%d] = %v, want %v (all: %v)", i, waits[i], want[i], waits)
 		}
+	}
+}
+
+// TestNextBackoff_SaturatesInsteadOfOverflowing pins the growth function. When
+// only a local copy of the wait was capped, `backoff` kept multiplying, wrapped
+// to a negative Duration at ~34 attempts, and every later sleep silently became
+// a no-op — turning the tail of the retry budget into a hot loop.
+func TestNextBackoff_SaturatesInsteadOfOverflowing(t *testing.T) {
+	backoff := time.Second
+	for i := 0; i < 200; i++ {
+		backoff = nextBackoff(backoff, 2.0, MaxRetryBackoff)
+		if backoff <= 0 {
+			t.Fatalf("backoff went non-positive (%v) after %d growth steps", backoff, i+1)
+		}
+		if backoff > MaxRetryBackoff {
+			t.Fatalf("backoff %v exceeded the %v cap after %d growth steps", backoff, MaxRetryBackoff, i+1)
+		}
+	}
+	if backoff != MaxRetryBackoff {
+		t.Fatalf("expected backoff to saturate at %v, got %v", MaxRetryBackoff, backoff)
+	}
+}
+
+// TestExecuteWithRetry_ClampsAboveCeilingPolicy is defense in depth: creation
+// rejects such a policy, but a task stored before validation existed must still
+// be bounded at execution time.
+func TestExecuteWithRetry_ClampsAboveCeilingPolicy(t *testing.T) {
+	var calls int
+	var waits []time.Duration
+	policy := &avsproto.RetryPolicy{MaxAttempts: 100, BackoffMs: 600000}
+
+	_, _ = executeWithRetry(context.Background(), policy, nil, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
+		calls++
+		return stepWithID("x"), errors.New("i/o timeout")
+	})
+
+	if calls != MaxRetryAttempts {
+		t.Fatalf("expected attempts to be clamped to %d, got %d", MaxRetryAttempts, calls)
+	}
+	for i, w := range waits {
+		if w > MaxRetryBackoff {
+			t.Fatalf("sleep[%d] = %v exceeds the %v cap (all: %v)", i, w, MaxRetryBackoff, waits)
+		}
+	}
+}
+
+// TestExecuteWithRetry_StopsWhenContextCancelled: the async queue path has no
+// deadline, but a request-scoped execution must be able to abandon a backoff.
+func TestExecuteWithRetry_StopsWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var calls int
+	policy := &avsproto.RetryPolicy{MaxAttempts: 5, BackoffMs: 10}
+	_, err := executeWithRetry(ctx, policy, nil, contextSleep, func() (*avsproto.Execution_Step, error) {
+		calls++
+		return stepWithID("x"), errors.New("i/o timeout")
+	})
+
+	if calls != 1 {
+		t.Fatalf("expected a cancelled context to stop after the first attempt, got %d attempts", calls)
+	}
+	if err == nil {
+		t.Fatal("expected the last attempt's error to be returned")
+	}
+}
+
+// TestExecuteWithRetry_HonorsExecutionBudget covers the fan-out case per-node
+// validation cannot see: a Loop runs the same retryable runner once per element.
+func TestExecuteWithRetry_HonorsExecutionBudget(t *testing.T) {
+	budget := newRetryBudget(25 * time.Millisecond)
+	policy := &avsproto.RetryPolicy{MaxAttempts: 5, BackoffMs: 10, BackoffMultiplier: 1}
+
+	var calls int
+	var waits []time.Duration
+	_, _ = executeWithRetry(context.Background(), policy, budget, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
+		calls++
+		return stepWithID("x"), errors.New("i/o timeout")
+	})
+
+	// 25ms of budget covers two 10ms backoffs, so the third is refused and the
+	// node stops after 3 attempts rather than its configured 5.
+	if calls != 3 {
+		t.Fatalf("expected the budget to cut retries off after 3 attempts, got %d (waits %v)", calls, waits)
+	}
+	if budget.remaining() != 5*time.Millisecond {
+		t.Fatalf("expected 5ms of budget left, got %v", budget.remaining())
+	}
+
+	// A later node in the same execution inherits the drained budget.
+	calls = 0
+	_, _ = executeWithRetry(context.Background(), policy, budget, recordingSleep(&waits), func() (*avsproto.Execution_Step, error) {
+		calls++
+		return stepWithID("y"), errors.New("i/o timeout")
+	})
+	if calls != 1 {
+		t.Fatalf("expected a drained budget to leave one attempt, got %d", calls)
 	}
 }

--- a/core/taskengine/retry_test.go
+++ b/core/taskengine/retry_test.go
@@ -1,0 +1,225 @@
+package taskengine
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// fakeNetErr is a net.Error whose Timeout() we control, to exercise the
+// structured-timeout branch of classifyRetryableError independently of the
+// error string.
+type fakeNetErr struct{ timeout bool }
+
+func (e fakeNetErr) Error() string   { return "dial tcp: something happened" }
+func (e fakeNetErr) Timeout() bool   { return e.timeout }
+func (e fakeNetErr) Temporary() bool { return false }
+
+func TestClassifyRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"structured net timeout", fakeNetErr{timeout: true}, retryClassTimeout},
+		{"non-timeout net error is not classified by string", fakeNetErr{timeout: false}, ""},
+		{"timeout keyword", errors.New("request timeout after 30s"), retryClassTimeout},
+		{"context deadline", errors.New("context deadline exceeded"), retryClassTimeout},
+		{"http 429", errors.New("server returned 429"), retryClassHTTP429},
+		{"too many requests phrase", errors.New("Too Many Requests"), retryClassHTTP429},
+		{"http 500", errors.New("unexpected status 500 from upstream"), retryClassHTTP5xx},
+		{"http 503", errors.New("HTTP 503"), retryClassHTTP5xx},
+		{"internal server error phrase", errors.New("Internal Server Error"), retryClassHTTP5xx},
+		{"bad gateway phrase", errors.New("502 Bad Gateway"), retryClassHTTP5xx},
+		{"connection refused", errors.New("dial: connection refused"), retryClassRPC},
+		{"connection reset", errors.New("read: connection reset by peer"), retryClassRPC},
+		{"no such host", errors.New("lookup foo: no such host"), retryClassRPC},
+		{"eof", errors.New("unexpected EOF"), retryClassRPC},
+		{"rpc keyword", errors.New("rpc call failed"), retryClassRPC},
+		{"non-transient", errors.New("invalid ABI: field not found"), ""},
+		{"4xx that is not 429 is not retryable", errors.New("400 bad request"), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyRetryableError(tt.err); got != tt.want {
+				t.Fatalf("classifyRetryableError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableError(t *testing.T) {
+	timeoutErr := errors.New("i/o timeout")
+	rpcErr := errors.New("connection refused")
+	fatalErr := errors.New("nonsense")
+
+	tests := []struct {
+		name   string
+		err    error
+		policy *avsproto.RetryPolicy
+		want   bool
+	}{
+		{"nil policy uses default classes", timeoutErr, nil, true},
+		{"empty retry_on uses default classes", rpcErr, &avsproto.RetryPolicy{}, true},
+		{"class explicitly enabled", timeoutErr, &avsproto.RetryPolicy{RetryOn: []string{retryClassTimeout}}, true},
+		{"class not in list", rpcErr, &avsproto.RetryPolicy{RetryOn: []string{retryClassTimeout}}, false},
+		{"unclassifiable error never retryable", fatalErr, &avsproto.RetryPolicy{}, false},
+		{"unclassifiable error even with all classes", fatalErr, &avsproto.RetryPolicy{RetryOn: defaultRetryClasses}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableError(tt.err, tt.policy); got != tt.want {
+				t.Fatalf("isRetryableError(%v, %v) = %v, want %v", tt.err, tt.policy, got, tt.want)
+			}
+		})
+	}
+}
+
+// stepWithID builds a minimal execution step tagged with an id so tests can
+// assert which attempt's step is returned.
+func stepWithID(id string) *avsproto.Execution_Step {
+	return &avsproto.Execution_Step{Id: id}
+}
+
+func TestExecuteWithRetry_SingleAttemptWhenNotConfigured(t *testing.T) {
+	cases := []struct {
+		name   string
+		policy *avsproto.RetryPolicy
+	}{
+		{"nil policy", nil},
+		{"max_attempts 0 treated as 1", &avsproto.RetryPolicy{}},
+		{"max_attempts 1", &avsproto.RetryPolicy{MaxAttempts: 1, RetryOn: defaultRetryClasses}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls, sleeps int
+			retryErr := errors.New("i/o timeout") // retryable class, but policy forbids more than one attempt
+			step, err := executeWithRetry(tc.policy, func(time.Duration) { sleeps++ }, func() (*avsproto.Execution_Step, error) {
+				calls++
+				return stepWithID("s"), retryErr
+			})
+			if calls != 1 {
+				t.Fatalf("expected exactly 1 attempt, got %d", calls)
+			}
+			if sleeps != 0 {
+				t.Fatalf("expected no sleeps, got %d", sleeps)
+			}
+			if err != retryErr || step.GetId() != "s" {
+				t.Fatalf("expected the single attempt's step and error, got step=%v err=%v", step, err)
+			}
+		})
+	}
+}
+
+func TestExecuteWithRetry_SuccessFirstTryDoesNotRetry(t *testing.T) {
+	var calls, sleeps int
+	policy := &avsproto.RetryPolicy{MaxAttempts: 3, BackoffMs: 10}
+	step, err := executeWithRetry(policy, func(time.Duration) { sleeps++ }, func() (*avsproto.Execution_Step, error) {
+		calls++
+		return stepWithID("ok"), nil
+	})
+	if calls != 1 || sleeps != 0 {
+		t.Fatalf("expected 1 call and 0 sleeps, got calls=%d sleeps=%d", calls, sleeps)
+	}
+	if err != nil || step.GetId() != "ok" {
+		t.Fatalf("expected success step, got step=%v err=%v", step, err)
+	}
+}
+
+func TestExecuteWithRetry_RetriesThenSucceeds(t *testing.T) {
+	var calls int
+	var waits []time.Duration
+	policy := &avsproto.RetryPolicy{MaxAttempts: 3, BackoffMs: 10, RetryOn: []string{retryClassTimeout}}
+
+	step, err := executeWithRetry(policy, func(d time.Duration) { waits = append(waits, d) }, func() (*avsproto.Execution_Step, error) {
+		calls++
+		if calls < 3 {
+			return stepWithID(fmt.Sprintf("fail-%d", calls)), errors.New("i/o timeout")
+		}
+		return stepWithID("success"), nil
+	})
+
+	if calls != 3 {
+		t.Fatalf("expected 3 attempts, got %d", calls)
+	}
+	if err != nil || step.GetId() != "success" {
+		t.Fatalf("expected final success step, got step=%v err=%v", step, err)
+	}
+	// Backoff doubles by the default multiplier (2.0) between attempts.
+	want := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond}
+	if len(waits) != len(want) {
+		t.Fatalf("expected %d sleeps, got %d (%v)", len(want), len(waits), waits)
+	}
+	for i := range want {
+		if waits[i] != want[i] {
+			t.Fatalf("sleep[%d] = %v, want %v (all: %v)", i, waits[i], want[i], waits)
+		}
+	}
+}
+
+func TestExecuteWithRetry_NonRetryableFailsImmediately(t *testing.T) {
+	var calls, sleeps int
+	policy := &avsproto.RetryPolicy{MaxAttempts: 5, BackoffMs: 10}
+	fatal := errors.New("invalid ABI: field not found")
+	step, err := executeWithRetry(policy, func(time.Duration) { sleeps++ }, func() (*avsproto.Execution_Step, error) {
+		calls++
+		return stepWithID("boom"), fatal
+	})
+	if calls != 1 || sleeps != 0 {
+		t.Fatalf("expected 1 call and 0 sleeps for a non-retryable error, got calls=%d sleeps=%d", calls, sleeps)
+	}
+	if err != fatal || step.GetId() != "boom" {
+		t.Fatalf("expected the failing step and error, got step=%v err=%v", step, err)
+	}
+}
+
+func TestExecuteWithRetry_ExhaustsAndReturnsLastFailure(t *testing.T) {
+	var calls int
+	var waits []time.Duration
+	policy := &avsproto.RetryPolicy{MaxAttempts: 2, BackoffMs: 5, RetryOn: []string{retryClassTimeout}}
+
+	step, err := executeWithRetry(policy, func(d time.Duration) { waits = append(waits, d) }, func() (*avsproto.Execution_Step, error) {
+		calls++
+		return stepWithID(fmt.Sprintf("attempt-%d", calls)), errors.New("i/o timeout")
+	})
+
+	if calls != 2 {
+		t.Fatalf("expected 2 attempts, got %d", calls)
+	}
+	if len(waits) != 1 || waits[0] != 5*time.Millisecond {
+		t.Fatalf("expected one 5ms sleep between the two attempts, got %v", waits)
+	}
+	if err == nil || step.GetId() != "attempt-2" {
+		t.Fatalf("expected the last attempt's step and its error, got step=%v err=%v", step, err)
+	}
+}
+
+func TestExecuteWithRetry_MaxBackoffCaps(t *testing.T) {
+	var waits []time.Duration
+	policy := &avsproto.RetryPolicy{
+		MaxAttempts:       4,
+		BackoffMs:         100,
+		BackoffMultiplier: 10,
+		MaxBackoffMs:      150,
+		RetryOn:           []string{retryClassTimeout},
+	}
+	_, _ = executeWithRetry(policy, func(d time.Duration) { waits = append(waits, d) }, func() (*avsproto.Execution_Step, error) {
+		return stepWithID("x"), errors.New("i/o timeout")
+	})
+
+	// 3 sleeps for 4 attempts. Raw backoffs would be 100, 1000, 10000; the cap
+	// clamps every wait to at most 150ms.
+	want := []time.Duration{100 * time.Millisecond, 150 * time.Millisecond, 150 * time.Millisecond}
+	if len(waits) != len(want) {
+		t.Fatalf("expected %d sleeps, got %d (%v)", len(want), len(waits), waits)
+	}
+	for i := range want {
+		if waits[i] != want[i] {
+			t.Fatalf("sleep[%d] = %v, want %v (all: %v)", i, waits[i], want[i], waits)
+		}
+	}
+}

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -1381,6 +1381,26 @@ func (v *VM) executeIndependentPath(startStep *Step) {
 	}
 }
 
+// executeNodeWithRetry runs a read/off-chain node runner under the node's
+// RetryPolicy. It is called ONLY from the retry allowlist branches in executeNode
+// (REST, GraphQL, ContractRead, Balance). Every other node type calls its runner
+// directly and is never retried, regardless of any retry_policy set on it — the
+// allowlist is enforced structurally by which branches call this helper.
+//
+// Retry re-invokes the runner, so it is only sound for idempotent reads. On-chain
+// write nodes (ContractWrite, EthTransfer) are deliberately excluded to avoid
+// resubmitting a UserOp on an ambiguous confirmation (see issue #676). REST is on
+// the allowlist for its common read (GET) use; because retry is opt-in per node,
+// a user enabling it on a non-idempotent POST accepts that trade-off.
+func (v *VM) executeNodeWithRetry(
+	node *avsproto.TaskNode,
+	run func(*avsproto.TaskNode) (*avsproto.Execution_Step, error),
+) (*avsproto.Execution_Step, error) {
+	return executeWithRetry(node.GetRetryPolicy(), time.Sleep, func() (*avsproto.Execution_Step, error) {
+		return run(node)
+	})
+}
+
 func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
 	v.mu.Lock()
 	v.instructionCount++
@@ -1414,7 +1434,7 @@ func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
 				"taskID", v.GetTaskId(),
 				"currentExecutionLogsCount", len(v.ExecutionLogs))
 		}
-		executionLogForNode, err = v.runRestApi(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runRestApi)
 		if executionLogForNode != nil {
 			if v.logger != nil {
 				v.logger.Info("🔍 executeNode DEBUG - REST API node completed, adding to logs",
@@ -1438,7 +1458,7 @@ func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
 			v.addExecutionLog(branchLog)
 		}
 	} else if node.GetGraphqlQuery() != nil {
-		executionLogForNode, err = v.runGraphQL(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runGraphQL)
 		if executionLogForNode != nil {
 			v.addExecutionLog(executionLogForNode)
 		}
@@ -1448,7 +1468,7 @@ func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
 			v.addExecutionLog(executionLogForNode)
 		}
 	} else if node.GetContractRead() != nil {
-		executionLogForNode, err = v.runContractRead(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runContractRead)
 		if executionLogForNode != nil {
 			v.addExecutionLog(executionLogForNode)
 		}
@@ -1483,7 +1503,7 @@ func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
 			}
 		}
 	} else if node.GetBalance() != nil {
-		executionLogForNode, err = v.runBalance(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runBalance)
 		if executionLogForNode != nil {
 			v.addExecutionLog(executionLogForNode)
 		}

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -288,6 +288,51 @@ type VM struct {
 	// keeping read-after-write coherent across nodes just like the DB-backed path.
 	// Guarded by mu. Never flushed to storage.
 	stateScratch map[string][]byte
+
+	// ctx is the caller's context, when one exists. Retry backoffs sleep against
+	// it, so a cancelled request aborts a pending backoff instead of holding the
+	// execution open. Nil for the async queue path (Perform → RunTask), which has
+	// no request-scoped context; context() substitutes context.Background().
+	// Set via WithContext before Run().
+	ctx context.Context
+
+	// retryBudget bounds the total time this execution may spend sleeping between
+	// retries, across all nodes. Lazily created (guarded by mu) so every VM
+	// constructor gets one without changing its signature. See MaxExecutionRetryDelay.
+	retryBudgetOnce *retryBudget
+}
+
+// WithContext attaches a caller context to the VM. Optional: without it the VM
+// behaves exactly as before, retry backoffs simply become uninterruptible.
+func (v *VM) WithContext(ctx context.Context) *VM {
+	if ctx == nil {
+		return v
+	}
+	v.mu.Lock()
+	v.ctx = ctx
+	v.mu.Unlock()
+	return v
+}
+
+// context returns the VM's context, or Background when none was attached.
+func (v *VM) context() context.Context {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.ctx == nil {
+		return context.Background()
+	}
+	return v.ctx
+}
+
+// retryDelayBudget returns this execution's shared retry-delay budget, creating
+// it on first use.
+func (v *VM) retryDelayBudget() *retryBudget {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.retryBudgetOnce == nil {
+		v.retryBudgetOnce = newRetryBudget(MaxExecutionRetryDelay)
+	}
+	return v.retryBudgetOnce
 }
 
 // scratchGet/scratchSet/scratchList back the {{state.*}} binding's non-persistent
@@ -1382,23 +1427,36 @@ func (v *VM) executeIndependentPath(startStep *Step) {
 }
 
 // executeNodeWithRetry runs a read/off-chain node runner under the node's
-// RetryPolicy. It is called ONLY from the retry allowlist branches in executeNode
-// (REST, GraphQL, ContractRead, Balance). Every other node type calls its runner
-// directly and is never retried, regardless of any retry_policy set on it — the
-// allowlist is enforced structurally by which branches call this helper.
+// RetryPolicy. It is called ONLY from the retry allowlist branches in the node
+// dispatchers (REST, GraphQL, ContractRead, Balance — in executeNode and in the
+// loop-iteration paths). Every other node type calls its runner directly and is
+// never retried, regardless of any retry_policy set on it: the allowlist is
+// enforced structurally by which branches call this helper, and
+// TestRetryAllowlist_WriteNodesRunExactlyOnce locks that in.
 //
 // Retry re-invokes the runner, so it is only sound for idempotent reads. On-chain
 // write nodes (ContractWrite, EthTransfer) are deliberately excluded to avoid
 // resubmitting a UserOp on an ambiguous confirmation (see issue #676). REST is on
 // the allowlist for its common read (GET) use; because retry is opt-in per node,
 // a user enabling it on a non-idempotent POST accepts that trade-off.
+//
+// Backoffs sleep against the VM context (cancellable) and draw on the
+// execution-wide retry budget, so loop fan-out cannot multiply the per-node
+// ceiling into an unbounded stall.
 func (v *VM) executeNodeWithRetry(
 	node *avsproto.TaskNode,
 	run func(*avsproto.TaskNode) (*avsproto.Execution_Step, error),
 ) (*avsproto.Execution_Step, error) {
-	return executeWithRetry(node.GetRetryPolicy(), time.Sleep, func() (*avsproto.Execution_Step, error) {
+	policy := node.GetRetryPolicy()
+	if policy.GetMaxAttempts() <= 1 {
+		// No retry configured: skip the budget/context plumbing entirely so the
+		// common path is byte-for-byte the pre-retry behavior.
 		return run(node)
-	})
+	}
+	return executeWithRetry(v.context(), policy, v.retryDelayBudget(), contextSleep,
+		func() (*avsproto.Execution_Step, error) {
+			return run(node)
+		})
 }
 
 func (v *VM) executeNode(node *avsproto.TaskNode) (*Step, error) {
@@ -4800,15 +4858,15 @@ func (v *VM) executeNodeWithIsolatedVars(node *avsproto.TaskNode, stepID string,
 		executionLogForNode, err = v.runCustomCodeWithIsolatedVars(stepID, node.GetCustomCode(), isolatedVars)
 	} else if node.GetRestApi() != nil {
 		// For other node types, fall back to regular execution (they may need similar isolation)
-		executionLogForNode, err = v.runRestApi(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runRestApi)
 	} else if node.GetBranch() != nil {
 		var nextStep *Step
 		executionLogForNode, nextStep, err = v.runBranch(node)
 		_ = nextStep // Ignore nextStep in direct execution
 	} else if node.GetGraphqlQuery() != nil {
-		executionLogForNode, err = v.runGraphQL(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runGraphQL)
 	} else if node.GetContractRead() != nil {
-		executionLogForNode, err = v.runContractRead(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runContractRead)
 	} else if node.GetContractWrite() != nil {
 		executionLogForNode, err = v.runContractWrite(node)
 		// Wait for on-chain confirmation before returning to the loop,
@@ -4899,18 +4957,18 @@ func (v *VM) executeNodeDirect(node *avsproto.TaskNode, stepID string) (*avsprot
 
 	// Execute the appropriate node type
 	if node.GetRestApi() != nil {
-		executionLogForNode, err = v.runRestApi(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runRestApi)
 	} else if node.GetBranch() != nil {
 		var nextStep *Step
 		executionLogForNode, nextStep, err = v.runBranch(node)
 		// Note: We ignore nextStep in direct execution as we don't follow jumps
 		_ = nextStep
 	} else if node.GetGraphqlQuery() != nil {
-		executionLogForNode, err = v.runGraphQL(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runGraphQL)
 	} else if node.GetCustomCode() != nil {
 		executionLogForNode, err = v.runCustomCode(node)
 	} else if node.GetContractRead() != nil {
-		executionLogForNode, err = v.runContractRead(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runContractRead)
 	} else if node.GetContractWrite() != nil {
 		executionLogForNode, err = v.runContractWrite(node)
 	} else if node.GetFilter() != nil {
@@ -4918,7 +4976,7 @@ func (v *VM) executeNodeDirect(node *avsproto.TaskNode, stepID string) (*avsprot
 	} else if node.GetEthTransfer() != nil {
 		executionLogForNode, err = v.runEthTransfer(node)
 	} else if node.GetBalance() != nil {
-		executionLogForNode, err = v.runBalance(node)
+		executionLogForNode, err = v.executeNodeWithRetry(node, v.runBalance)
 	} else if node.GetLoop() != nil {
 		// For loop nodes, we need special handling to use the execution queue
 		loopNode := node.GetLoop()
@@ -5057,6 +5115,7 @@ func (v *VM) executeLoopWithQueue(stepID string, taskNode *avsproto.TaskNode, no
 
 				iterationStepID := fmt.Sprintf("%s_iter_%d", stepID, iterationIndex)
 				nestedNode := createNestedNodeFromLoop(node, iterationStepID, iterInputs, v)
+				propagateRetryPolicyToIteration(taskNode, nestedNode)
 
 				// Debug: Log what variables are being set for this iteration
 				if v.logger != nil {
@@ -5134,6 +5193,7 @@ func (v *VM) executeLoopWithQueue(stepID string, taskNode *avsproto.TaskNode, no
 
 			iterationStepID := fmt.Sprintf("%s_iter_%d", stepID, i)
 			nestedNode := createNestedNodeFromLoop(node, iterationStepID, iterInputs, v)
+			propagateRetryPolicyToIteration(taskNode, nestedNode)
 
 			resultChannel := make(chan *ExecutionResult, 1)
 			task := &ExecutionTask{

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -1982,7 +1982,9 @@ type TaskNode struct {
 	// NEW: Use the enum for type identification (Phase 1: add alongside existing)
 	Type NodeType `protobuf:"varint,1,opt,name=type,proto3,enum=aggregator.NodeType" json:"type,omitempty"`
 	// Optional per-node retry policy for transient failures. Additive (field 4);
-	// absent = single attempt. Honored only for the read/off-chain node allowlist.
+	// absent = single attempt. Honored only for the read/off-chain node allowlist
+	// (see RetryPolicy); setting it on any other node type is rejected at task
+	// creation rather than silently ignored.
 	RetryPolicy *RetryPolicy `protobuf:"bytes,4,opt,name=retry_policy,json=retryPolicy,proto3" json:"retry_policy,omitempty"`
 	// based on node_type one and only one of these field are set
 	//
@@ -7216,18 +7218,37 @@ func (x *EventCondition) GetFieldType() string {
 
 // RetryPolicy configures automatic retries for transient node failures (RPC
 // blips, HTTP 429/5xx, timeouts). It is opt-in and additive: an absent policy
-// means a single attempt, i.e. today's behavior. The policy is honored only for
-// an allowlist of idempotent read/off-chain nodes (REST, GraphQL, ContractRead,
-// Balance); it is ignored on control-flow, stateful, and on-chain write nodes.
+// means a single attempt, i.e. today's behavior.
+//
+// Honored only for an allowlist of idempotent read/off-chain nodes: REST,
+// GraphQL, ContractRead, Balance, and a Loop whose runner is one of REST,
+// GraphQL, or ContractRead — there each iteration is retried under the policy.
+// On-chain write nodes (ContractWrite, EthTransfer) are excluded, because
+// re-invoking one could resubmit a UserOp, and so is a Loop over them. Setting a
+// policy on a node that cannot honor it is rejected at task creation rather than
+// silently ignored.
+//
+// Every field is bounded; an over-limit policy is rejected at task creation
+// rather than clamped, so a stored task always means what it says. Retries also
+// draw on a per-execution delay budget shared by every node, which bounds the
+// loop fan-out case a per-node limit cannot see.
 type RetryPolicy struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	MaxAttempts       uint32                 `protobuf:"varint,1,opt,name=max_attempts,json=maxAttempts,proto3" json:"max_attempts,omitempty"`                    // total attempts including the first (default 1 = no retry)
-	BackoffMs         uint32                 `protobuf:"varint,2,opt,name=backoff_ms,json=backoffMs,proto3" json:"backoff_ms,omitempty"`                          // initial backoff before the second attempt
-	BackoffMultiplier float64                `protobuf:"fixed64,3,opt,name=backoff_multiplier,json=backoffMultiplier,proto3" json:"backoff_multiplier,omitempty"` // exponential factor applied each attempt (default 2.0)
-	MaxBackoffMs      uint32                 `protobuf:"varint,4,opt,name=max_backoff_ms,json=maxBackoffMs,proto3" json:"max_backoff_ms,omitempty"`               // upper bound on any single backoff
-	RetryOn           []string               `protobuf:"bytes,5,rep,name=retry_on,json=retryOn,proto3" json:"retry_on,omitempty"`                                 // retryable error classes, e.g. ["timeout","http_5xx","http_429","rpc_error"]
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Total attempts including the first. 0 and 1 both mean no retry. Maximum 5.
+	MaxAttempts uint32 `protobuf:"varint,1,opt,name=max_attempts,json=maxAttempts,proto3" json:"max_attempts,omitempty"`
+	// Initial backoff before the second attempt. Defaults to 1000ms whenever
+	// max_attempts > 1 — 0 would retry with no delay at all. Maximum 30000ms.
+	BackoffMs uint32 `protobuf:"varint,2,opt,name=backoff_ms,json=backoffMs,proto3" json:"backoff_ms,omitempty"`
+	// Exponential factor applied to the backoff after each attempt. Default 2.0.
+	BackoffMultiplier float64 `protobuf:"fixed64,3,opt,name=backoff_multiplier,json=backoffMultiplier,proto3" json:"backoff_multiplier,omitempty"`
+	// Upper bound on any single backoff. Defaults to, and is capped at, 30000ms.
+	MaxBackoffMs uint32 `protobuf:"varint,4,opt,name=max_backoff_ms,json=maxBackoffMs,proto3" json:"max_backoff_ms,omitempty"`
+	// Retryable error classes. Empty enables all of them. Valid values are
+	// "timeout", "http_429", "http_5xx" and "rpc_error"; anything else is rejected
+	// at task creation. A failure matching no class is never retried.
+	RetryOn       []string `protobuf:"bytes,5,rep,name=retry_on,json=retryOn,proto3" json:"retry_on,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RetryPolicy) Reset() {

--- a/protobuf/avs.pb.go
+++ b/protobuf/avs.pb.go
@@ -1981,6 +1981,9 @@ type TaskNode struct {
 	Name  string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// NEW: Use the enum for type identification (Phase 1: add alongside existing)
 	Type NodeType `protobuf:"varint,1,opt,name=type,proto3,enum=aggregator.NodeType" json:"type,omitempty"`
+	// Optional per-node retry policy for transient failures. Additive (field 4);
+	// absent = single attempt. Honored only for the read/off-chain node allowlist.
+	RetryPolicy *RetryPolicy `protobuf:"bytes,4,opt,name=retry_policy,json=retryPolicy,proto3" json:"retry_policy,omitempty"`
 	// based on node_type one and only one of these field are set
 	//
 	// Types that are valid to be assigned to TaskType:
@@ -2050,6 +2053,13 @@ func (x *TaskNode) GetType() NodeType {
 		return x.Type
 	}
 	return NodeType_NODE_TYPE_UNSPECIFIED
+}
+
+func (x *TaskNode) GetRetryPolicy() *RetryPolicy {
+	if x != nil {
+		return x.RetryPolicy
+	}
+	return nil
 }
 
 func (x *TaskNode) GetTaskType() isTaskNode_TaskType {
@@ -7204,6 +7214,87 @@ func (x *EventCondition) GetFieldType() string {
 	return ""
 }
 
+// RetryPolicy configures automatic retries for transient node failures (RPC
+// blips, HTTP 429/5xx, timeouts). It is opt-in and additive: an absent policy
+// means a single attempt, i.e. today's behavior. The policy is honored only for
+// an allowlist of idempotent read/off-chain nodes (REST, GraphQL, ContractRead,
+// Balance); it is ignored on control-flow, stateful, and on-chain write nodes.
+type RetryPolicy struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	MaxAttempts       uint32                 `protobuf:"varint,1,opt,name=max_attempts,json=maxAttempts,proto3" json:"max_attempts,omitempty"`                    // total attempts including the first (default 1 = no retry)
+	BackoffMs         uint32                 `protobuf:"varint,2,opt,name=backoff_ms,json=backoffMs,proto3" json:"backoff_ms,omitempty"`                          // initial backoff before the second attempt
+	BackoffMultiplier float64                `protobuf:"fixed64,3,opt,name=backoff_multiplier,json=backoffMultiplier,proto3" json:"backoff_multiplier,omitempty"` // exponential factor applied each attempt (default 2.0)
+	MaxBackoffMs      uint32                 `protobuf:"varint,4,opt,name=max_backoff_ms,json=maxBackoffMs,proto3" json:"max_backoff_ms,omitempty"`               // upper bound on any single backoff
+	RetryOn           []string               `protobuf:"bytes,5,rep,name=retry_on,json=retryOn,proto3" json:"retry_on,omitempty"`                                 // retryable error classes, e.g. ["timeout","http_5xx","http_429","rpc_error"]
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *RetryPolicy) Reset() {
+	*x = RetryPolicy{}
+	mi := &file_avs_proto_msgTypes[85]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetryPolicy) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetryPolicy) ProtoMessage() {}
+
+func (x *RetryPolicy) ProtoReflect() protoreflect.Message {
+	mi := &file_avs_proto_msgTypes[85]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetryPolicy.ProtoReflect.Descriptor instead.
+func (*RetryPolicy) Descriptor() ([]byte, []int) {
+	return file_avs_proto_rawDescGZIP(), []int{85}
+}
+
+func (x *RetryPolicy) GetMaxAttempts() uint32 {
+	if x != nil {
+		return x.MaxAttempts
+	}
+	return 0
+}
+
+func (x *RetryPolicy) GetBackoffMs() uint32 {
+	if x != nil {
+		return x.BackoffMs
+	}
+	return 0
+}
+
+func (x *RetryPolicy) GetBackoffMultiplier() float64 {
+	if x != nil {
+		return x.BackoffMultiplier
+	}
+	return 0
+}
+
+func (x *RetryPolicy) GetMaxBackoffMs() uint32 {
+	if x != nil {
+		return x.MaxBackoffMs
+	}
+	return 0
+}
+
+func (x *RetryPolicy) GetRetryOn() []string {
+	if x != nil {
+		return x.RetryOn
+	}
+	return nil
+}
+
 type FixedTimeTrigger_Config struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Epochs        []int64                `protobuf:"varint,1,rep,packed,name=epochs,proto3" json:"epochs,omitempty"`
@@ -7213,7 +7304,7 @@ type FixedTimeTrigger_Config struct {
 
 func (x *FixedTimeTrigger_Config) Reset() {
 	*x = FixedTimeTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7225,7 +7316,7 @@ func (x *FixedTimeTrigger_Config) String() string {
 func (*FixedTimeTrigger_Config) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[85]
+	mi := &file_avs_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7257,7 +7348,7 @@ type FixedTimeTrigger_Output struct {
 
 func (x *FixedTimeTrigger_Output) Reset() {
 	*x = FixedTimeTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7269,7 +7360,7 @@ func (x *FixedTimeTrigger_Output) String() string {
 func (*FixedTimeTrigger_Output) ProtoMessage() {}
 
 func (x *FixedTimeTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[86]
+	mi := &file_avs_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7301,7 +7392,7 @@ type CronTrigger_Config struct {
 
 func (x *CronTrigger_Config) Reset() {
 	*x = CronTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7313,7 +7404,7 @@ func (x *CronTrigger_Config) String() string {
 func (*CronTrigger_Config) ProtoMessage() {}
 
 func (x *CronTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[87]
+	mi := &file_avs_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7345,7 +7436,7 @@ type CronTrigger_Output struct {
 
 func (x *CronTrigger_Output) Reset() {
 	*x = CronTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7357,7 +7448,7 @@ func (x *CronTrigger_Output) String() string {
 func (*CronTrigger_Output) ProtoMessage() {}
 
 func (x *CronTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[88]
+	mi := &file_avs_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7391,7 +7482,7 @@ type BlockTrigger_Config struct {
 
 func (x *BlockTrigger_Config) Reset() {
 	*x = BlockTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7403,7 +7494,7 @@ func (x *BlockTrigger_Config) String() string {
 func (*BlockTrigger_Config) ProtoMessage() {}
 
 func (x *BlockTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[89]
+	mi := &file_avs_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7442,7 +7533,7 @@ type BlockTrigger_Output struct {
 
 func (x *BlockTrigger_Output) Reset() {
 	*x = BlockTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7454,7 +7545,7 @@ func (x *BlockTrigger_Output) String() string {
 func (*BlockTrigger_Output) ProtoMessage() {}
 
 func (x *BlockTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[90]
+	mi := &file_avs_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7514,7 +7605,7 @@ type EventTrigger_Query struct {
 
 func (x *EventTrigger_Query) Reset() {
 	*x = EventTrigger_Query{}
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7526,7 +7617,7 @@ func (x *EventTrigger_Query) String() string {
 func (*EventTrigger_Query) ProtoMessage() {}
 
 func (x *EventTrigger_Query) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[91]
+	mi := &file_avs_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7597,7 +7688,7 @@ type EventTrigger_MethodCall struct {
 
 func (x *EventTrigger_MethodCall) Reset() {
 	*x = EventTrigger_MethodCall{}
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7609,7 +7700,7 @@ func (x *EventTrigger_MethodCall) String() string {
 func (*EventTrigger_MethodCall) ProtoMessage() {}
 
 func (x *EventTrigger_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[92]
+	mi := &file_avs_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7672,7 +7763,7 @@ type EventTrigger_Config struct {
 
 func (x *EventTrigger_Config) Reset() {
 	*x = EventTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7684,7 +7775,7 @@ func (x *EventTrigger_Config) String() string {
 func (*EventTrigger_Config) ProtoMessage() {}
 
 func (x *EventTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[93]
+	mi := &file_avs_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7730,7 +7821,7 @@ type EventTrigger_Output struct {
 
 func (x *EventTrigger_Output) Reset() {
 	*x = EventTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7742,7 +7833,7 @@ func (x *EventTrigger_Output) String() string {
 func (*EventTrigger_Output) ProtoMessage() {}
 
 func (x *EventTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[94]
+	mi := &file_avs_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7782,7 +7873,7 @@ type ManualTrigger_Config struct {
 
 func (x *ManualTrigger_Config) Reset() {
 	*x = ManualTrigger_Config{}
-	mi := &file_avs_proto_msgTypes[95]
+	mi := &file_avs_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7794,7 +7885,7 @@ func (x *ManualTrigger_Config) String() string {
 func (*ManualTrigger_Config) ProtoMessage() {}
 
 func (x *ManualTrigger_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[95]
+	mi := &file_avs_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7848,7 +7939,7 @@ type ManualTrigger_Output struct {
 
 func (x *ManualTrigger_Output) Reset() {
 	*x = ManualTrigger_Output{}
-	mi := &file_avs_proto_msgTypes[96]
+	mi := &file_avs_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7860,7 +7951,7 @@ func (x *ManualTrigger_Output) String() string {
 func (*ManualTrigger_Output) ProtoMessage() {}
 
 func (x *ManualTrigger_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[96]
+	mi := &file_avs_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7895,7 +7986,7 @@ type ETHTransferNode_Config struct {
 
 func (x *ETHTransferNode_Config) Reset() {
 	*x = ETHTransferNode_Config{}
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7907,7 +7998,7 @@ func (x *ETHTransferNode_Config) String() string {
 func (*ETHTransferNode_Config) ProtoMessage() {}
 
 func (x *ETHTransferNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[99]
+	mi := &file_avs_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7953,7 +8044,7 @@ type ETHTransferNode_Output struct {
 
 func (x *ETHTransferNode_Output) Reset() {
 	*x = ETHTransferNode_Output{}
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7965,7 +8056,7 @@ func (x *ETHTransferNode_Output) String() string {
 func (*ETHTransferNode_Output) ProtoMessage() {}
 
 func (x *ETHTransferNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[100]
+	mi := &file_avs_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8010,7 +8101,7 @@ type ContractWriteNode_Config struct {
 
 func (x *ContractWriteNode_Config) Reset() {
 	*x = ContractWriteNode_Config{}
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8022,7 +8113,7 @@ func (x *ContractWriteNode_Config) String() string {
 func (*ContractWriteNode_Config) ProtoMessage() {}
 
 func (x *ContractWriteNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[101]
+	mi := &file_avs_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8111,7 +8202,7 @@ type ContractWriteNode_MethodCall struct {
 
 func (x *ContractWriteNode_MethodCall) Reset() {
 	*x = ContractWriteNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8123,7 +8214,7 @@ func (x *ContractWriteNode_MethodCall) String() string {
 func (*ContractWriteNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[102]
+	mi := &file_avs_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8185,7 +8276,7 @@ type ContractWriteNode_Output struct {
 
 func (x *ContractWriteNode_Output) Reset() {
 	*x = ContractWriteNode_Output{}
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8197,7 +8288,7 @@ func (x *ContractWriteNode_Output) String() string {
 func (*ContractWriteNode_Output) ProtoMessage() {}
 
 func (x *ContractWriteNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[103]
+	mi := &file_avs_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8235,7 +8326,7 @@ type ContractWriteNode_MethodResult struct {
 
 func (x *ContractWriteNode_MethodResult) Reset() {
 	*x = ContractWriteNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8247,7 +8338,7 @@ func (x *ContractWriteNode_MethodResult) String() string {
 func (*ContractWriteNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractWriteNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[104]
+	mi := &file_avs_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8324,7 +8415,7 @@ type ContractReadNode_MethodCall struct {
 
 func (x *ContractReadNode_MethodCall) Reset() {
 	*x = ContractReadNode_MethodCall{}
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8336,7 +8427,7 @@ func (x *ContractReadNode_MethodCall) String() string {
 func (*ContractReadNode_MethodCall) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodCall) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[105]
+	mi := &file_avs_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8395,7 +8486,7 @@ type ContractReadNode_Config struct {
 
 func (x *ContractReadNode_Config) Reset() {
 	*x = ContractReadNode_Config{}
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8407,7 +8498,7 @@ func (x *ContractReadNode_Config) String() string {
 func (*ContractReadNode_Config) ProtoMessage() {}
 
 func (x *ContractReadNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[106]
+	mi := &file_avs_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8464,7 +8555,7 @@ type ContractReadNode_MethodResult struct {
 
 func (x *ContractReadNode_MethodResult) Reset() {
 	*x = ContractReadNode_MethodResult{}
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8476,7 +8567,7 @@ func (x *ContractReadNode_MethodResult) String() string {
 func (*ContractReadNode_MethodResult) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[107]
+	mi := &file_avs_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8531,7 +8622,7 @@ type ContractReadNode_Output struct {
 
 func (x *ContractReadNode_Output) Reset() {
 	*x = ContractReadNode_Output{}
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8543,7 +8634,7 @@ func (x *ContractReadNode_Output) String() string {
 func (*ContractReadNode_Output) ProtoMessage() {}
 
 func (x *ContractReadNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[108]
+	mi := &file_avs_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8578,7 +8669,7 @@ type ContractReadNode_MethodResult_StructuredField struct {
 
 func (x *ContractReadNode_MethodResult_StructuredField) Reset() {
 	*x = ContractReadNode_MethodResult_StructuredField{}
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8590,7 +8681,7 @@ func (x *ContractReadNode_MethodResult_StructuredField) String() string {
 func (*ContractReadNode_MethodResult_StructuredField) ProtoMessage() {}
 
 func (x *ContractReadNode_MethodResult_StructuredField) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[109]
+	mi := &file_avs_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8639,7 +8730,7 @@ type GraphQLQueryNode_Config struct {
 
 func (x *GraphQLQueryNode_Config) Reset() {
 	*x = GraphQLQueryNode_Config{}
-	mi := &file_avs_proto_msgTypes[110]
+	mi := &file_avs_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8651,7 +8742,7 @@ func (x *GraphQLQueryNode_Config) String() string {
 func (*GraphQLQueryNode_Config) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[110]
+	mi := &file_avs_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8699,7 +8790,7 @@ type GraphQLQueryNode_Output struct {
 
 func (x *GraphQLQueryNode_Output) Reset() {
 	*x = GraphQLQueryNode_Output{}
-	mi := &file_avs_proto_msgTypes[111]
+	mi := &file_avs_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8711,7 +8802,7 @@ func (x *GraphQLQueryNode_Output) String() string {
 func (*GraphQLQueryNode_Output) ProtoMessage() {}
 
 func (x *GraphQLQueryNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[111]
+	mi := &file_avs_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8748,7 +8839,7 @@ type RestAPINode_Config struct {
 
 func (x *RestAPINode_Config) Reset() {
 	*x = RestAPINode_Config{}
-	mi := &file_avs_proto_msgTypes[113]
+	mi := &file_avs_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8760,7 +8851,7 @@ func (x *RestAPINode_Config) String() string {
 func (*RestAPINode_Config) ProtoMessage() {}
 
 func (x *RestAPINode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[113]
+	mi := &file_avs_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8821,7 +8912,7 @@ type RestAPINode_Output struct {
 
 func (x *RestAPINode_Output) Reset() {
 	*x = RestAPINode_Output{}
-	mi := &file_avs_proto_msgTypes[114]
+	mi := &file_avs_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8833,7 +8924,7 @@ func (x *RestAPINode_Output) String() string {
 func (*RestAPINode_Output) ProtoMessage() {}
 
 func (x *RestAPINode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[114]
+	mi := &file_avs_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8866,7 +8957,7 @@ type CustomCodeNode_Config struct {
 
 func (x *CustomCodeNode_Config) Reset() {
 	*x = CustomCodeNode_Config{}
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8878,7 +8969,7 @@ func (x *CustomCodeNode_Config) String() string {
 func (*CustomCodeNode_Config) ProtoMessage() {}
 
 func (x *CustomCodeNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[116]
+	mi := &file_avs_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8918,7 +9009,7 @@ type CustomCodeNode_Output struct {
 
 func (x *CustomCodeNode_Output) Reset() {
 	*x = CustomCodeNode_Output{}
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8930,7 +9021,7 @@ func (x *CustomCodeNode_Output) String() string {
 func (*CustomCodeNode_Output) ProtoMessage() {}
 
 func (x *CustomCodeNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[117]
+	mi := &file_avs_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8995,7 +9086,7 @@ type BalanceNode_Config struct {
 
 func (x *BalanceNode_Config) Reset() {
 	*x = BalanceNode_Config{}
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9007,7 +9098,7 @@ func (x *BalanceNode_Config) String() string {
 func (*BalanceNode_Config) ProtoMessage() {}
 
 func (x *BalanceNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[118]
+	mi := &file_avs_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9078,7 +9169,7 @@ type BalanceNode_Output struct {
 
 func (x *BalanceNode_Output) Reset() {
 	*x = BalanceNode_Output{}
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9090,7 +9181,7 @@ func (x *BalanceNode_Output) String() string {
 func (*BalanceNode_Output) ProtoMessage() {}
 
 func (x *BalanceNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[119]
+	mi := &file_avs_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9132,7 +9223,7 @@ type AwaitNode_Config struct {
 
 func (x *AwaitNode_Config) Reset() {
 	*x = AwaitNode_Config{}
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9144,7 +9235,7 @@ func (x *AwaitNode_Config) String() string {
 func (*AwaitNode_Config) ProtoMessage() {}
 
 func (x *AwaitNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[120]
+	mi := &file_avs_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9205,7 +9296,7 @@ type AwaitNode_Output struct {
 
 func (x *AwaitNode_Output) Reset() {
 	*x = AwaitNode_Output{}
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9217,7 +9308,7 @@ func (x *AwaitNode_Output) String() string {
 func (*AwaitNode_Output) ProtoMessage() {}
 
 func (x *AwaitNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[121]
+	mi := &file_avs_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9251,7 +9342,7 @@ type BranchNode_Condition struct {
 
 func (x *BranchNode_Condition) Reset() {
 	*x = BranchNode_Condition{}
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9263,7 +9354,7 @@ func (x *BranchNode_Condition) String() string {
 func (*BranchNode_Condition) ProtoMessage() {}
 
 func (x *BranchNode_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[122]
+	mi := &file_avs_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9309,7 +9400,7 @@ type BranchNode_Config struct {
 
 func (x *BranchNode_Config) Reset() {
 	*x = BranchNode_Config{}
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9321,7 +9412,7 @@ func (x *BranchNode_Config) String() string {
 func (*BranchNode_Config) ProtoMessage() {}
 
 func (x *BranchNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[123]
+	mi := &file_avs_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9356,7 +9447,7 @@ type BranchNode_Output struct {
 
 func (x *BranchNode_Output) Reset() {
 	*x = BranchNode_Output{}
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9368,7 +9459,7 @@ func (x *BranchNode_Output) String() string {
 func (*BranchNode_Output) ProtoMessage() {}
 
 func (x *BranchNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[124]
+	mi := &file_avs_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9404,7 +9495,7 @@ type FilterNode_Config struct {
 
 func (x *FilterNode_Config) Reset() {
 	*x = FilterNode_Config{}
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9416,7 +9507,7 @@ func (x *FilterNode_Config) String() string {
 func (*FilterNode_Config) ProtoMessage() {}
 
 func (x *FilterNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[125]
+	mi := &file_avs_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9456,7 +9547,7 @@ type FilterNode_Output struct {
 
 func (x *FilterNode_Output) Reset() {
 	*x = FilterNode_Output{}
-	mi := &file_avs_proto_msgTypes[126]
+	mi := &file_avs_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9468,7 +9559,7 @@ func (x *FilterNode_Output) String() string {
 func (*FilterNode_Output) ProtoMessage() {}
 
 func (x *FilterNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[126]
+	mi := &file_avs_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9512,7 +9603,7 @@ type LoopNode_Config struct {
 
 func (x *LoopNode_Config) Reset() {
 	*x = LoopNode_Config{}
-	mi := &file_avs_proto_msgTypes[127]
+	mi := &file_avs_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9524,7 +9615,7 @@ func (x *LoopNode_Config) String() string {
 func (*LoopNode_Config) ProtoMessage() {}
 
 func (x *LoopNode_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[127]
+	mi := &file_avs_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9584,7 +9675,7 @@ type LoopNode_Output struct {
 
 func (x *LoopNode_Output) Reset() {
 	*x = LoopNode_Output{}
-	mi := &file_avs_proto_msgTypes[128]
+	mi := &file_avs_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9596,7 +9687,7 @@ func (x *LoopNode_Output) String() string {
 func (*LoopNode_Output) ProtoMessage() {}
 
 func (x *LoopNode_Output) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[128]
+	mi := &file_avs_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9671,7 +9762,7 @@ type Execution_Step struct {
 
 func (x *Execution_Step) Reset() {
 	*x = Execution_Step{}
-	mi := &file_avs_proto_msgTypes[129]
+	mi := &file_avs_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9683,7 +9774,7 @@ func (x *Execution_Step) String() string {
 func (*Execution_Step) ProtoMessage() {}
 
 func (x *Execution_Step) ProtoReflect() protoreflect.Message {
-	mi := &file_avs_proto_msgTypes[129]
+	mi := &file_avs_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10321,11 +10412,12 @@ const file_avs_proto_rawDesc = "" +
 	"\bTaskEdge\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06source\x18\x02 \x01(\tR\x06source\x12\x16\n" +
-	"\x06target\x18\x03 \x01(\tR\x06target\"\xe2\x05\n" +
+	"\x06target\x18\x03 \x01(\tR\x06target\"\x9e\x06\n" +
 	"\bTaskNode\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12(\n" +
-	"\x04type\x18\x01 \x01(\x0e2\x14.aggregator.NodeTypeR\x04type\x12@\n" +
+	"\x04type\x18\x01 \x01(\x0e2\x14.aggregator.NodeTypeR\x04type\x12:\n" +
+	"\fretry_policy\x18\x04 \x01(\v2\x17.aggregator.RetryPolicyR\vretryPolicy\x12@\n" +
 	"\feth_transfer\x18\n" +
 	" \x01(\v2\x1b.aggregator.ETHTransferNodeH\x00R\vethTransfer\x12F\n" +
 	"\x0econtract_write\x18\v \x01(\v2\x1d.aggregator.ContractWriteNodeH\x00R\rcontractWrite\x12C\n" +
@@ -10811,7 +10903,14 @@ const file_avs_proto_rawDesc = "" +
 	"\boperator\x18\x02 \x01(\tR\boperator\x12\x14\n" +
 	"\x05value\x18\x03 \x01(\tR\x05value\x12\x1d\n" +
 	"\n" +
-	"field_type\x18\x04 \x01(\tR\tfieldType*\xa8\x01\n" +
+	"field_type\x18\x04 \x01(\tR\tfieldType\"\xbf\x01\n" +
+	"\vRetryPolicy\x12!\n" +
+	"\fmax_attempts\x18\x01 \x01(\rR\vmaxAttempts\x12\x1d\n" +
+	"\n" +
+	"backoff_ms\x18\x02 \x01(\rR\tbackoffMs\x12-\n" +
+	"\x12backoff_multiplier\x18\x03 \x01(\x01R\x11backoffMultiplier\x12$\n" +
+	"\x0emax_backoff_ms\x18\x04 \x01(\rR\fmaxBackoffMs\x12\x19\n" +
+	"\bretry_on\x18\x05 \x03(\tR\aretryOn*\xa8\x01\n" +
 	"\vTriggerType\x12\x1c\n" +
 	"\x18TRIGGER_TYPE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13TRIGGER_TYPE_MANUAL\x10\x01\x12\x1b\n" +
@@ -10922,7 +11021,7 @@ func file_avs_proto_rawDescGZIP() []byte {
 }
 
 var file_avs_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 137)
+var file_avs_proto_msgTypes = make([]protoimpl.MessageInfo, 138)
 var file_avs_proto_goTypes = []any{
 	(TriggerType)(0),                                      // 0: aggregator.TriggerType
 	(NodeType)(0),                                         // 1: aggregator.NodeType
@@ -11018,253 +11117,255 @@ var file_avs_proto_goTypes = []any{
 	(*FeeDiscount)(nil),                                   // 91: aggregator.FeeDiscount
 	(*EstimateFeesResp)(nil),                              // 92: aggregator.EstimateFeesResp
 	(*EventCondition)(nil),                                // 93: aggregator.EventCondition
-	(*FixedTimeTrigger_Config)(nil),                       // 94: aggregator.FixedTimeTrigger.Config
-	(*FixedTimeTrigger_Output)(nil),                       // 95: aggregator.FixedTimeTrigger.Output
-	(*CronTrigger_Config)(nil),                            // 96: aggregator.CronTrigger.Config
-	(*CronTrigger_Output)(nil),                            // 97: aggregator.CronTrigger.Output
-	(*BlockTrigger_Config)(nil),                           // 98: aggregator.BlockTrigger.Config
-	(*BlockTrigger_Output)(nil),                           // 99: aggregator.BlockTrigger.Output
-	(*EventTrigger_Query)(nil),                            // 100: aggregator.EventTrigger.Query
-	(*EventTrigger_MethodCall)(nil),                       // 101: aggregator.EventTrigger.MethodCall
-	(*EventTrigger_Config)(nil),                           // 102: aggregator.EventTrigger.Config
-	(*EventTrigger_Output)(nil),                           // 103: aggregator.EventTrigger.Output
-	(*ManualTrigger_Config)(nil),                          // 104: aggregator.ManualTrigger.Config
-	(*ManualTrigger_Output)(nil),                          // 105: aggregator.ManualTrigger.Output
-	nil,                                                   // 106: aggregator.ManualTrigger.Config.HeadersEntry
-	nil,                                                   // 107: aggregator.ManualTrigger.Config.PathParamsEntry
-	(*ETHTransferNode_Config)(nil),                        // 108: aggregator.ETHTransferNode.Config
-	(*ETHTransferNode_Output)(nil),                        // 109: aggregator.ETHTransferNode.Output
-	(*ContractWriteNode_Config)(nil),                      // 110: aggregator.ContractWriteNode.Config
-	(*ContractWriteNode_MethodCall)(nil),                  // 111: aggregator.ContractWriteNode.MethodCall
-	(*ContractWriteNode_Output)(nil),                      // 112: aggregator.ContractWriteNode.Output
-	(*ContractWriteNode_MethodResult)(nil),                // 113: aggregator.ContractWriteNode.MethodResult
-	(*ContractReadNode_MethodCall)(nil),                   // 114: aggregator.ContractReadNode.MethodCall
-	(*ContractReadNode_Config)(nil),                       // 115: aggregator.ContractReadNode.Config
-	(*ContractReadNode_MethodResult)(nil),                 // 116: aggregator.ContractReadNode.MethodResult
-	(*ContractReadNode_Output)(nil),                       // 117: aggregator.ContractReadNode.Output
-	(*ContractReadNode_MethodResult_StructuredField)(nil), // 118: aggregator.ContractReadNode.MethodResult.StructuredField
-	(*GraphQLQueryNode_Config)(nil),                       // 119: aggregator.GraphQLQueryNode.Config
-	(*GraphQLQueryNode_Output)(nil),                       // 120: aggregator.GraphQLQueryNode.Output
-	nil,                                                   // 121: aggregator.GraphQLQueryNode.Config.VariablesEntry
-	(*RestAPINode_Config)(nil),                            // 122: aggregator.RestAPINode.Config
-	(*RestAPINode_Output)(nil),                            // 123: aggregator.RestAPINode.Output
-	nil,                                                   // 124: aggregator.RestAPINode.Config.HeadersEntry
-	(*CustomCodeNode_Config)(nil),                         // 125: aggregator.CustomCodeNode.Config
-	(*CustomCodeNode_Output)(nil),                         // 126: aggregator.CustomCodeNode.Output
-	(*BalanceNode_Config)(nil),                            // 127: aggregator.BalanceNode.Config
-	(*BalanceNode_Output)(nil),                            // 128: aggregator.BalanceNode.Output
-	(*AwaitNode_Config)(nil),                              // 129: aggregator.AwaitNode.Config
-	(*AwaitNode_Output)(nil),                              // 130: aggregator.AwaitNode.Output
-	(*BranchNode_Condition)(nil),                          // 131: aggregator.BranchNode.Condition
-	(*BranchNode_Config)(nil),                             // 132: aggregator.BranchNode.Config
-	(*BranchNode_Output)(nil),                             // 133: aggregator.BranchNode.Output
-	(*FilterNode_Config)(nil),                             // 134: aggregator.FilterNode.Config
-	(*FilterNode_Output)(nil),                             // 135: aggregator.FilterNode.Output
-	(*LoopNode_Config)(nil),                               // 136: aggregator.LoopNode.Config
-	(*LoopNode_Output)(nil),                               // 137: aggregator.LoopNode.Output
-	(*Execution_Step)(nil),                                // 138: aggregator.Execution.Step
-	nil,                                                   // 139: aggregator.Task.InputVariablesEntry
-	nil,                                                   // 140: aggregator.CreateTaskReq.InputVariablesEntry
-	nil,                                                   // 141: aggregator.TriggerTaskReq.TriggerInputEntry
-	nil,                                                   // 142: aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	nil,                                                   // 143: aggregator.RunTriggerReq.TriggerInputEntry
-	nil,                                                   // 144: aggregator.SimulateTaskReq.InputVariablesEntry
-	nil,                                                   // 145: aggregator.EstimateFeesReq.InputVariablesEntry
-	(*structpb.Value)(nil),                                // 146: google.protobuf.Value
+	(*RetryPolicy)(nil),                                   // 94: aggregator.RetryPolicy
+	(*FixedTimeTrigger_Config)(nil),                       // 95: aggregator.FixedTimeTrigger.Config
+	(*FixedTimeTrigger_Output)(nil),                       // 96: aggregator.FixedTimeTrigger.Output
+	(*CronTrigger_Config)(nil),                            // 97: aggregator.CronTrigger.Config
+	(*CronTrigger_Output)(nil),                            // 98: aggregator.CronTrigger.Output
+	(*BlockTrigger_Config)(nil),                           // 99: aggregator.BlockTrigger.Config
+	(*BlockTrigger_Output)(nil),                           // 100: aggregator.BlockTrigger.Output
+	(*EventTrigger_Query)(nil),                            // 101: aggregator.EventTrigger.Query
+	(*EventTrigger_MethodCall)(nil),                       // 102: aggregator.EventTrigger.MethodCall
+	(*EventTrigger_Config)(nil),                           // 103: aggregator.EventTrigger.Config
+	(*EventTrigger_Output)(nil),                           // 104: aggregator.EventTrigger.Output
+	(*ManualTrigger_Config)(nil),                          // 105: aggregator.ManualTrigger.Config
+	(*ManualTrigger_Output)(nil),                          // 106: aggregator.ManualTrigger.Output
+	nil,                                                   // 107: aggregator.ManualTrigger.Config.HeadersEntry
+	nil,                                                   // 108: aggregator.ManualTrigger.Config.PathParamsEntry
+	(*ETHTransferNode_Config)(nil),                        // 109: aggregator.ETHTransferNode.Config
+	(*ETHTransferNode_Output)(nil),                        // 110: aggregator.ETHTransferNode.Output
+	(*ContractWriteNode_Config)(nil),                      // 111: aggregator.ContractWriteNode.Config
+	(*ContractWriteNode_MethodCall)(nil),                  // 112: aggregator.ContractWriteNode.MethodCall
+	(*ContractWriteNode_Output)(nil),                      // 113: aggregator.ContractWriteNode.Output
+	(*ContractWriteNode_MethodResult)(nil),                // 114: aggregator.ContractWriteNode.MethodResult
+	(*ContractReadNode_MethodCall)(nil),                   // 115: aggregator.ContractReadNode.MethodCall
+	(*ContractReadNode_Config)(nil),                       // 116: aggregator.ContractReadNode.Config
+	(*ContractReadNode_MethodResult)(nil),                 // 117: aggregator.ContractReadNode.MethodResult
+	(*ContractReadNode_Output)(nil),                       // 118: aggregator.ContractReadNode.Output
+	(*ContractReadNode_MethodResult_StructuredField)(nil), // 119: aggregator.ContractReadNode.MethodResult.StructuredField
+	(*GraphQLQueryNode_Config)(nil),                       // 120: aggregator.GraphQLQueryNode.Config
+	(*GraphQLQueryNode_Output)(nil),                       // 121: aggregator.GraphQLQueryNode.Output
+	nil,                                                   // 122: aggregator.GraphQLQueryNode.Config.VariablesEntry
+	(*RestAPINode_Config)(nil),                            // 123: aggregator.RestAPINode.Config
+	(*RestAPINode_Output)(nil),                            // 124: aggregator.RestAPINode.Output
+	nil,                                                   // 125: aggregator.RestAPINode.Config.HeadersEntry
+	(*CustomCodeNode_Config)(nil),                         // 126: aggregator.CustomCodeNode.Config
+	(*CustomCodeNode_Output)(nil),                         // 127: aggregator.CustomCodeNode.Output
+	(*BalanceNode_Config)(nil),                            // 128: aggregator.BalanceNode.Config
+	(*BalanceNode_Output)(nil),                            // 129: aggregator.BalanceNode.Output
+	(*AwaitNode_Config)(nil),                              // 130: aggregator.AwaitNode.Config
+	(*AwaitNode_Output)(nil),                              // 131: aggregator.AwaitNode.Output
+	(*BranchNode_Condition)(nil),                          // 132: aggregator.BranchNode.Condition
+	(*BranchNode_Config)(nil),                             // 133: aggregator.BranchNode.Config
+	(*BranchNode_Output)(nil),                             // 134: aggregator.BranchNode.Output
+	(*FilterNode_Config)(nil),                             // 135: aggregator.FilterNode.Config
+	(*FilterNode_Output)(nil),                             // 136: aggregator.FilterNode.Output
+	(*LoopNode_Config)(nil),                               // 137: aggregator.LoopNode.Config
+	(*LoopNode_Output)(nil),                               // 138: aggregator.LoopNode.Output
+	(*Execution_Step)(nil),                                // 139: aggregator.Execution.Step
+	nil,                                                   // 140: aggregator.Task.InputVariablesEntry
+	nil,                                                   // 141: aggregator.CreateTaskReq.InputVariablesEntry
+	nil,                                                   // 142: aggregator.TriggerTaskReq.TriggerInputEntry
+	nil,                                                   // 143: aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	nil,                                                   // 144: aggregator.RunTriggerReq.TriggerInputEntry
+	nil,                                                   // 145: aggregator.SimulateTaskReq.InputVariablesEntry
+	nil,                                                   // 146: aggregator.EstimateFeesReq.InputVariablesEntry
+	(*structpb.Value)(nil),                                // 147: google.protobuf.Value
 }
 var file_avs_proto_depIdxs = []int32{
 	9,   // 0: aggregator.GetTokenMetadataResp.token:type_name -> aggregator.TokenMetadata
-	94,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
-	96,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
-	98,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
-	102, // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
-	104, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
+	95,  // 1: aggregator.FixedTimeTrigger.config:type_name -> aggregator.FixedTimeTrigger.Config
+	97,  // 2: aggregator.CronTrigger.config:type_name -> aggregator.CronTrigger.Config
+	99,  // 3: aggregator.BlockTrigger.config:type_name -> aggregator.BlockTrigger.Config
+	103, // 4: aggregator.EventTrigger.config:type_name -> aggregator.EventTrigger.Config
+	105, // 5: aggregator.ManualTrigger.config:type_name -> aggregator.ManualTrigger.Config
 	0,   // 6: aggregator.TaskTrigger.type:type_name -> aggregator.TriggerType
 	17,  // 7: aggregator.TaskTrigger.manual:type_name -> aggregator.ManualTrigger
 	13,  // 8: aggregator.TaskTrigger.fixed_time:type_name -> aggregator.FixedTimeTrigger
 	14,  // 9: aggregator.TaskTrigger.cron:type_name -> aggregator.CronTrigger
 	15,  // 10: aggregator.TaskTrigger.block:type_name -> aggregator.BlockTrigger
 	16,  // 11: aggregator.TaskTrigger.event:type_name -> aggregator.EventTrigger
-	108, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
-	110, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
-	115, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
-	119, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
-	122, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
-	125, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
-	127, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
-	129, // 19: aggregator.AwaitNode.config:type_name -> aggregator.AwaitNode.Config
-	132, // 20: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
-	134, // 21: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
+	109, // 12: aggregator.ETHTransferNode.config:type_name -> aggregator.ETHTransferNode.Config
+	111, // 13: aggregator.ContractWriteNode.config:type_name -> aggregator.ContractWriteNode.Config
+	116, // 14: aggregator.ContractReadNode.config:type_name -> aggregator.ContractReadNode.Config
+	120, // 15: aggregator.GraphQLQueryNode.config:type_name -> aggregator.GraphQLQueryNode.Config
+	123, // 16: aggregator.RestAPINode.config:type_name -> aggregator.RestAPINode.Config
+	126, // 17: aggregator.CustomCodeNode.config:type_name -> aggregator.CustomCodeNode.Config
+	128, // 18: aggregator.BalanceNode.config:type_name -> aggregator.BalanceNode.Config
+	130, // 19: aggregator.AwaitNode.config:type_name -> aggregator.AwaitNode.Config
+	133, // 20: aggregator.BranchNode.config:type_name -> aggregator.BranchNode.Config
+	135, // 21: aggregator.FilterNode.config:type_name -> aggregator.FilterNode.Config
 	19,  // 22: aggregator.LoopNode.eth_transfer:type_name -> aggregator.ETHTransferNode
 	20,  // 23: aggregator.LoopNode.contract_write:type_name -> aggregator.ContractWriteNode
 	21,  // 24: aggregator.LoopNode.contract_read:type_name -> aggregator.ContractReadNode
 	22,  // 25: aggregator.LoopNode.graphql_data_query:type_name -> aggregator.GraphQLQueryNode
 	23,  // 26: aggregator.LoopNode.rest_api:type_name -> aggregator.RestAPINode
 	24,  // 27: aggregator.LoopNode.custom_code:type_name -> aggregator.CustomCodeNode
-	136, // 28: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
+	137, // 28: aggregator.LoopNode.config:type_name -> aggregator.LoopNode.Config
 	1,   // 29: aggregator.TaskNode.type:type_name -> aggregator.NodeType
-	19,  // 30: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
-	20,  // 31: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
-	21,  // 32: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
-	22,  // 33: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
-	23,  // 34: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
-	27,  // 35: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
-	28,  // 36: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
-	29,  // 37: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
-	24,  // 38: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
-	25,  // 39: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
-	26,  // 40: aggregator.TaskNode.await:type_name -> aggregator.AwaitNode
-	8,   // 41: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
-	87,  // 42: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
-	89,  // 43: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
-	90,  // 44: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
-	138, // 45: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
-	6,   // 46: aggregator.Task.status:type_name -> aggregator.TaskStatus
-	18,  // 47: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
-	31,  // 48: aggregator.Task.nodes:type_name -> aggregator.TaskNode
-	30,  // 49: aggregator.Task.edges:type_name -> aggregator.TaskEdge
-	139, // 50: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
-	7,   // 51: aggregator.Task.completion_reason:type_name -> aggregator.TaskCompletionReason
-	18,  // 52: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	31,  // 53: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
-	30,  // 54: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
-	140, // 55: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
-	39,  // 56: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
-	33,  // 57: aggregator.ListTasksResp.items:type_name -> aggregator.Task
-	58,  // 58: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
-	32,  // 59: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
-	58,  // 60: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
-	8,   // 61: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
-	0,   // 62: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
-	99,  // 63: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	95,  // 64: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	97,  // 65: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	103, // 66: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
-	105, // 67: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	141, // 68: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
-	8,   // 69: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
-	138, // 70: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
-	59,  // 71: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
-	58,  // 72: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
-	31,  // 73: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
-	142, // 74: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
-	77,  // 75: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
-	146, // 76: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
-	146, // 77: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 78: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
-	109, // 79: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	120, // 80: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	117, // 81: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
-	112, // 82: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	126, // 83: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	123, // 84: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
-	133, // 85: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
-	135, // 86: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
-	137, // 87: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
-	128, // 88: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
-	18,  // 89: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
-	143, // 90: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
-	146, // 91: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
-	146, // 92: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
-	5,   // 93: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
-	99,  // 94: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	95,  // 95: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	97,  // 96: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	103, // 97: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
-	105, // 98: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	18,  // 99: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
-	31,  // 100: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
-	30,  // 101: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
-	144, // 102: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
-	18,  // 103: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
-	31,  // 104: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
-	30,  // 105: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
-	145, // 106: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
-	83,  // 107: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
-	85,  // 108: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
-	83,  // 109: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
-	83,  // 110: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
-	83,  // 111: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
-	87,  // 112: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
-	87,  // 113: aggregator.ValueFee.fee:type_name -> aggregator.Fee
-	2,   // 114: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
-	87,  // 115: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
-	5,   // 116: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
-	88,  // 117: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
-	87,  // 118: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
-	89,  // 119: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
-	90,  // 120: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
-	91,  // 121: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
-	146, // 122: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
-	146, // 123: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
-	146, // 124: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
-	146, // 125: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
-	93,  // 126: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
-	101, // 127: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
-	100, // 128: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
-	146, // 129: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
-	146, // 130: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
-	106, // 131: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
-	107, // 132: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
-	4,   // 133: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
-	146, // 134: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
-	146, // 135: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
-	146, // 136: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
-	111, // 137: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
-	146, // 138: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
-	146, // 139: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
-	146, // 140: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
-	146, // 141: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
-	146, // 142: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
-	114, // 143: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
-	118, // 144: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
-	146, // 145: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
-	121, // 146: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
-	146, // 147: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
-	124, // 148: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
-	146, // 149: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
-	146, // 150: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
-	4,   // 151: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
-	146, // 152: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
-	146, // 153: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
-	102, // 154: aggregator.AwaitNode.Config.chain_event:type_name -> aggregator.EventTrigger.Config
-	146, // 155: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
-	131, // 156: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
-	146, // 157: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
-	146, // 158: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
-	3,   // 159: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
-	146, // 160: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
-	5,   // 161: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
-	146, // 162: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
-	146, // 163: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
-	146, // 164: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
-	99,  // 165: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
-	95,  // 166: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
-	97,  // 167: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
-	103, // 168: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
-	105, // 169: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
-	109, // 170: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
-	120, // 171: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
-	117, // 172: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
-	112, // 173: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
-	126, // 174: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
-	123, // 175: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
-	133, // 176: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
-	135, // 177: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
-	137, // 178: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
-	128, // 179: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
-	146, // 180: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	146, // 181: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	146, // 182: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	146, // 183: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	146, // 184: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
-	146, // 185: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	146, // 186: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
-	187, // [187:187] is the sub-list for method output_type
-	187, // [187:187] is the sub-list for method input_type
-	187, // [187:187] is the sub-list for extension type_name
-	187, // [187:187] is the sub-list for extension extendee
-	0,   // [0:187] is the sub-list for field type_name
+	94,  // 30: aggregator.TaskNode.retry_policy:type_name -> aggregator.RetryPolicy
+	19,  // 31: aggregator.TaskNode.eth_transfer:type_name -> aggregator.ETHTransferNode
+	20,  // 32: aggregator.TaskNode.contract_write:type_name -> aggregator.ContractWriteNode
+	21,  // 33: aggregator.TaskNode.contract_read:type_name -> aggregator.ContractReadNode
+	22,  // 34: aggregator.TaskNode.graphql_query:type_name -> aggregator.GraphQLQueryNode
+	23,  // 35: aggregator.TaskNode.rest_api:type_name -> aggregator.RestAPINode
+	27,  // 36: aggregator.TaskNode.branch:type_name -> aggregator.BranchNode
+	28,  // 37: aggregator.TaskNode.filter:type_name -> aggregator.FilterNode
+	29,  // 38: aggregator.TaskNode.loop:type_name -> aggregator.LoopNode
+	24,  // 39: aggregator.TaskNode.custom_code:type_name -> aggregator.CustomCodeNode
+	25,  // 40: aggregator.TaskNode.balance:type_name -> aggregator.BalanceNode
+	26,  // 41: aggregator.TaskNode.await:type_name -> aggregator.AwaitNode
+	8,   // 42: aggregator.Execution.status:type_name -> aggregator.ExecutionStatus
+	87,  // 43: aggregator.Execution.execution_fee:type_name -> aggregator.Fee
+	89,  // 44: aggregator.Execution.cogs:type_name -> aggregator.NodeCOGS
+	90,  // 45: aggregator.Execution.value_fee:type_name -> aggregator.ValueFee
+	139, // 46: aggregator.Execution.steps:type_name -> aggregator.Execution.Step
+	6,   // 47: aggregator.Task.status:type_name -> aggregator.TaskStatus
+	18,  // 48: aggregator.Task.trigger:type_name -> aggregator.TaskTrigger
+	31,  // 49: aggregator.Task.nodes:type_name -> aggregator.TaskNode
+	30,  // 50: aggregator.Task.edges:type_name -> aggregator.TaskEdge
+	140, // 51: aggregator.Task.input_variables:type_name -> aggregator.Task.InputVariablesEntry
+	7,   // 52: aggregator.Task.completion_reason:type_name -> aggregator.TaskCompletionReason
+	18,  // 53: aggregator.CreateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	31,  // 54: aggregator.CreateTaskReq.nodes:type_name -> aggregator.TaskNode
+	30,  // 55: aggregator.CreateTaskReq.edges:type_name -> aggregator.TaskEdge
+	141, // 56: aggregator.CreateTaskReq.input_variables:type_name -> aggregator.CreateTaskReq.InputVariablesEntry
+	39,  // 57: aggregator.ListWalletResp.items:type_name -> aggregator.SmartWallet
+	33,  // 58: aggregator.ListTasksResp.items:type_name -> aggregator.Task
+	58,  // 59: aggregator.ListTasksResp.page_info:type_name -> aggregator.PageInfo
+	32,  // 60: aggregator.ListExecutionsResp.items:type_name -> aggregator.Execution
+	58,  // 61: aggregator.ListExecutionsResp.page_info:type_name -> aggregator.PageInfo
+	8,   // 62: aggregator.ExecutionStatusResp.status:type_name -> aggregator.ExecutionStatus
+	0,   // 63: aggregator.TriggerTaskReq.trigger_type:type_name -> aggregator.TriggerType
+	100, // 64: aggregator.TriggerTaskReq.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	96,  // 65: aggregator.TriggerTaskReq.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	98,  // 66: aggregator.TriggerTaskReq.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	104, // 67: aggregator.TriggerTaskReq.event_trigger:type_name -> aggregator.EventTrigger.Output
+	106, // 68: aggregator.TriggerTaskReq.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	142, // 69: aggregator.TriggerTaskReq.trigger_input:type_name -> aggregator.TriggerTaskReq.TriggerInputEntry
+	8,   // 70: aggregator.TriggerTaskResp.status:type_name -> aggregator.ExecutionStatus
+	139, // 71: aggregator.TriggerTaskResp.steps:type_name -> aggregator.Execution.Step
+	59,  // 72: aggregator.ListSecretsResp.items:type_name -> aggregator.Secret
+	58,  // 73: aggregator.ListSecretsResp.page_info:type_name -> aggregator.PageInfo
+	31,  // 74: aggregator.RunNodeWithInputsReq.node:type_name -> aggregator.TaskNode
+	143, // 75: aggregator.RunNodeWithInputsReq.input_variables:type_name -> aggregator.RunNodeWithInputsReq.InputVariablesEntry
+	77,  // 76: aggregator.RunNodeWithInputsReq.erc20_overrides:type_name -> aggregator.ERC20StateOverride
+	147, // 77: aggregator.RunNodeWithInputsResp.metadata:type_name -> google.protobuf.Value
+	147, // 78: aggregator.RunNodeWithInputsResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 79: aggregator.RunNodeWithInputsResp.error_code:type_name -> aggregator.ErrorCode
+	110, // 80: aggregator.RunNodeWithInputsResp.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	121, // 81: aggregator.RunNodeWithInputsResp.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	118, // 82: aggregator.RunNodeWithInputsResp.contract_read:type_name -> aggregator.ContractReadNode.Output
+	113, // 83: aggregator.RunNodeWithInputsResp.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	127, // 84: aggregator.RunNodeWithInputsResp.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	124, // 85: aggregator.RunNodeWithInputsResp.rest_api:type_name -> aggregator.RestAPINode.Output
+	134, // 86: aggregator.RunNodeWithInputsResp.branch:type_name -> aggregator.BranchNode.Output
+	136, // 87: aggregator.RunNodeWithInputsResp.filter:type_name -> aggregator.FilterNode.Output
+	138, // 88: aggregator.RunNodeWithInputsResp.loop:type_name -> aggregator.LoopNode.Output
+	129, // 89: aggregator.RunNodeWithInputsResp.balance:type_name -> aggregator.BalanceNode.Output
+	18,  // 90: aggregator.RunTriggerReq.trigger:type_name -> aggregator.TaskTrigger
+	144, // 91: aggregator.RunTriggerReq.trigger_input:type_name -> aggregator.RunTriggerReq.TriggerInputEntry
+	147, // 92: aggregator.RunTriggerResp.metadata:type_name -> google.protobuf.Value
+	147, // 93: aggregator.RunTriggerResp.execution_context:type_name -> google.protobuf.Value
+	5,   // 94: aggregator.RunTriggerResp.error_code:type_name -> aggregator.ErrorCode
+	100, // 95: aggregator.RunTriggerResp.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	96,  // 96: aggregator.RunTriggerResp.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	98,  // 97: aggregator.RunTriggerResp.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	104, // 98: aggregator.RunTriggerResp.event_trigger:type_name -> aggregator.EventTrigger.Output
+	106, // 99: aggregator.RunTriggerResp.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	18,  // 100: aggregator.SimulateTaskReq.trigger:type_name -> aggregator.TaskTrigger
+	31,  // 101: aggregator.SimulateTaskReq.nodes:type_name -> aggregator.TaskNode
+	30,  // 102: aggregator.SimulateTaskReq.edges:type_name -> aggregator.TaskEdge
+	145, // 103: aggregator.SimulateTaskReq.input_variables:type_name -> aggregator.SimulateTaskReq.InputVariablesEntry
+	18,  // 104: aggregator.EstimateFeesReq.trigger:type_name -> aggregator.TaskTrigger
+	31,  // 105: aggregator.EstimateFeesReq.nodes:type_name -> aggregator.TaskNode
+	30,  // 106: aggregator.EstimateFeesReq.edges:type_name -> aggregator.TaskEdge
+	146, // 107: aggregator.EstimateFeesReq.input_variables:type_name -> aggregator.EstimateFeesReq.InputVariablesEntry
+	83,  // 108: aggregator.GasFeeBreakdown.total_gas_fees:type_name -> aggregator.FeeAmount
+	85,  // 109: aggregator.GasFeeBreakdown.operations:type_name -> aggregator.GasOperationFee
+	83,  // 110: aggregator.GasOperationFee.fee:type_name -> aggregator.FeeAmount
+	83,  // 111: aggregator.SmartWalletCreationFee.creation_fee:type_name -> aggregator.FeeAmount
+	83,  // 112: aggregator.SmartWalletCreationFee.initial_funding:type_name -> aggregator.FeeAmount
+	87,  // 113: aggregator.NodeCOGS.fee:type_name -> aggregator.Fee
+	87,  // 114: aggregator.ValueFee.fee:type_name -> aggregator.Fee
+	2,   // 115: aggregator.ValueFee.tier:type_name -> aggregator.ExecutionTier
+	87,  // 116: aggregator.FeeDiscount.discount:type_name -> aggregator.Fee
+	5,   // 117: aggregator.EstimateFeesResp.error_code:type_name -> aggregator.ErrorCode
+	88,  // 118: aggregator.EstimateFeesResp.native_token:type_name -> aggregator.NativeToken
+	87,  // 119: aggregator.EstimateFeesResp.execution_fee:type_name -> aggregator.Fee
+	89,  // 120: aggregator.EstimateFeesResp.cogs:type_name -> aggregator.NodeCOGS
+	90,  // 121: aggregator.EstimateFeesResp.value_fee:type_name -> aggregator.ValueFee
+	91,  // 122: aggregator.EstimateFeesResp.discounts:type_name -> aggregator.FeeDiscount
+	147, // 123: aggregator.FixedTimeTrigger.Output.data:type_name -> google.protobuf.Value
+	147, // 124: aggregator.CronTrigger.Output.data:type_name -> google.protobuf.Value
+	147, // 125: aggregator.BlockTrigger.Output.data:type_name -> google.protobuf.Value
+	147, // 126: aggregator.EventTrigger.Query.contract_abi:type_name -> google.protobuf.Value
+	93,  // 127: aggregator.EventTrigger.Query.conditions:type_name -> aggregator.EventCondition
+	102, // 128: aggregator.EventTrigger.Query.method_calls:type_name -> aggregator.EventTrigger.MethodCall
+	101, // 129: aggregator.EventTrigger.Config.queries:type_name -> aggregator.EventTrigger.Query
+	147, // 130: aggregator.EventTrigger.Output.data:type_name -> google.protobuf.Value
+	147, // 131: aggregator.ManualTrigger.Config.data:type_name -> google.protobuf.Value
+	107, // 132: aggregator.ManualTrigger.Config.headers:type_name -> aggregator.ManualTrigger.Config.HeadersEntry
+	108, // 133: aggregator.ManualTrigger.Config.pathParams:type_name -> aggregator.ManualTrigger.Config.PathParamsEntry
+	4,   // 134: aggregator.ManualTrigger.Config.lang:type_name -> aggregator.Lang
+	147, // 135: aggregator.ManualTrigger.Output.data:type_name -> google.protobuf.Value
+	147, // 136: aggregator.ETHTransferNode.Output.data:type_name -> google.protobuf.Value
+	147, // 137: aggregator.ContractWriteNode.Config.contract_abi:type_name -> google.protobuf.Value
+	112, // 138: aggregator.ContractWriteNode.Config.method_calls:type_name -> aggregator.ContractWriteNode.MethodCall
+	147, // 139: aggregator.ContractWriteNode.Output.data:type_name -> google.protobuf.Value
+	147, // 140: aggregator.ContractWriteNode.MethodResult.method_abi:type_name -> google.protobuf.Value
+	147, // 141: aggregator.ContractWriteNode.MethodResult.receipt:type_name -> google.protobuf.Value
+	147, // 142: aggregator.ContractWriteNode.MethodResult.value:type_name -> google.protobuf.Value
+	147, // 143: aggregator.ContractReadNode.Config.contract_abi:type_name -> google.protobuf.Value
+	115, // 144: aggregator.ContractReadNode.Config.method_calls:type_name -> aggregator.ContractReadNode.MethodCall
+	119, // 145: aggregator.ContractReadNode.MethodResult.data:type_name -> aggregator.ContractReadNode.MethodResult.StructuredField
+	147, // 146: aggregator.ContractReadNode.Output.data:type_name -> google.protobuf.Value
+	122, // 147: aggregator.GraphQLQueryNode.Config.variables:type_name -> aggregator.GraphQLQueryNode.Config.VariablesEntry
+	147, // 148: aggregator.GraphQLQueryNode.Output.data:type_name -> google.protobuf.Value
+	125, // 149: aggregator.RestAPINode.Config.headers:type_name -> aggregator.RestAPINode.Config.HeadersEntry
+	147, // 150: aggregator.RestAPINode.Config.options:type_name -> google.protobuf.Value
+	147, // 151: aggregator.RestAPINode.Output.data:type_name -> google.protobuf.Value
+	4,   // 152: aggregator.CustomCodeNode.Config.lang:type_name -> aggregator.Lang
+	147, // 153: aggregator.CustomCodeNode.Output.data:type_name -> google.protobuf.Value
+	147, // 154: aggregator.BalanceNode.Output.data:type_name -> google.protobuf.Value
+	103, // 155: aggregator.AwaitNode.Config.chain_event:type_name -> aggregator.EventTrigger.Config
+	147, // 156: aggregator.AwaitNode.Output.data:type_name -> google.protobuf.Value
+	132, // 157: aggregator.BranchNode.Config.conditions:type_name -> aggregator.BranchNode.Condition
+	147, // 158: aggregator.BranchNode.Output.data:type_name -> google.protobuf.Value
+	147, // 159: aggregator.FilterNode.Output.data:type_name -> google.protobuf.Value
+	3,   // 160: aggregator.LoopNode.Config.execution_mode:type_name -> aggregator.ExecutionMode
+	147, // 161: aggregator.LoopNode.Output.data:type_name -> google.protobuf.Value
+	5,   // 162: aggregator.Execution.Step.error_code:type_name -> aggregator.ErrorCode
+	147, // 163: aggregator.Execution.Step.config:type_name -> google.protobuf.Value
+	147, // 164: aggregator.Execution.Step.metadata:type_name -> google.protobuf.Value
+	147, // 165: aggregator.Execution.Step.execution_context:type_name -> google.protobuf.Value
+	100, // 166: aggregator.Execution.Step.block_trigger:type_name -> aggregator.BlockTrigger.Output
+	96,  // 167: aggregator.Execution.Step.fixed_time_trigger:type_name -> aggregator.FixedTimeTrigger.Output
+	98,  // 168: aggregator.Execution.Step.cron_trigger:type_name -> aggregator.CronTrigger.Output
+	104, // 169: aggregator.Execution.Step.event_trigger:type_name -> aggregator.EventTrigger.Output
+	106, // 170: aggregator.Execution.Step.manual_trigger:type_name -> aggregator.ManualTrigger.Output
+	110, // 171: aggregator.Execution.Step.eth_transfer:type_name -> aggregator.ETHTransferNode.Output
+	121, // 172: aggregator.Execution.Step.graphql:type_name -> aggregator.GraphQLQueryNode.Output
+	118, // 173: aggregator.Execution.Step.contract_read:type_name -> aggregator.ContractReadNode.Output
+	113, // 174: aggregator.Execution.Step.contract_write:type_name -> aggregator.ContractWriteNode.Output
+	127, // 175: aggregator.Execution.Step.custom_code:type_name -> aggregator.CustomCodeNode.Output
+	124, // 176: aggregator.Execution.Step.rest_api:type_name -> aggregator.RestAPINode.Output
+	134, // 177: aggregator.Execution.Step.branch:type_name -> aggregator.BranchNode.Output
+	136, // 178: aggregator.Execution.Step.filter:type_name -> aggregator.FilterNode.Output
+	138, // 179: aggregator.Execution.Step.loop:type_name -> aggregator.LoopNode.Output
+	129, // 180: aggregator.Execution.Step.balance:type_name -> aggregator.BalanceNode.Output
+	147, // 181: aggregator.Task.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	147, // 182: aggregator.CreateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	147, // 183: aggregator.TriggerTaskReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	147, // 184: aggregator.RunNodeWithInputsReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	147, // 185: aggregator.RunTriggerReq.TriggerInputEntry.value:type_name -> google.protobuf.Value
+	147, // 186: aggregator.SimulateTaskReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	147, // 187: aggregator.EstimateFeesReq.InputVariablesEntry.value:type_name -> google.protobuf.Value
+	188, // [188:188] is the sub-list for method output_type
+	188, // [188:188] is the sub-list for method input_type
+	188, // [188:188] is the sub-list for extension type_name
+	188, // [188:188] is the sub-list for extension extendee
+	0,   // [0:188] is the sub-list for field type_name
 }
 
 func init() { file_avs_proto_init() }
@@ -11328,15 +11429,15 @@ func file_avs_proto_init() {
 		(*RunTriggerResp_EventTrigger)(nil),
 		(*RunTriggerResp_ManualTrigger)(nil),
 	}
-	file_avs_proto_msgTypes[91].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[92].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[93].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[101].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[94].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[102].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[104].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[103].OneofWrappers = []any{}
 	file_avs_proto_msgTypes[105].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[113].OneofWrappers = []any{}
-	file_avs_proto_msgTypes[129].OneofWrappers = []any{
+	file_avs_proto_msgTypes[106].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[114].OneofWrappers = []any{}
+	file_avs_proto_msgTypes[130].OneofWrappers = []any{
 		(*Execution_Step_BlockTrigger)(nil),
 		(*Execution_Step_FixedTimeTrigger)(nil),
 		(*Execution_Step_CronTrigger)(nil),
@@ -11359,7 +11460,7 @@ func file_avs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_avs_proto_rawDesc), len(file_avs_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   137,
+			NumMessages:   138,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -738,7 +738,9 @@ message TaskNode {
   NodeType type = 1;
 
   // Optional per-node retry policy for transient failures. Additive (field 4);
-  // absent = single attempt. Honored only for the read/off-chain node allowlist.
+  // absent = single attempt. Honored only for the read/off-chain node allowlist
+  // (see RetryPolicy); setting it on any other node type is rejected at task
+  // creation rather than silently ignored.
   RetryPolicy retry_policy = 4;
 
   // based on node_type one and only one of these field are set
@@ -1554,13 +1556,35 @@ message EventCondition {
 
 // RetryPolicy configures automatic retries for transient node failures (RPC
 // blips, HTTP 429/5xx, timeouts). It is opt-in and additive: an absent policy
-// means a single attempt, i.e. today's behavior. The policy is honored only for
-// an allowlist of idempotent read/off-chain nodes (REST, GraphQL, ContractRead,
-// Balance); it is ignored on control-flow, stateful, and on-chain write nodes.
+// means a single attempt, i.e. today's behavior.
+//
+// Honored only for an allowlist of idempotent read/off-chain nodes: REST,
+// GraphQL, ContractRead, Balance, and a Loop whose runner is one of REST,
+// GraphQL, or ContractRead — there each iteration is retried under the policy.
+// On-chain write nodes (ContractWrite, EthTransfer) are excluded, because
+// re-invoking one could resubmit a UserOp, and so is a Loop over them. Setting a
+// policy on a node that cannot honor it is rejected at task creation rather than
+// silently ignored.
+//
+// Every field is bounded; an over-limit policy is rejected at task creation
+// rather than clamped, so a stored task always means what it says. Retries also
+// draw on a per-execution delay budget shared by every node, which bounds the
+// loop fan-out case a per-node limit cannot see.
 message RetryPolicy {
-  uint32 max_attempts = 1;        // total attempts including the first (default 1 = no retry)
-  uint32 backoff_ms = 2;          // initial backoff before the second attempt
-  double backoff_multiplier = 3;  // exponential factor applied each attempt (default 2.0)
-  uint32 max_backoff_ms = 4;      // upper bound on any single backoff
-  repeated string retry_on = 5;   // retryable error classes, e.g. ["timeout","http_5xx","http_429","rpc_error"]
+  // Total attempts including the first. 0 and 1 both mean no retry. Maximum 5.
+  uint32 max_attempts = 1;
+  // Initial backoff before the second attempt. Defaults to 1000ms whenever
+  // max_attempts > 1 — 0 would retry with no delay at all. Maximum 30000ms.
+  uint32 backoff_ms = 2;
+  // Exponential factor applied to the backoff after each attempt. Default 2.0.
+  double backoff_multiplier = 3;
+  // Upper bound on any single backoff. Defaults to, and is capped at, 30000ms.
+  uint32 max_backoff_ms = 4;
+  // Retryable error classes. Empty enables all of them. Valid values are
+  // "timeout", "http_429", "http_5xx" and "rpc_error"; anything else is rejected
+  // at task creation. A failure matching no class is never retried.
+  repeated string retry_on = 5;
+
+  // The total time one policy can sleep (the sum of its backoffs) is capped at
+  // 60s per node, and at 5 minutes across a whole execution.
 }

--- a/protobuf/avs.proto
+++ b/protobuf/avs.proto
@@ -733,9 +733,13 @@ message TaskEdge {
 message TaskNode {
   string id   = 2;
   string name = 3;
-  
+
   // NEW: Use the enum for type identification (Phase 1: add alongside existing)
   NodeType type = 1;
+
+  // Optional per-node retry policy for transient failures. Additive (field 4);
+  // absent = single attempt. Honored only for the read/off-chain node allowlist.
+  RetryPolicy retry_policy = 4;
 
   // based on node_type one and only one of these field are set
   oneof task_type {
@@ -1546,4 +1550,17 @@ message EventCondition {
   string operator = 2;          // Comparison operator: "gt", "gte", "lt", "lte", "eq", "ne"
   string value = 3;             // Value to compare against (as string, parsed based on type)
   string field_type = 4;        // Field type: "uint256", "int256", "address", "bool", "bytes32", etc.
+}
+
+// RetryPolicy configures automatic retries for transient node failures (RPC
+// blips, HTTP 429/5xx, timeouts). It is opt-in and additive: an absent policy
+// means a single attempt, i.e. today's behavior. The policy is honored only for
+// an allowlist of idempotent read/off-chain nodes (REST, GraphQL, ContractRead,
+// Balance); it is ignored on control-flow, stateful, and on-chain write nodes.
+message RetryPolicy {
+  uint32 max_attempts = 1;        // total attempts including the first (default 1 = no retry)
+  uint32 backoff_ms = 2;          // initial backoff before the second attempt
+  double backoff_multiplier = 3;  // exponential factor applied each attempt (default 2.0)
+  uint32 max_backoff_ms = 4;      // upper bound on any single backoff
+  repeated string retry_on = 5;   // retryable error classes, e.g. ["timeout","http_5xx","http_429","rpc_error"]
 }


### PR DESCRIPTION
## What

Adds an opt-in per-node `RetryPolicy` that re-runs a node's runner with exponential backoff when it fails with a transient error (RPC blip, HTTP 429/5xx, timeout). Absent policy → a single attempt, identical to today's behavior — fully additive.

```proto
message RetryPolicy {
  uint32 max_attempts = 1;        // total attempts incl. the first (default 1 = no retry)
  uint32 backoff_ms = 2;          // initial backoff before the second attempt
  double backoff_multiplier = 3;  // exponential factor per attempt (default 2.0)
  uint32 max_backoff_ms = 4;      // upper bound on any single backoff
  repeated string retry_on = 5;   // classes: ["timeout","http_5xx","http_429","rpc_error"]
}
```

Attached to a node via `retry_policy` (field 4). Empty `retry_on` enables all classes.

## Safety — idempotent nodes only (#676)

Retry re-invokes the runner, so it is sound only for idempotent reads. The policy is honored for a **read/off-chain allowlist — REST, GraphQL, ContractRead, Balance** — enforced *structurally*: only those four branches in `executeNode` call `executeNodeWithRetry`.

- **`ContractWrite` and `EthTransfer` call their runners directly and are never retried**, so an ambiguous confirmation can't resubmit a UserOp (#676).
- The loop/isolated and direct single-node dispatch paths are intentionally left un-retried (a loop iteration already waits for its own confirmation).

## Error classification

`classifyRetryableError` maps errors to `timeout` / `http_429` / `http_5xx` / `rpc_error`. It's best-effort and string-based — node runners surface upstream failures as wrapped errors rather than typed status codes — and errs toward **not** retrying when unsure. Structured `net.Error` timeouts are matched first.

## Tests

`retry_test.go` (unit, no VM/config, injected sleep → no wall time): classification table, class gating, single-attempt defaults (nil / 0 / 1), retry-then-succeed with backoff assertions, immediate stop on a non-retryable error, exhaustion returns the last failure, and the max-backoff cap.

`go build` + `go vet ./core/taskengine/` clean.

## Notes for review

- No storage-model or key-template changes **in this PR** (model structs unchanged; no keys added/removed by the retry code). `make storage-check` flags pre-existing breaking changes already on the branch (hetznermerge key consolidation, wallet-salt index) — a staging→main release concern, unrelated to this feature.
- `avs.pb.go` diff is `RetryPolicy` codegen + descriptor reflow only — one new struct, nothing removed, no protoc-toolchain version change.
