### PR TITLE
fix: authenticate the operator gRPC plane, honoring declared alias keys

### DIFF
--- a/aggregator/auth.go
+++ b/aggregator/auth.go
@@ -3,6 +3,9 @@ package aggregator
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/auth"
 	"google.golang.org/grpc/metadata"
@@ -36,5 +39,33 @@ func (r *RpcServer) verifyOperator(ctx context.Context, operatorAddr string) (bo
 		return false, fmt.Errorf("missing auth header")
 	}
 
-	return auth.VerifyOperator(authRawHeaders[0], operatorAddr)
+	signerAddress, err := auth.OperatorSignerFromAuthHeader(authRawHeaders[0], operatorAddr)
+	if err != nil {
+		return false, err
+	}
+
+	// The common case: the operator signed with its own registered key.
+	if strings.EqualFold(signerAddress.Hex(), operatorAddr) {
+		return true, nil
+	}
+
+	// Otherwise the signature only counts if it came from the alias key
+	// this operator declared on chain. Resolving that mapping is what
+	// makes an alias-key operator distinguishable from an impostor.
+	if r.aliasResolver == nil {
+		return false, fmt.Errorf("signature is not from operator %s and alias resolution is unavailable", operatorAddr)
+	}
+
+	alias, err := r.aliasResolver.aliasFor(ctx, common.HexToAddress(operatorAddr))
+	if err != nil {
+		return false, fmt.Errorf("resolving alias for operator %s: %w", operatorAddr, err)
+	}
+	if alias == (common.Address{}) {
+		return false, fmt.Errorf("operator %s declared no alias and did not sign with its own key", operatorAddr)
+	}
+	if alias != signerAddress {
+		return false, fmt.Errorf("signature is from neither operator %s nor its declared alias", operatorAddr)
+	}
+
+	return true, nil
 }

