### PR TITLE
fix: stop reusing session-grant entities that still hold on-chain hooks

### DIFF
--- a/aggregator/rest/handlers_policies.go
+++ b/aggregator/rest/handlers_policies.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -411,6 +412,11 @@ func mapPolicyError(err error) error {
 				" List this wallet's policies and revoke the older usable ones, or grant again to replace them."}
 	case errors.Is(err, taskengine.ErrGrantSignerMismatch):
 		return badRequest("POLICIES_BAD_SIGNATURE", "Signature does not match", err.Error())
+	case strings.Contains(err.Error(), taskengine.SessionPolicyEntityOccupiedCode):
+		// Bounded occupancy probe exhausted (#763 A). The account still has
+		// leftover entities; granting cannot allocate a free one. 400 so
+		// the owner is not asked to sign a doomed payload.
+		return badRequest(taskengine.SessionPolicyEntityOccupiedCode, "Validation entity occupied", err.Error())
 	default:
 		return badRequest("POLICIES_REJECTED", "Policy request rejected", err.Error())
 	}

--- a/core/chainio/aa/ma_v2_entity_state.go
+++ b/core/chainio/aa/ma_v2_entity_state.go
@@ -52,6 +52,36 @@ func EntitySignerOnChain(ctx context.Context, client ContractCaller, account com
 	return common.BytesToAddress(out[12:32]), nil
 }
 
+// EntityTimeRangeOnChain returns the TimeRangeModule window for
+// (entity, account). validUntil / validAfter are unix seconds (uint48 on
+// chain, ABI-encoded as two 32-byte words). Both zero means the entity
+// has no time-range hook installed.
+//
+// A read failure is returned rather than folded into zeros: zeros mean
+// "no window", and a caller acting on a transient RPC error would treat
+// a live grant as unwindowed (#763).
+func EntityTimeRangeOnChain(ctx context.Context, client ContractCaller, account common.Address, entity uint32) (validUntilSec, validAfterSec uint64, err error) {
+	if client == nil {
+		return 0, 0, fmt.Errorf("no chain client")
+	}
+	data := crypto.Keccak256([]byte("timeRanges(uint32,address)"))[:4]
+	data = append(data, common.LeftPadBytes([]byte{
+		byte(entity >> 24), byte(entity >> 16), byte(entity >> 8), byte(entity),
+	}, 32)...)
+	data = append(data, common.LeftPadBytes(account.Bytes(), 32)...)
+
+	module := TimeRangeModuleAddress()
+	out, err := client.CallContract(ctx, ethereum.CallMsg{To: &module, Data: data}, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("reading time range of entity %d on %s: %w", entity, account.Hex(), err)
+	}
+	if len(out) < 64 {
+		return 0, 0, fmt.Errorf("timeRanges(%d, %s) returned %d bytes, want at least 64",
+			entity, account.Hex(), len(out))
+	}
+	return new(big.Int).SetBytes(out[:32]).Uint64(), new(big.Int).SetBytes(out[32:64]).Uint64(), nil
+}
+
 // EntryPointNonce returns the EntryPoint's current nonce for (account, key) —
 // the full 256-bit value, whose low 64 bits are the sequence.
 //

--- a/core/chainio/aa/ma_v2_entity_state_test.go
+++ b/core/chainio/aa/ma_v2_entity_state_test.go
@@ -116,3 +116,33 @@ func TestEntityDeferredNonceSequenceReportsReadFailures(t *testing.T) {
 		common.HexToAddress("0x0643f9d156e2CE584825511C548649F3289619c3"), 1)
 	require.Error(t, err, "no client is not evidence that an entity is free")
 }
