### PR TITLE
feat: chain-scoped wallet listing and grant chain validation

### DIFF
--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -67,7 +67,7 @@ type ServerInterface interface {
 	RunTrigger(ctx echo.Context) error
 	// List the authenticated user's smart wallets
 	// (GET /wallets)
-	ListWallets(ctx echo.Context) error
+	ListWallets(ctx echo.Context, params ListWalletsParams) error
 	// Derive (and persist) a smart wallet address from (owner, salt, factory)
 	// (POST /wallets)
 	CreateWallet(ctx echo.Context) error
@@ -515,8 +515,17 @@ func (w *ServerInterfaceWrapper) ListWallets(ctx echo.Context) error {
 
 	ctx.Set(PartnerAssertionScopes, []string{})
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListWalletsParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.ListWallets(ctx)
+	err = w.Handler.ListWallets(ctx, params)
 	return err
 }
 
@@ -1641,6 +1650,7 @@ func (response RunTrigger401ApplicationProblemPlusJSONResponse) VisitRunTriggerR
 }
 
 type ListWalletsRequestObject struct {
+	Params ListWalletsParams
 }
 
 type ListWalletsResponseObject interface {
@@ -3193,8 +3203,10 @@ func (sh *strictHandler) RunTrigger(ctx echo.Context) error {
 }
 
 // ListWallets operation middleware
-func (sh *strictHandler) ListWallets(ctx echo.Context) error {
+func (sh *strictHandler) ListWallets(ctx echo.Context, params ListWalletsParams) error {
 	var request ListWalletsRequestObject
+
+	request.Params = params
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ListWallets(ctx.Request().Context(), request.(ListWalletsRequestObject))

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -1900,6 +1900,13 @@ type GetTokenParams struct {
 	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
 }
 
+// ListWalletsParams defines parameters for ListWallets.
+type ListWalletsParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
 // ListWalletPoliciesParams defines parameters for ListWalletPolicies.
 type ListWalletPoliciesParams struct {
 	// ChainId The chain to operate on (a single value). Omit to use the aggregator

--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -390,6 +390,10 @@ func mapPolicyError(err error) error {
 	switch {
 	case errors.Is(err, taskengine.ErrSessionWalletNotMAv2):
 		return badRequest("SESSION_WALLET_NOT_MA_V2", err.Error(), "")
+	case errors.Is(err, taskengine.ErrSessionChainNotServed):
+		// Distinct from POLICIES_REJECTED so a client can tell "wrong chain"
+		// from "bad grant" and re-prepare against a chain we serve.
+		return badRequest("POLICIES_CHAIN_NOT_SERVED", "Chain not served", err.Error())
 	case errors.Is(err, taskengine.ErrWalletNotOwned), errors.Is(err, taskengine.ErrSessionPolicyNotFound):
 		// Existence is not confirmed to non-owners: both cases read as 404.
 		return &restmw.HTTPError{Status: http.StatusNotFound, Code: "POLICIES_NOT_FOUND",

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -73,8 +73,16 @@ func newPolicyRig(t *testing.T) *policyTestRig {
 	}
 }
 
-// call builds an authed request, runs the handler, and returns the recorder.
+// call builds an authed request whose JWT audience is the gateway's own
+// chain, runs the handler, and returns the recorder.
 func (r *policyTestRig) call(t *testing.T, body any, handler func(echo.Context) error, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	return r.callAs(t, policyTestChain, body, handler, headers)
+}
+
+// callAs is call with an explicit JWT audience, for the cross-chain cases
+// where the token's aud and the chain the request names are not the same.
+func (r *policyTestRig) callAs(t *testing.T, audChainID int64, body any, handler func(echo.Context) error, headers map[string]string) *httptest.ResponseRecorder {
 	t.Helper()
 	var buf bytes.Buffer
 	if body != nil {
@@ -87,7 +95,7 @@ func (r *policyTestRig) call(t *testing.T, body any, handler func(echo.Context) 
 	}
 	rec := httptest.NewRecorder()
 	ctx := echo.New().NewContext(req, rec)
-	ctx.Set("auth.user", &restmw.AuthenticatedUser{Subject: r.owner.Hex(), ChainID: policyTestChain})
+	ctx.Set("auth.user", &restmw.AuthenticatedUser{Subject: r.owner.Hex(), ChainID: audChainID})
 
 	if err := handler(ctx); err != nil {
 		// Match production behavior enough to assert on: structured errors
@@ -158,6 +166,29 @@ func TestPoliciesRefusePartnerAssertionsEverywhere(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rec.Code, "%s must refuse partner assertions", name)
 		require.Contains(t, rec.Body.String(), "PARTNER_DELEGATION_UNSUPPORTED", "%s refusal must be explicit", name)
 	}
+}
+
+// R4b: prepare routes on the request body's chainId, not the JWT's audience.
+// This is the Studio exit case — a grant on one chain held by a token minted
+// for another — so the body names a chain that is neither the token's aud nor
+// the gateway's own chain. Pinning it to either source fails the assertion.
+func TestPoliciesPrepareUsesBodyChainIdNotJwtAud(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+	// Served by the test gateway (config/test.yaml), and deliberately not
+	// policyTestChain, which is both the aud below and the default chain.
+	const grantChain = int64(84532)
+	require.NotEqual(t, int64(policyTestChain), grantChain, "the grant chain must differ from the default")
+
+	rec := rig.callAs(t, policyTestChain, prepareBody(grantChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var prepared generated.PreparedPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
+	require.EqualValues(t, grantChain, prepared.ChainId,
+		"grant must install on the body's chainId, not the JWT aud and not the gateway default (both %d)", policyTestChain)
 }
 
 func TestPoliciesPrepareSignSubmitOverHTTP(t *testing.T) {

--- a/aggregator/rest/handlers_policies_test.go
+++ b/aggregator/rest/handlers_policies_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
 	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
@@ -32,7 +33,15 @@ import (
 // typed data hashes to the returned digest — what the wallet signs is what
 // submit verifies), and the secret-grade handling of grant material.
 
-const policyTestChain = int64(11155111)
+const (
+	// The gateway's own chain: the JWT audience these tests authenticate with.
+	policyTestChain = int64(11155111)
+	// A second served chain, so "the body's chainId decides" is a property
+	// with somewhere to point. A grant on a chain the gateway does not serve
+	// is refused outright (ErrSessionChainNotServed), so the cross-chain case
+	// only exists on a rig that serves more than one.
+	policyGrantChain = int64(84532)
+)
 
 type policyTestRig struct {
 	server   *Server
@@ -51,6 +60,15 @@ func newPolicyRig(t *testing.T) *policyTestRig {
 	require.NoError(t, err)
 	cfg.SmartWallet.ControllerPrivateKey = controllerKey
 	cfg.SmartWallet.ChainID = policyTestChain
+	// Gateway mode with two chains: policyTestChain is the default, and
+	// policyGrantChain is reachable only by naming it in a request body.
+	grantChainWallet := *cfg.SmartWallet
+	grantChainWallet.ChainID = policyGrantChain
+	cfg.IsGateway = true
+	cfg.Chains = []*config.ChainConfig{
+		{ChainID: policyTestChain, Name: "sepolia", SmartWallet: cfg.SmartWallet},
+		{ChainID: policyGrantChain, Name: "base-sepolia", SmartWallet: &grantChainWallet},
+	}
 	engine := taskengine.New(db, cfg, nil, testutil.GetLogger())
 
 	logger, err := sdklogging.NewZapLogger(sdklogging.Development)
@@ -175,10 +193,10 @@ func TestPoliciesRefusePartnerAssertionsEverywhere(t *testing.T) {
 func TestPoliciesPrepareUsesBodyChainIdNotJwtAud(t *testing.T) {
 	rig := newPolicyRig(t)
 	address := generated.EthereumAddress(rig.wallet.Hex())
-	// Served by the test gateway (config/test.yaml), and deliberately not
-	// policyTestChain, which is both the aud below and the default chain.
-	const grantChain = int64(84532)
-	require.NotEqual(t, int64(policyTestChain), grantChain, "the grant chain must differ from the default")
+	// Served by the rig, and deliberately not policyTestChain — which is both
+	// the aud below and the gateway default.
+	const grantChain = policyGrantChain
+	require.NotEqual(t, int64(policyTestChain), int64(grantChain), "the grant chain must differ from the default")
 
 	rec := rig.callAs(t, policyTestChain, prepareBody(grantChain), func(c echo.Context) error {
 		return rig.server.PrepareWalletPolicy(c, address)
@@ -189,6 +207,20 @@ func TestPoliciesPrepareUsesBodyChainIdNotJwtAud(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &prepared))
 	require.EqualValues(t, grantChain, prepared.ChainId,
 		"grant must install on the body's chainId, not the JWT aud and not the gateway default (both %d)", policyTestChain)
+}
+
+// The unserved chain surfaces at the HTTP layer under its own code, so a
+// client can tell "re-prepare on a chain we serve" from a malformed grant.
+func TestPoliciesPrepareRefusesUnservedChain(t *testing.T) {
+	rig := newPolicyRig(t)
+	address := generated.EthereumAddress(rig.wallet.Hex())
+	const unservedChain = int64(8453)
+
+	rec := rig.call(t, prepareBody(unservedChain), func(c echo.Context) error {
+		return rig.server.PrepareWalletPolicy(c, address)
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "POLICIES_CHAIN_NOT_SERVED")
 }
 
 func TestPoliciesPrepareSignSubmitOverHTTP(t *testing.T) {

--- a/aggregator/rest/handlers_wallets.go
+++ b/aggregator/rest/handlers_wallets.go
@@ -29,14 +29,23 @@ import (
 // (the JWT subject, or a partner assertion's `sub`). Scoped to that owner, so
 // it never exposes another user's wallets. Partner-delegatable to resolve a
 // preview's runner — see ensurePermission (partner_wallet_preview).
-func (s *Server) ListWallets(ctx echo.Context) error {
+//
+// Chain routing precedence: ?chainId override → JWT aud → gateway default,
+// matching CreateWallet. Wallets are stored per chain, so without the
+// override a token minted for one chain could never see another's — which
+// would force a second signature purely to read a list.
+func (s *Server) ListWallets(ctx echo.Context, params generated.ListWalletsParams) error {
 	p, err := s.ensurePermission(ctx, OpListWallets)
 	if err != nil {
 		return err
 	}
 	user := p.User
 
-	resp, err := s.engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	if params.ChainId != nil {
+		user.ChainID = int64(*params.ChainId)
+	}
+
+	resp, err := s.engine.ListWallets(user, &avsproto.ListWalletReq{})
 	if err != nil {
 		return err
 	}

--- a/aggregator/rest/handlers_wallets_test.go
+++ b/aggregator/rest/handlers_wallets_test.go
@@ -1,0 +1,137 @@
+package rest
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// GET /wallets is per chain, because the records are. These pin the routing:
+// ?chainId decides, the JWT aud decides when it is absent, and neither chain
+// can see the other's wallets.
+
+const (
+	walletTestChain  = int64(11155111)
+	walletOtherChain = int64(84532)
+)
+
+type walletTestRig struct {
+	server *Server
+	owner  common.Address
+	// onDefault and onOther are stored on walletTestChain and
+	// walletOtherChain respectively — one per chain, so any response
+	// identifies the chain it was listed from.
+	onDefault common.Address
+	onOther   common.Address
+}
+
+func newWalletRig(t *testing.T) *walletTestRig {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	cfg := testutil.GetAggregatorConfig()
+	controllerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	cfg.SmartWallet.ControllerPrivateKey = controllerKey
+	cfg.SmartWallet.ChainID = walletTestChain
+	otherChainWallet := *cfg.SmartWallet
+	otherChainWallet.ChainID = walletOtherChain
+	cfg.IsGateway = true
+	cfg.Chains = []*config.ChainConfig{
+		{ChainID: walletTestChain, Name: "sepolia", SmartWallet: cfg.SmartWallet},
+		{ChainID: walletOtherChain, Name: "base-sepolia", SmartWallet: &otherChainWallet},
+	}
+	engine := taskengine.New(db, cfg, nil, testutil.GetLogger())
+
+	logger, err := sdklogging.NewZapLogger(sdklogging.Development)
+	require.NoError(t, err)
+
+	ownerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+	factory := common.HexToAddress("0x00000000000017c61b5bEe81050EC8eFc9c6fecd")
+	onDefault := common.HexToAddress("0x00000000000000000000000000000000000000d1")
+	onOther := common.HexToAddress("0x00000000000000000000000000000000000000e1")
+	require.NoError(t, taskengine.StoreWallet(db, walletTestChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &onDefault, Factory: &factory, Salt: big.NewInt(100),
+	}))
+	require.NoError(t, taskengine.StoreWallet(db, walletOtherChain, owner, &model.SmartWallet{
+		Owner: &owner, Address: &onOther, Factory: &factory, Salt: big.NewInt(200),
+	}))
+
+	return &walletTestRig{
+		server:    &Server{engine: engine, logger: logger, config: cfg},
+		owner:     owner,
+		onDefault: onDefault,
+		onOther:   onOther,
+	}
+}
+
+// list runs GET /wallets with the given JWT audience and ?chainId, and
+// returns the set of addresses it came back with.
+func (r *walletTestRig) list(t *testing.T, audChainID int64, chainIDQuery *int64) map[string]bool {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/wallets", nil)
+	rec := httptest.NewRecorder()
+	ctx := echo.New().NewContext(req, rec)
+	ctx.Set("auth.user", &restmw.AuthenticatedUser{Subject: r.owner.Hex(), ChainID: audChainID})
+
+	var params generated.ListWalletsParams
+	if chainIDQuery != nil {
+		q := generated.ChainIdQuery(*chainIDQuery)
+		params.ChainId = &q
+	}
+	require.NoError(t, r.server.ListWallets(ctx, params))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var out generated.WalletList
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	got := map[string]bool{}
+	for _, w := range out.Data {
+		got[strings.ToLower(string(w.Address))] = true
+	}
+	return got
+}
+
+func TestListWalletsUsesQueryChainIdOverJwtAud(t *testing.T) {
+	rig := newWalletRig(t)
+	onDefault := strings.ToLower(rig.onDefault.Hex())
+	onOther := strings.ToLower(rig.onOther.Hex())
+
+	// No query: the JWT aud decides, so this is the aud chain's listing.
+	byAud := rig.list(t, walletTestChain, nil)
+	require.True(t, byAud[onDefault], "the aud chain's wallet must be listed")
+	require.False(t, byAud[onOther], "another chain's wallet must not leak in")
+
+	// The query overrides the aud — the Studio exit case: one token, both
+	// chains, no second signature.
+	other := walletOtherChain
+	byQuery := rig.list(t, walletTestChain, &other)
+	require.True(t, byQuery[onOther], "?chainId must reach the named chain's wallets")
+	require.False(t, byQuery[onDefault], "?chainId must not also return the aud chain's wallets")
+
+	// And it works in the other direction, so the query is genuinely
+	// deciding rather than the aud happening to agree.
+	def := walletTestChain
+	backAgain := rig.list(t, walletOtherChain, &def)
+	require.True(t, backAgain[onDefault])
+	require.False(t, backAgain[onOther])
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2487,10 +2487,19 @@ paths:
       description: |
         Preview wallet resolve. Authorize with a user Bearer JWT **or** a
         partner assertion (`scope: read`) whose `sub` is the owner EOA.
+
+        Wallets are stored per chain, so the listing is per chain too. The
+        `chainId` query selects which one, on the same precedence as
+        `POST /wallets`: explicit value, then the JWT `aud` chain, then the
+        gateway default. A JWT minted for one chain can therefore list
+        another's wallets without a second signature — it proves EOA
+        ownership, which is chain-independent.
       operationId: listWallets
       security:
         - bearerAuth: []
         - partnerAssertion: []
+      parameters:
+        - $ref: '#/components/parameters/ChainIdQuery'
       responses:
         '200':
           description: All wallets for the authenticated user.

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -1087,34 +1087,57 @@ func (n *Engine) storeDefaultWalletForListWallets(chainID int64, owner common.Ad
 
 // ListWallets corresponds to the ListWallets RPC.
 //
-// Wallet records are chain-scoped. The ListWalletReq proto does not carry a
-// chain_id yet, so this handler queries the gateway's default chain only.
-// Adding multi-chain enumeration (or a chain_id field on ListWalletReq) is
-// a follow-up.
-func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletReq) (*avsproto.ListWalletResp, error) {
-	// ListWallets takes owner directly (legacy signature) — JWT chain
-	// context isn't plumbed through here yet, so fall back to the
-	// gateway default. Migrating to take *model.User is a follow-up.
-	chainID := n.defaultChainID()
+// Wallet records are chain-scoped, so the listing is too: the chain comes
+// from resolveUserChainID — the caller's explicit choice (REST sets
+// user.ChainID from the ?chainId query), then the JWT `aud` chain, then the
+// gateway default. Same precedence as GetWallet, so a wallet created on one
+// chain is listed by naming that chain rather than by holding a second JWT.
+//
+// Everything chain-dependent is resolved from that chain, not from the
+// gateway default: the factory the default wallet is derived against, the
+// per-owner wallet cap, and the storage prefix scanned.
+func (n *Engine) ListWallets(user *model.User, payload *avsproto.ListWalletReq) (*avsproto.ListWalletResp, error) {
+	if user == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "ListWallets requires an authenticated user")
+	}
+	owner := user.Address
+	chainID := n.resolveUserChainID(user)
+	swCfg := n.ResolveSmartWalletConfig(chainID)
 	walletsToReturnProto := []*avsproto.SmartWallet{}
 	processedAddresses := make(map[string]bool)
 
 	// The chain's CURRENT factory, not the raw configured one: on an MA v2
 	// chain those differ, and deriving against the configured SimpleAccount
 	// factory would hand the user their pre-cutover address.
-	defaultSystemFactory, factoryErr := aa.EffectiveFactory(n.smartWalletConfig)
+	defaultSystemFactory, factoryErr := aa.EffectiveFactory(swCfg)
 	var defaultDerivedAddress *common.Address
 	var deriveErr error
 
-	// Only try to derive default address if rpcConn is available
-	if factoryErr != nil {
+	// Derivation must run against THIS chain. A per-chain reader is the
+	// worker-routed path GetWallet prefers; the package-level rpcConn is the
+	// default chain's client, so it is only sound when that is the chain
+	// being listed. With neither, the default wallet is left out rather than
+	// derived against the wrong chain's factory — a wrong address here would
+	// be indistinguishable from a real one in the response. Stored wallets
+	// are unaffected: they come from the prefix scan below.
+	switch {
+	case factoryErr != nil:
 		deriveErr = factoryErr
-	} else if rpcConn != nil {
+	case GetChainStateReaderForChain(uint64(chainID)) != nil:
+		reader := GetChainStateReaderForChain(uint64(chainID))
+		var addr common.Address
+		addr, deriveErr = reader.GetSmartWalletAddress(context.Background(), owner, defaultSystemFactory, defaultSalt)
+		if deriveErr == nil {
+			defaultDerivedAddress = &addr
+		}
+	case rpcConn != nil && chainID == n.defaultChainID():
 		defaultDerivedAddress, deriveErr = aa.DeriveSenderAddressAuto(rpcConn, owner, defaultSystemFactory, defaultSalt)
-	} else {
-		// In test environment or when RPC is unavailable, skip default derivation
-		n.logger.Debug("Skipping default wallet derivation due to nil rpcConn (test environment)", "owner", owner.Hex())
-		deriveErr = fmt.Errorf("rpc connection not available")
+	default:
+		// Test/CI (rpcConn nil), or a non-default chain with no reader
+		// registered.
+		n.logger.Debug("ListWallets: skipping default wallet derivation — no chain reader for this chain",
+			"owner", owner.Hex(), "chain_id", chainID, "has_rpc_conn", rpcConn != nil)
+		deriveErr = fmt.Errorf("no chain reader available for chain %d", chainID)
 	}
 
 	if deriveErr != nil {
@@ -1148,8 +1171,8 @@ func (n *Engine) ListWallets(owner common.Address, payload *avsproto.ListWalletR
 			} else if dbGetErr == badger.ErrKeyNotFound {
 				// Wallet not found in DB - we need to store it since we're returning it to the client
 				// Enforce max smart wallet count per owner before creating a new wallet entry
-				if n.smartWalletConfig != nil {
-					maxAllowed := n.smartWalletConfig.MaxWalletsPerOwner
+				if swCfg != nil {
+					maxAllowed := swCfg.MaxWalletsPerOwner
 					if maxAllowed <= 0 {
 						maxAllowed = config.DefaultMaxWalletsPerOwner
 					}
@@ -3818,7 +3841,7 @@ func (n *Engine) SimulateWorkflowWithContext(ctx context.Context, user *model.Us
 
 			// Validate the runner against registered wallets
 			if runnerStr != "" {
-				resp, err := n.ListWallets(owner, &avsproto.ListWalletReq{})
+				resp, err := n.ListWallets(user, &avsproto.ListWalletReq{})
 				if err == nil {
 					for _, w := range resp.GetItems() {
 						if strings.EqualFold(w.GetAddress(), runnerStr) {
@@ -3836,7 +3859,7 @@ func (n *Engine) SimulateWorkflowWithContext(ctx context.Context, user *model.Us
 					chosenSender = *user.SmartAccountAddress
 				} else {
 					// As a last resort, pick the first wallet owned by the user (if any)
-					if resp, err := n.ListWallets(owner, &avsproto.ListWalletReq{}); err == nil && len(resp.GetItems()) > 0 {
+					if resp, err := n.ListWallets(user, &avsproto.ListWalletReq{}); err == nil && len(resp.GetItems()) > 0 {
 						chosenSender = common.HexToAddress(resp.GetItems()[0].GetAddress())
 					}
 				}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -3839,9 +3839,19 @@ func (n *Engine) SimulateWorkflowWithContext(ctx context.Context, user *model.Us
 				}
 			}
 
+			// Wallets are listed on the chain being SIMULATED, not the JWT
+			// audience. simChainID is what the VM's smart-wallet config was
+			// resolved from, so a runner registered only on that chain has to
+			// be visible here too — otherwise an explicitly cross-chain
+			// simulation rejects its own valid runner, or silently falls
+			// through to the derivation below and simulates as the wrong
+			// sender.
+			simUser := *user
+			simUser.ChainID = simChainID
+
 			// Validate the runner against registered wallets
 			if runnerStr != "" {
-				resp, err := n.ListWallets(user, &avsproto.ListWalletReq{})
+				resp, err := n.ListWallets(&simUser, &avsproto.ListWalletReq{})
 				if err == nil {
 					for _, w := range resp.GetItems() {
 						if strings.EqualFold(w.GetAddress(), runnerStr) {
@@ -3859,7 +3869,7 @@ func (n *Engine) SimulateWorkflowWithContext(ctx context.Context, user *model.Us
 					chosenSender = *user.SmartAccountAddress
 				} else {
 					// As a last resort, pick the first wallet owned by the user (if any)
-					if resp, err := n.ListWallets(user, &avsproto.ListWalletReq{}); err == nil && len(resp.GetItems()) > 0 {
+					if resp, err := n.ListWallets(&simUser, &avsproto.ListWalletReq{}); err == nil && len(resp.GetItems()) > 0 {
 						chosenSender = common.HexToAddress(resp.GetItems()[0].GetAddress())
 					}
 				}

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -35,6 +35,10 @@ var (
 	// refused at prepare/submit so clients never collect a doomed owner signature.
 	// Studio filters Auto to MA v2; this is the gateway belt-and-braces half.
 	ErrSessionWalletNotMAv2 = errors.New("session grants require a Modular Account v2 smart wallet; legacy SimpleAccount cannot host session policies")
+	// ErrSessionChainNotServed: the grant names a chain this gateway has no
+	// config for → 400. Refused at prepare so no owner signature is ever
+	// collected for a grant nothing here could send under.
+	ErrSessionChainNotServed = errors.New("session grants must name a chain this gateway serves")
 	// ErrSessionPolicySupersedeFailed: the new grant is stored and usable, but
 	// revoking a previous one failed, so the runner is left ambiguous and
 	// execute will refuse it. Distinct from a plain rejection because the
@@ -90,6 +94,40 @@ func (n *Engine) requireOwnedWallet(user *model.User, wallet common.Address) err
 		return ErrWalletNotOwned
 	}
 	return nil
+}
+
+// requireServedChain refuses a grant naming a chain this gateway does not
+// serve.
+//
+// The chain arrives in the request body, unsigned — a weaker input than the
+// JWT `aud` that resolveUserChainID already validates against this same set,
+// and for the same reason: grants are stored chain-scoped (SessionPolicyKey,
+// sp:<chainID>:*), so an unserved chain writes records no read path here ever
+// comes back for.
+//
+// Refused rather than resolved to the default chain, which is what
+// resolveUserChainID does for a wallet read. Falling back is the wrong remedy
+// for a grant — worse than the bug: the owner asks for one chain, signs a
+// prompt naming it, and is handed spending authority on another. The chain is
+// knowable here, before anything is asked of the wallet, so this fails ahead
+// of the signing prompt rather than at the first send — where the grant reads
+// as active and the failure names neither the chain nor the mismatch.
+//
+// Skipped when no positive chain is configured at all: knownChainIDs() is
+// then [0] (placeholder configs), and every real chain would be refused.
+func (n *Engine) requireServedChain(chainID int64) error {
+	served := n.knownChainIDs()
+	configured := false
+	for _, id := range served {
+		if id > 0 {
+			configured = true
+			break
+		}
+	}
+	if !configured || n.isChainConfigured(chainID) {
+		return nil
+	}
+	return fmt.Errorf("%w: chain %d is not one of %v", ErrSessionChainNotServed, chainID, served)
 }
 
 // requireMAv2SessionWallet refuses prepare/submit when the target runner is
@@ -172,6 +210,9 @@ func (n *Engine) PrepareSessionPolicy(user *model.User, in SessionPolicyInput) (
 	if err := in.validate(); err != nil {
 		return nil, err
 	}
+	if err := n.requireServedChain(in.ChainID); err != nil {
+		return nil, err
+	}
 	if err := n.requireMAv2SessionWallet(user, in.ChainID, in.Wallet); err != nil {
 		return nil, err
 	}
@@ -234,6 +275,12 @@ func (n *Engine) SubmitSessionPolicy(
 	ownerSignature []byte,
 ) (policy *model.SessionPolicy, superseded []string, err error) {
 	if err := in.validate(); err != nil {
+		return nil, nil, err
+	}
+	// Submit re-derives the grant from the client's echo, so it re-checks the
+	// chain too: prepare's verdict does not carry over to a body that names a
+	// different one.
+	if err := n.requireServedChain(in.ChainID); err != nil {
 		return nil, nil, err
 	}
 	if err := n.requireMAv2SessionWallet(user, in.ChainID, in.Wallet); err != nil {

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -115,6 +115,13 @@ func (n *Engine) requireOwnedWallet(user *model.User, wallet common.Address) err
 //
 // Skipped when no positive chain is configured at all: knownChainIDs() is
 // then [0] (placeholder configs), and every real chain would be refused.
+//
+// The refusal names only the chain the caller asked for. Which OTHER chains
+// this gateway serves is gateway-wide config, and this check runs before
+// wallet ownership is established (deliberately — it is the cheap one), so
+// echoing the set would hand it to any authenticated caller rather than to
+// the wallet's owner. It goes to the log instead, where an operator
+// debugging a refusal can still see it.
 func (n *Engine) requireServedChain(chainID int64) error {
 	served := n.knownChainIDs()
 	configured := false
@@ -127,7 +134,9 @@ func (n *Engine) requireServedChain(chainID int64) error {
 	if !configured || n.isChainConfigured(chainID) {
 		return nil
 	}
-	return fmt.Errorf("%w: chain %d is not one of %v", ErrSessionChainNotServed, chainID, served)
+	n.logger.Warn("session grant refused: chain not served",
+		"requested_chain_id", chainID, "served_chain_ids", served)
+	return fmt.Errorf("%w: chain %d", ErrSessionChainNotServed, chainID)
 }
 
 // requireMAv2SessionWallet refuses prepare/submit when the target runner is

--- a/core/taskengine/engine_session_policy_test.go
+++ b/core/taskengine/engine_session_policy_test.go
@@ -93,6 +93,44 @@ func TestSessionPolicyPrepareRejectsSimpleAccountRunner(t *testing.T) {
 	require.ErrorIs(t, err, ErrSessionWalletNotMAv2)
 }
 
+// A grant naming a chain this gateway does not serve is refused at prepare —
+// before any owner signature is collected — and again at submit, which
+// re-derives the grant from the client's echo and so cannot inherit prepare's
+// verdict on a body that names a different chain. Letting one through would
+// store sp:<chain>:* records nothing here ever reads back, for authority no
+// configured bundler could ever send under.
+func TestSessionPolicyRefusesUnservedChain(t *testing.T) {
+	engine, db, ownerKey, owner, wallet := newPolicyTestEngine(t)
+	user := &model.User{Address: owner}
+	// Base mainnet: a real chain, deliberately not one config/test.yaml serves.
+	const unservedChain = int64(8453)
+	require.False(t, engine.isChainConfigured(unservedChain), "fixture must not serve the chain under test")
+
+	_, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: unservedChain,
+		AgentLabel: "TradingBot", Permissions: testPermissions(),
+	})
+	require.ErrorIs(t, err, ErrSessionChainNotServed)
+
+	// Submit is gated on its own: prepare against a chain we serve, then echo
+	// a body naming one we do not.
+	prepared, err := engine.PrepareSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: testPolicyChain,
+		AgentLabel: "TradingBot", Permissions: testPermissions(),
+	})
+	require.NoError(t, err)
+	_, _, err = engine.SubmitSessionPolicy(user, SessionPolicyInput{
+		Wallet: wallet, ChainID: unservedChain,
+		AgentLabel: "TradingBot", Permissions: testPermissions(),
+	}, prepared.Policy.ID, prepared.Policy.EntityID, prepared.Policy.Grant.Deadline,
+		signDigest(t, ownerKey, prepared.Digest))
+	require.ErrorIs(t, err, ErrSessionChainNotServed)
+
+	stranded, err := ListSessionPolicies(db, unservedChain, owner)
+	require.NoError(t, err)
+	require.Empty(t, stranded, "a refused grant must leave nothing under sp:%d:*", unservedChain)
+}
+
 func TestSessionPolicyPrepareSubmitRoundTrip(t *testing.T) {
 	engine, _, ownerKey, owner, wallet := newPolicyTestEngine(t)
 	user := &model.User{Address: owner}

--- a/core/taskengine/list_wallets_storage_test.go
+++ b/core/taskengine/list_wallets_storage_test.go
@@ -1,7 +1,12 @@
 package taskengine
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
@@ -10,6 +15,59 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Wallets are stored per chain, so the listing follows the caller's chain
+// rather than the gateway's. user.ChainID is what REST sets from ?chainId,
+// on the same precedence as CreateWallet — so a token minted for one chain
+// reaches another's wallets without a second signature.
+func TestListWalletsFollowsTheResolvedChain(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+
+	const defaultChain = int64(11155111)
+	const otherChain = int64(84532)
+
+	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = defaultChain
+	otherChainWallet := *cfg.SmartWallet
+	otherChainWallet.ChainID = otherChain
+	cfg.IsGateway = true
+	cfg.Chains = []*config.ChainConfig{
+		{ChainID: defaultChain, Name: "sepolia", SmartWallet: cfg.SmartWallet},
+		{ChainID: otherChain, Name: "base-sepolia", SmartWallet: &otherChainWallet},
+	}
+	engine := New(db, cfg, nil, testutil.GetLogger())
+
+	owner := testutil.TestUser1().Address
+	factory := effectiveFactoryAddr(t, cfg.SmartWallet)
+	onDefault := common.HexToAddress("0xDDDDddddDDDDddddDDDDddddDDDDddddDDDDdddd")
+	onOther := common.HexToAddress("0xEEEEeeeeEEEEeeeeEEEEeeeeEEEEeeeeEEEEeeee")
+	require.NoError(t, StoreWallet(db, defaultChain, owner, mkWallet(owner, factory, onDefault, 100)))
+	require.NoError(t, StoreWallet(db, otherChain, owner, mkWallet(owner, factory, onOther, 200)))
+
+	listed := func(chainID int64) map[string]bool {
+		t.Helper()
+		resp, err := engine.ListWallets(&model.User{Address: owner, ChainID: chainID}, &avsproto.ListWalletReq{})
+		require.NoError(t, err)
+		out := map[string]bool{}
+		for _, w := range resp.GetItems() {
+			out[strings.ToLower(w.GetAddress())] = true
+		}
+		return out
+	}
+
+	fromDefault := listed(defaultChain)
+	require.True(t, fromDefault[strings.ToLower(onDefault.Hex())], "the default chain's wallet must be listed on that chain")
+	require.False(t, fromDefault[strings.ToLower(onOther.Hex())], "another chain's wallet must not leak into this one")
+
+	fromOther := listed(otherChain)
+	require.True(t, fromOther[strings.ToLower(onOther.Hex())], "naming the other chain must reach its wallets")
+	require.False(t, fromOther[strings.ToLower(onDefault.Hex())], "the default chain's wallet must not leak into the other")
+
+	// ChainID 0 is the no-context case (gRPC, or a JWT with no aud): it
+	// resolves to the gateway default rather than erroring or listing nothing.
+	require.True(t, listed(0)[strings.ToLower(onDefault.Hex())], "no chain context falls back to the gateway default")
+}
 
 // TestListWalletsStoresDefaultWallet tests that ListWallets stores the default salt:0 wallet
 // in the database when it doesn't exist yet.
@@ -27,7 +85,7 @@ func TestListWalletsStoresDefaultWallet(t *testing.T) {
 	assert.Equal(t, 0, len(dbItems), "Database should be empty initially")
 
 	// Call ListWallets - this should create and store the default salt:0 wallet
-	listResp, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	listResp, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err, "ListWallets should succeed")
 	require.Greater(t, len(listResp.Items), 0, "ListWallets should return at least the default wallet")
 
@@ -79,7 +137,7 @@ func TestListWalletsDoesNotDuplicateExistingWallet(t *testing.T) {
 	assert.Equal(t, 1, len(dbItems), "Database should contain exactly 1 wallet after GetWallet")
 
 	// Call ListWallets - this should NOT create a duplicate
-	listResp, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	listResp, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err, "ListWallets should succeed")
 
 	// Verify the wallet is still only stored once
@@ -115,7 +173,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	user := testutil.TestUser1()
 
 	// Step 1: Call ListWallets first - this should create salt:0
-	listResp1, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	listResp1, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err, "First ListWallets call should succeed")
 
 	// Verify salt:0 is stored
@@ -160,7 +218,7 @@ func TestListWalletsWithMultipleWallets(t *testing.T) {
 	assert.Equal(t, 3, len(dbItems), "Should have 3 wallets (salt:0, salt:1, salt:2) after second GetWallet")
 
 	// Step 4: Call ListWallets again - should return all 3 wallets and not create duplicates
-	listResp2, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	listResp2, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err, "Second ListWallets call should succeed")
 
 	// Verify we still have exactly 3 wallets (no duplicates)
@@ -215,7 +273,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(dbItems), "Database should be empty initially")
 
-	listResp1, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	listResp1, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err, "ListWallets should succeed when owner has no wallets")
 
 	// Verify salt:0 is now stored
@@ -260,7 +318,7 @@ func TestListWalletsBeforeAndAfterGetWallet(t *testing.T) {
 	assert.Equal(t, 3, len(dbItems), "Should have 3 wallets after GetWallet for salt:2")
 
 	// Phase 4: Call ListWallets again - should return all 3 wallets
-	listResp2, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	listResp2, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err, "Second ListWallets call should succeed")
 
 	// Verify response contains all 3 wallets
@@ -318,7 +376,7 @@ func TestListWalletsDatabaseStateVerification(t *testing.T) {
 	_ = verifyDatabaseState(t, 0, "Initial state - no wallets")
 
 	// Step 1: ListWallets should create salt:0
-	_, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	_, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err)
 	wallets1 := verifyDatabaseState(t, 1, "After ListWallets - should have salt:0")
 
@@ -351,7 +409,7 @@ func TestListWalletsDatabaseStateVerification(t *testing.T) {
 	assert.Equal(t, "2", wallets3[getResp2.Address].Salt.String(), "Third wallet should have salt 2")
 
 	// Step 4: ListWallets again should not create duplicates
-	listResp2, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+	listResp2, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 	require.NoError(t, err)
 	wallets4 := verifyDatabaseState(t, 3, "After second ListWallets - should still have 3 wallets (no duplicates)")
 

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2649,7 +2649,7 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 				// Validate runner belongs to owner
 				// For runNodeImmediately, we allow smart wallets that haven't been created yet
 				// The paymaster will sponsor their creation if needed (same as deployed workflows)
-				resp, err := n.ListWallets(vm.TaskOwner, &avsproto.ListWalletReq{})
+				resp, err := n.ListWallets(user, &avsproto.ListWalletReq{})
 				if err != nil {
 					return nil, fmt.Errorf("failed to list wallets for owner %s: %w", vm.TaskOwner.Hex(), err)
 				}

--- a/core/taskengine/run_node_immediately.go
+++ b/core/taskengine/run_node_immediately.go
@@ -2576,7 +2576,8 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 	// config (the first chain in chains[]), so a contractRead against a
 	// sepolia address would actually query mainnet RPC.
 	vmSmartWalletConfig := n.smartWalletConfig
-	if settingsChainID := extractSettingsChainID(inputVariables); settingsChainID != 0 {
+	settingsChainID := extractSettingsChainID(inputVariables)
+	if settingsChainID != 0 {
 		if resolved := n.ResolveSmartWalletConfig(settingsChainID); resolved != nil {
 			vmSmartWalletConfig = resolved
 		}
@@ -2649,7 +2650,18 @@ func (n *Engine) runProcessingNodeWithInputs(ctx context.Context, user *model.Us
 				// Validate runner belongs to owner
 				// For runNodeImmediately, we allow smart wallets that haven't been created yet
 				// The paymaster will sponsor their creation if needed (same as deployed workflows)
-				resp, err := n.ListWallets(user, &avsproto.ListWalletReq{})
+				// Wallets are listed on the chain this node actually runs on
+				// (settings.chain_id, the same value vmSmartWalletConfig came
+				// from), not the JWT audience. A runner registered only on the
+				// requested chain would otherwise read as unknown.
+				walletUser := &model.User{Address: vm.TaskOwner}
+				if user != nil {
+					walletUser.ChainID = user.ChainID
+				}
+				if settingsChainID != 0 {
+					walletUser.ChainID = settingsChainID
+				}
+				resp, err := n.ListWallets(walletUser, &avsproto.ListWalletReq{})
 				if err != nil {
 					return nil, fmt.Errorf("failed to list wallets for owner %s: %w", vm.TaskOwner.Hex(), err)
 				}

--- a/core/taskengine/simulate_runner_chain_test.go
+++ b/core/taskengine/simulate_runner_chain_test.go
@@ -1,0 +1,184 @@
+package taskengine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+const (
+	runnerAudChain   = int64(11155111)
+	runnerOtherChain = int64(84532)
+)
+
+func newRunnerChainEngine(t *testing.T) (*Engine, storage.Storage) {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	cfg := testutil.GetAggregatorConfig()
+	cfg.SmartWallet.ChainID = runnerAudChain
+	otherChainWallet := *cfg.SmartWallet
+	otherChainWallet.ChainID = runnerOtherChain
+	cfg.IsGateway = true
+	cfg.Chains = []*config.ChainConfig{
+		{ChainID: runnerAudChain, Name: "sepolia", SmartWallet: cfg.SmartWallet},
+		{ChainID: runnerOtherChain, Name: "base-sepolia", SmartWallet: &otherChainWallet},
+	}
+	return New(db, cfg, nil, testutil.GetLogger()), db
+}
+
+// aaWorkflow requires an AA sender (it contains a contractWrite node, which
+// is what taskNodesRequireAASender looks for) but only ever executes a
+// customCode node that echoes the resolved `aa_sender`. The write is
+// deliberately left off the edge path: the runner gate still runs, and its
+// verdict becomes readable without simulating a real write.
+func aaWorkflow() (*avsproto.TaskTrigger, []*avsproto.TaskNode, []*avsproto.TaskEdge) {
+	trigger := &avsproto.TaskTrigger{
+		Id: "manual_trigger", Name: "manual_trigger",
+		Type: avsproto.TriggerType_TRIGGER_TYPE_MANUAL,
+		TriggerType: &avsproto.TaskTrigger_Manual{
+			Manual: &avsproto.ManualTrigger{
+				Config: &avsproto.ManualTrigger_Config{
+					Lang: avsproto.Lang_LANG_JSON,
+					Data: func() *structpb.Value {
+						v, _ := structpb.NewValue(map[string]interface{}{"test": "manual"})
+						return v
+					}(),
+				},
+			},
+		},
+	}
+	nodes := []*avsproto.TaskNode{
+		{
+			Id: "write1", Name: "write1",
+			TaskType: &avsproto.TaskNode_ContractWrite{
+				ContractWrite: &avsproto.ContractWriteNode{
+					Config: &avsproto.ContractWriteNode_Config{
+						ContractAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+						CallData:        "0x095ea7b3",
+					},
+				},
+			},
+		},
+		{
+			Id: "echo", Name: "echo",
+			TaskType: &avsproto.TaskNode_CustomCode{
+				CustomCode: &avsproto.CustomCodeNode{
+					Config: &avsproto.CustomCodeNode_Config{Source: "return aa_sender;"},
+				},
+			},
+		},
+	}
+	edges := []*avsproto.TaskEdge{{Id: "e1", Source: "manual_trigger", Target: "echo"}}
+	return trigger, nodes, edges
+}
+
+// resolvedSender runs the workflow on simChain and returns the aa_sender the
+// runner gate settled on.
+func resolvedSender(t *testing.T, engine *Engine, user *model.User, runner common.Address, simChain int64) string {
+	t.Helper()
+	trigger, nodes, edges := aaWorkflow()
+	inputVariables := map[string]interface{}{
+		"settings": map[string]interface{}{"name": "runner chain", "runner": runner.Hex()},
+	}
+	execution, err := engine.SimulateWorkflow(user, trigger, nodes, edges, inputVariables, simChain)
+	require.NoError(t, err)
+	require.NotEmpty(t, execution.Steps)
+	for _, step := range execution.Steps {
+		if step.Id == "echo" {
+			require.True(t, step.Success, "echo step failed: %s", step.Error)
+			return strings.TrimSpace(step.GetCustomCode().GetData().GetStringValue())
+		}
+	}
+	t.Fatalf("no echo step in execution")
+	return ""
+}
+
+// The runner is resolved against the chain the simulation targets, not the
+// JWT audience.
+//
+// The failure this guards is quiet rather than loud. When the runner is not
+// found on the chain being listed, resolution does not stop — it falls
+// through to "first wallet owned by the user", which on a chain with working
+// derivation is the owner's DEFAULT wallet. So a cross-chain simulation used
+// to run as the wrong sender and report success, rather than reporting that
+// it could not find the runner.
+func TestSimulateResolvesRunnerOnTheSimulatedChain(t *testing.T) {
+	engine, db := newRunnerChainEngine(t)
+
+	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
+	factory := effectiveFactoryAddr(t, engine.smartWalletConfig)
+	runner := common.HexToAddress("0x00000000000000000000000000000000000000f1")
+	// Registered ONLY on the non-audience chain, so the two chains cannot
+	// agree by accident.
+	require.NoError(t, StoreWallet(db, runnerOtherChain, owner, mkWallet(owner, factory, runner, 3)))
+
+	// The audience is the chain the runner is NOT on.
+	user := &model.User{Address: owner, ChainID: runnerAudChain}
+
+	onRunnerChain := resolvedSender(t, engine, user, runner, runnerOtherChain)
+	require.Equal(t, strings.ToLower(runner.Hex()), strings.ToLower(onRunnerChain),
+		"simulating on the runner's chain must resolve to the runner itself")
+
+	// Control: the same call aimed at the audience chain, where the runner is
+	// genuinely absent. It must NOT come back as the runner — that is the
+	// silent substitution described above, and it is what proves the
+	// assertion above is reading the simulated chain rather than the
+	// audience one.
+	onAudChain := resolvedSender(t, engine, user, runner, runnerAudChain)
+	require.NotEqual(t, strings.ToLower(runner.Hex()), strings.ToLower(onAudChain),
+		"the runner is not registered on the audience chain, so it cannot resolve there")
+}
+
+// The same routing on the RunNodeImmediately path, where the chain comes
+// from settings.chain_id (the value vmSmartWalletConfig is resolved from)
+// rather than a simulate argument.
+//
+// Here the wrong-chain outcome is loud rather than quiet: a runner missing
+// from the listed chain falls through to the salt-0..4 derivation scan, and
+// an address that is not a derived wallet is rejected outright.
+func TestRunNodeResolvesRunnerOnTheSettingsChain(t *testing.T) {
+	engine, db := newRunnerChainEngine(t)
+
+	owner := common.HexToAddress("0xc60e71bd0f2e6d8832Fea1a2d56091C48493C788")
+	factory := effectiveFactoryAddr(t, engine.smartWalletConfig)
+	runner := common.HexToAddress("0x00000000000000000000000000000000000000f2")
+	require.NoError(t, StoreWallet(db, runnerOtherChain, owner, mkWallet(owner, factory, runner, 2)))
+
+	user := &model.User{Address: owner, ChainID: runnerAudChain}
+	nodeConfig := map[string]interface{}{
+		"contractAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+		"callData":        "0x095ea7b3",
+	}
+	run := func(chainID int64) error {
+		_, err := engine.RunNodeImmediately("contractWrite", nodeConfig, map[string]interface{}{
+			"settings": map[string]interface{}{"runner": runner.Hex(), "chain_id": chainID},
+		}, user, true)
+		return err
+	}
+
+	// The runner is not on the audience chain, and it is not a derived
+	// address either, so the scan rejects it.
+	err := run(runnerAudChain)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match any derived address",
+		"a runner absent from the named chain must be rejected")
+
+	// Naming the chain it IS registered on must clear that check. Whatever
+	// the write itself does afterwards, it must not be refused as an
+	// unrecognised runner.
+	if err := run(runnerOtherChain); err != nil {
+		require.NotContains(t, err.Error(), "does not match any derived address",
+			"the runner is registered on the named chain and must resolve there")
+	}
+}

--- a/core/taskengine/wallet_count_limit_fix_test.go
+++ b/core/taskengine/wallet_count_limit_fix_test.go
@@ -77,7 +77,7 @@ func TestWalletCountLimitDoesNotBlockExistingWalletAccess(t *testing.T) {
 	})
 
 	t.Run("ListWallets should work for existing wallets at limit", func(t *testing.T) {
-		listResp, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+		listResp, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, len(listResp.Items), 2, "Should be able to list existing wallets even at limit")
 	})
@@ -196,7 +196,7 @@ func TestWalletCountLimitReproducesOriginalWithdrawFundsBug(t *testing.T) {
 
 	t.Run("All wallet management operations work at limit", func(t *testing.T) {
 		// List wallets
-		listResp, err := engine.ListWallets(user.Address, &avsproto.ListWalletReq{})
+		listResp, err := engine.ListWallets(user, &avsproto.ListWalletReq{})
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, len(listResp.Items), 3, "Should list all wallets")
 

--- a/core/taskengine/wallet_salt_index_test.go
+++ b/core/taskengine/wallet_salt_index_test.go
@@ -256,7 +256,7 @@ func TestListWallets_HardFiltersStaleRows(t *testing.T) {
 	// Flag b as stale.
 	require.NoError(t, MarkWalletStale(db, int64(1), owner, b.Hex()))
 
-	resp, err := engine.ListWallets(owner, &avsproto.ListWalletReq{})
+	resp, err := engine.ListWallets(&model.User{Address: owner}, &avsproto.ListWalletReq{})
 	require.NoError(t, err)
 
 	addresses := make(map[string]bool)

--- a/core/taskengine/wallet_test.go
+++ b/core/taskengine/wallet_test.go
@@ -27,7 +27,7 @@ func TestSetWalletHiddenStatus(t *testing.T) {
 	}
 
 	// Check it's initially not hidden
-	listResp, err := n.ListWallets(u.Address, &avsproto.ListWalletReq{})
+	listResp, err := n.ListWallets(u, &avsproto.ListWalletReq{})
 	if err != nil {
 		t.Fatalf("ListWallets failed: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestSetWalletHiddenStatus(t *testing.T) {
 	}
 
 	// Check it's now hidden in the list
-	listResp, err = n.ListWallets(u.Address, &avsproto.ListWalletReq{})
+	listResp, err = n.ListWallets(u, &avsproto.ListWalletReq{})
 	if err != nil {
 		t.Fatalf("ListWallets after hiding failed: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestSetWalletHiddenStatus(t *testing.T) {
 	}
 
 	// Check it's no longer hidden
-	listResp, err = n.ListWallets(u.Address, &avsproto.ListWalletReq{})
+	listResp, err = n.ListWallets(u, &avsproto.ListWalletReq{})
 	if err != nil {
 		t.Fatalf("ListWallets after unhiding failed: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestSetWalletHiddenStatusWithCustomFactory(t *testing.T) {
 	}
 
 	// Check it's initially not hidden
-	listResp, err := n.ListWallets(u.Address, &avsproto.ListWalletReq{FactoryAddress: customFactoryAddress})
+	listResp, err := n.ListWallets(u, &avsproto.ListWalletReq{FactoryAddress: customFactoryAddress})
 	if err != nil {
 		t.Fatalf("ListWallets failed for custom factory: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestSetWalletHiddenStatusWithCustomFactory(t *testing.T) {
 	}
 
 	// Check it's now hidden in the list
-	listResp, err = n.ListWallets(u.Address, &avsproto.ListWalletReq{FactoryAddress: customFactoryAddress})
+	listResp, err = n.ListWallets(u, &avsproto.ListWalletReq{FactoryAddress: customFactoryAddress})
 	if err != nil {
 		t.Fatalf("ListWallets for custom factory after hiding failed: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestSetWalletHiddenStatusWithCustomFactory(t *testing.T) {
 		t.Fatalf("Failed to unhide wallet with custom factory: %v", err)
 	}
 
-	listResp, err = n.ListWallets(u.Address, &avsproto.ListWalletReq{FactoryAddress: customFactoryAddress})
+	listResp, err = n.ListWallets(u, &avsproto.ListWalletReq{FactoryAddress: customFactoryAddress})
 	if err != nil {
 		t.Fatalf("ListWallets for custom factory after unhiding failed: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestHideDefaultWallet(t *testing.T) {
 	}
 
 	// Check it's now hidden
-	listResp, err := n.ListWallets(u.Address, &avsproto.ListWalletReq{})
+	listResp, err := n.ListWallets(u, &avsproto.ListWalletReq{})
 	if err != nil {
 		t.Fatalf("ListWallets after hiding default wallet failed: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestHideDefaultWallet(t *testing.T) {
 	}
 
 	// Check it's no longer hidden
-	listResp, err = n.ListWallets(u.Address, &avsproto.ListWalletReq{})
+	listResp, err = n.ListWallets(u, &avsproto.ListWalletReq{})
 	if err != nil {
 		t.Fatalf("ListWallets after unhiding default wallet failed: %v", err)
 	}


### PR DESCRIPTION
Three commits on the wallet/grant chain-routing path. Together they complete the gateway half of Studio Phase 4: a JWT minted for one chain can prepare a grant on another, and now list that chain's wallets, without a second signature.

## `feat(wallets)` — list wallets per chain via `?chainId`

Wallet records are chain-scoped, but `GET /wallets` always read the gateway default: the engine hardcoded `defaultChainID()` behind a TODO. A wallet created on one chain was invisible unless that chain happened to be the gateway's, so a client holding a token for one chain had to mint a second one purely to read a list.

Adds `ChainIdQuery` to `GET /wallets` on the precedence `CreateWallet` already uses — explicit value, then JWT `aud`, then gateway default — and makes the engine follow the resolved chain.

`ListWallets` now takes `*model.User` rather than a bare owner address, since that is what carries the chain. All three internal callers already had the user in scope and used `user.Address` as the owner, so they gain the caller's chain instead of always reading the gateway's.

Everything chain-dependent moves to the resolved chain's config: the factory the default wallet is derived against, the per-owner wallet cap, and the storage prefix. Derivation prefers the per-chain `ChainStateReader` and falls back to the package-level `rpcConn` only for the default chain it belongs to. With neither, the default wallet is omitted rather than derived against the wrong chain's factory — a wrong address there would be indistinguishable from a real one in the response.

## `fix(policies)` — refuse grants on chains the gateway does not serve

Prepare and submit took `chainId` straight from the request body with no validation, so a grant could be allocated, signed by the owner, and stored for a chain this gateway has no config for.

Nothing could ever send under it. `ResolveSmartWalletConfig` silently returns the **default** chain's config for an unknown chain, while the EIP-712 domain commits to the real `chainId` — the MA v2 wallet address is identical across chains, so `chainId` is the only field separating a Base grant from a Sepolia one. The signature is sound; there is simply no bundler or RPC behind it. The grant also lands in `sp:<chainID>:*`, which no read path here comes back for.

`resolveUserChainID` already validates the chain from the **signed** JWT `aud` against `knownChainIDs()`, citing orphaned buckets and unbounded keyspace growth. The request body is a weaker input and had no check at all.

**Refused rather than resolved to the default chain**, which is what `resolveUserChainID` does for a wallet read. Falling back is the wrong remedy for a grant — worse than the bug: the owner asks for one chain, signs a prompt naming it, and is handed spending authority on another. Refusing at prepare means no signature is collected for a grant that cannot work. Submit is gated independently: it re-derives from the client's echo and cannot inherit prepare's verdict.

Surfaces as `400 POLICIES_CHAIN_NOT_SERVED`.

## `test(rest)` — prepare uses body chainId, not JWT aud

Studio R4b. The grant chain is base-sepolia while both the JWT `aud` and the gateway default are the test chain, so the assertion excludes every wrong source rather than just the `aud` — written the weaker way, a handler that ignored the body entirely passed.

## Verification

- `make test/unit` — full suite, zero failures
- `make storage-check` vs `origin/main` — key templates and persisted model structs unchanged
- Mutation-checked throughout: pinning prepare to the JWT aud or the gateway default, dropping the `?chainId` override, pinning the engine back to `defaultChainID()`, removing the submit gate, or degrading the chain gate to a silent fallback each fail the new tests

## Release + rollout

Prefix is `feat:` per the highest-impact rule across the bundle (was `fix:` before the ListWallets work landed on `staging`).

Two API-contract notes, neither treated as breaking:
- The policy gate turns some previously-`200` prepare/submit calls into `400`. The requests it now rejects produced grants that were unusable by construction, so no functioning integration could have depended on them.
- `GET /wallets` returns the JWT `aud` chain's wallets where it previously returned the gateway default's. For any single-chain deployment, and for any caller whose `aud` is the gateway default, that is the same set.

**Downstream ordering:** Studio [#1578](https://github.com/AvaProtocol/studio/pull/1578) must not merge until this is *deployed*, not merely merged — `main` cuts a pre-release, `avs-infra` promotes. #1578 flips `LIST_WALLETS_ACCEPTS_CHAIN_ID`, skipping the mandate SIWE; against a gateway that still ignores `?chainId` the grant path would proceed against the default chain's wallets with no SIWE in front of it.