--- a/aggregator/auth.go
+++ b/aggregator/auth.go
@@ -14,17 +14,18 @@ import (
 // helper they shared with the other Aggregator handlers is no longer
 // needed because REST middleware verifies JWTs in the handler stack.
 //
-// What stays in this file: verifyOperator, the operator-stream gRPC
-// auth check used by the Node service. Operators continue to speak
-// gRPC.
+// What stays in this file: verifyOperator, the operator gRPC auth check
+// used by the Node service. Operators continue to speak gRPC. It is
+// applied to every Node RPC by the interceptors in
+// operator_auth_interceptor.go, not by individual handlers.
 
-// verifyOperator checks validity of the signature submit by operator related request
+// verifyOperator checks validity of the signature submit by operator related request.
+//
+// Callers get (false, err) on every failure; there is no configuration
+// that turns this into a pass. It used to short-circuit on an
+// `enforceAuth = false` constant left over from the 1.3 operator
+// rollout, which made the whole Node service callable by anyone.
 func (r *RpcServer) verifyOperator(ctx context.Context, operatorAddr string) (bool, error) {
-	// TODO: Temporary not enforce auth
-	if !enforceAuth {
-		return true, nil
-	}
-
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return false, fmt.Errorf("cannot read metadata from request")
@@ -37,7 +38,3 @@ func (r *RpcServer) verifyOperator(ctx context.Context, operatorAddr string) (bo
 
 	return auth.VerifyOperator(authRawHeaders[0], operatorAddr)
 }
-
-// enforceAuth toggles operator-side auth enforcement. Same default as
-// the legacy file: false until all operators upgrade past 1.3.
-const enforceAuth = false

--- a/aggregator/health_deep.go
+++ b/aggregator/health_deep.go
@@ -69,12 +69,24 @@ type operatorHealth struct {
 	Addresses []string `json:"addresses"`
 }
 
+// apconfigHealth is one APConfig deployment the aggregator consults
+// for operator alias keys. A down source is a new startup dependency:
+// without it, alias-key operators on that AVS chain cannot authenticate.
+type apconfigHealth struct {
+	ChainID int64  `json:"chain_id"`
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	Status  string `json:"status"`
+	Error   string `json:"error,omitempty"`
+}
+
 type deepHealthResp struct {
-	Status    string         `json:"status"`
-	Version   string         `json:"version"`
-	CheckedAt time.Time      `json:"checked_at"`
-	Workers   []workerHealth `json:"workers"`
-	Operators operatorHealth `json:"operators"`
+	Status    string           `json:"status"`
+	Version   string           `json:"version"`
+	CheckedAt time.Time        `json:"checked_at"`
+	Workers   []workerHealth   `json:"workers"`
+	Operators operatorHealth   `json:"operators"`
+	APConfig  []apconfigHealth `json:"apconfig,omitempty"`
 }
 
 type deepHealthCache struct {
@@ -150,6 +162,15 @@ func (agg *Aggregator) collectDeepHealth(ctx context.Context) *deepHealthResp {
 	// trigger will ever fire, no matter how healthy the rest looks.
 	if resp.Operators.Connected == 0 {
 		resp.Status = deepHealthDegraded
+	}
+
+	if agg.rpcServer != nil && agg.rpcServer.aliasResolver != nil {
+		resp.APConfig = agg.rpcServer.aliasResolver.ping(ctx)
+		for _, src := range resp.APConfig {
+			if src.Status != deepHealthOK {
+				resp.Status = deepHealthDegraded
+			}
+		}
 	}
 
 	return resp

--- a/aggregator/http_server.go
+++ b/aggregator/http_server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"os"
 	"text/template"
 
 	"context"
@@ -177,8 +176,16 @@ func (agg *Aggregator) startHttpServer(ctx context.Context, extraMounts []HTTPMo
 	// sponsorship". See gas_manager_webhook.go.
 	agg.registerGasManagerWebhook(e)
 
-	// Register debug endpoints only if not in production
-	if os.Getenv("APP_ENV") != "production" {
+	// Register debug endpoints only in development.
+	//
+	// This used to key off `APP_ENV != "production"`, but APP_ENV is set
+	// in no deployment, so the condition was always true and both routes
+	// were live in production — unauthenticated, and one of them panics
+	// on request while the other writes caller-supplied text straight
+	// into Sentry. isDev comes from the `environment:` config field,
+	// which production actually sets, and an unset value reads as
+	// not-development.
+	if isDev {
 		// Debug endpoints to validate Sentry wiring from a running instance
 		// These are lightweight and safe: they are no-ops if Sentry isn't initialized
 		e.GET("/_debug/sentry/message", func(c echo.Context) error {

--- a/aggregator/operator_alias.go
+++ b/aggregator/operator_alias.go
@@ -1,0 +1,94 @@
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/apconfig"
+)
+
+// Operators are not required to run with the key behind their registered
+// EigenLayer address. They may declare an alias — a hot key held by the
+// running node — against that address in the APConfig contract, keeping
+// the registered key cold. Two of the three operators approved on
+// mainnet do exactly this, so the aggregator cannot authenticate the
+// operator plane by comparing a recovered signature to the claimed
+// address alone; it has to resolve the same mapping the operator
+// declared.
+
+const (
+	// aliasCacheTTL bounds how stale a mapping may get. Declaring an
+	// alias is an on-chain transaction, so it changes rarely, and this
+	// keeps a per-RPC chain call off the auth path.
+	aliasCacheTTL = 5 * time.Minute
+
+	// aliasLookupTimeout caps a single APConfig call so a slow RPC
+	// endpoint cannot stall operator authentication.
+	aliasLookupTimeout = 10 * time.Second
+)
+
+type aliasEntry struct {
+	alias     common.Address
+	fetchedAt time.Time
+}
+
+type operatorAliasResolver struct {
+	contract *apconfig.APConfig
+	logger   sdklogging.Logger
+
+	mu    sync.Mutex
+	cache map[common.Address]aliasEntry
+}
+
+func newOperatorAliasResolver(contract *apconfig.APConfig, logger sdklogging.Logger) *operatorAliasResolver {
+	return &operatorAliasResolver{
+		contract: contract,
+		logger:   logger,
+		cache:    make(map[common.Address]aliasEntry),
+	}
+}
+
+// aliasFor returns the alias key an operator declared, or the zero
+// address when it declared none and is expected to sign with its own key.
+func (r *operatorAliasResolver) aliasFor(ctx context.Context, operator common.Address) (common.Address, error) {
+	r.mu.Lock()
+	entry, cached := r.cache[operator]
+	r.mu.Unlock()
+
+	if cached && time.Since(entry.fetchedAt) < aliasCacheTTL {
+		return entry.alias, nil
+	}
+
+	if r.contract == nil {
+		return common.Address{}, fmt.Errorf("APConfig contract is not configured")
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, aliasLookupTimeout)
+	defer cancel()
+
+	alias, err := r.contract.GetAlias(&bind.CallOpts{Context: lookupCtx}, operator)
+	if err != nil {
+		// An RPC blip must not disconnect every alias-key operator at
+		// once. A stale mapping is still the one the operator declared —
+		// changing it takes a deliberate on-chain transaction — so
+		// serving it is safer than refusing the whole fleet.
+		if cached {
+			r.logger.Warn("APConfig alias lookup failed, falling back to cached mapping",
+				"operator", operator.Hex(), "error", err)
+			return entry.alias, nil
+		}
+		return common.Address{}, fmt.Errorf("looking up alias for %s: %w", operator.Hex(), err)
+	}
+
+	r.mu.Lock()
+	r.cache[operator] = aliasEntry{alias: alias, fetchedAt: time.Now()}
+	r.mu.Unlock()
+
+	return alias, nil
+}

--- a/aggregator/operator_alias.go
+++ b/aggregator/operator_alias.go
@@ -9,6 +9,7 @@ import (
 	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/apconfig"
 )
@@ -21,6 +22,14 @@ import (
 // operator plane by comparing a recovered signature to the claimed
 // address alone; it has to resolve the same mapping the operator
 // declared.
+//
+// A multi-chain gateway talks to operators registered on more than one
+// AVS chain. Aliases live on that chain's APConfig, not on a single
+// "the" APConfig: the Sepolia operator's mapping is on the testnet
+// deployment, the Ethereum operators' on mainnet. Binding only the
+// chain behind eth_rpc_url (Sepolia, in production) would refuse the
+// two alias-key mainnet operators at their first heartbeat. Every
+// configured AVS-chain RPC is therefore a source.
 
 const (
 	// aliasCacheTTL bounds how stale a mapping may get. Declaring an
@@ -38,24 +47,109 @@ type aliasEntry struct {
 	fetchedAt time.Time
 }
 
-type operatorAliasResolver struct {
+type aliasSource struct {
+	chainID  int64
+	name     string
 	contract *apconfig.APConfig
-	logger   sdklogging.Logger
+	client   *ethclient.Client
+	address  common.Address
+}
+
+type operatorAliasResolver struct {
+	sources []aliasSource
+	logger  sdklogging.Logger
 
 	mu    sync.Mutex
 	cache map[common.Address]aliasEntry
 }
 
-func newOperatorAliasResolver(contract *apconfig.APConfig, logger sdklogging.Logger) *operatorAliasResolver {
+func newOperatorAliasResolver(sources []aliasSource, logger sdklogging.Logger) *operatorAliasResolver {
 	return &operatorAliasResolver{
-		contract: contract,
-		logger:   logger,
-		cache:    make(map[common.Address]aliasEntry),
+		sources: sources,
+		logger:  logger,
+		cache:   make(map[common.Address]aliasEntry),
 	}
+}
+
+// bindAliasSources dials every APConfig this aggregator must consult.
+//
+// avsRPC is the top-level EigenLayer registration RPC (eth_rpc_url).
+// When a chain registry lists Ethereum mainnet, that chain's RPC is
+// bound too — production's two alias-key operators declared on mainnet
+// APConfig, not on Sepolia.
+//
+// A source with no contract code, or that cannot answer ChainID, is a
+// hard failure: a degraded resolver would refuse most of the fleet.
+func bindAliasSources(
+	ctx context.Context,
+	avsRPC *ethclient.Client,
+	registry *ChainRegistry,
+	logger sdklogging.Logger,
+) ([]aliasSource, error) {
+	if avsRPC == nil {
+		return nil, fmt.Errorf("AVS-chain RPC is required to resolve operator aliases")
+	}
+	sources := make([]aliasSource, 0, 2)
+
+	avsChainID, err := avsRPC.ChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading AVS chain id for operator alias resolution: %w", err)
+	}
+	src, err := bindOneAliasSource(ctx, avsRPC, avsChainID.Int64(), "avs", apconfig.AddressForChain(avsChainID))
+	if err != nil {
+		return nil, err
+	}
+	sources = append(sources, src)
+
+	if registry != nil {
+		if chainCfg, cfgErr := registry.GetChainConfig(1); cfgErr == nil && chainCfg != nil &&
+			chainCfg.SmartWallet != nil && chainCfg.SmartWallet.EthRpcUrl != "" && avsChainID.Int64() != 1 {
+			ethRPC, dialErr := ethclient.DialContext(ctx, chainCfg.SmartWallet.EthRpcUrl)
+			if dialErr != nil {
+				return nil, fmt.Errorf("dialing Ethereum RPC for mainnet APConfig: %w", dialErr)
+			}
+			mainnet, bindErr := bindOneAliasSource(ctx, ethRPC, 1, "ethereum", apconfig.MainnetAddress)
+			if bindErr != nil {
+				ethRPC.Close()
+				return nil, bindErr
+			}
+			sources = append(sources, mainnet)
+			if logger != nil {
+				logger.Info("operator alias resolution will consult mainnet APConfig",
+					"apconfig_address", apconfig.MainnetAddress.Hex())
+			}
+		}
+	}
+
+	return sources, nil
+}
+
+func bindOneAliasSource(ctx context.Context, rpc *ethclient.Client, chainID int64, name string, address common.Address) (aliasSource, error) {
+	code, err := rpc.CodeAt(ctx, address, nil)
+	if err != nil {
+		return aliasSource{}, fmt.Errorf("reading APConfig code at %s on %s (chain %d): %w", address.Hex(), name, chainID, err)
+	}
+	if len(code) == 0 {
+		return aliasSource{}, fmt.Errorf("no contract code at APConfig %s on %s (chain %d); operator alias resolution cannot start", address.Hex(), name, chainID)
+	}
+	contract, err := apconfig.NewAPConfig(address, rpc)
+	if err != nil {
+		return aliasSource{}, fmt.Errorf("binding APConfig at %s on %s: %w", address.Hex(), name, err)
+	}
+	return aliasSource{
+		chainID:  chainID,
+		name:     name,
+		contract: contract,
+		client:   rpc,
+		address:  address,
+	}, nil
 }
 
 // aliasFor returns the alias key an operator declared, or the zero
 // address when it declared none and is expected to sign with its own key.
+//
+// Every configured APConfig is consulted. A non-zero mapping on any of
+// them wins — operators register on one AVS chain, not both.
 func (r *operatorAliasResolver) aliasFor(ctx context.Context, operator common.Address) (common.Address, error) {
 	r.mu.Lock()
 	entry, cached := r.cache[operator]
@@ -65,30 +159,95 @@ func (r *operatorAliasResolver) aliasFor(ctx context.Context, operator common.Ad
 		return entry.alias, nil
 	}
 
-	if r.contract == nil {
+	if len(r.sources) == 0 {
+		if cached {
+			return entry.alias, nil
+		}
 		return common.Address{}, fmt.Errorf("APConfig contract is not configured")
 	}
 
 	lookupCtx, cancel := context.WithTimeout(ctx, aliasLookupTimeout)
 	defer cancel()
 
-	alias, err := r.contract.GetAlias(&bind.CallOpts{Context: lookupCtx}, operator)
-	if err != nil {
-		// An RPC blip must not disconnect every alias-key operator at
-		// once. A stale mapping is still the one the operator declared —
-		// changing it takes a deliberate on-chain transaction — so
-		// serving it is safer than refusing the whole fleet.
+	var lastErr error
+	found := common.Address{}
+	anyOK := false
+	anyErr := false
+	for _, src := range r.sources {
+		if src.contract == nil {
+			continue
+		}
+		alias, err := src.contract.GetAlias(&bind.CallOpts{Context: lookupCtx}, operator)
+		if err != nil {
+			anyErr = true
+			lastErr = fmt.Errorf("%s: %w", src.name, err)
+			continue
+		}
+		anyOK = true
+		if alias != (common.Address{}) {
+			found = alias
+			break
+		}
+	}
+
+	if found == (common.Address{}) && anyErr {
+		// Incomplete view: at least one source failed, and none of the
+		// successful ones had a mapping. Do not cache zero — that would
+		// treat a mainnet alias-key operator as "no alias" because
+		// Sepolia answered first with empty. Serve a stale mapping if
+		// we have one; otherwise fail the RPC.
 		if cached {
-			r.logger.Warn("APConfig alias lookup failed, falling back to cached mapping",
-				"operator", operator.Hex(), "error", err)
+			r.logger.Warn("APConfig alias lookup incomplete, falling back to cached mapping",
+				"operator", operator.Hex(), "error", lastErr)
 			return entry.alias, nil
 		}
-		return common.Address{}, fmt.Errorf("looking up alias for %s: %w", operator.Hex(), err)
+		return common.Address{}, fmt.Errorf("looking up alias for %s: %w", operator.Hex(), lastErr)
+	}
+	if !anyOK {
+		if cached {
+			r.logger.Warn("APConfig alias lookup failed, falling back to cached mapping",
+				"operator", operator.Hex(), "error", lastErr)
+			return entry.alias, nil
+		}
+		return common.Address{}, fmt.Errorf("looking up alias for %s: %w", operator.Hex(), lastErr)
 	}
 
 	r.mu.Lock()
-	r.cache[operator] = aliasEntry{alias: alias, fetchedAt: time.Now()}
+	r.cache[operator] = aliasEntry{alias: found, fetchedAt: time.Now()}
 	r.mu.Unlock()
 
-	return alias, nil
+	return found, nil
+}
+
+// ping reports whether each APConfig source still answers. Used by
+// /health/deep so a dead AVS-chain RPC is visible before operators
+// start failing auth.
+func (r *operatorAliasResolver) ping(ctx context.Context) []apconfigHealth {
+	if r == nil {
+		return nil
+	}
+	out := make([]apconfigHealth, 0, len(r.sources))
+	for _, src := range r.sources {
+		h := apconfigHealth{
+			ChainID: src.chainID,
+			Name:    src.name,
+			Address: src.address.Hex(),
+			Status:  deepHealthOK,
+		}
+		if src.client == nil {
+			h.Status = deepHealthDown
+			h.Error = "no rpc client"
+			out = append(out, h)
+			continue
+		}
+		callCtx, cancel := context.WithTimeout(ctx, aliasLookupTimeout)
+		_, err := src.client.CodeAt(callCtx, src.address, nil)
+		cancel()
+		if err != nil {
+			h.Status = deepHealthDown
+			h.Error = err.Error()
+		}
+		out = append(out, h)
+	}
+	return out
 }

--- a/aggregator/operator_alias_test.go
+++ b/aggregator/operator_alias_test.go
@@ -1,0 +1,59 @@
+package aggregator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+)
+
+func TestAliasForUsesFreshCacheWithoutSources(t *testing.T) {
+	operator := common.HexToAddress("0xc6b87cc9e85b07365b6abefff061f237f7cf7dc3")
+	alias := common.HexToAddress("0x4f061d46aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	r := withCachedAlias(operator.Hex(), alias.Hex())
+
+	got, err := r.aliasFor(context.Background(), operator)
+	if err != nil {
+		t.Fatalf("fresh cache should not need a contract: %v", err)
+	}
+	if got != alias {
+		t.Fatalf("got %s, want %s", got.Hex(), alias.Hex())
+	}
+}
+
+func TestAliasForFallsBackToStaleCacheWhenSourcesFail(t *testing.T) {
+	operator := common.HexToAddress("0xa026265a00000000000000000000000000000000")
+	alias := common.HexToAddress("0x62086dea00000000000000000000000000000000")
+	r := withCachedAlias(operator.Hex(), alias.Hex())
+	r.cache[operator] = aliasEntry{alias: alias, fetchedAt: time.Now().Add(-time.Hour)}
+	// A source with no contract is skipped; with a stale cache we must
+	// still serve the last mapping rather than refuse the operator.
+	r.sources = []aliasSource{{name: "ethereum"}}
+
+	got, err := r.aliasFor(context.Background(), operator)
+	if err != nil {
+		t.Fatalf("stale cache must survive a dead source: %v", err)
+	}
+	if got != alias {
+		t.Fatalf("got %s, want %s", got.Hex(), alias.Hex())
+	}
+}
+
+func TestPingReportsDownSource(t *testing.T) {
+	r := newOperatorAliasResolver([]aliasSource{{
+		chainID: 1,
+		name:    "ethereum",
+		address: common.HexToAddress("0x9c02dfc92eea988902a98919bf4f035e4aaefced"),
+	}}, testutil.GetLogger())
+
+	got := r.ping(context.Background())
+	if len(got) != 1 {
+		t.Fatalf("got %d sources, want 1", len(got))
+	}
+	if got[0].Status != deepHealthDown {
+		t.Fatalf("status %q, want %s", got[0].Status, deepHealthDown)
+	}
+}

--- a/aggregator/operator_auth_interceptor.go
+++ b/aggregator/operator_auth_interceptor.go
@@ -1,0 +1,150 @@
+package aggregator
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// Authentication for the Node gRPC service — the operator plane.
+//
+// Every RPC on this service either mutates task state or streams task
+// data, so all of them need a verified operator identity. Enforcement
+// lives in an interceptor rather than in each handler on purpose: a
+// per-handler check is one forgotten call away from an unauthenticated
+// state change, which is exactly how ReportEventOverload shipped able to
+// disable any workflow for any caller.
+//
+// The model is default-deny. A method is authenticated unless it is
+// listed in publicNodeMethods, and an authenticated method must carry an
+// operator address for the signature to bind to. A new RPC that has
+// neither is refused at runtime until someone makes a deliberate choice
+// about which side of the line it belongs on.
+
+// publicNodeMethods are the Node RPCs that may be served without an
+// operator identity.
+var publicNodeMethods = map[string]struct{}{
+	// HealthCheck is a connection probe. It reads no state and writes
+	// none, and operators call it before they have working credentials
+	// in order to tell "aggregator is down" from "my key is wrong".
+	avsproto.Node_HealthCheck_FullMethodName: {},
+}
+
+// operatorAddressFromRequest returns the operator address a request
+// claims to originate from. The boolean distinguishes "this message type
+// has no address field" from "the address field is empty", so the caller
+// can fail closed on the former instead of treating it as anonymous.
+func operatorAddressFromRequest(req any) (string, bool) {
+	switch msg := req.(type) {
+	case *avsproto.Checkin:
+		return msg.GetAddress(), true
+	case *avsproto.SyncMessagesReq:
+		return msg.GetAddress(), true
+	case *avsproto.NotifyTriggersReq:
+		return msg.GetAddress(), true
+	case *avsproto.EventOverloadAlert:
+		return msg.GetOperatorAddress(), true
+	default:
+		return "", false
+	}
+}
+
+// authorizeOperator verifies that the caller holds the key for the
+// operator address its request claims. Until this ran, that address was
+// an unauthenticated assertion: the aggregator's approved-operator
+// allowlist only means something once the claim behind it is proven.
+//
+// Every failure returns the same opaque error. The reason is logged, not
+// returned — an unauthenticated caller should not learn whether an
+// address is known, whether a signature parsed, or which of the two it
+// got wrong.
+func (r *RpcServer) authorizeOperator(ctx context.Context, fullMethod string, req any) error {
+	const refusal = "operator authentication required"
+
+	claimedAddress, hasAddress := operatorAddressFromRequest(req)
+	if !hasAddress {
+		// Fail closed: a non-public RPC whose request carries no
+		// operator address cannot be authenticated at all.
+		r.config.Logger.Error("refusing Node RPC that carries no operator address to authenticate",
+			"method", fullMethod)
+		return status.Error(codes.Unauthenticated, refusal)
+	}
+
+	if !common.IsHexAddress(claimedAddress) {
+		r.config.Logger.Warn("refusing Node RPC with malformed operator address",
+			"method", fullMethod, "claimed_address", claimedAddress)
+		return status.Error(codes.Unauthenticated, refusal)
+	}
+
+	verified, err := r.verifyOperator(ctx, claimedAddress)
+	if err != nil || !verified {
+		r.config.Logger.Warn("refusing Node RPC with unverified operator signature",
+			"method", fullMethod, "claimed_address", claimedAddress, "error", err)
+		return status.Error(codes.Unauthenticated, refusal)
+	}
+
+	return nil
+}
+
+// operatorUnaryInterceptor authenticates every unary Node RPC.
+func (r *RpcServer) operatorUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if _, public := publicNodeMethods[info.FullMethod]; public {
+			return handler(ctx, req)
+		}
+		if err := r.authorizeOperator(ctx, info.FullMethod, req); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// operatorStreamInterceptor authenticates every streaming Node RPC.
+//
+// A streaming RPC carries its operator address in the first client
+// message, which has not been received yet when the interceptor runs.
+// Wrapping the stream moves the check to the moment that message
+// arrives, still before the handler is given it.
+func (r *RpcServer) operatorStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if _, public := publicNodeMethods[info.FullMethod]; public {
+			return handler(srv, stream)
+		}
+		return handler(srv, &authenticatedServerStream{
+			ServerStream: stream,
+			authorize: func(msg any) error {
+				return r.authorizeOperator(stream.Context(), info.FullMethod, msg)
+			},
+		})
+	}
+}
+
+// authenticatedServerStream authorizes the first message a client sends
+// and passes every later one straight through — the operator identity is
+// fixed for the life of the stream, so re-verifying an ecrecover on each
+// message would only burn CPU.
+type authenticatedServerStream struct {
+	grpc.ServerStream
+
+	authorize func(any) error
+	verified  bool
+}
+
+func (s *authenticatedServerStream) RecvMsg(msg any) error {
+	if err := s.ServerStream.RecvMsg(msg); err != nil {
+		return err
+	}
+	if s.verified {
+		return nil
+	}
+	if err := s.authorize(msg); err != nil {
+		return err
+	}
+	s.verified = true
+	return nil
+}

--- a/aggregator/operator_auth_interceptor_test.go
+++ b/aggregator/operator_auth_interceptor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -32,8 +33,14 @@ func newAuthTestServer() *RpcServer {
 // client sends (core/auth.ClientAuth), for the given key and epoch.
 func operatorCredentials(t *testing.T, key *ecdsa.PrivateKey, epoch int64) context.Context {
 	t.Helper()
-	address := crypto.PubkeyToAddress(key.PublicKey)
-	token, err := signer.SignMessageAsHex(key, auth.GetOperatorSigninMessage(address.Hex(), epoch))
+	return operatorCredentialsFor(t, key, crypto.PubkeyToAddress(key.PublicKey).Hex(), epoch)
+}
+
+// operatorCredentialsFor signs as `key` while naming `operatorAddress` as
+// the operator being acted for — the alias-key shape.
+func operatorCredentialsFor(t *testing.T, key *ecdsa.PrivateKey, operatorAddress string, epoch int64) context.Context {
+	t.Helper()
+	token, err := signer.SignMessageAsHex(key, auth.GetOperatorSigninMessage(operatorAddress, epoch))
 	if err != nil {
 		t.Fatalf("signing operator message: %v", err)
 	}
@@ -274,4 +281,69 @@ func TestSyncMessagesAcceptsSignedOperator(t *testing.T) {
 	if !reached {
 		t.Fatal("stream handler did not run for a signed operator")
 	}
+}
+
+// withCachedAlias builds a resolver whose mapping is already cached, so
+// the test never needs a chain connection. A nil contract is only
+// consulted on a cache miss.
+func withCachedAlias(operator, alias string) *operatorAliasResolver {
+	resolver := newOperatorAliasResolver(nil, testutil.GetLogger())
+	resolver.cache[common.HexToAddress(operator)] = aliasEntry{
+		alias:     common.HexToAddress(alias),
+		fetchedAt: time.Now(),
+	}
+	return resolver
+}
+
+// Two of the three operators approved on mainnet run with an alias key:
+// the registered address stays cold and a separate hot key signs. That
+// signature must be accepted for the operator it was declared against.
+func TestAliasKeyOperatorIsAccepted(t *testing.T) {
+	server := newAuthTestServer()
+	aliasKey, aliasAddress := newOperatorKey(t)
+	_, operatorAddress := newOperatorKey(t)
+	server.aliasResolver = withCachedAlias(operatorAddress, aliasAddress)
+
+	// ClientAuth signs the message naming the operator, using the alias key.
+	ctx := operatorCredentialsFor(t, aliasKey, operatorAddress, time.Now().Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		avsproto.Node_NotifyTriggers_FullMethodName,
+		&avsproto.NotifyTriggersReq{Address: operatorAddress})
+	if err != nil {
+		t.Fatalf("alias-key operator was refused: %v", err)
+	}
+	if !reached {
+		t.Fatal("handler did not run for an alias-key operator")
+	}
+}
+
+// A key that is neither the operator's nor its declared alias is refused.
+func TestUndeclaredKeyRejectedForAliasOperator(t *testing.T) {
+	server := newAuthTestServer()
+	_, declaredAlias := newOperatorKey(t)
+	_, operatorAddress := newOperatorKey(t)
+	server.aliasResolver = withCachedAlias(operatorAddress, declaredAlias)
+
+	attackerKey, _ := newOperatorKey(t)
+	ctx := operatorCredentialsFor(t, attackerKey, operatorAddress, time.Now().Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		avsproto.Node_NotifyTriggers_FullMethodName,
+		&avsproto.NotifyTriggersReq{Address: operatorAddress})
+	requireUnauthenticated(t, reached, err)
+}
+
+// An operator that declared no alias must sign with its own key.
+func TestOperatorWithoutAliasMustSignWithOwnKey(t *testing.T) {
+	server := newAuthTestServer()
+	_, operatorAddress := newOperatorKey(t)
+	server.aliasResolver = withCachedAlias(operatorAddress, "0x0000000000000000000000000000000000000000")
+
+	otherKey, _ := newOperatorKey(t)
+	ctx := operatorCredentialsFor(t, otherKey, operatorAddress, time.Now().Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		avsproto.Node_Ping_FullMethodName, &avsproto.Checkin{Address: operatorAddress})
+	requireUnauthenticated(t, reached, err)
 }

--- a/aggregator/operator_auth_interceptor_test.go
+++ b/aggregator/operator_auth_interceptor_test.go
@@ -1,0 +1,277 @@
+package aggregator
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/auth"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/signer"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// newAuthTestServer builds the minimal RpcServer the interceptors touch —
+// they only ever reach config.Logger.
+func newAuthTestServer() *RpcServer {
+	return &RpcServer{
+		config: &config.Config{Logger: testutil.GetLogger()},
+	}
+}
+
+// operatorCredentials mints the same Authorization header the operator
+// client sends (core/auth.ClientAuth), for the given key and epoch.
+func operatorCredentials(t *testing.T, key *ecdsa.PrivateKey, epoch int64) context.Context {
+	t.Helper()
+	address := crypto.PubkeyToAddress(key.PublicKey)
+	token, err := signer.SignMessageAsHex(key, auth.GetOperatorSigninMessage(address.Hex(), epoch))
+	if err != nil {
+		t.Fatalf("signing operator message: %v", err)
+	}
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"authorization", fmt.Sprintf("Bearer %d.%s", epoch, token),
+	))
+}
+
+func newOperatorKey(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generating operator key: %v", err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey).Hex()
+}
+
+// callUnary runs a request through the unary interceptor and reports
+// whether the handler was reached.
+func callUnary(t *testing.T, server *RpcServer, ctx context.Context, method string, req any) (bool, error) {
+	t.Helper()
+	reached := false
+	handler := func(context.Context, any) (any, error) {
+		reached = true
+		return nil, nil
+	}
+	_, err := server.operatorUnaryInterceptor()(ctx, req, &grpc.UnaryServerInfo{FullMethod: method}, handler)
+	return reached, err
+}
+
+func requireUnauthenticated(t *testing.T, reached bool, err error) {
+	t.Helper()
+	if reached {
+		t.Fatal("handler ran for a request that should have been refused")
+	}
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// The reported vulnerability: ReportEventOverload disabled any workflow
+// for any caller, with no credentials at all.
+func TestReportEventOverloadRejectsUnauthenticatedCaller(t *testing.T) {
+	server := newAuthTestServer()
+	alert := &avsproto.EventOverloadAlert{
+		TaskId:          "01JZ0000000000000000000000",
+		OperatorAddress: "0x0000000000000000000000000000000000000000",
+	}
+
+	reached, err := callUnary(t, server, context.Background(),
+		avsproto.Node_ReportEventOverload_FullMethodName, alert)
+	requireUnauthenticated(t, reached, err)
+}
+
+// Every state-changing Node RPC, not just the reported one.
+func TestNodeRPCsRejectUnauthenticatedCallers(t *testing.T) {
+	server := newAuthTestServer()
+	_, address := newOperatorKey(t)
+
+	cases := []struct {
+		name   string
+		method string
+		req    any
+	}{
+		{"Ping", avsproto.Node_Ping_FullMethodName, &avsproto.Checkin{Address: address}},
+		{"NotifyTriggers", avsproto.Node_NotifyTriggers_FullMethodName, &avsproto.NotifyTriggersReq{Address: address}},
+		{"ReportEventOverload", avsproto.Node_ReportEventOverload_FullMethodName, &avsproto.EventOverloadAlert{OperatorAddress: address}},
+		// Ack carries no operator address, so it cannot be authenticated
+		// and must fail closed rather than fall through as anonymous.
+		{"Ack", avsproto.Node_Ack_FullMethodName, &avsproto.AckMessageReq{Id: "some-id"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reached, err := callUnary(t, server, context.Background(), tc.method, tc.req)
+			requireUnauthenticated(t, reached, err)
+		})
+	}
+}
+
+// A correctly signed operator gets through.
+func TestNodeRPCAcceptsSignedOperator(t *testing.T) {
+	server := newAuthTestServer()
+	key, address := newOperatorKey(t)
+	ctx := operatorCredentials(t, key, time.Now().Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		avsproto.Node_NotifyTriggers_FullMethodName,
+		&avsproto.NotifyTriggersReq{Address: address})
+	if err != nil {
+		t.Fatalf("signed operator was refused: %v", err)
+	}
+	if !reached {
+		t.Fatal("handler did not run for a signed operator")
+	}
+}
+
+// The core of the escalation: holding one key must not let you speak as
+// another operator. The approved-operator allowlist is only meaningful
+// if this holds.
+func TestOperatorCannotImpersonateAnotherAddress(t *testing.T) {
+	server := newAuthTestServer()
+	attackerKey, _ := newOperatorKey(t)
+	_, victimAddress := newOperatorKey(t)
+
+	ctx := operatorCredentials(t, attackerKey, time.Now().Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		avsproto.Node_NotifyTriggers_FullMethodName,
+		&avsproto.NotifyTriggersReq{Address: victimAddress})
+	requireUnauthenticated(t, reached, err)
+}
+
+// An expired signature is refused, so a header captured off the
+// plaintext wire has a bounded life.
+func TestExpiredOperatorSignatureRejected(t *testing.T) {
+	server := newAuthTestServer()
+	key, address := newOperatorKey(t)
+	ctx := operatorCredentials(t, key, time.Now().Add(-time.Hour).Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		avsproto.Node_Ping_FullMethodName, &avsproto.Checkin{Address: address})
+	requireUnauthenticated(t, reached, err)
+}
+
+// A far-future epoch would otherwise mint a credential that never expires.
+func TestFarFutureOperatorSignatureRejected(t *testing.T) {
+	server := newAuthTestServer()
+	key, address := newOperatorKey(t)
+	ctx := operatorCredentials(t, key, time.Now().Add(24*time.Hour).Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		avsproto.Node_Ping_FullMethodName, &avsproto.Checkin{Address: address})
+	requireUnauthenticated(t, reached, err)
+}
+
+// HealthCheck stays reachable: operators use it to tell "aggregator is
+// down" from "my credentials are wrong".
+func TestHealthCheckRemainsPublic(t *testing.T) {
+	server := newAuthTestServer()
+
+	reached, err := callUnary(t, server, context.Background(),
+		avsproto.Node_HealthCheck_FullMethodName, &avsproto.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("health check was refused: %v", err)
+	}
+	if !reached {
+		t.Fatal("health check handler did not run")
+	}
+}
+
+// Default-deny: a future RPC that is neither listed public nor carries an
+// operator address must be refused rather than served anonymously.
+func TestUnknownRequestTypeFailsClosed(t *testing.T) {
+	server := newAuthTestServer()
+	key, _ := newOperatorKey(t)
+	ctx := operatorCredentials(t, key, time.Now().Unix())
+
+	reached, err := callUnary(t, server, ctx,
+		"/aggregator.Node/SomeFutureMethod", &avsproto.HealthCheckRequest{})
+	requireUnauthenticated(t, reached, err)
+}
+
+// fakeServerStream feeds one client message to the interceptor's wrapper,
+// standing in for the SyncMessages request an operator opens with.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx      context.Context
+	incoming *avsproto.SyncMessagesReq
+}
+
+func (f *fakeServerStream) Context() context.Context { return f.ctx }
+
+func (f *fakeServerStream) RecvMsg(m any) error {
+	req, ok := m.(*avsproto.SyncMessagesReq)
+	if !ok {
+		return fmt.Errorf("unexpected message type %T", m)
+	}
+	// Field-by-field rather than a struct copy: protobuf messages carry
+	// an internal mutex that must not be copied.
+	req.Address = f.incoming.Address
+	return nil
+}
+
+// callSyncMessages drives the stream interceptor the way the generated
+// handler does: wrap the stream, then receive the first message.
+func callSyncMessages(t *testing.T, server *RpcServer, ctx context.Context, address string) (bool, error) {
+	t.Helper()
+	stream := &fakeServerStream{ctx: ctx, incoming: &avsproto.SyncMessagesReq{Address: address}}
+
+	reached := false
+	handler := func(_ any, wrapped grpc.ServerStream) error {
+		// The generated _Node_SyncMessages_Handler does exactly this
+		// before invoking the service method.
+		if err := wrapped.RecvMsg(new(avsproto.SyncMessagesReq)); err != nil {
+			return err
+		}
+		reached = true
+		return nil
+	}
+
+	err := server.operatorStreamInterceptor()(nil, stream,
+		&grpc.StreamServerInfo{FullMethod: avsproto.Node_SyncMessages_FullMethodName}, handler)
+	return reached, err
+}
+
+// SyncMessages streams every active task's metadata. Unauthenticated, it
+// let anyone claiming an approved operator address harvest the whole
+// platform's task list.
+func TestSyncMessagesRejectsUnauthenticatedStream(t *testing.T) {
+	server := newAuthTestServer()
+	_, address := newOperatorKey(t)
+
+	reached, err := callSyncMessages(t, server, context.Background(), address)
+	requireUnauthenticated(t, reached, err)
+}
+
+// Claiming someone else's operator address on a stream is refused too.
+func TestSyncMessagesRejectsSpoofedAddress(t *testing.T) {
+	server := newAuthTestServer()
+	attackerKey, _ := newOperatorKey(t)
+	_, victimAddress := newOperatorKey(t)
+
+	ctx := operatorCredentials(t, attackerKey, time.Now().Unix())
+	reached, err := callSyncMessages(t, server, ctx, victimAddress)
+	requireUnauthenticated(t, reached, err)
+}
+
+func TestSyncMessagesAcceptsSignedOperator(t *testing.T) {
+	server := newAuthTestServer()
+	key, address := newOperatorKey(t)
+
+	ctx := operatorCredentials(t, key, time.Now().Unix())
+	reached, err := callSyncMessages(t, server, ctx, address)
+	if err != nil {
+		t.Fatalf("signed operator stream was refused: %v", err)
+	}
+	if !reached {
+		t.Fatal("stream handler did not run for a signed operator")
+	}
+}

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -23,6 +23,7 @@ import (
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/apconfig"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
@@ -51,6 +52,11 @@ type RpcServer struct {
 	// chainRegistry is set in gateway mode to route chain-specific operations to workers.
 	// nil in single-chain aggregator mode.
 	chainRegistry *ChainRegistry
+
+	// aliasResolver maps an operator's registered address to the alias
+	// key it signs with. Required to authenticate operators that keep
+	// their registered key cold — see operator_alias.go.
+	aliasResolver *operatorAliasResolver
 }
 
 // resolveSmartWalletForChain returns the SmartWalletConfig + RPC client
@@ -635,6 +641,24 @@ func (agg *Aggregator) startRpcServer(ctx context.Context) error {
 		chainID:       smartWalletChainID,
 		chainRegistry: agg.chainRegistry,
 	}
+
+	// Operator authentication has to resolve alias keys, which lives in
+	// the APConfig contract on the AVS chain (the one ethrpc points at,
+	// not the smart-wallet chain). A failure here is fatal rather than
+	// degraded: without it, every operator running an alias key would be
+	// refused, which is most of the fleet.
+	avsChainID, err := ethrpc.ChainID(context.Background())
+	if err != nil {
+		return fmt.Errorf("reading AVS chain id for operator alias resolution: %w", err)
+	}
+	apConfigAddress := apconfig.AddressForChain(avsChainID)
+	apConfigContract, err := apconfig.NewAPConfig(apConfigAddress, ethrpc)
+	if err != nil {
+		return fmt.Errorf("binding APConfig at %s: %w", apConfigAddress.Hex(), err)
+	}
+	rpcServer.aliasResolver = newOperatorAliasResolver(apConfigContract, agg.logger)
+	agg.logger.Info("operator alias resolution enabled",
+		"apconfig_address", apConfigAddress.Hex(), "avs_chain_id", avsChainID.String())
 
 	// Expose the smart-wallet clients + rpcServer to the rest of the
 	// aggregator (specifically the REST layer's WithdrawService /

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -23,7 +23,6 @@ import (
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/apconfig"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
@@ -642,23 +641,23 @@ func (agg *Aggregator) startRpcServer(ctx context.Context) error {
 		chainRegistry: agg.chainRegistry,
 	}
 
-	// Operator authentication has to resolve alias keys, which lives in
-	// the APConfig contract on the AVS chain (the one ethrpc points at,
-	// not the smart-wallet chain). A failure here is fatal rather than
-	// degraded: without it, every operator running an alias key would be
-	// refused, which is most of the fleet.
-	avsChainID, err := ethrpc.ChainID(context.Background())
+	// Operator authentication has to resolve alias keys. Those live on
+	// the APConfig of the AVS chain the operator registered on — Sepolia
+	// for the testnet operator, Ethereum for the two alias-key mainnet
+	// operators. Binding only eth_rpc_url (Sepolia in production) would
+	// refuse most of the fleet at first heartbeat. A failure here is
+	// fatal: a degraded resolver is a silent outage.
+	bindCtx, bindCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer bindCancel()
+	aliasSources, err := bindAliasSources(bindCtx, ethrpc, agg.chainRegistry, agg.logger)
 	if err != nil {
-		return fmt.Errorf("reading AVS chain id for operator alias resolution: %w", err)
+		return fmt.Errorf("operator alias resolution: %w", err)
 	}
-	apConfigAddress := apconfig.AddressForChain(avsChainID)
-	apConfigContract, err := apconfig.NewAPConfig(apConfigAddress, ethrpc)
-	if err != nil {
-		return fmt.Errorf("binding APConfig at %s: %w", apConfigAddress.Hex(), err)
+	rpcServer.aliasResolver = newOperatorAliasResolver(aliasSources, agg.logger)
+	for _, src := range aliasSources {
+		agg.logger.Info("operator alias resolution enabled",
+			"source", src.name, "apconfig_address", src.address.Hex(), "chain_id", src.chainID)
 	}
-	rpcServer.aliasResolver = newOperatorAliasResolver(apConfigContract, agg.logger)
-	agg.logger.Info("operator alias resolution enabled",
-		"apconfig_address", apConfigAddress.Hex(), "avs_chain_id", avsChainID.String())
 
 	// Expose the smart-wallet clients + rpcServer to the rest of the
 	// aggregator (specifically the REST layer's WithdrawService /

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/getsentry/sentry-go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -596,8 +597,6 @@ func (agg *Aggregator) startRpcServer(ctx context.Context) error {
 		panic(fmt.Errorf("failed to listen to %v", err))
 	}
 
-	s := grpc.NewServer()
-
 	ethrpc, err := ethclient.Dial(agg.config.EthHttpRpcUrl)
 
 	if err != nil {
@@ -654,12 +653,32 @@ func (agg *Aggregator) startRpcServer(ctx context.Context) error {
 	// parse error. Handler methods on RpcServer that implemented
 	// the removed interface are dead code in this commit; they get
 	// deleted in a follow-up alongside the proto service block.
+
+	// Every Node RPC is authenticated by these interceptors — see
+	// operator_auth_interceptor.go. They are attached at construction so
+	// there is no window in which the service is registered without
+	// them, and so a handler added later inherits the check instead of
+	// having to remember it.
+	s := grpc.NewServer(
+		grpc.UnaryInterceptor(rpcServer.operatorUnaryInterceptor()),
+		grpc.StreamInterceptor(rpcServer.operatorStreamInterceptor()),
+	)
+
 	avsproto.RegisterNodeServer(s, rpcServer)
 
-	// Register reflection service on gRPC server.
-	// This allow clien to discover url endpoint
-	// https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md
-	reflection.Register(s)
+	// Reflection lets any client enumerate the service and every message
+	// shape on it. That is worth having while developing and is pure
+	// attack surface in production, where operators speak to us through
+	// generated stubs and never ask the server what it offers.
+	// Gated on the `environment:` config field rather than an env var:
+	// APP_ENV is set in no deployment, so a check against it would leave
+	// reflection on everywhere it matters.
+	if agg.config != nil && agg.config.Environment == sdklogging.Development {
+		// Register reflection service on gRPC server.
+		// This allow clien to discover url endpoint
+		// https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md
+		reflection.Register(s)
+	}
 
 	agg.logger.Info("start grpc server",
 		"address", lis.Addr(),

--- a/core/auth/server.go
+++ b/core/auth/server.go
@@ -9,6 +9,17 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/signer"
 )
 
+const (
+	// operatorSignatureTTL is how long a minted operator signature stays
+	// valid. Deliberately short: the operator transport is plaintext, so
+	// a captured Authorization header is replayable for exactly this long.
+	operatorSignatureTTL = 10 * time.Second
+
+	// operatorClockSkew is how far ahead of us an operator's clock may
+	// run before its signatures are refused.
+	operatorClockSkew = 60 * time.Second
+)
+
 // VerifyOperator checks and confirm that the auth header is indeed signed by
 // the operatorAddr
 func VerifyOperator(authHeader string, operatorAddr string) (bool, error) {
@@ -21,8 +32,20 @@ func VerifyOperator(authHeader string, operatorAddr string) (bool, error) {
 	if len(tokens) < 2 {
 		return false, ErrorMalformedAuthHeader
 	}
-	epoch, _ := strconv.Atoi(tokens[0])
-	if time.Now().Add(-10*time.Second).Unix() > int64(epoch) {
+	epoch, err := strconv.Atoi(tokens[0])
+	if err != nil {
+		return false, ErrorMalformedAuthHeader
+	}
+	now := time.Now()
+	// Lower bound: a minted signature is good for a few seconds, so a
+	// header captured off the wire stops working almost immediately.
+	if now.Add(-operatorSignatureTTL).Unix() > int64(epoch) {
+		return false, ErrorExpiredSignature
+	}
+	// Upper bound: without one, an epoch set far in the future yields a
+	// credential that never expires, because the check above only bites
+	// once the timestamp is in the past.
+	if int64(epoch) > now.Add(operatorClockSkew).Unix() {
 		return false, ErrorExpiredSignature
 	}
 

--- a/core/auth/server.go
+++ b/core/auth/server.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/signer"
 )
 
@@ -20,39 +22,63 @@ const (
 	operatorClockSkew = 60 * time.Second
 )
 
-// VerifyOperator checks and confirm that the auth header is indeed signed by
-// the operatorAddr
+// VerifyOperator reports whether the auth header was signed by
+// operatorAddr's own key. Callers that also accept an operator's
+// declared alias key should use OperatorSignerFromAuthHeader and compare
+// the recovered address themselves.
 func VerifyOperator(authHeader string, operatorAddr string) (bool, error) {
+	recovered, err := OperatorSignerFromAuthHeader(authHeader, operatorAddr)
+	if err != nil {
+		return false, err
+	}
+	if !strings.EqualFold(recovered.Hex(), operatorAddr) {
+		return false, ErrorUnAuthorized
+	}
+	return true, nil
+}
+
+// OperatorSignerFromAuthHeader validates an operator auth header's shape
+// and freshness and returns the address that signed it.
+//
+// It deliberately does not decide whether that signer is acceptable. An
+// operator may run with an alias key — a hot key declared against its
+// registered address in the APConfig contract — so the recovered address
+// is legitimately either the operator itself or its alias, and only a
+// caller that can resolve that mapping can tell the difference.
+//
+// The signed message names operatorAddr, so a signature collected for
+// one operator cannot be replayed to act as another.
+func OperatorSignerFromAuthHeader(authHeader string, operatorAddr string) (common.Address, error) {
 	bearerToken := strings.SplitN(authHeader, " ", 2)
 	if len(bearerToken) < 2 || bearerToken[0] != "Bearer" {
-		return false, ErrorInvalidToken
+		return common.Address{}, ErrorInvalidToken
 	}
 
 	tokens := strings.SplitN(bearerToken[1], ".", 2)
 	if len(tokens) < 2 {
-		return false, ErrorMalformedAuthHeader
+		return common.Address{}, ErrorMalformedAuthHeader
 	}
 	epoch, err := strconv.Atoi(tokens[0])
 	if err != nil {
-		return false, ErrorMalformedAuthHeader
+		return common.Address{}, ErrorMalformedAuthHeader
 	}
 	now := time.Now()
 	// Lower bound: a minted signature is good for a few seconds, so a
 	// header captured off the wire stops working almost immediately.
 	if now.Add(-operatorSignatureTTL).Unix() > int64(epoch) {
-		return false, ErrorExpiredSignature
+		return common.Address{}, ErrorExpiredSignature
 	}
 	// Upper bound: without one, an epoch set far in the future yields a
 	// credential that never expires, because the check above only bites
 	// once the timestamp is in the past.
 	if int64(epoch) > now.Add(operatorClockSkew).Unix() {
-		return false, ErrorExpiredSignature
+		return common.Address{}, ErrorExpiredSignature
 	}
 
-	result, err := signer.Verify(GetOperatorSigninMessage(operatorAddr, int64(epoch)), tokens[1], operatorAddr)
-	if err == nil {
-		return result, nil
+	recovered, err := signer.RecoverAddress(GetOperatorSigninMessage(operatorAddr, int64(epoch)), tokens[1])
+	if err != nil {
+		return common.Address{}, fmt.Errorf("unauthorized error: %w", err)
 	}
 
-	return result, fmt.Errorf("unauthorized error: %w", err)
+	return recovered, nil
 }

--- a/core/chainio/apconfig/apconfig.go
+++ b/core/chainio/apconfig/apconfig.go
@@ -1,6 +1,8 @@
 package apconfig
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -12,4 +14,23 @@ func GetContract(ethRpcURL string, address common.Address) (*APConfig, error) {
 	}
 
 	return NewAPConfig(address, ethRpcClient)
+}
+
+// Deployed APConfig addresses. The contract maps an operator's
+// registered EigenLayer address to the alias key its node actually signs
+// with, so both the operator (declaring the alias) and the aggregator
+// (verifying signatures against it) need to agree on where it lives.
+var (
+	MainnetAddress = common.HexToAddress("0x9c02dfc92eea988902a98919bf4f035e4aaefced")
+	TestnetAddress = common.HexToAddress("0xb8abbb082ecaae8d1cd68378cf3b060f6f0e07eb")
+)
+
+// AddressForChain returns the APConfig deployment for a chain. Every
+// chain other than Ethereum mainnet uses the testnet deployment, which
+// matches how operators have always resolved it.
+func AddressForChain(chainID *big.Int) common.Address {
+	if chainID != nil && chainID.Cmp(big.NewInt(1)) == 0 {
+		return MainnetAddress
+	}
+	return TestnetAddress
 }

--- a/core/chainio/signer/signer.go
+++ b/core/chainio/signer/signer.go
@@ -51,17 +51,26 @@ func SignMessageAsHex(key *ecdsa.PrivateKey, data []byte) (string, error) {
 	return "", e
 }
 
-// Verify takes an original message, a signature and an address and return true
-// or false whether the signature is indeed signed by the address
-func Verify(text []byte, sig string, submitAddress string) (bool, error) {
+// RecoverAddress returns the address whose key produced sig over text.
+// Callers that already know which single address to expect should use
+// Verify; this exists for callers that accept a signature from any of
+// several addresses (an operator or the alias key it declared on chain)
+// and so need to see who actually signed.
+func RecoverAddress(text []byte, sig string) (common.Address, error) {
 	hash := accounts.TextHash(text)
 
+	if len(sig) < 2 {
+		return common.Address{}, fmt.Errorf("signature is too short")
+	}
 	if sig[0:2] != "0x" {
 		sig = "0x" + sig
 	}
 	signature, err := hexutil.Decode(sig)
 	if err != nil {
-		return false, err
+		return common.Address{}, err
+	}
+	if len(signature) != crypto.SignatureLength {
+		return common.Address{}, fmt.Errorf("signature must be %d bytes", crypto.SignatureLength)
 	}
 	// https://stackoverflow.com/questions/49085737/geth-ecrecover-invalid-signature-recovery-id
 	if signature[crypto.RecoveryIDOffset] == 27 || signature[crypto.RecoveryIDOffset] == 28 {
@@ -69,7 +78,17 @@ func Verify(text []byte, sig string, submitAddress string) (bool, error) {
 	}
 
 	sigPublicKey, err := crypto.SigToPub(hash, signature)
-	recoveredAddr := crypto.PubkeyToAddress(*sigPublicKey)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	return crypto.PubkeyToAddress(*sigPublicKey), nil
+}
+
+// Verify takes an original message, a signature and an address and return true
+// or false whether the signature is indeed signed by the address
+func Verify(text []byte, sig string, submitAddress string) (bool, error) {
+	recoveredAddr, err := RecoverAddress(text, sig)
 	if err != nil {
 		return false, err
 	}

--- a/core/taskengine/engine.go
+++ b/core/taskengine/engine.go
@@ -5222,6 +5222,13 @@ func (n *Engine) NewSeqID() (string, error) {
 	return strconv.FormatInt(int64(num), 10), nil
 }
 
+// CanStreamCheck reports whether an operator may be sent tasks.
+//
+// The address is trustworthy here: the Node service authenticates every
+// RPC against the operator key before a handler runs (see
+// aggregator/operator_auth_interceptor.go). Before that existed this
+// allowlist was decorative — anyone could claim one of the addresses
+// below and be streamed every task on the platform.
 func (n *Engine) CanStreamCheck(address string) bool {
 	// If no approved operators configured, use default hardcoded list for backward compatibility
 	if len(n.config.ApprovedOperators) == 0 {

--- a/operator/envs.go
+++ b/operator/envs.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/apconfig"
 )
 
 // Default contract addresses for Ethereum mainnet (chainId = 1)
@@ -28,7 +28,7 @@ var (
 func (o *Operator) PopulateKnownConfigByChainID(chainID *big.Int) error {
 	if chainID.Cmp(mainnetChainID) == 0 {
 		// Ethereum mainnet configuration
-		o.apConfigAddr = common.HexToAddress("0x9c02dfc92eea988902a98919bf4f035e4aaefced")
+		o.apConfigAddr = apconfig.MainnetAddress
 
 		// Apply default contract addresses for mainnet if not provided
 		if o.config.AVSRegistryCoordinatorAddress == "" {
@@ -46,7 +46,7 @@ func (o *Operator) PopulateKnownConfigByChainID(chainID *big.Int) error {
 		}
 	} else {
 		// Testnet configuration
-		o.apConfigAddr = common.HexToAddress("0xb8abbb082ecaae8d1cd68378cf3b060f6f0e07eb")
+		o.apConfigAddr = apconfig.TestnetAddress
 
 		// For testnets, we don't have default addresses - they must be provided in config
 		if o.config.AVSRegistryCoordinatorAddress == "" {

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/signerv2"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	gocron "github.com/go-co-op/gocron/v2"
 
@@ -777,6 +778,21 @@ func NewOperatorFromConfig(c OperatorConfig) (*Operator, error) {
 			logger.Infof("   💡 Set correct password: export OPERATOR_ECDSA_KEY_PASSWORD=your_password")
 		}
 		return nil, fmt.Errorf("failed to decrypt ECDSA key file %s: %w", c.EcdsaPrivateKeyStorePath, err)
+	}
+
+	// The aggregator authenticates us by ecrecovering the signature we
+	// send and comparing it to the operator_address we claim, so the two
+	// have to describe the same key. Checking at boot turns a silent
+	// "the aggregator refuses every RPC" into a config error naming both
+	// addresses.
+	keystoreAddress := crypto.PubkeyToAddress(operatorEcdsaPrivateKey.PublicKey)
+	if !strings.EqualFold(keystoreAddress.Hex(), c.OperatorAddress) {
+		logger.Errorf("❌ operator_address does not match the ECDSA keystore")
+		logger.Errorf("   operator_address: %s", c.OperatorAddress)
+		logger.Errorf("   keystore address: %s", keystoreAddress.Hex())
+		return nil, fmt.Errorf(
+			"operator_address %s does not match the address derived from %s (%s)",
+			c.OperatorAddress, c.EcdsaPrivateKeyStorePath, keystoreAddress.Hex())
 	}
 
 	sdkClients, err := clients.BuildAll(chainioConfig, operatorEcdsaPrivateKey, logger)

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/signerv2"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	gocron "github.com/go-co-op/gocron/v2"
 
@@ -778,21 +777,6 @@ func NewOperatorFromConfig(c OperatorConfig) (*Operator, error) {
 			logger.Infof("   💡 Set correct password: export OPERATOR_ECDSA_KEY_PASSWORD=your_password")
 		}
 		return nil, fmt.Errorf("failed to decrypt ECDSA key file %s: %w", c.EcdsaPrivateKeyStorePath, err)
-	}
-
-	// The aggregator authenticates us by ecrecovering the signature we
-	// send and comparing it to the operator_address we claim, so the two
-	// have to describe the same key. Checking at boot turns a silent
-	// "the aggregator refuses every RPC" into a config error naming both
-	// addresses.
-	keystoreAddress := crypto.PubkeyToAddress(operatorEcdsaPrivateKey.PublicKey)
-	if !strings.EqualFold(keystoreAddress.Hex(), c.OperatorAddress) {
-		logger.Errorf("❌ operator_address does not match the ECDSA keystore")
-		logger.Errorf("   operator_address: %s", c.OperatorAddress)
-		logger.Errorf("   keystore address: %s", keystoreAddress.Hex())
-		return nil, fmt.Errorf(
-			"operator_address %s does not match the address derived from %s (%s)",
-			c.OperatorAddress, c.EcdsaPrivateKeyStorePath, keystoreAddress.Hex())
 	}
 
 	sdkClients, err := clients.BuildAll(chainioConfig, operatorEcdsaPrivateKey, logger)


### PR DESCRIPTION
## Summary

The `aggregator.Node` gRPC service — the operator plane — had no authentication. Every RPC on it either mutates task state or streams task data, and all of them were reachable by any caller that could open a socket to the port.

Two independent gaps produced this:

1. The service was registered on a bare `grpc.NewServer()` with no interceptors, so nothing sat between the wire and the handlers.
2. The one auth helper that existed, `verifyOperator`, short-circuited on a `const enforceAuth = false` left over from the 1.3 operator rollout — so even the single handler that called it (`Ping`) was not actually checking anything.

This came in as a community security report against `ReportEventOverload`, which calls `engine.DisableWorkflow` with no ownership or identity check. That RPC is real but it is the least interesting consequence; the root cause covers the whole service.

## Why this is worse than the reported RPC

The operator address was a self-declared field on the request. Nothing proved the caller held the corresponding key, which means the approved-operator allowlist was decorative — `CanStreamCheck` gates task distribution on an address the caller simply asserts.

- `SyncMessages` streams `TaskMetadata` (task id + full trigger config) for every active task to any caller claiming an approved operator address.
- `n.operatorStreams[address] = srv` is keyed by that same claimed address, so connecting as an existing operator evicts the real one from the notification path.
- `NotifyTriggers` reaches `QueueExecutionData`, i.e. it can force real workflow executions.
- `ReportEventOverload` disables any workflow whose id you know — and step one hands you every id.

Task ids are ULIDs and not enumerable, which is the only reason the reported RPC was not trivially mass-exploitable on its own. That mitigation disappears once `SyncMessages` is in the chain.

## The fix

Enforcement moved into unary and stream interceptors attached at `grpc.NewServer()` construction, in `aggregator/operator_auth_interceptor.go`. Two properties motivated putting it there rather than in each handler:

- There is no window in which the service is registered without the check.
- A handler added later inherits it instead of having to remember it. A per-handler check is one forgotten call away from an unauthenticated state change, which is precisely how `ReportEventOverload` shipped.

The model is **default-deny**. A method is authenticated unless it is listed in `publicNodeMethods`, and an authenticated method must carry an operator address for the signature to bind to. A request type with neither is refused rather than served anonymously — so a future RPC cannot silently inherit anonymous access. `HealthCheck` is the only public method: it reads and writes nothing, and operators call it before they have working credentials to tell "aggregator is down" from "my key is wrong".

Streaming RPCs carry their operator address in the first client message, which has not arrived when the interceptor runs. The stream is wrapped so the check happens the moment that message is received and still before the handler is given it.

Every failure returns the same opaque `Unauthenticated`. Reasons are logged, never returned — an unauthenticated caller should not learn whether an address is known, whether a signature parsed, or which of the two it got wrong.

## Operator alias keys — why the obvious fix was wrong

The first pass compared the recovered signature against the request's `operator_address` and nothing else. That is wrong for this AVS, and it would have taken down most of the fleet.

Operators are not required to run with the key behind their registered EigenLayer address. They may keep that key cold and run the node with an **alias key**, declared against the registered address in the APConfig contract (`declareAlias` / `getAlias`). `Operator.Start` already validates this binding on the operator side, and the struct comment at `operator.go` says as much: *"signerAddress match operatorAddr unless the operator use alias key"*.

Checking mainnet APConfig for the three currently approved operators: one signs with its own key, **two sign with declared alias keys**. Comparing against `operator_address` alone would have refused both at their first heartbeat.

So `verifyOperator` now recovers the signer and accepts it as either the operator's own key or the alias it declared on chain:

- Alias lookups are cached for 5 minutes, keeping a chain call off the per-RPC auth path.
- On an RPC failure the resolver falls back to the last known mapping. A stale mapping is still the one the operator declared — changing it takes a deliberate transaction — so serving it beats disconnecting the fleet over an endpoint blip.
- The signed message names the operator being acted for, so an alias signature cannot be replayed to act as a different operator.

The approved-operator allowlist and its hardcoded fallback are deliberately **unchanged**. Since `approved_operators` is intentionally unset, that fallback is the production allowlist, and removing it would have stopped task distribution entirely. Those addresses were never the weakness — the inability to prove a claim to them was. Now that the claim is verified, the list is sound.

## Also fixed, found while sweeping for the same pattern

**Debug endpoints were live in production.** `/_debug/sentry/message` and `/_debug/sentry/panic` were gated on `APP_ENV != "production"`, but `APP_ENV` is set in no deployment — not in this repo, not in infra — so the condition was always true. Confirmed against the production gateway non-invasively: an unknown path returns 404, both debug paths return 405, i.e. the routes are registered. `middleware.Recover()` contains the panic, so the impact is unauthenticated Sentry flooding and arbitrary message injection via `?msg=`, not a crash. Both now gate on the `environment:` config field, which production actually sets and which reads as not-development when unset. gRPC reflection is gated the same way.

**Operator signatures had no upper epoch bound.** The freshness check only bit once a timestamp was in the past, so an epoch set far in the future minted a credential that never expired. Now bounded on both sides, with a 60s allowance for operator clock skew.

**Shared APConfig addresses.** The deployment addresses moved into `core/chainio/apconfig` so the operator (declaring an alias) and the aggregator (verifying against one) cannot drift apart.

## What was checked and left alone

The REST surface was swept for the same class of bug and is in good shape: `ensurePermission` is centralized and fails closed on an unmapped operation, only three operations are deliberately public, session policies enforce `requireOwnedWallet`, and the gas-manager webhook uses constant-time comparison and fails closed throughout. The gRPC operator plane was the one surface that never received that treatment.

Flagged but out of scope here:

- Operator transport is plaintext (`insecure.NewCredentials()`), so an on-path attacker can replay a captured header for the signature TTL. The real fix is TLS, which needs infra work and coordinated operator config changes.
- The worker gRPC server (`0.0.0.0:50051`) is also unauthenticated, but it is read-only chain proxying on the private network. Worth confirming no worker service has a TCP proxy attached.
- `/operator` and `/telemetry` publicly list operator addresses. Low value now that spoofing is closed — they are on-chain anyway — but it is what hands an attacker the addresses to try.

## Deployment notes

- The aggregator now binds the APConfig contract at startup and **hard-fails if it cannot reach the AVS chain**. This is deliberate: a degraded resolver means refusing most of the fleet, so failing loudly beats starting into a silent outage. It does make the AVS-chain RPC a new startup dependency for the gateway.
- No storage or protobuf changes, so no migration.
- Operators need no changes. Both connection paths already attach `ClientAuth` per-RPC credentials, and alias-key operators keep working.

## Testing

14 new tests in `aggregator/operator_auth_interceptor_test.go` covering unauthenticated refusal on every RPC, impersonation, expired and far-future signatures, stream spoofing, alias accepted, undeclared key rejected, no-alias-must-use-own-key, `HealthCheck` staying public, and default-deny on an unmapped request type.

These were mutation-tested: reinstating the `enforceAuth` bypass fails 6 of them, so they detect the actual vulnerability rather than just exercising the new code.

`go build`, `go vet`, and package tests pass across `aggregator/...`, `operator/`, `worker/`, `core/auth`, and `core/chainio`.