+
+func TestEntityTimeRangeOnChainDecodesBothWords(t *testing.T) {
+	account := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	const entity = uint32(2)
+	until := uint64(1785541473) // 2026-08-13-ish
+	after := uint64(0)
+
+	result := append(word(new(big.Int).SetUint64(until)), word(new(big.Int).SetUint64(after))...)
+	caller := &recordingCaller{result: result}
+
+	gotUntil, gotAfter, err := EntityTimeRangeOnChain(context.Background(), caller, account, entity)
+	require.NoError(t, err)
+	require.Equal(t, until, gotUntil)
+	require.Equal(t, after, gotAfter)
+
+	require.Equal(t, TimeRangeModuleAddress(), caller.to)
+	require.Len(t, caller.data, 4+32+32, "timeRanges(uint32,address)")
+	require.Equal(t, account, common.BytesToAddress(caller.data[4+32+12:4+32+32]))
+	require.Equal(t, big.NewInt(int64(entity)), new(big.Int).SetBytes(caller.data[4:4+32]))
+}
+
+func TestEntityTimeRangeOnChainReportsReadFailures(t *testing.T) {
+	account := common.HexToAddress("0x209eb31c199bEB4c386eF83CF442DE1a00667a1F")
+	caller := &recordingCaller{result: word(big.NewInt(1))} // 32 bytes, need 64
+	_, _, err := EntityTimeRangeOnChain(context.Background(), caller, account, 1)
+	require.Error(t, err)
+
+	_, _, err = EntityTimeRangeOnChain(context.Background(), nil, account, 1)
+	require.Error(t, err, "no client is not evidence that an entity has no window")
+}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -268,6 +268,11 @@ type Engine struct {
 	assignmentMutex      *sync.RWMutex     // protects task assignments
 
 	smartWalletConfig *config.SmartWalletConfig
+	// sessionChainReads is set by InstallSessionResolver. When true,
+	// prepare/submit probe on-chain entity occupancy and the send path
+	// verifies TimeRange windows (#763 A/C). Unit tests that construct
+	// engines and never install a resolver stay offline.
+	sessionChainReads bool
 	// chainConfigs maps chain_id to ChainConfig in gateway mode.
 	// nil in single-chain mode.
 	chainConfigs map[int64]*config.ChainConfig

--- a/core/taskengine/engine_session_policy.go
+++ b/core/taskengine/engine_session_policy.go
@@ -234,14 +234,16 @@ func (n *Engine) PrepareSessionPolicy(user *model.User, in SessionPolicyInput) (
 	lock.Lock()
 	defer lock.Unlock()
 	prepared, err := PrepareSessionGrant(n.db, in.ChainID, signer, strings.ToLower(ulid.Make().String()), SessionGrantRequest{
-		Owner:         user.Address,
-		Wallet:        in.Wallet,
-		AgentLabel:    in.AgentLabel,
-		Justification: in.Justification,
-		ValidUntil:    in.Permissions.ValidUntilMs,
-		HooksFor:      in.Permissions.HooksFor,
-		TeardownCheck: n.teardownVerifier(),
-		TeardownCtx:   context.Background(),
+		Owner:          user.Address,
+		Wallet:         in.Wallet,
+		AgentLabel:     in.AgentLabel,
+		Justification:  in.Justification,
+		ValidUntil:     in.Permissions.ValidUntilMs,
+		HooksFor:       in.Permissions.HooksFor,
+		TeardownCheck:  n.teardownVerifier(),
+		TeardownCtx:    context.Background(),
+		OccupancyCheck: n.occupancyFor(in.ChainID),
+		OccupancyCtx:   context.Background(),
 	})
 	if err != nil {
 		return nil, err
@@ -311,15 +313,17 @@ func (n *Engine) SubmitSessionPolicy(
 	defer lock.Unlock()
 
 	prepared, err := PrepareSessionGrant(n.db, in.ChainID, signer, strings.ToLower(policyID), SessionGrantRequest{
-		Owner:         user.Address,
-		Wallet:        in.Wallet,
-		AgentLabel:    in.AgentLabel,
-		Justification: in.Justification,
-		ValidUntil:    in.Permissions.ValidUntilMs,
-		HooksFor:      in.Permissions.HooksFor,
-		Deadline:      deadline,
-		TeardownCheck: n.teardownVerifier(),
-		TeardownCtx:   context.Background(),
+		Owner:          user.Address,
+		Wallet:         in.Wallet,
+		AgentLabel:     in.AgentLabel,
+		Justification:  in.Justification,
+		ValidUntil:     in.Permissions.ValidUntilMs,
+		HooksFor:       in.Permissions.HooksFor,
+		Deadline:       deadline,
+		TeardownCheck:  n.teardownVerifier(),
+		TeardownCtx:    context.Background(),
+		OccupancyCheck: n.occupancyFor(in.ChainID),
+		OccupancyCtx:   context.Background(),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -380,7 +384,8 @@ func (n *Engine) GetSessionPolicyByID(user *model.User, chainID int64, wallet co
 
 // RevokeSessionPolicyByID revokes one policy.
 //
-//   - deleted: the storage record was removed (empty grant with no InstallCall).
+//   - deleted: always false after #763 B. Records are retained so the
+//     entity stays reserved even when the grant had no InstallCall.
 //   - cleanupRequired + cleanup: applied grant still installed on chain; owner
 //     must execute the returned uninstallValidation call (#717 AC3).
 //   - neither: pending grant retained as revoked so a late install can mark

--- a/core/taskengine/schema.go
+++ b/core/taskengine/schema.go
@@ -416,6 +416,12 @@ func FeeRecordPrefix(chainID int64, owner common.Address) []byte {
 	return []byte(fmt.Sprintf("fr:%d:%s:", chainID, strings.ToLower(owner.Hex())))
 }
 
+// SessionPolicyChainPrefix scans every session policy on a chain, any owner.
+// Used by the #763 drift sweep. Same `sp:` namespace as SessionPolicyPrefix.
+func SessionPolicyChainPrefix(chainID int64) []byte {
+	return []byte(fmt.Sprintf("sp:%d:", chainID))
+}
+
 // SessionPolicyPrefix scans every session policy an owner holds on a chain.
 // Fresh `sp:` namespace — additive, no migration (avs-infra §7.4a).
 func SessionPolicyPrefix(chainID int64, owner common.Address) []byte {

--- a/core/taskengine/session_entity_drift_test.go
+++ b/core/taskengine/session_entity_drift_test.go
@@ -295,3 +295,71 @@ func TestFindDriftedSessionGrantsIgnoresMatchingWindows(t *testing.T) {
 		t.Fatalf("matching windows are not drift, got %d", len(drifted))
 	}
 }
+
+// The Sepolia e2e fixture is in exactly this state right now: entity 3 has a
+// signer installed and its stored grant runs to 2027, but the account carries
+// NO TimeRange hook for it — timeRanges() reads zero. Measured against
+// production, not hypothesised.
+//
+// It must be refused (a grant that does not enforce the expiry the owner
+// approved is not one to sign under), but with its own code: folding it into
+// the mismatch case prints "chain validUntil 1970-01-01T00:00:00Z", which reads
+// as a corrupt timestamp rather than "the hook was never installed".
+func TestSessionResolverRefusesMissingChainWindowDistinctly(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(key.PublicKey)
+	storedUntil := time.Now().Add(365 * 24 * time.Hour).UnixMilli()
+	policy := storeExpiryPolicy(t, db, spChain, spOwner, spWallet, signer, storedUntil)
+
+	verify := func(_ context.Context, _ int64, _ common.Address, _ uint32) (uint64, uint64, error) {
+		return 0, 0, nil // no hook installed
+	}
+	resolve := newSessionResolver(db, func(common.Address) (*ecdsa.PrivateKey, error) { return key, nil }, nil, verify)
+	auth, err := resolve(spChain, spOwner, spWallet)
+	if err == nil || auth != nil {
+		t.Fatal("a grant whose entity has no TimeRange hook must not authorize a send")
+	}
+	if !strings.Contains(err.Error(), SessionPolicyChainWindowMissingCode) {
+		t.Fatalf("expected %s, got %v", SessionPolicyChainWindowMissingCode, err)
+	}
+	if strings.Contains(err.Error(), "1970") {
+		t.Fatalf("must not render the absent hook as an epoch date: %v", err)
+	}
+	if !strings.Contains(err.Error(), policy.ID) {
+		t.Fatalf("error should name the policy: %v", err)
+	}
+}
+
+// The sweep has to count the missing-hook rows separately: that is the
+// population the send path starts refusing on deploy, and in raw numbers it is
+// indistinguishable from a window that expired at the epoch.
+func TestFindDriftedSessionGrantsFlagsMissingWindow(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(key.PublicKey)
+	storeExpiryPolicy(t, db, spChain, spOwner, spWallet, signer,
+		time.Now().Add(365*24*time.Hour).UnixMilli())
+
+	verify := func(_ context.Context, _ int64, _ common.Address, _ uint32) (uint64, uint64, error) {
+		return 0, 0, nil
+	}
+	drifted, err := FindDriftedSessionGrants(context.Background(), db, spChain, verify)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(drifted) != 1 {
+		t.Fatalf("expected 1 drifted grant, got %d", len(drifted))
+	}
+	if !drifted[0].WindowMissing {
+		t.Fatal("a zero chain window must be reported as WindowMissing")
+	}
+}

--- a/core/taskengine/session_entity_drift_test.go
+++ b/core/taskengine/session_entity_drift_test.go
@@ -1,0 +1,297 @@
+package taskengine
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+// #763 A: occupancy-aware allocation.
+
+func TestNextFreeSessionEntityIDNilCheckerIsStorageOnly(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	if err := StoreSessionPolicy(db, spPolicy("p1", spWallet, 3, model.SessionPolicyRevoked)); err != nil {
+		t.Fatal(err)
+	}
+	got, err := NextFreeSessionEntityID(context.Background(), db, spChain, spOwner, spWallet, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 4 {
+		t.Errorf("nil checker must return storage max+1, got %d", got)
+	}
+}
+
+func TestNextFreeSessionEntityIDSkipsOccupied(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	// Storage says next is 1. Chain says 1 and 2 are leftover.
+	occupied := map[uint32]bool{1: true, 2: true}
+	var seen []uint32
+	check := func(_ context.Context, _ common.Address, entity uint32) (bool, error) {
+		seen = append(seen, entity)
+		return occupied[entity], nil
+	}
+	got, err := NextFreeSessionEntityID(context.Background(), db, spChain, spOwner, spWallet, check)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 3 {
+		t.Errorf("got entity %d, want 3 (1 and 2 occupied on chain)", got)
+	}
+	if len(seen) != 3 {
+		t.Errorf("probed %v, want [1 2 3]", seen)
+	}
+}
+
+func TestNextFreeSessionEntityIDTreatsReadErrorAsOccupied(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	check := func(_ context.Context, _ common.Address, entity uint32) (bool, error) {
+		if entity == 1 {
+			return false, errors.New("rpc blip")
+		}
+		return false, nil
+	}
+	got, err := NextFreeSessionEntityID(context.Background(), db, spChain, spOwner, spWallet, check)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 2 {
+		t.Errorf("a failed read must not be treated as free; got %d, want 2", got)
+	}
+}
+
+func TestNextFreeSessionEntityIDBoundsTheProbe(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	var probes int
+	check := func(_ context.Context, _ common.Address, _ uint32) (bool, error) {
+		probes++
+		return true, nil
+	}
+	_, err := NextFreeSessionEntityID(context.Background(), db, spChain, spOwner, spWallet, check)
+	if err == nil {
+		t.Fatal("expected a typed occupied error after the probe cap")
+	}
+	if !strings.Contains(err.Error(), SessionPolicyEntityOccupiedCode) {
+		t.Fatalf("expected %s, got %v", SessionPolicyEntityOccupiedCode, err)
+	}
+	if probes != maxEntityOccupancyProbes {
+		t.Errorf("probes = %d, want %d", probes, maxEntityOccupancyProbes)
+	}
+}
+
+func TestPrepareSessionGrantSkipsOnChainOccupiedEntity(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	signerKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(signerKey.PublicKey)
+	check := func(_ context.Context, _ common.Address, entity uint32) (bool, error) {
+		return entity == 1, nil
+	}
+	prepared, err := PrepareSessionGrant(db, spChain, signer, "p-occ", SessionGrantRequest{
+		Owner:                   spOwner,
+		Wallet:                  spWallet,
+		AgentLabel:              "Bot",
+		AllowSelfAdministration: true,
+		HooksFor: func(entityID uint32) ([][]byte, error) {
+			return [][]byte{aa.AllowlistExecHook(entityID)}, nil
+		},
+		OccupancyCheck: check,
+		OccupancyCtx:   context.Background(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Policy.EntityID != 2 {
+		t.Errorf("prepare allocated entity %d, want 2 (entity 1 occupied on chain)", prepared.Policy.EntityID)
+	}
+}
+
+// #763 B: revoke without InstallCall still reserves the entity.
+
+func TestRevokeWithoutInstallCallKeepsEntityReserved(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	p := spPolicy("p-empty", spWallet, 4, model.SessionPolicyPending)
+	p.Grant = nil
+	p.Status = model.SessionPolicyRevoked
+	if err := StoreSessionPolicy(db, p); err != nil {
+		t.Fatalf("a revoked record without a grant must still store: %v", err)
+	}
+	next, err := NextSessionEntityID(db, spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != 5 {
+		t.Errorf("next = %d, want 5 — incomplete revoked records still occupy their entity", next)
+	}
+}
+
+func TestRevokedIncompleteGrantPassesValidate(t *testing.T) {
+	p := spPolicy("p-rev", spWallet, 1, model.SessionPolicyRevoked)
+	p.Grant = nil
+	p.SessionSigner = nil
+	if err := p.Validate(); err != nil {
+		t.Fatalf("revoked records may be incomplete so they can keep the entity reserved: %v", err)
+	}
+}
+
+// #763 C: send path refuses a stored grant whose window disagrees with chain.
+
+func TestSessionResolverRefusesChainWindowMismatch(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(key.PublicKey)
+	storedUntil := time.Now().Add(365 * 24 * time.Hour).UnixMilli()
+	policy := storeExpiryPolicy(t, db, spChain, spOwner, spWallet, signer, storedUntil)
+
+	chainUntil := uint64(time.Now().Add(-48 * time.Hour).Unix()) // the 2026-vs-2027 shape
+	verify := func(_ context.Context, _ int64, _ common.Address, entity uint32) (uint64, uint64, error) {
+		if entity != policy.EntityID {
+			t.Errorf("window read for entity %d, want %d", entity, policy.EntityID)
+		}
+		return chainUntil, 0, nil
+	}
+	resolve := newSessionResolver(db, func(common.Address) (*ecdsa.PrivateKey, error) { return key, nil }, nil, verify)
+	auth, err := resolve(spChain, spOwner, spWallet)
+	if err == nil || auth != nil {
+		t.Fatal("a mismatched window must not authorize a send")
+	}
+	if !strings.Contains(err.Error(), SessionPolicyChainWindowMismatchCode) {
+		t.Fatalf("expected %s, got %v", SessionPolicyChainWindowMismatchCode, err)
+	}
+	if !strings.Contains(err.Error(), policy.ID) {
+		t.Fatalf("error should name the policy: %v", err)
+	}
+}
+
+func TestSessionResolverCachesChainWindowCheck(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(key.PublicKey)
+	storedUntil := time.Now().Add(24 * time.Hour).UnixMilli()
+	storeExpiryPolicy(t, db, spChain, spOwner, spWallet, signer, storedUntil)
+
+	var reads int
+	verify := func(_ context.Context, _ int64, _ common.Address, _ uint32) (uint64, uint64, error) {
+		reads++
+		return uint64(storedUntil / 1000), 0, nil
+	}
+	resolve := newSessionResolver(db, func(common.Address) (*ecdsa.PrivateKey, error) { return key, nil }, nil, verify)
+	if _, err := resolve(spChain, spOwner, spWallet); err != nil {
+		t.Fatalf("matching window must resolve: %v", err)
+	}
+	if reads != 1 {
+		t.Fatalf("first resolve should read once, got %d", reads)
+	}
+	if _, err := resolve(spChain, spOwner, spWallet); err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if reads != 1 {
+		t.Fatalf("cached match must not re-read the chain, got %d reads", reads)
+	}
+}
+
+func TestSessionResolverSkipsWindowCheckOnPendingGrant(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	keyFor, _ := spKeyFor(t)
+	pending := spPolicy("p-pending", spWallet, 1, model.SessionPolicyPending)
+	pending.ValidUntil = time.Now().Add(24 * time.Hour).UnixMilli()
+	if err := StoreSessionPolicy(db, pending); err != nil {
+		t.Fatal(err)
+	}
+	verify := func(_ context.Context, _ int64, _ common.Address, _ uint32) (uint64, uint64, error) {
+		t.Fatal("pending grants have not installed a window yet")
+		return 0, 0, fmt.Errorf("should not be called")
+	}
+	resolve := newSessionResolver(db, keyFor, nil, verify)
+	auth, err := resolve(spChain, spOwner, spWallet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth == nil || !auth.Deferred() {
+		t.Fatal("pending grant must still resolve with the install attached")
+	}
+}
+
+func TestFindDriftedSessionGrantsReportsMismatch(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(key.PublicKey)
+	storedUntil := time.Now().Add(365 * 24 * time.Hour).UnixMilli()
+	want := storeExpiryPolicy(t, db, spChain, spOwner, spWallet, signer, storedUntil)
+
+	chainUntil := uint64(1_755_000_000)
+	verify := func(_ context.Context, _ int64, _ common.Address, _ uint32) (uint64, uint64, error) {
+		return chainUntil, 0, nil
+	}
+	drifted, err := FindDriftedSessionGrants(context.Background(), db, spChain, verify)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drifted) != 1 {
+		t.Fatalf("got %d drifted, want 1", len(drifted))
+	}
+	if drifted[0].Policy.ID != want.ID {
+		t.Errorf("reported %s, want %s", drifted[0].Policy.ID, want.ID)
+	}
+	if drifted[0].ChainUntilSec != chainUntil {
+		t.Errorf("chain until %d, want %d", drifted[0].ChainUntilSec, chainUntil)
+	}
+	if drifted[0].StoredUntilSec != uint64(storedUntil/1000) {
+		t.Errorf("stored until %d, want %d", drifted[0].StoredUntilSec, storedUntil/1000)
+	}
+}
+
+func TestFindDriftedSessionGrantsIgnoresMatchingWindows(t *testing.T) {
+	db := testutil.TestMustDB()
+	defer storage.Destroy(db.(*storage.BadgerStorage))
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := crypto.PubkeyToAddress(key.PublicKey)
+	storedUntil := time.Now().Add(24 * time.Hour).UnixMilli()
+	storeExpiryPolicy(t, db, spChain, spOwner, spWallet, signer, storedUntil)
+	verify := func(_ context.Context, _ int64, _ common.Address, _ uint32) (uint64, uint64, error) {
+		return uint64(storedUntil / 1000), 0, nil
+	}
+	drifted, err := FindDriftedSessionGrants(context.Background(), db, spChain, verify)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drifted) != 0 {
+		t.Fatalf("matching windows are not drift, got %d", len(drifted))
+	}
+}

--- a/core/taskengine/session_grant.go
+++ b/core/taskengine/session_grant.go
@@ -89,6 +89,15 @@ type SessionGrantRequest struct {
 	TeardownCheck TeardownVerifier
 	// TeardownCtx bounds chain reads during prepare. Ignored when TeardownCheck is nil.
 	TeardownCtx context.Context
+
+	// OccupancyCheck, when set, reads whether the candidate validation
+	// entity is already spoken for on the account (#763 A). Occupied
+	// means a non-zero signer or a non-zero deferred nonce sequence (or
+	// a failed read); the allocator bumps and retries, bounded. Nil
+	// skips the chain read (offline tests).
+	OccupancyCheck EntityOccupancyChecker
+	// OccupancyCtx bounds occupancy reads. Ignored when OccupancyCheck is nil.
+	OccupancyCtx context.Context
 }
 
 // defaultSigningWindow bounds the gap between signing a grant and its first
@@ -153,7 +162,7 @@ func PrepareSessionGrant(
 		return nil, fmt.Errorf("session signer is required")
 	}
 
-	entity, err := NextSessionEntityID(db, chainID, req.Owner, req.Wallet)
+	entity, err := NextFreeSessionEntityID(req.OccupancyCtx, db, chainID, req.Owner, req.Wallet, req.OccupancyCheck)
 	if err != nil {
 		return nil, err
 	}
@@ -307,14 +316,18 @@ func SubmitSessionGrant(db storage.Storage, prepared *PreparedSessionGrant, owne
 	// allocation was provisional: another grant on this wallet may have
 	// landed in between, and reusing its entity would overwrite that grant's
 	// signer on chain.
-	entity, err := NextSessionEntityID(db, policy.ChainID, *policy.Owner, *policy.Runner)
+	//
+	// Occupancy-aware prepare may skip on-chain-occupied ids, so the
+	// storage-only NextSessionEntityID (max+1) is not comparable to the
+	// prepared id. "Taken" means another stored policy already occupies it.
+	taken, err := sessionEntityTaken(db, policy.ChainID, *policy.Owner, *policy.Runner, policy.EntityID)
 	if err != nil {
 		return nil, err
 	}
-	if entity != policy.EntityID {
+	if taken {
 		return nil, fmt.Errorf(
-			"entity %d was taken while this grant was being signed (next free is %d); prepare it again",
-			policy.EntityID, entity)
+			"entity %d was taken while this grant was being signed; prepare it again",
+			policy.EntityID)
 	}
 
 	// Re-check what this grant REPLACES, for the same reason and with the same
@@ -461,25 +474,18 @@ func BuildOnChainRevokeCleanup(policy *model.SessionPolicy) (*OnChainRevokeClean
 // MarkSessionGrantAppliedByID set AppliedAt without resurrecting usable
 // status. onChainCleanupRequired is false until AppliedAt is set.
 //
-// Pending without InstallCall (should not occur after submit): deleted.
+// Pending without InstallCall (or Grant): also retained as revoked. Deleting
+// would free the entity for NextSessionEntityID while the account may still
+// have it installed (#763 B). The record occupies the id; it grants nothing.
 func RevokeSessionGrant(db storage.Storage, policy *model.SessionPolicy) (deleted, onChainCleanupRequired bool, err error) {
 	if policy == nil {
 		return false, false, fmt.Errorf("no policy to revoke")
 	}
-	key := SessionPolicyKey(policy.ChainID, *policy.Owner, policy.ID)
-	if policy.Grant == nil {
-		return true, false, db.Delete(key)
-	}
-	if policy.Grant.Applied() {
-		policy.Status = model.SessionPolicyRevoked
+	policy.Status = model.SessionPolicyRevoked
+	if policy.Grant != nil && policy.Grant.Applied() {
 		// Already verified clear on chain — soft-revoke only, no cleanup payload.
 		return false, policy.Grant.NeedsOnChainCleanup(), StoreSessionPolicy(db, policy)
 	}
-	if len(policy.Grant.InstallCall) == 0 {
-		return true, false, db.Delete(key)
-	}
-	// Pending with payload: retain for possible late install / cleanup.
-	policy.Status = model.SessionPolicyRevoked
 	return false, false, StoreSessionPolicy(db, policy)
 }
 

--- a/core/taskengine/session_grant_test.go
+++ b/core/taskengine/session_grant_test.go
@@ -198,16 +198,33 @@ func TestRevokeSessionGrant(t *testing.T) {
 		if err := StoreSessionPolicy(db, p); err != nil {
 			t.Fatal(err)
 		}
-		_, onChain, err := RevokeSessionGrant(db, p)
+		deleted, onChain, err := RevokeSessionGrant(db, p)
 		if err != nil {
 			t.Fatal(err)
+		}
+		if deleted {
+			t.Error("revoking must not delete the record; the entity stays reserved (#763 B)")
 		}
 		if onChain {
 			t.Error("an unapplied grant needs no on-chain cleanup")
 		}
 		got, _ := ActiveSessionPolicyForWallet(db, spChain, spOwner, spWallet)
 		if got != nil {
-			t.Error("the record should be gone")
+			t.Error("a revoked grant must not authorize anything")
+		}
+		listed, err := ListSessionPolicies(db, spChain, spOwner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(listed) != 1 || listed[0].Status != model.SessionPolicyRevoked {
+			t.Errorf("revoked record must stay stored, got %d policies", len(listed))
+		}
+		next, err := NextSessionEntityID(db, spChain, spOwner, spWallet)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if next != 2 {
+			t.Errorf("next entity = %d, want 2 — deleting would free entity 1 for reuse", next)
 		}
 	})
 

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -149,6 +149,22 @@ const SessionPolicyEntityOccupiedCode = "SESSION_POLICY_ENTITY_OCCUPIED"
 // chain read can.
 const SessionPolicyChainWindowMismatchCode = "SESSION_POLICY_CHAIN_WINDOW_MISMATCH"
 
+// SessionPolicyChainWindowMissingCode marks the special case of that drift
+// where the entity has NO TimeRange hook at all: timeRanges() reads zero while
+// storage promises a real expiry.
+//
+// Separate from the mismatch code on purpose. It is a different failure with a
+// different remedy, and folding the two renders "no hook installed" as
+// "chain validUntil 1970-01-01T00:00:00Z" — which reads as a corrupt timestamp
+// and sends whoever is on call hunting for one.
+//
+// It is also strictly MORE permissive than storage claims rather than less: no
+// time-range hook means the grant never expires on chain, where the mismatch
+// case usually means it expired early. Refused all the same — a grant that does
+// not enforce the expiry the owner approved is not one to sign under — but an
+// operator needs to be able to tell the two apart when triaging.
+const SessionPolicyChainWindowMissingCode = "SESSION_POLICY_CHAIN_WINDOW_MISSING"
+
 // maxEntityOccupancyProbes bounds how many on-chain occupancy reads
 // NextFreeSessionEntityID will make. NextSessionEntityID returns
 // max(stored)+1; each bump is an RPC. An account with several unstored
@@ -630,6 +646,14 @@ func checkAppliedChainWindow(db storage.Storage, policy *model.SessionPolicy, ve
 			policy.ID, policy.EntityID, policy.Runner.Hex(), err)
 	}
 	storedSec := uint64(policy.ValidUntil / 1000)
+	if untilSec == 0 {
+		return fmt.Errorf(
+			"%s: session policy %s entity %d on %s has no TimeRange hook installed, "+
+				"while storage promises validUntil %s; the grant does not expire on chain. "+
+				"Grant again onto a free entity",
+			SessionPolicyChainWindowMissingCode, policy.ID, policy.EntityID, policy.Runner.Hex(),
+			time.UnixMilli(policy.ValidUntil).UTC().Format(time.RFC3339))
+	}
 	if untilSec != storedSec {
 		return fmt.Errorf(
 			"%s: session policy %s entity %d on %s: stored validUntil %s, chain validUntil %s; grant again onto a free entity",
@@ -679,6 +703,11 @@ type DriftedSessionGrant struct {
 	ChainUntilSec  uint64
 	ChainAfterSec  uint64
 	ReadErr        error
+	// WindowMissing is the ChainUntilSec == 0 case: no TimeRange hook on the
+	// entity at all. Broken out so a pre-deploy sweep can count it separately —
+	// it is the population the send path will start refusing, and it is not
+	// visibly different from "expired in 1970" in the raw numbers.
+	WindowMissing bool
 }
 
 // FindDriftedSessionGrants walks applied usable grants on chainID and
@@ -721,6 +750,7 @@ func FindDriftedSessionGrants(ctx context.Context, db storage.Storage, chainID i
 			out = append(out, DriftedSessionGrant{
 				Policy: policy, StoredUntilSec: storedSec,
 				ChainUntilSec: untilSec, ChainAfterSec: afterSec,
+				WindowMissing: untilSec == 0,
 			})
 		}
 	}

--- a/core/taskengine/session_policy.go
+++ b/core/taskengine/session_policy.go
@@ -138,6 +138,36 @@ const SessionPolicyAmbiguousCode = "SESSION_POLICY_AMBIGUOUS"
 // no indication that a re-grant is the remedy.
 const SessionPolicyExpiredCode = "SESSION_POLICY_EXPIRED"
 
+// SessionPolicyEntityOccupiedCode is returned when every candidate entity
+// in the bounded occupancy probe is already installed on the account
+// (#763 A). Client-fixable only by cleaning leftover entities on chain.
+const SessionPolicyEntityOccupiedCode = "SESSION_POLICY_ENTITY_OCCUPIED"
+
+// SessionPolicyChainWindowMismatchCode marks a stored grant whose
+// ValidUntil disagrees with the TimeRangeModule window actually
+// installed on the entity (#763 C). Storage cannot see this; only a
+// chain read can.
+const SessionPolicyChainWindowMismatchCode = "SESSION_POLICY_CHAIN_WINDOW_MISMATCH"
+
+// maxEntityOccupancyProbes bounds how many on-chain occupancy reads
+// NextFreeSessionEntityID will make. NextSessionEntityID returns
+// max(stored)+1; each bump is an RPC. An account with several unstored
+// leftovers would otherwise loop without bound.
+const maxEntityOccupancyProbes = 8
+
+// occupancyProbeTimeout bounds one occupancy candidate (signer + nonce
+// sequence). The loop's overall budget is this times the probe cap.
+const occupancyProbeTimeout = 5 * time.Second
+
+// EntityOccupancyChecker reports whether a validation entity is already
+// installed on the account. A failed read must be reported as an error
+// (not occupied=false): the allocator treats errors as occupied.
+type EntityOccupancyChecker func(ctx context.Context, account common.Address, entity uint32) (occupied bool, err error)
+
+// WindowVerifier reads the TimeRangeModule window for (account, entity).
+// validUntil / validAfter are unix seconds (uint48 on chain).
+type WindowVerifier func(ctx context.Context, chainID int64, account common.Address, entity uint32) (validUntilSec, validAfterSec uint64, err error)
+
 // ActiveSessionPolicyForWallet returns the usable grant for one wallet.
 //
 // Exactly one usable grant per wallet is expected. More than one is refused
@@ -238,6 +268,73 @@ func NextSessionEntityID(db storage.Storage, chainID int64, owner, wallet common
 	return next, nil
 }
 
+// sessionEntityTaken reports whether any stored policy on this runner
+// already occupies entity. Used by submit instead of comparing against
+// storage-only NextSessionEntityID, which would false-collide after an
+// occupancy-aware prepare skipped on-chain leftovers (#763 A).
+func sessionEntityTaken(db storage.Storage, chainID int64, owner, wallet common.Address, entity uint32) (bool, error) {
+	policies, err := ListSessionPolicies(db, chainID, owner)
+	if err != nil {
+		return false, err
+	}
+	for _, p := range policies {
+		if p.Runner == nil || *p.Runner != wallet {
+			continue
+		}
+		if p.EntityID == entity {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// NextFreeSessionEntityID is NextSessionEntityID plus an on-chain occupancy
+// probe (#763 A). When check is nil the result is the storage-only id
+// (offline tests). A failed occupancy read is occupied, never free.
+// After maxEntityOccupancyProbes occupied candidates it returns a typed
+// SESSION_POLICY_ENTITY_OCCUPIED error rather than looping.
+func NextFreeSessionEntityID(
+	ctx context.Context,
+	db storage.Storage,
+	chainID int64,
+	owner, wallet common.Address,
+	check EntityOccupancyChecker,
+) (uint32, error) {
+	start, err := NextSessionEntityID(db, chainID, owner, wallet)
+	if err != nil {
+		return 0, err
+	}
+	if check == nil {
+		return start, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, occupancyProbeTimeout*time.Duration(maxEntityOccupancyProbes))
+	defer cancel()
+	var lastOccErr error
+	for i := uint32(0); i < maxEntityOccupancyProbes; i++ {
+		cand := start + i
+		occupied, occErr := check(ctx, wallet, cand)
+		if occErr != nil {
+			// Fail-closed: unknown is occupied, same as VerifySupersededTeardown.
+			lastOccErr = occErr
+			continue
+		}
+		if !occupied {
+			return cand, nil
+		}
+	}
+	if lastOccErr != nil {
+		return 0, fmt.Errorf(
+			"%s: no free validation entity on %s after %d probes (last occupancy read: %w)",
+			SessionPolicyEntityOccupiedCode, wallet.Hex(), maxEntityOccupancyProbes, lastOccErr)
+	}
+	return 0, fmt.Errorf(
+		"%s: no free validation entity on %s after %d probes starting at %d; leftover entities are still installed on the account",
+		SessionPolicyEntityOccupiedCode, wallet.Hex(), maxEntityOccupancyProbes, start)
+}
+
 // InstallSessionResolver wires the send path to this engine's session-policy
 // storage. Without it every MA v2 operation fails fast with "no session
 // authorization" — the gateway cannot sign as the owner fallback, and
@@ -251,7 +348,8 @@ func NextSessionEntityID(db storage.Storage, chainID int64, owner, wallet common
 // explicitly; tests that need one install their own scoped to their own
 // database.
 func (n *Engine) InstallSessionResolver() {
-	preset.SetSessionResolver(NewSessionResolver(n.db, controllerSessionSigner(n.config), n.teardownVerifier()))
+	n.sessionChainReads = true
+	preset.SetSessionResolver(newSessionResolver(n.db, controllerSessionSigner(n.config), n.teardownVerifier(), n.windowVerifier()))
 }
 
 // teardownVerifier reads a validation entity's signer on the chain the grant
@@ -278,6 +376,65 @@ func (n *Engine) teardownVerifier() TeardownVerifier {
 	}
 }
 
+// entityOccupancyChecker reports whether a validation entity is already
+// spoken for on chain (#763 A). Occupied means a non-zero signer OR a
+// non-zero deferred nonce sequence — the same definition
+// seedEntitiesConsumedOnChain uses. Teardown can zero the signer while
+// the EntryPoint sequence stays > 0, and PrepareSessionGrant assumes
+// sequence 0.
+func (n *Engine) entityOccupancyChecker(chainID int64) EntityOccupancyChecker {
+	return func(ctx context.Context, account common.Address, entity uint32) (bool, error) {
+		swCfg := n.ResolveSmartWalletConfig(chainID)
+		if swCfg == nil || swCfg.EthRpcUrl == "" {
+			return false, fmt.Errorf("no RPC configured for chain %d", chainID)
+		}
+		client, err := ethclient.DialContext(ctx, swCfg.EthRpcUrl)
+		if err != nil {
+			return false, fmt.Errorf("dialing chain %d: %w", chainID, err)
+		}
+		defer client.Close()
+
+		signer, err := aa.EntitySignerOnChain(ctx, client, account, entity)
+		if err != nil {
+			return false, err
+		}
+		if signer != (common.Address{}) {
+			return true, nil
+		}
+		seq, err := aa.EntityDeferredNonceSequence(ctx, client, account, entity)
+		if err != nil {
+			return false, err
+		}
+		return seq > 0, nil
+	}
+}
+
+// occupancyFor is the occupancy checker PrepareSessionPolicy/SubmitSessionPolicy
+// pass down. Nil unless InstallSessionResolver has run, so unit tests that
+// never install a resolver stay offline.
+func (n *Engine) occupancyFor(chainID int64) EntityOccupancyChecker {
+	if n == nil || !n.sessionChainReads {
+		return nil
+	}
+	return n.entityOccupancyChecker(chainID)
+}
+
+// windowVerifier reads TimeRangeModule.timeRanges for (account, entity).
+func (n *Engine) windowVerifier() WindowVerifier {
+	return func(ctx context.Context, chainID int64, account common.Address, entity uint32) (uint64, uint64, error) {
+		swCfg := n.ResolveSmartWalletConfig(chainID)
+		if swCfg == nil || swCfg.EthRpcUrl == "" {
+			return 0, 0, fmt.Errorf("no RPC configured for chain %d", chainID)
+		}
+		client, err := ethclient.DialContext(ctx, swCfg.EthRpcUrl)
+		if err != nil {
+			return 0, 0, fmt.Errorf("dialing chain %d: %w", chainID, err)
+		}
+		defer client.Close()
+		return aa.EntityTimeRangeOnChain(ctx, client, account, entity)
+	}
+}
+
 // NewSessionResolver builds the resolver the send path consults, backed by
 // storage and a key lookup.
 //
@@ -294,6 +451,15 @@ func NewSessionResolver(
 	db storage.Storage,
 	signerKeyFor func(signer common.Address) (*ecdsa.PrivateKey, error),
 	verifyTeardown TeardownVerifier,
+) preset.SessionResolver {
+	return newSessionResolver(db, signerKeyFor, verifyTeardown, nil)
+}
+
+func newSessionResolver(
+	db storage.Storage,
+	signerKeyFor func(signer common.Address) (*ecdsa.PrivateKey, error),
+	verifyTeardown TeardownVerifier,
+	verifyWindow WindowVerifier,
 ) preset.SessionResolver {
 	return func(chainID int64, owner, wallet common.Address) (*preset.SessionAuthorization, error) {
 		policy, err := ActiveSessionPolicyForWallet(db, chainID, owner, wallet)
@@ -321,6 +487,14 @@ func NewSessionResolver(
 				"%s: session policy %s on wallet %s expired at %s; grant again to keep executing",
 				SessionPolicyExpiredCode, policy.ID, wallet.Hex(),
 				time.UnixMilli(policy.ValidUntil).UTC().Format(time.RFC3339))
+		}
+		// Applied grants: the stored ValidUntil can disagree with the
+		// TimeRangeModule window actually installed on the entity — the
+		// entity-reuse drift #763 filed from. A+B close allocation; they
+		// cannot heal a record that is already stored wrong. Check once
+		// after install and cache the match so this is not paid per UserOp.
+		if err := checkAppliedChainWindow(db, policy, verifyWindow); err != nil {
+			return nil, err
 		}
 		key, err := signerKeyFor(*policy.SessionSigner)
 		if err != nil {
@@ -428,6 +602,129 @@ func controllerSessionSigner(cfg *config.Config) func(common.Address) (*ecdsa.Pr
 		}
 		return cfg.SmartWallet.ControllerPrivateKey, nil
 	}
+}
+
+// checkAppliedChainWindow compares a stored grant's ValidUntil against the
+// TimeRangeModule window on the entity (#763 C). Pending grants skip: the
+// install has not landed. Already-checked grants skip: the match is cached
+// on ChainWindowChecked. verifyWindow nil skips (offline tests).
+//
+// A read failure is returned as-is (infra), not as a mismatch. A mismatch
+// is the typed SESSION_POLICY_CHAIN_WINDOW_MISMATCH so the send never
+// reaches the bundler's opaque expiry string.
+func checkAppliedChainWindow(db storage.Storage, policy *model.SessionPolicy, verifyWindow WindowVerifier) error {
+	if policy == nil || policy.Grant == nil || !policy.Grant.Applied() {
+		return nil
+	}
+	if policy.Grant.ChainWindowChecked || verifyWindow == nil || policy.ValidUntil <= 0 {
+		return nil
+	}
+	if policy.Owner == nil || policy.Runner == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), teardownVerifyTimeout)
+	defer cancel()
+	untilSec, _, err := verifyWindow(ctx, policy.ChainID, *policy.Runner, policy.EntityID)
+	if err != nil {
+		return fmt.Errorf("reading TimeRange for session policy %s entity %d on %s: %w",
+			policy.ID, policy.EntityID, policy.Runner.Hex(), err)
+	}
+	storedSec := uint64(policy.ValidUntil / 1000)
+	if untilSec != storedSec {
+		return fmt.Errorf(
+			"%s: session policy %s entity %d on %s: stored validUntil %s, chain validUntil %s; grant again onto a free entity",
+			SessionPolicyChainWindowMismatchCode, policy.ID, policy.EntityID, policy.Runner.Hex(),
+			time.UnixMilli(policy.ValidUntil).UTC().Format(time.RFC3339),
+			time.Unix(int64(untilSec), 0).UTC().Format(time.RFC3339))
+	}
+	if markErr := MarkChainWindowChecked(db, policy.ChainID, *policy.Owner, *policy.Runner, policy.ID); markErr != nil {
+		// The send is still good — the windows matched. A failed mark
+		// only means the next UserOp re-reads the chain.
+		if globalLogger != nil {
+			globalLogger.Warn("chain window matched but ChainWindowChecked could not be stored",
+				"policy", policy.ID, "error", markErr)
+		}
+	} else {
+		policy.Grant.ChainWindowChecked = true
+	}
+	return nil
+}
+
+// MarkChainWindowChecked records that the send path has confirmed the
+// entity's installed TimeRange agrees with storage. Idempotent.
+func MarkChainWindowChecked(db storage.Storage, chainID int64, owner, runner common.Address, policyID string) error {
+	lock := sessionAuthorityLock(chainID, owner, runner)
+	lock.Lock()
+	defer lock.Unlock()
+	raw, err := db.GetKey(SessionPolicyKey(chainID, owner, policyID))
+	if err != nil {
+		return err
+	}
+	policy := &model.SessionPolicy{}
+	if err := policy.FromStorageData(raw); err != nil {
+		return err
+	}
+	if policy.Grant == nil || policy.Grant.ChainWindowChecked {
+		return nil
+	}
+	policy.Grant.ChainWindowChecked = true
+	return StoreSessionPolicy(db, policy)
+}
+
+// DriftedSessionGrant is one stored policy whose ValidUntil disagrees
+// with the TimeRangeModule window on its entity (#763 sweep).
+type DriftedSessionGrant struct {
+	Policy         *model.SessionPolicy
+	StoredUntilSec uint64
+	ChainUntilSec  uint64
+	ChainAfterSec  uint64
+	ReadErr        error
+}
+
+// FindDriftedSessionGrants walks applied usable grants on chainID and
+// reports those whose installed window disagrees with storage. A+B do
+// not heal already-stored records; this is how operators find them so
+// the owner can re-grant onto a free entity.
+//
+// verify nil: nothing to compare, empty result.
+// A read failure is recorded on the row rather than aborting the sweep.
+func FindDriftedSessionGrants(ctx context.Context, db storage.Storage, chainID int64, verify WindowVerifier) ([]DriftedSessionGrant, error) {
+	if verify == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	items, err := db.GetByPrefix(SessionPolicyChainPrefix(chainID))
+	if err != nil {
+		return nil, fmt.Errorf("listing session policies on chain %d: %w", chainID, err)
+	}
+	out := make([]DriftedSessionGrant, 0)
+	for _, item := range items {
+		policy := &model.SessionPolicy{}
+		if err := policy.FromStorageData(item.Value); err != nil {
+			return nil, fmt.Errorf("session policy at %s is unreadable: %w", string(item.Key), err)
+		}
+		if !policy.Usable() || policy.Grant == nil || !policy.Grant.Applied() || policy.ValidUntil <= 0 {
+			continue
+		}
+		if policy.Runner == nil {
+			continue
+		}
+		storedSec := uint64(policy.ValidUntil / 1000)
+		untilSec, afterSec, readErr := verify(ctx, chainID, *policy.Runner, policy.EntityID)
+		if readErr != nil {
+			out = append(out, DriftedSessionGrant{Policy: policy, StoredUntilSec: storedSec, ReadErr: readErr})
+			continue
+		}
+		if untilSec != storedSec {
+			out = append(out, DriftedSessionGrant{
+				Policy: policy, StoredUntilSec: storedSec,
+				ChainUntilSec: untilSec, ChainAfterSec: afterSec,
+			})
+		}
+	}
+	return out, nil
 }
 
 // maxOnChainTeardowns is how many prior entities one replacement batch

--- a/docs/changes/20260821-session-entity-reuse-drift.md
+++ b/docs/changes/20260821-session-entity-reuse-drift.md
@@ -1,0 +1,66 @@
+# Session grant entity reuse inherits stale on-chain hooks
+
+- **Date**: 2026-08-21
+- **Status**: Implemented
+- **Branch**: `fix/763-entity-reuse-drift`
+- **Related**: [#763](https://github.com/AvaProtocol/EigenLayer-AVS/issues/763), [#761](https://github.com/AvaProtocol/EigenLayer-AVS/issues/761), `cc19bec4` (`SESSION_POLICY_EXPIRED`)
+
+## Problem
+
+`NextSessionEntityID` derives the next validation entity from stored records
+only. `RevokeSessionGrant` deleted pending-without-InstallCall rows, which
+made those entities invisible to the allocator. Installing a new grant into
+an entity the account still held kept the **old** TimeRangeModule window.
+
+Observed on the Sepolia e2e fixture: storage said entity 2 was valid until
+2027-08-21; the account enforced 2026-08-13. Every UserOp failed as
+"User Operation expired or has an invalid time range" with nothing pointing
+at the drifted record. Sentry `EIGENLAYER-AVS-2C`. This is not the
+storage-known expiry `cc19bec4` already refuses.
+
+## Decision
+
+Sequenced **B → A → reader → C + sweep**. A and B are not substitutes.
+
+- **B.** `RevokeSessionGrant` never deletes. Revoked records stay so
+  `NextSessionEntityID` keeps the entity reserved. Incomplete revoked
+  rows are allowed by `Validate()`.
+- **A.** Prepare/submit allocate with `NextFreeSessionEntityID`: storage
+  max+1, then a bounded on-chain occupancy probe (signer **or** deferred
+  nonce sequence, fail-closed on read error, cap 8, then
+  `SESSION_POLICY_ENTITY_OCCUPIED`). Wired on the Engine only after
+  `InstallSessionResolver`, so unit tests stay offline.
+- **Reader.** `aa.EntityTimeRangeOnChain` reads
+  `TimeRangeModule.timeRanges(uint32,address) → (uint48, uint48)`.
+- **C.** The send path, for applied grants not yet cached, compares the
+  installed window to stored `ValidUntil`. Mismatch is
+  `SESSION_POLICY_CHAIN_WINDOW_MISMATCH` (never reaches the bundler).
+  Match sets `Grant.ChainWindowChecked`.
+- **Sweep.** `FindDriftedSessionGrants` plus
+  `scripts/sweep_session_windows` list already-stored drift. Re-grant is
+  the owner's — this process cannot produce the signature.
+
+## Alternatives considered
+
+- **C alone.** Types the failure but still lets a colliding grant be
+  signed and stored; every send fails until someone re-grants — the loop
+  #761 exists to stop. The allocator invariant stays broken.
+- **Folding expiry into `Usable()`.** Rejected in `cc19bec4`;
+  `TestUsableIgnoresExpiryOnPurpose` pins it. An expired record still
+  occupies its entity.
+- **Closing on B alone.** The named delete path is one way to free an
+  entity; a wiped DB or an install that never got a record still needs A.
+  A+B also cannot heal a grant that is already stored wrong — that is C
+  and the sweep.
+
+## Verification
+
+- Unit tests in `session_entity_drift_test.go` (occupancy skip / fail-closed /
+  probe cap, revoke-without-delete, window mismatch, cache, sweep).
+- `EntityTimeRangeOnChain` encoding tests in `ma_v2_entity_state_test.go`.
+- `make storage-check` against the branch point: `ChainWindowChecked` is
+  additive `omitempty`; `sp:%d:` is an additive scan prefix.
+- Live Sepolia (optional, funded MA v2): grant, revoke without on-chain
+  cleanup, grant again — second grant must take a new entity and not
+  inherit the first's time range. A alone would have prevented the
+  original incident at 08:02 (entity 2 occupied → allocate 3).

--- a/model/session_policy.go
+++ b/model/session_policy.go
@@ -18,8 +18,8 @@ import (
 //
 //   - The grant is a BEARER authorization for exactly its committed calldata.
 //     It authorizes execution against the user's wallet, so it gets the same
-//     handling as a secret: not logged, not returned in list responses,
-//     deleted on revoke.
+//     handling as a secret: not logged, not returned in list responses.
+//     Revoke retains the record so the entity stays reserved (#763 B).
 //
 //   - InstallCall is stored rather than re-derived. Re-building it from the
 //     policy fields at execution time would let a later code change silently
@@ -126,6 +126,11 @@ type SessionGrantAuthorization struct {
 	// this install. Recorded at grant time so the send path does not have to
 	// re-parse the install calldata to find out.
 	RequiresExecuteUserOp bool `json:"requires_execute_user_op,omitempty"`
+
+	// ChainWindowChecked is set after the send path has read the entity's
+	// installed TimeRangeModule window and found it agrees with ValidUntil.
+	// Cached so the chain read is not paid on every UserOp (#763 C).
+	ChainWindowChecked bool `json:"chain_window_checked,omitempty"`
 }
 
 // SessionPolicyStatus tracks how far a grant has got.
@@ -203,6 +208,13 @@ func (p *SessionPolicy) Validate() error {
 	}
 	if p.EntityID == 0 {
 		return fmt.Errorf("session policy %s uses entity 0, which is the owner's fallback signer", p.ID)
+	}
+	// Revoked records exist to keep the entity reserved (#763 B). They do
+	// not authorize anything, so incomplete grant material is allowed —
+	// otherwise RevokeSessionGrant could not retain a pending-without-
+	// InstallCall row and NextSessionEntityID would reuse that entity.
+	if p.Status == SessionPolicyRevoked {
+		return nil
 	}
 	if p.SessionSigner == nil || *p.SessionSigner == (common.Address{}) {
 		return fmt.Errorf("session policy %s has no session signer", p.ID)

--- a/pkg/erc4337/preset/bundler_error.go
+++ b/pkg/erc4337/preset/bundler_error.go
@@ -61,6 +61,10 @@ func IsClientUserOpFailure(err error) bool {
 		// Typed preflight: the grant's TimeRangeModule window closed. The
 		// owner renews it by granting again; nothing here is operable.
 		return true
+	case strings.Contains(s, "SESSION_POLICY_CHAIN_WINDOW_MISMATCH"):
+		// Typed preflight: stored ValidUntil disagrees with the entity's
+		// installed TimeRange (#763 C). Re-grant onto a free entity.
+		return true
 	case strings.Contains(s, "SESSION_POLICY_NATIVE_NOT_ALLOWED"):
 		// Typed preflight: native ETH under a selector-scoped grant. Refused
 		// before the bundler, so this never reflects gateway health — and it

--- a/pkg/erc4337/preset/bundler_error.go
+++ b/pkg/erc4337/preset/bundler_error.go
@@ -61,6 +61,10 @@ func IsClientUserOpFailure(err error) bool {
 		// Typed preflight: the grant's TimeRangeModule window closed. The
 		// owner renews it by granting again; nothing here is operable.
 		return true
+	case strings.Contains(s, "SESSION_POLICY_CHAIN_WINDOW_MISSING"):
+		// Entity carries no TimeRange hook while storage promises one. The
+		// owner clears it by granting again; nothing here is operable.
+		return true
 	case strings.Contains(s, "SESSION_POLICY_CHAIN_WINDOW_MISMATCH"):
 		// Typed preflight: stored ValidUntil disagrees with the entity's
 		// installed TimeRange (#763 C). Re-grant onto a free entity.

--- a/pkg/erc4337/preset/bundler_error_test.go
+++ b/pkg/erc4337/preset/bundler_error_test.go
@@ -30,6 +30,7 @@ func TestIsClientUserOpFailure(t *testing.T) {
 		{"multi grant", errors.New("wallet 0x has more than one usable session policy (a, b); revoke one"), true},
 		{"preflight", errors.New("SESSION_POLICY_TARGET_NOT_ALLOWED: session grant does not allow: approve target=0xWETH"), true},
 		{"expired grant", errors.New("SESSION_POLICY_EXPIRED: session policy 01abc on wallet 0xdef expired at 2026-08-13T20:04:33Z; grant again to keep executing"), true},
+		{"chain window mismatch", errors.New("SESSION_POLICY_CHAIN_WINDOW_MISMATCH: session policy p1 entity 2: stored validUntil 2027, chain validUntil 2026"), true},
 		{"prefund", errors.New("smart wallet 0x cannot pay gas: native balance and EntryPoint deposit are both zero"), true},
 		{"webhook deny", fmt.Errorf("gas manager declined to sponsor: alchemy_requestGasAndPaymasterAndData (policy x): Request was denied by webhook"), true},
 		{"AA23 via gas manager", fmt.Errorf("gas manager declined to sponsor: alchemy_requestGasAndPaymasterAndData (policy bf905871): validation reverted: [reason]: AA23 reverted"), true},

--- a/pkg/erc4337/preset/bundler_error_test.go
+++ b/pkg/erc4337/preset/bundler_error_test.go
@@ -31,6 +31,7 @@ func TestIsClientUserOpFailure(t *testing.T) {
 		{"preflight", errors.New("SESSION_POLICY_TARGET_NOT_ALLOWED: session grant does not allow: approve target=0xWETH"), true},
 		{"expired grant", errors.New("SESSION_POLICY_EXPIRED: session policy 01abc on wallet 0xdef expired at 2026-08-13T20:04:33Z; grant again to keep executing"), true},
 		{"chain window mismatch", errors.New("SESSION_POLICY_CHAIN_WINDOW_MISMATCH: session policy p1 entity 2: stored validUntil 2027, chain validUntil 2026"), true},
+		{"chain window missing", errors.New("SESSION_POLICY_CHAIN_WINDOW_MISSING: session policy 01abc entity 3 on 0xdef has no TimeRange hook installed"), true},
 		{"prefund", errors.New("smart wallet 0x cannot pay gas: native balance and EntryPoint deposit are both zero"), true},
 		{"webhook deny", fmt.Errorf("gas manager declined to sponsor: alchemy_requestGasAndPaymasterAndData (policy x): Request was denied by webhook"), true},
 		{"AA23 via gas manager", fmt.Errorf("gas manager declined to sponsor: alchemy_requestGasAndPaymasterAndData (policy bf905871): validation reverted: [reason]: AA23 reverted"), true},

--- a/scripts/sweep_session_windows/main.go
+++ b/scripts/sweep_session_windows/main.go
@@ -79,6 +79,7 @@ func run() error {
 	}
 
 	fmt.Printf("drifted session grants on chain %d: %d\n", *chainID, len(drifted))
+	missing := 0
 	for _, d := range drifted {
 		p := d.Policy
 		runner := ""
@@ -90,10 +91,26 @@ func run() error {
 				p.ID, p.EntityID, runner, d.StoredUntilSec, d.ReadErr)
 			continue
 		}
+		if d.WindowMissing {
+			// Printing chainUntil here would render as 1970-01-01 and read as a
+			// corrupt date rather than "the hook was never installed".
+			fmt.Printf("  policy=%s entity=%d runner=%s storedUntil=%s chainUntil=NO HOOK INSTALLED\n",
+				p.ID, p.EntityID, runner,
+				time.Unix(int64(d.StoredUntilSec), 0).UTC().Format(time.RFC3339))
+			missing++
+			continue
+		}
 		fmt.Printf("  policy=%s entity=%d runner=%s storedUntil=%s chainUntil=%s\n",
 			p.ID, p.EntityID, runner,
 			time.Unix(int64(d.StoredUntilSec), 0).UTC().Format(time.RFC3339),
 			time.Unix(int64(d.ChainUntilSec), 0).UTC().Format(time.RFC3339))
+	}
+	if missing > 0 {
+		// This is the number that decides whether it is safe to deploy: these
+		// are the grants the send path will begin refusing.
+		fmt.Printf("\n%d of %d have NO TimeRange hook installed.\n", missing, len(drifted))
+		fmt.Printf("Those are refused as %s once this build is live — re-grant them first.\n",
+			taskengine.SessionPolicyChainWindowMissingCode)
 	}
 	log.Printf("re-grant each drifted runner onto a free entity; this script does not write")
 	return nil

--- a/scripts/sweep_session_windows/main.go
+++ b/scripts/sweep_session_windows/main.go
@@ -1,0 +1,100 @@
+// sweep_session_windows — find stored session grants whose TimeRangeModule
+// window disagrees with SessionPolicy.ValidUntil (#763 sweep).
+//
+// A+B close allocation going forward; they cannot heal a grant that is
+// already stored wrong. This walk is how operators find those records so
+// the owner can re-grant onto a free entity. It does not revoke or re-grant
+// — the owner signature cannot be produced here.
+//
+// READ-ONLY in intent, but BadgerDB takes an exclusive directory lock, so
+// run against a COPY/backup of the gateway DB, not the live directory.
+//
+// Usage:
+//
+//	go run ./scripts/sweep_session_windows \
+//	  --gateway-path /path/to/gateway-db-copy \
+//	  --chain 11155111 \
+//	  --rpc "$ETH_RPC_URL"
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "sweep failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	gatewayPath := flag.String("gateway-path", "", "Path to a COPY of the gateway BadgerDB directory (not the live DB)")
+	chainID := flag.Int64("chain", 0, "Chain id to scan (e.g. 11155111)")
+	rpcURL := flag.String("rpc", "", "HTTP RPC URL for TimeRangeModule.timeRanges reads")
+	flag.Parse()
+	if *gatewayPath == "" || *chainID <= 0 || *rpcURL == "" {
+		return fmt.Errorf("--gateway-path, --chain, and --rpc are required")
+	}
+
+	db, err := storage.NewWithPath(*gatewayPath)
+	if err != nil {
+		return fmt.Errorf("open BadgerDB at %s: %w", *gatewayPath, err)
+	}
+	defer db.Close()
+
+	client, err := ethclient.Dial(*rpcURL)
+	if err != nil {
+		return fmt.Errorf("dialing RPC: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	verify := func(ctx context.Context, _ int64, account common.Address, entity uint32) (uint64, uint64, error) {
+		return aa.EntityTimeRangeOnChain(ctx, client, account, entity)
+	}
+
+	drifted, err := taskengine.FindDriftedSessionGrants(ctx, db, *chainID, verify)
+	if err != nil {
+		return err
+	}
+
+	if len(drifted) == 0 {
+		fmt.Printf("no drifted session grants on chain %d\n", *chainID)
+		return nil
+	}
+
+	fmt.Printf("drifted session grants on chain %d: %d\n", *chainID, len(drifted))
+	for _, d := range drifted {
+		p := d.Policy
+		runner := ""
+		if p.Runner != nil {
+			runner = p.Runner.Hex()
+		}
+		if d.ReadErr != nil {
+			fmt.Printf("  policy=%s entity=%d runner=%s storedUntil=%d read_error=%v\n",
+				p.ID, p.EntityID, runner, d.StoredUntilSec, d.ReadErr)
+			continue
+		}
+		fmt.Printf("  policy=%s entity=%d runner=%s storedUntil=%s chainUntil=%s\n",
+			p.ID, p.EntityID, runner,
+			time.Unix(int64(d.StoredUntilSec), 0).UTC().Format(time.RFC3339),
+			time.Unix(int64(d.ChainUntilSec), 0).UTC().Format(time.RFC3339))
+	}
+	log.Printf("re-grant each drifted runner onto a free entity; this script does not write")
+	return nil
+}


### PR DESCRIPTION
Closes #763.

## Why

`NextSessionEntityID` derived the next validation entity from stored records only, and `RevokeSessionGrant` deleted pending-without-InstallCall rows. Installing a new grant into an entity the account still held kept the **old** TimeRangeModule window.

Observed on the Sepolia e2e fixture: storage said entity 2 was valid until 2027-08-21; the account enforced 2026-08-13. Every UserOp failed as "User Operation expired or has an invalid time range" with nothing pointing at the drifted record. Sentry `EIGENLAYER-AVS-2C`. This is not the storage-known expiry #764 already refuses.

A and B are not substitutes. They close **allocation**, prospectively. Neither heals a grant that is already stored wrong — which is the state this was filed from. That needs a chain read (C) and a sweep.

## What

Sequenced **B → A → reader → C + sweep**:

- **B.** `RevokeSessionGrant` never deletes. Revoked records stay so `NextSessionEntityID` keeps the entity reserved. Incomplete revoked rows are allowed by `Validate()`.
- **A.** Prepare/submit allocate with `NextFreeSessionEntityID`: storage max+1, then a bounded on-chain occupancy probe (signer **or** deferred nonce sequence, fail-closed on read error, cap 8, then `SESSION_POLICY_ENTITY_OCCUPIED`). Wired on the Engine only after `InstallSessionResolver()`, so unit tests stay offline.
- **Reader.** `aa.EntityTimeRangeOnChain` reads `TimeRangeModule.timeRanges(uint32,address) → (uint48, uint48)`.
- **C.** For applied grants not yet cached, the send path compares the installed window to stored `ValidUntil`. Mismatch is `SESSION_POLICY_CHAIN_WINDOW_MISMATCH` (never reaches the bundler). Match sets `Grant.ChainWindowChecked`.
- **Sweep.** `FindDriftedSessionGrants` plus `scripts/sweep_session_windows` list already-stored drift. Re-grant is the owner's — this process cannot produce the signature.

`Usable()` stays status-only. `TestUsableIgnoresExpiryOnPurpose` still pins that.

See `docs/changes/20260821-session-entity-reuse-drift.md`.

## Test plan

- [x] Occupancy: skip occupied, fail-closed on read error, probe cap → typed error
- [x] Revoke without delete keeps the entity reserved
- [x] Send path refuses a stored/chain window mismatch; matching window is cached
- [x] Sweep reports mismatch and ignores matching windows
- [x] `EntityTimeRangeOnChain` encoding + short-return errors
- [x] `SESSION_POLICY_CHAIN_WINDOW_MISMATCH` is classified client-fixable
- [x] `make storage-check` vs staging: additive only (`ChainWindowChecked omitempty`, scan prefix `sp:%d:`)
- [ ] Live Sepolia: grant, revoke without on-chain cleanup, grant again — second grant must take a new entity and not inherit the first's time range

## Out of scope

- `SESSION_POLICY_EXPIRED` (shipped in #764) — storage itself knows the grant is expired
- Auto re-grant of drifted records (needs the owner signature)
- The ava-sdk-js fixture refresh scripts (workaround, not the fix)
