### PR TITLE
fix: send Sentry Release from the operator

### DIFF
--- a/aggregator/http_server.go
+++ b/aggregator/http_server.go
@@ -3,7 +3,6 @@ package aggregator
 import (
 	"bytes"
 	"embed"
-	"fmt"
 	"text/template"
 
 	"context"
@@ -69,7 +68,7 @@ func (agg *Aggregator) startHttpServer(ctx context.Context, extraMounts []HTTPMo
 
 		agg.logger.Infof("Sentry ServerName from config: %s", serverName)
 
-		release := fmt.Sprintf("%s@%s", version.Get(), version.GetRevision())
+		release := version.SentryRelease()
 
 		// Sentry's `environment` tag is driven from config so that
 		// feature-branch / staging deployments don't bucket into the

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -611,16 +611,18 @@ func NewOperatorFromConfig(c OperatorConfig) (*Operator, error) {
 		if c.SentryEnvironment != "" {
 			sentryEnv = c.SentryEnvironment
 		}
+		release := version.SentryRelease()
 		if err := sentry.Init(sentry.ClientOptions{
 			Dsn:              c.SentryDsn,
 			ServerName:       serverName,
 			Environment:      sentryEnv,
+			Release:          release,
 			AttachStacktrace: true,
 			TracesSampleRate: 1.0,
 		}); err != nil {
 			logger.Errorf("Sentry initialization failed: %v", err)
 		} else {
-			logger.Infof("Sentry initialized for operator: %s (env: %s)", serverName, sentryEnv)
+			logger.Infof("Sentry initialized for operator: %s (env: %s, release: %s)", serverName, sentryEnv, release)
 		}
 	} else if c.SentryDsn != "" {
 		logger.Info("Sentry disabled in development environment")

--- a/version/version.go
+++ b/version/version.go
@@ -35,3 +35,11 @@ func Get() string {
 func GetRevision() string {
 	return revision
 }
+
+// SentryRelease is the release string both the aggregator and the operator
+// send as sentry.ClientOptions.Release. Same scheme on purpose: one binary,
+// one ldflags stamp, so "resolved in next release" can match operator events
+// the same way it already matches gateway events.
+func SentryRelease() string {
+	return Get() + "@" + GetRevision()
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,17 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSentryRelease(t *testing.T) {
+	got := SentryRelease()
+	want := Get() + "@" + GetRevision()
+	if got != want {
+		t.Fatalf("SentryRelease() = %q, want %q", got, want)
+	}
+	if !strings.Contains(got, "@") {
+		t.Fatal("SentryRelease must be version@revision")
+	}
+}


### PR DESCRIPTION
## Why

Operator Sentry events (including [EIGENLAYER-AVS-37](https://ava-protocol.sentry.io/issues/7683902826/)) had `release: null`. The gateway already sends `version@revision`. Without a release on the operator, Sentry cannot do “resolved in next release” for operator issues.

## Same version number?

Yes. One scheme, one source:

- Both processes call `version.SentryRelease()` → `version.Get() + "@" + version.GetRevision()`
- Both binaries are stamped by the same Makefile/Docker ldflags (`SEMVER` from `git describe`, `REVISION` from `git rev-parse --short HEAD`)
- A gateway and an operator built from tag `v4.17.5` both report `4.17.5@abc1234`

They only *differ* if one process was not rebuilt — which is the signal we want. Inventing a separate operator version would hide lagging deploys.

## What

- `version.SentryRelease()` is the single format
- Aggregator uses it instead of an inline `fmt.Sprintf`
- Operator `sentry.Init` now sets `Release` and logs it

Fixes EIGENLAYER-AVS-37 is **not** claimed here — that code fix is already on staging (#772). This is the telemetry so a future resolve-in-release can stick.