### PR TITLE
feat: stamp inner UserOp calls on nodes:run and add status GET

### DIFF
--- a/PLAN_AGENT_ONDEMAND_ACTIONS.md
+++ b/PLAN_AGENT_ONDEMAND_ACTIONS.md
@@ -176,6 +176,7 @@ The deployed-task executor adds a platform `executionFeeWei` batch transfer ([ex
 2. ✅ **G5 (idempotency)** — shipped: `Idempotency-Key` header dedupes retries/double-clicks. (commit `feat(taskengine): idempotent nodes:run via Idempotency-Key header`)
 3. ✅ **G4 (atomic batch)** — shipped: on-demand multi-call real execution submits one `executeBatch` UserOp, composes with the reimbursement wrapper, gated on the run-node route. Heterogeneous targets via a per-call `contract_address`.
 4. ✅ **G7 (fee)** — decided fee-free for v1 (confirmed); monetization is a separate design (see G7 analysis).
+5. 🟡 **N14.a typed inner calls + status GET** — `receipt.calls` from `UnpackExecuteCalldata` on pending and mined `nodes:run` results; JWT-gated `GET /userops/{userOpHash}` (sender must be the caller's wallet). Branch `feat/userop-unwrap`.
 
 Deferred (later hardening): server-side spend/fund-authorization policy; fee monetization (G7).
 

--- a/aggregator/rest/generated/server.gen.go
+++ b/aggregator/rest/generated/server.gen.go
@@ -65,6 +65,9 @@ type ServerInterface interface {
 	// Evaluate a trigger definition with inline input
 	// (POST /triggers:run)
 	RunTrigger(ctx echo.Context) error
+	// Look up a UserOp this user submitted
+	// (GET /userops/{userOpHash})
+	GetUserOp(ctx echo.Context, userOpHash Bytes32, params GetUserOpParams) error
 	// List the authenticated user's smart wallets
 	// (GET /wallets)
 	ListWallets(ctx echo.Context, params ListWalletsParams) error
@@ -504,6 +507,33 @@ func (w *ServerInterfaceWrapper) RunTrigger(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.RunTrigger(ctx)
+	return err
+}
+
+// GetUserOp converts echo context to params.
+func (w *ServerInterfaceWrapper) GetUserOp(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "userOpHash" -------------
+	var userOpHash Bytes32
+
+	err = runtime.BindStyledParameterWithOptions("simple", "userOpHash", ctx.Param("userOpHash"), &userOpHash, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter userOpHash: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetUserOpParams
+	// ------------- Optional query parameter "chainId" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "chainId", ctx.QueryParams(), &params.ChainId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter chainId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetUserOp(ctx, userOpHash, params)
 	return err
 }
 
@@ -1021,6 +1051,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.PUT(baseURL+"/secrets/:name", wrapper.PutSecret)
 	router.GET(baseURL+"/tokens/:address", wrapper.GetToken)
 	router.POST(baseURL+"/triggers:run", wrapper.RunTrigger)
+	router.GET(baseURL+"/userops/:userOpHash", wrapper.GetUserOp)
 	router.GET(baseURL+"/wallets", wrapper.ListWallets)
 	router.POST(baseURL+"/wallets", wrapper.CreateWallet)
 	router.PATCH(baseURL+"/wallets/:address", wrapper.UpdateWallet)
@@ -1645,6 +1676,57 @@ type RunTrigger401ApplicationProblemPlusJSONResponse struct {
 func (response RunTrigger401ApplicationProblemPlusJSONResponse) VisitRunTriggerResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUserOpRequestObject struct {
+	UserOpHash Bytes32 `json:"userOpHash"`
+	Params     GetUserOpParams
+}
+
+type GetUserOpResponseObject interface {
+	VisitGetUserOpResponse(w http.ResponseWriter) error
+}
+
+type GetUserOp200JSONResponse UserOpStatusResponse
+
+func (response GetUserOp200JSONResponse) VisitGetUserOpResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUserOp400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response GetUserOp400ApplicationProblemPlusJSONResponse) VisitGetUserOpResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUserOp401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response GetUserOp401ApplicationProblemPlusJSONResponse) VisitGetUserOpResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUserOp404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response GetUserOp404ApplicationProblemPlusJSONResponse) VisitGetUserOpResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -2699,6 +2781,9 @@ type StrictServerInterface interface {
 	// Evaluate a trigger definition with inline input
 	// (POST /triggers:run)
 	RunTrigger(ctx context.Context, request RunTriggerRequestObject) (RunTriggerResponseObject, error)
+	// Look up a UserOp this user submitted
+	// (GET /userops/{userOpHash})
+	GetUserOp(ctx context.Context, request GetUserOpRequestObject) (GetUserOpResponseObject, error)
 	// List the authenticated user's smart wallets
 	// (GET /wallets)
 	ListWallets(ctx context.Context, request ListWalletsRequestObject) (ListWalletsResponseObject, error)
@@ -3196,6 +3281,32 @@ func (sh *strictHandler) RunTrigger(ctx echo.Context) error {
 		return err
 	} else if validResponse, ok := response.(RunTriggerResponseObject); ok {
 		return validResponse.VisitRunTriggerResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// GetUserOp operation middleware
+func (sh *strictHandler) GetUserOp(ctx echo.Context, userOpHash Bytes32, params GetUserOpParams) error {
+	var request GetUserOpRequestObject
+
+	request.UserOpHash = userOpHash
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetUserOp(ctx.Request().Context(), request.(GetUserOpRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetUserOp")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetUserOpResponseObject); ok {
+		return validResponse.VisitGetUserOpResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -250,6 +250,13 @@ const (
 	TriggerTypeManual    TriggerType = "manual"
 )
 
+// Defines values for UserOpStatusResponseExecutionStatus.
+const (
+	UserOpStatusResponseExecutionStatusConfirmed UserOpStatusResponseExecutionStatus = "confirmed"
+	UserOpStatusResponseExecutionStatusFailed    UserOpStatusResponseExecutionStatus = "failed"
+	UserOpStatusResponseExecutionStatusPending   UserOpStatusResponseExecutionStatus = "pending"
+)
+
 // Defines values for ValueFeeClassificationMethod.
 const (
 	Llm       ValueFeeClassificationMethod = "llm"
@@ -272,11 +279,11 @@ const (
 
 // Defines values for WorkflowStatus.
 const (
-	WorkflowStatusCompleted WorkflowStatus = "completed"
-	WorkflowStatusDisabled  WorkflowStatus = "disabled"
-	WorkflowStatusEnabled   WorkflowStatus = "enabled"
-	WorkflowStatusFailed    WorkflowStatus = "failed"
-	WorkflowStatusRunning   WorkflowStatus = "running"
+	Completed WorkflowStatus = "completed"
+	Disabled  WorkflowStatus = "disabled"
+	Enabled   WorkflowStatus = "enabled"
+	Failed    WorkflowStatus = "failed"
+	Running   WorkflowStatus = "running"
 )
 
 // AllowedAction One contract the agent may call, scoped to selectors.
@@ -426,6 +433,9 @@ type BranchNodeType string
 type BranchNodeConfig struct {
 	Conditions []BranchCondition `json:"conditions"`
 }
+
+// Bytes32 32-byte hex hash (UserOp hash, transaction hash).
+type Bytes32 = string
 
 // ChainId Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
 // chain-aware trigger/node configs this is required and must be a
@@ -1617,6 +1627,49 @@ type UpdateWalletRequest struct {
 	IsHidden *bool `json:"isHidden,omitempty"`
 }
 
+// UserOpInnerCall defines model for UserOpInnerCall.
+type UserOpInnerCall struct {
+	// Data Arbitrary-length hex-encoded byte string.
+	Data Hex `json:"data"`
+
+	// Selector 4-byte function selector of `data` (`0x00000000` for a value-only call).
+	Selector string `json:"selector"`
+
+	// To Lowercase or checksummed hex EOA / contract address.
+	To EthereumAddress `json:"to"`
+
+	// Value Native value in wei (decimal string).
+	Value string `json:"value"`
+}
+
+// UserOpStatusResponse defines model for UserOpStatusResponse.
+type UserOpStatusResponse struct {
+	// BlockNumber Block number as a hex string when mined.
+	BlockNumber *string            `json:"blockNumber,omitempty"`
+	Calls       *[]UserOpInnerCall `json:"calls,omitempty"`
+
+	// ExecutionStatus `pending` means the bundler accepted the op and it is not yet
+	// mined. It is not a failure.
+	ExecutionStatus UserOpStatusResponseExecutionStatus `json:"executionStatus"`
+	FailedCall      *UserOpInnerCall                    `json:"failedCall,omitempty"`
+
+	// Sender Lowercase or checksummed hex EOA / contract address.
+	Sender *EthereumAddress `json:"sender,omitempty"`
+
+	// Success Inner UserOp success from the bundler receipt. Absent while pending.
+	Success *bool `json:"success,omitempty"`
+
+	// TransactionHash Arbitrary-length hex-encoded byte string.
+	TransactionHash *Hex `json:"transactionHash,omitempty"`
+
+	// UserOpHash 32-byte hex hash (UserOp hash, transaction hash).
+	UserOpHash Bytes32 `json:"userOpHash"`
+}
+
+// UserOpStatusResponseExecutionStatus `pending` means the bundler accepted the op and it is not yet
+// mined. It is not a failure.
+type UserOpStatusResponseExecutionStatus string
+
 // ValueFee defines model for ValueFee.
 type ValueFee struct {
 	ClassificationMethod *ValueFeeClassificationMethod `json:"classificationMethod,omitempty"`
@@ -1895,6 +1948,13 @@ type DeleteSecretParams struct {
 
 // GetTokenParams defines parameters for GetToken.
 type GetTokenParams struct {
+	// ChainId The chain to operate on (a single value). Omit to use the aggregator
+	// default (the request's JWT `aud` chain, then the gateway default).
+	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`
+}
+
+// GetUserOpParams defines parameters for GetUserOp.
+type GetUserOpParams struct {
 	// ChainId The chain to operate on (a single value). Omit to use the aggregator
 	// default (the request's JWT `aud` chain, then the gateway default).
 	ChainId *ChainIdQuery `form:"chainId,omitempty" json:"chainId,omitempty"`

--- a/aggregator/rest/handlers_userops.go
+++ b/aggregator/rest/handlers_userops.go
@@ -1,0 +1,94 @@
+package rest
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/generated"
+	restmw "github.com/AvaProtocol/EigenLayer-AVS/aggregator/rest/middleware"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+)
+
+// UserOps resource — see api/openapi.yaml `tags: [UserOps]`.
+
+// GetUserOp — GET /api/v1/userops/{userOpHash}
+//
+// Re-poll a UserOp this user submitted (G3 / N14.a). Partner assertion
+// alone is not enough. Unknown hashes and hashes whose sender is not one
+// of the caller's smart wallets both 404 — this is not a public explorer.
+func (s *Server) GetUserOp(ctx echo.Context, userOpHash generated.Bytes32, params generated.GetUserOpParams) error {
+	p, err := s.ensurePermission(ctx, OpGetUserOp)
+	if err != nil {
+		return err
+	}
+	user := p.User
+
+	var chainID int64
+	if params.ChainId != nil {
+		chainID = int64(*params.ChainId)
+	} else if authed := restmw.UserFromContext(ctx); authed != nil && authed.ChainID != 0 {
+		chainID = authed.ChainID
+	}
+
+	status, err := s.engine.LookupUserOpStatus(ctx.Request().Context(), user, string(userOpHash), chainID)
+	if err != nil {
+		if errors.Is(err, taskengine.ErrUserOpHashInvalid) {
+			return badRequest("USEROP_BAD_HASH", "Invalid userOpHash", err.Error())
+		}
+		if errors.Is(err, taskengine.ErrUserOpNotFound) {
+			return &restmw.HTTPError{
+				Status: http.StatusNotFound,
+				Code:   "USEROP_NOT_FOUND",
+				Title:  "User operation not found",
+				Detail: "No UserOp with this hash for the authenticated user.",
+			}
+		}
+		return err
+	}
+	return ctx.JSON(http.StatusOK, userOpStatusToOpenAPI(status))
+}
+
+func userOpStatusToOpenAPI(in *taskengine.UserOpStatus) generated.UserOpStatusResponse {
+	out := generated.UserOpStatusResponse{
+		UserOpHash:      generated.Bytes32(in.UserOpHash),
+		ExecutionStatus: generated.UserOpStatusResponseExecutionStatus(in.ExecutionStatus),
+	}
+	if in.Sender != "" {
+		sender := generated.EthereumAddress(in.Sender)
+		out.Sender = &sender
+	}
+	if in.TransactionHash != "" {
+		tx := generated.Hex(in.TransactionHash)
+		out.TransactionHash = &tx
+	}
+	if in.BlockNumber != "" {
+		bn := in.BlockNumber
+		out.BlockNumber = &bn
+	}
+	if in.Success != nil {
+		out.Success = in.Success
+	}
+	if len(in.Calls) > 0 {
+		calls := make([]generated.UserOpInnerCall, len(in.Calls))
+		for i, c := range in.Calls {
+			calls[i] = innerCallToOpenAPI(c)
+		}
+		out.Calls = &calls
+	}
+	if in.FailedCall != nil {
+		fc := innerCallToOpenAPI(*in.FailedCall)
+		out.FailedCall = &fc
+	}
+	return out
+}
+
+func innerCallToOpenAPI(c taskengine.InnerCall) generated.UserOpInnerCall {
+	return generated.UserOpInnerCall{
+		To:       generated.EthereumAddress(c.To),
+		Value:    c.Value,
+		Selector: c.Selector,
+		Data:     generated.Hex(c.Data),
+	}
+}

--- a/aggregator/rest/handlers_userops.go
+++ b/aggregator/rest/handlers_userops.go
@@ -37,6 +37,9 @@ func (s *Server) GetUserOp(ctx echo.Context, userOpHash generated.Bytes32, param
 		if errors.Is(err, taskengine.ErrUserOpHashInvalid) {
 			return badRequest("USEROP_BAD_HASH", "Invalid userOpHash", err.Error())
 		}
+		if errors.Is(err, taskengine.ErrUserOpChainUnsupported) {
+			return badRequest("USEROP_BAD_CHAIN", "Unsupported chain", err.Error())
+		}
 		if errors.Is(err, taskengine.ErrUserOpNotFound) {
 			return &restmw.HTTPError{
 				Status: http.StatusNotFound,

--- a/aggregator/rest/handlers_userops_test.go
+++ b/aggregator/rest/handlers_userops_test.go
@@ -1,0 +1,39 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/taskengine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserOpStatusToOpenAPI(t *testing.T) {
+	failed := false
+	status := &taskengine.UserOpStatus{
+		UserOpHash:      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Sender:          "0x2222222222222222222222222222222222222222",
+		ExecutionStatus: "failed",
+		TransactionHash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BlockNumber:     "0x64",
+		Success:         &failed,
+		Calls: []taskengine.InnerCall{{
+			To:       "0xAaaa000000000000000000000000000000000001",
+			Value:    "0",
+			Selector: "0xa9059cbb",
+			Data:     "0xa9059cbb",
+		}},
+	}
+	status.FailedCall = &status.Calls[0]
+
+	out := userOpStatusToOpenAPI(status)
+	assert.Equal(t, status.UserOpHash, string(out.UserOpHash))
+	require.NotNil(t, out.Sender)
+	assert.Equal(t, status.Sender, string(*out.Sender))
+	assert.Equal(t, "failed", string(out.ExecutionStatus))
+	require.NotNil(t, out.Calls)
+	require.Len(t, *out.Calls, 1)
+	assert.Equal(t, "0xa9059cbb", (*out.Calls)[0].Selector)
+	require.NotNil(t, out.FailedCall)
+	assert.Equal(t, (*out.Calls)[0].To, out.FailedCall.To)
+}

--- a/aggregator/rest/permission.go
+++ b/aggregator/rest/permission.go
@@ -82,6 +82,7 @@ const (
 	OpGetToken = "getToken"
 
 	OpRunNode    = "runNode"
+	OpGetUserOp  = "getUserOp"
 	OpRunTrigger = "runTrigger"
 
 	OpListOperators = "listOperators"
@@ -103,6 +104,7 @@ var permissionMap = map[string]Level{
 	// Simulate family: user JWT only (partner alone insufficient).
 	OpSimulateWorkflow: LevelUser,
 	OpRunNode:          LevelUser,
+	OpGetUserOp:        LevelUser,
 	OpRunTrigger:       LevelUser,
 
 	// User-owned workflows / executions / secrets / wallet fund surface.

--- a/aggregator/rest/permission_test.go
+++ b/aggregator/rest/permission_test.go
@@ -20,6 +20,7 @@ var expectedPermissionLevels = map[string]Level{
 
 	OpSimulateWorkflow: LevelUser,
 	OpRunNode:          LevelUser,
+	OpGetUserOp:        LevelUser,
 	OpRunTrigger:       LevelUser,
 
 	OpCreateWorkflow:            LevelUser,
@@ -125,6 +126,8 @@ func TestEnsurePermission_SimulateRequiresUserJWT(t *testing.T) {
 		_, err := s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpSimulateWorkflow)
 		assertHTTPStatus(t, err, http.StatusUnauthorized)
 		_, err = s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpRunNode)
+		assertHTTPStatus(t, err, http.StatusUnauthorized)
+		_, err = s.ensurePermission(ctxWithAssertion(signAssertion(t, priv, validClaims())), OpGetUserOp)
 		assertHTTPStatus(t, err, http.StatusUnauthorized)
 	})
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -56,6 +56,8 @@ tags:
     description: ERC-20 metadata lookup
   - name: Nodes
     description: Stand-alone node execution
+  - name: UserOps
+    description: Status lookup for UserOps this user submitted (not a public AA explorer)
   - name: Triggers
     description: Stand-alone trigger evaluation
   - name: Operators
@@ -146,6 +148,58 @@ components:
       type: string
       pattern: '^0x[a-fA-F0-9]*$'
       description: Arbitrary-length hex-encoded byte string.
+
+    Bytes32:
+      type: string
+      pattern: '^0x[a-fA-F0-9]{64}$'
+      description: 32-byte hex hash (UserOp hash, transaction hash).
+      example: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    UserOpInnerCall:
+      type: object
+      required: [to, value, selector, data]
+      properties:
+        to:
+          $ref: '#/components/schemas/EthereumAddress'
+        value:
+          type: string
+          description: Native value in wei (decimal string).
+        selector:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{8}$'
+          description: 4-byte function selector of `data` (`0x00000000` for a value-only call).
+        data:
+          $ref: '#/components/schemas/Hex'
+
+    UserOpStatusResponse:
+      type: object
+      required: [userOpHash, executionStatus]
+      properties:
+        userOpHash:
+          $ref: '#/components/schemas/Bytes32'
+        sender:
+          $ref: '#/components/schemas/EthereumAddress'
+        executionStatus:
+          type: string
+          enum: [pending, confirmed, failed]
+          description: |
+            `pending` means the bundler accepted the op and it is not yet
+            mined. It is not a failure.
+        transactionHash:
+          $ref: '#/components/schemas/Hex'
+        blockNumber:
+          type: string
+          description: Block number as a hex string when mined.
+        success:
+          type: boolean
+          description: Inner UserOp success from the bundler receipt. Absent while pending.
+        calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserOpInnerCall'
+        failedCall:
+          $ref: '#/components/schemas/UserOpInnerCall'
+          description: Present when the inner call reverted and there is a single inner call.
 
     Ulid:
       type: string
@@ -2909,6 +2963,40 @@ paths:
               schema: { $ref: '#/components/schemas/RunNodeResponse' }
         '400': { $ref: '#/components/responses/BadRequest' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /userops/{userOpHash}:
+    get:
+      tags: [UserOps]
+      summary: Look up a UserOp this user submitted
+      description: |
+        Re-poll a UserOp by hash (G3 / N14.a). Same gate as `nodes:run`
+        (user Bearer JWT; partner assertion alone is not sufficient). The
+        sender must be one of the caller's smart wallets — this is **not**
+        a public AA explorer. Unknown hashes and hashes that belong to
+        another user both return 404.
+
+        Inner `calls` are unpacked from the UserOp `callData` via the
+        gateway's existing `UnpackExecuteCalldata` (execute / executeBatch
+        / MA v2). Pending is not failed.
+      operationId: getUserOp
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userOpHash
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Bytes32'
+        - $ref: '#/components/parameters/ChainIdQuery'
+      responses:
+        '200':
+          description: Typed UserOp status and inner calls.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UserOpStatusResponse' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
 
   /triggers:run:
     post:

--- a/core/chainio/aa/aa.go
+++ b/core/chainio/aa/aa.go
@@ -367,6 +367,7 @@ func PackExecuteBatchWithValues(targetAddresses []common.Address, values []*big.
 // It is the inverse the paymaster reimbursement wrapper needs to append its own batch entries onto
 // an already-batched call without having to know how that call was originally packed.
 func UnpackExecuteCalldata(calldata []byte) (targets []common.Address, values []*big.Int, datas [][]byte, err error) {
+	calldata = UnwrapExecuteUserOp(calldata)
 	if len(calldata) < 4 {
 		return nil, nil, nil, fmt.Errorf("calldata too short: %d bytes", len(calldata))
 	}

--- a/core/chainio/aa/aa_batch_test.go
+++ b/core/chainio/aa/aa_batch_test.go
@@ -31,6 +31,20 @@ func TestUnpackExecuteCalldata_Roundtrip(t *testing.T) {
 		assert.True(t, bytes.Equal(dataA, datas[0]))
 	})
 
+	t.Run("executeUserOp-wrapped execute -> one entry", func(t *testing.T) {
+		packed, err := PackExecute(tokenA, big.NewInt(7), dataA)
+		require.NoError(t, err)
+		wrapped, err := WrapExecuteUserOp(packed)
+		require.NoError(t, err)
+
+		targets, values, datas, err := UnpackExecuteCalldata(wrapped)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		assert.Equal(t, tokenA, targets[0])
+		assert.Equal(t, int64(7), values[0].Int64())
+		assert.True(t, bytes.Equal(dataA, datas[0]))
+	})
+
 	t.Run("executeBatch -> N entries, values default to 0", func(t *testing.T) {
 		packed, err := PackExecuteBatch([]common.Address{tokenA, router}, [][]byte{dataA, dataB})
 		require.NoError(t, err)

--- a/core/chainio/aa/ma_v2_hooks.go
+++ b/core/chainio/aa/ma_v2_hooks.go
@@ -1,6 +1,7 @@
 package aa
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"sync"
@@ -224,4 +225,16 @@ func WrapExecuteUserOp(execCallData []byte) ([]byte, error) {
 		return nil, fmt.Errorf("execution calldata is %d bytes, shorter than a selector", len(execCallData))
 	}
 	return append(selectorExecuteUserOp[:], execCallData...), nil
+}
+
+// UnwrapExecuteUserOp strips a leading executeUserOp selector if present.
+// The send path prepends that selector when a grant has execution hooks
+// (WrapExecuteUserOp); bundler eth_getUserOperationByHash then returns the
+// wrapped bytes. Callers that unpack execute/executeBatch must strip first.
+// Unwrapped calldata is returned unchanged.
+func UnwrapExecuteUserOp(callData []byte) []byte {
+	if len(callData) >= 4 && bytes.Equal(callData[:4], selectorExecuteUserOp[:]) {
+		return callData[4:]
+	}
+	return callData
 }

--- a/core/chainio/aa/ma_v2_hooks_test.go
+++ b/core/chainio/aa/ma_v2_hooks_test.go
@@ -134,4 +134,12 @@ func TestWrapExecuteUserOp(t *testing.T) {
 	if _, err := WrapExecuteUserOp([]byte{0x01}); err == nil {
 		t.Error("expected sub-selector calldata to be rejected")
 	}
+
+	unwrapped := UnwrapExecuteUserOp(wrapped)
+	if !bytes.Equal(unwrapped, inner) {
+		t.Fatal("UnwrapExecuteUserOp did not restore inner execute calldata")
+	}
+	if !bytes.Equal(UnwrapExecuteUserOp(inner), inner) {
+		t.Fatal("UnwrapExecuteUserOp must leave unwrapped execute calldata unchanged")
+	}
 }

--- a/core/taskengine/userop_calls.go
+++ b/core/taskengine/userop_calls.go
@@ -70,8 +70,9 @@ func innerCallsAsInterface(calls []InnerCall) []interface{} {
 	return out
 }
 
-// stampInnerCalls writes receipt.calls (and receipt.failedCall when a single
-// inner call reverted or was refused) onto an existing receipt map.
+// stampInnerCalls writes receipt.calls onto an existing receipt map.
+// failedCall is set only when innerFailed is true (observed inner revert)
+// and there is a single inner call.
 func stampInnerCalls(receiptMap map[string]interface{}, packed []byte, innerFailed bool) {
 	if receiptMap == nil || len(packed) == 0 {
 		return
@@ -88,11 +89,12 @@ func stampInnerCalls(receiptMap map[string]interface{}, packed []byte, innerFail
 
 // failedReceiptWithInnerCalls builds a failed receipt that still carries the
 // inner calls we packed — used on AA23 / bundler reject after calldata exists.
+// Those paths never ran the inner call, so failedCall is omitted.
 func failedReceiptWithInnerCalls(packed []byte) *structpb.Value {
 	receiptMap := map[string]interface{}{
 		"executionStatus": "failed",
 	}
-	stampInnerCalls(receiptMap, packed, true)
+	stampInnerCalls(receiptMap, packed, false)
 	v, err := structpb.NewValue(receiptMap)
 	if err != nil {
 		return nil
@@ -119,7 +121,7 @@ func attachFailedInnerCalls(results []*avsproto.ContractWriteNode_MethodResult, 
 			mr.Receipt = failedReceiptWithInnerCalls(packed)
 			continue
 		}
-		stampInnerCalls(m, packed, true)
+		stampInnerCalls(m, packed, false)
 		if v, err := structpb.NewValue(m); err == nil {
 			mr.Receipt = v
 		}

--- a/core/taskengine/userop_calls.go
+++ b/core/taskengine/userop_calls.go
@@ -1,0 +1,127 @@
+package taskengine
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+	"github.com/ethereum/go-ethereum/common"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// InnerCall is one decoded smart-wallet execute / executeBatch entry:
+// the destination, native value, 4-byte selector, and raw calldata.
+// This is the typed shape stamped on nodes:run receipts (N14.a).
+type InnerCall struct {
+	To       string
+	Value    string
+	Selector string
+	Data     string
+}
+
+// InnerCallsFromExecuteCalldata unpacks smart-wallet execute calldata
+// (v0.6 execute / executeBatch / executeBatchWithValues, or MA v2 tuple-batch)
+// into typed inner calls. Empty input yields a nil slice, not an error.
+func InnerCallsFromExecuteCalldata(packed []byte) ([]InnerCall, error) {
+	if len(packed) == 0 {
+		return nil, nil
+	}
+	targets, values, datas, err := aa.UnpackExecuteCalldata(packed)
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) != len(values) || len(targets) != len(datas) {
+		return nil, fmt.Errorf("unpacked execute calldata length mismatch")
+	}
+	out := make([]InnerCall, len(targets))
+	for i := range targets {
+		out[i] = InnerCall{
+			To:       targets[i].Hex(),
+			Value:    weiString(values[i]),
+			Selector: SelectorFromCalldata(datas[i]),
+			Data:     "0x" + common.Bytes2Hex(datas[i]),
+		}
+	}
+	return out, nil
+}
+
+func weiString(v *big.Int) string {
+	if v == nil {
+		return "0"
+	}
+	return v.String()
+}
+
+func innerCallAsMap(c InnerCall) map[string]interface{} {
+	return map[string]interface{}{
+		"to":       c.To,
+		"value":    c.Value,
+		"selector": c.Selector,
+		"data":     c.Data,
+	}
+}
+
+func innerCallsAsInterface(calls []InnerCall) []interface{} {
+	out := make([]interface{}, len(calls))
+	for i, c := range calls {
+		out[i] = innerCallAsMap(c)
+	}
+	return out
+}
+
+// stampInnerCalls writes receipt.calls (and receipt.failedCall when a single
+// inner call reverted or was refused) onto an existing receipt map.
+func stampInnerCalls(receiptMap map[string]interface{}, packed []byte, innerFailed bool) {
+	if receiptMap == nil || len(packed) == 0 {
+		return
+	}
+	calls, err := InnerCallsFromExecuteCalldata(packed)
+	if err != nil || len(calls) == 0 {
+		return
+	}
+	receiptMap["calls"] = innerCallsAsInterface(calls)
+	if innerFailed && len(calls) == 1 {
+		receiptMap["failedCall"] = innerCallAsMap(calls[0])
+	}
+}
+
+// failedReceiptWithInnerCalls builds a failed receipt that still carries the
+// inner calls we packed — used on AA23 / bundler reject after calldata exists.
+func failedReceiptWithInnerCalls(packed []byte) *structpb.Value {
+	receiptMap := map[string]interface{}{
+		"executionStatus": "failed",
+	}
+	stampInnerCalls(receiptMap, packed, true)
+	v, err := structpb.NewValue(receiptMap)
+	if err != nil {
+		return nil
+	}
+	return v
+}
+
+// attachFailedInnerCalls stamps a failed receipt with inner calls onto every
+// method result that does not already have one (atomic-batch AA23 path).
+func attachFailedInnerCalls(results []*avsproto.ContractWriteNode_MethodResult, packed []byte) {
+	if len(packed) == 0 {
+		return
+	}
+	for _, mr := range results {
+		if mr == nil {
+			continue
+		}
+		if mr.Receipt == nil {
+			mr.Receipt = failedReceiptWithInnerCalls(packed)
+			continue
+		}
+		m, ok := mr.Receipt.AsInterface().(map[string]interface{})
+		if !ok || m == nil {
+			mr.Receipt = failedReceiptWithInnerCalls(packed)
+			continue
+		}
+		stampInnerCalls(m, packed, true)
+		if v, err := structpb.NewValue(m); err == nil {
+			mr.Receipt = v
+		}
+	}
+}

--- a/core/taskengine/userop_calls_test.go
+++ b/core/taskengine/userop_calls_test.go
@@ -26,6 +26,22 @@ func TestInnerCallsFromExecuteCalldata_Execute(t *testing.T) {
 	assert.Equal(t, "0x095ea7b3010203", calls[0].Data)
 }
 
+func TestInnerCallsFromExecuteCalldata_ExecuteUserOpWrapped(t *testing.T) {
+	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	data := []byte{0x09, 0x5e, 0xa7, 0xb3, 0x01, 0x02, 0x03}
+	packed, err := aa.PackExecute(token, big.NewInt(7), data)
+	require.NoError(t, err)
+	wrapped, err := aa.WrapExecuteUserOp(packed)
+	require.NoError(t, err)
+
+	calls, err := InnerCallsFromExecuteCalldata(wrapped)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, token.Hex(), calls[0].To)
+	assert.Equal(t, "7", calls[0].Value)
+	assert.Equal(t, "0x095ea7b3", calls[0].Selector)
+}
+
 func TestInnerCallsFromExecuteCalldata_ExecuteBatch(t *testing.T) {
 	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
 	router := common.HexToAddress("0xbbbb000000000000000000000000000000000002")

--- a/core/taskengine/userop_calls_test.go
+++ b/core/taskengine/userop_calls_test.go
@@ -1,0 +1,89 @@
+package taskengine
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInnerCallsFromExecuteCalldata_Execute(t *testing.T) {
+	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	data := []byte{0x09, 0x5e, 0xa7, 0xb3, 0x01, 0x02, 0x03}
+
+	packed, err := aa.PackExecute(token, big.NewInt(7), data)
+	require.NoError(t, err)
+
+	calls, err := InnerCallsFromExecuteCalldata(packed)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, token.Hex(), calls[0].To)
+	assert.Equal(t, "7", calls[0].Value)
+	assert.Equal(t, "0x095ea7b3", calls[0].Selector)
+	assert.Equal(t, "0x095ea7b3010203", calls[0].Data)
+}
+
+func TestInnerCallsFromExecuteCalldata_ExecuteBatch(t *testing.T) {
+	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	router := common.HexToAddress("0xbbbb000000000000000000000000000000000002")
+	dataA := []byte{0x09, 0x5e, 0xa7, 0xb3}
+	dataB := []byte{0x12, 0x34, 0x56, 0x78, 0x00}
+
+	packed, err := aa.PackExecuteBatch([]common.Address{token, router}, [][]byte{dataA, dataB})
+	require.NoError(t, err)
+
+	calls, err := InnerCallsFromExecuteCalldata(packed)
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	assert.Equal(t, token.Hex(), calls[0].To)
+	assert.Equal(t, "0", calls[0].Value)
+	assert.Equal(t, "0x095ea7b3", calls[0].Selector)
+	assert.Equal(t, router.Hex(), calls[1].To)
+	assert.Equal(t, "0x12345678", calls[1].Selector)
+}
+
+func TestInnerCallsFromExecuteCalldata_Empty(t *testing.T) {
+	calls, err := InnerCallsFromExecuteCalldata(nil)
+	require.NoError(t, err)
+	assert.Nil(t, calls)
+}
+
+func TestFailedReceiptWithInnerCalls_SingleCallSetsFailedCall(t *testing.T) {
+	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	packed, err := aa.PackExecute(token, big.NewInt(0), []byte{0xa9, 0x05, 0x9c, 0xbb})
+	require.NoError(t, err)
+
+	receipt := failedReceiptWithInnerCalls(packed)
+	require.NotNil(t, receipt)
+	m, ok := receipt.AsInterface().(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "failed", m["executionStatus"])
+	calls, ok := m["calls"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	failed, ok := m["failedCall"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, token.Hex(), failed["to"])
+	assert.Equal(t, "0xa9059cbb", failed["selector"])
+}
+
+func TestFailedReceiptWithInnerCalls_BatchOmitsFailedCall(t *testing.T) {
+	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	router := common.HexToAddress("0xbbbb000000000000000000000000000000000002")
+	packed, err := aa.PackExecuteBatch(
+		[]common.Address{token, router},
+		[][]byte{{0x09, 0x5e, 0xa7, 0xb3}, {0x12, 0x34, 0x56, 0x78}},
+	)
+	require.NoError(t, err)
+
+	receipt := failedReceiptWithInnerCalls(packed)
+	require.NotNil(t, receipt)
+	m := receipt.AsInterface().(map[string]interface{})
+	calls := m["calls"].([]interface{})
+	require.Len(t, calls, 2)
+	_, hasFailed := m["failedCall"]
+	assert.False(t, hasFailed, "atomic batch does not invent which sub-call failed")
+}

--- a/core/taskengine/userop_calls_test.go
+++ b/core/taskengine/userop_calls_test.go
@@ -51,7 +51,7 @@ func TestInnerCallsFromExecuteCalldata_Empty(t *testing.T) {
 	assert.Nil(t, calls)
 }
 
-func TestFailedReceiptWithInnerCalls_SingleCallSetsFailedCall(t *testing.T) {
+func TestFailedReceiptWithInnerCalls_SingleCallOmitsFailedCall(t *testing.T) {
 	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
 	packed, err := aa.PackExecute(token, big.NewInt(0), []byte{0xa9, 0x05, 0x9c, 0xbb})
 	require.NoError(t, err)
@@ -64,10 +64,8 @@ func TestFailedReceiptWithInnerCalls_SingleCallSetsFailedCall(t *testing.T) {
 	calls, ok := m["calls"].([]interface{})
 	require.True(t, ok)
 	require.Len(t, calls, 1)
-	failed, ok := m["failedCall"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, token.Hex(), failed["to"])
-	assert.Equal(t, "0xa9059cbb", failed["selector"])
+	_, hasFailed := m["failedCall"]
+	assert.False(t, hasFailed, "submission reject is not an inner revert")
 }
 
 func TestFailedReceiptWithInnerCalls_BatchOmitsFailedCall(t *testing.T) {

--- a/core/taskengine/userop_status.go
+++ b/core/taskengine/userop_status.go
@@ -32,6 +32,10 @@ var ErrUserOpNotFound = fmt.Errorf("user operation not found")
 // ErrUserOpHashInvalid is a 400: the path param is not a 32-byte hex hash.
 var ErrUserOpHashInvalid = fmt.Errorf("invalid userOpHash")
 
+// ErrUserOpChainUnsupported is a 400: the caller named a chain this
+// aggregator does not serve. Do not fall back to the default bundler.
+var ErrUserOpChainUnsupported = fmt.Errorf("unsupported chain")
+
 type userOpBundler interface {
 	GetUserOperationByHash(ctx context.Context, hash string) (interface{}, error)
 	GetUserOperationReceipt(ctx context.Context, hash string) (interface{}, error)
@@ -59,6 +63,9 @@ func (n *Engine) LookupUserOpStatus(ctx context.Context, user *model.User, userO
 	if chainID <= 0 && user.ChainID > 0 {
 		chainID = user.ChainID
 	}
+	if chainID > 0 && !n.isChainConfigured(chainID) {
+		return nil, fmt.Errorf("%w: %d", ErrUserOpChainUnsupported, chainID)
+	}
 	sw := n.ResolveSmartWalletConfig(chainID)
 	if sw == nil {
 		return nil, fmt.Errorf("smart wallet config is not available for chain %d", chainID)
@@ -82,7 +89,10 @@ func (n *Engine) LookupUserOpStatus(ctx context.Context, user *model.User, userO
 		return nil, ErrUserOpNotFound
 	}
 
-	owns, err := n.userOwnsWalletOnAnyChain(user, sender)
+	if n.db == nil {
+		return nil, fmt.Errorf("wallet storage is not available")
+	}
+	owns, err := ValidWalletOwner(n.db, sw.ChainID, user, sender)
 	if err != nil {
 		return nil, err
 	}
@@ -102,9 +112,7 @@ func (n *Engine) LookupUserOpStatus(ctx context.Context, user *model.User, userO
 
 	rawReceipt, recErr := client.GetUserOperationReceipt(ctx, normalized)
 	if recErr != nil {
-		// Receipt lookup failing while the op itself exists is still pending
-		// (bundler lag / method not implemented). Do not convert that to failed.
-		return out, nil
+		return nil, fmt.Errorf("eth_getUserOperationReceipt: %w", recErr)
 	}
 	success, txHash, blockNumber := parseBundlerReceipt(rawReceipt)
 	if txHash == "" && txFromOp != "" {

--- a/core/taskengine/userop_status.go
+++ b/core/taskengine/userop_status.go
@@ -1,0 +1,233 @@
+package taskengine
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/bundler"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// UserOpStatus is the typed lookup result for GET /userops/{userOpHash}.
+// Pending is not failed.
+type UserOpStatus struct {
+	UserOpHash      string
+	Sender          string
+	ExecutionStatus string
+	TransactionHash string
+	BlockNumber     string
+	Success         *bool
+	Calls           []InnerCall
+	FailedCall      *InnerCall
+}
+
+// ErrUserOpNotFound is returned for unknown hashes and for hashes whose
+// sender is not one of the caller's smart wallets (same 404 so this is
+// not a public AA explorer).
+var ErrUserOpNotFound = fmt.Errorf("user operation not found")
+
+// ErrUserOpHashInvalid is a 400: the path param is not a 32-byte hex hash.
+var ErrUserOpHashInvalid = fmt.Errorf("invalid userOpHash")
+
+type userOpBundler interface {
+	GetUserOperationByHash(ctx context.Context, hash string) (interface{}, error)
+	GetUserOperationReceipt(ctx context.Context, hash string) (interface{}, error)
+	Close()
+}
+
+var newUserOpBundler = func(url string) (userOpBundler, error) {
+	return bundler.NewBundlerClient(url)
+}
+
+// LookupUserOpStatus re-polls a UserOp this user submitted. Same gate as
+// nodes:run: the caller is a concrete user; the sender must be one of
+// their smart wallets. Internally: bundler GetUserOperationByHash +
+// GetUserOperationReceipt, then UnpackExecuteCalldata on the UserOp
+// callData.
+func (n *Engine) LookupUserOpStatus(ctx context.Context, user *model.User, userOpHash string, chainID int64) (*UserOpStatus, error) {
+	normalized, err := normalizeUserOpHash(userOpHash)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, ErrUserOpNotFound
+	}
+
+	if chainID <= 0 && user.ChainID > 0 {
+		chainID = user.ChainID
+	}
+	sw := n.ResolveSmartWalletConfig(chainID)
+	if sw == nil {
+		return nil, fmt.Errorf("smart wallet config is not available for chain %d", chainID)
+	}
+	bundlerURL, err := sw.ActiveBundlerURL()
+	if err != nil {
+		return nil, fmt.Errorf("resolve bundler endpoint: %w", err)
+	}
+	client, err := newUserOpBundler(bundlerURL)
+	if err != nil {
+		return nil, fmt.Errorf("bundler client: %w", err)
+	}
+	defer client.Close()
+
+	rawOp, err := client.GetUserOperationByHash(ctx, normalized)
+	if err != nil {
+		return nil, fmt.Errorf("eth_getUserOperationByHash: %w", err)
+	}
+	sender, callData, txFromOp, found := parseBundlerUserOp(rawOp)
+	if !found || (sender == (common.Address{})) {
+		return nil, ErrUserOpNotFound
+	}
+
+	owns, err := n.userOwnsWalletOnAnyChain(user, sender)
+	if err != nil {
+		return nil, err
+	}
+	if !owns {
+		return nil, ErrUserOpNotFound
+	}
+
+	out := &UserOpStatus{
+		UserOpHash:      normalized,
+		Sender:          sender.Hex(),
+		ExecutionStatus: "pending",
+		TransactionHash: txFromOp,
+	}
+	if calls, unpackErr := InnerCallsFromExecuteCalldata(callData); unpackErr == nil {
+		out.Calls = calls
+	}
+
+	rawReceipt, recErr := client.GetUserOperationReceipt(ctx, normalized)
+	if recErr != nil {
+		// Receipt lookup failing while the op itself exists is still pending
+		// (bundler lag / method not implemented). Do not convert that to failed.
+		return out, nil
+	}
+	success, txHash, blockNumber := parseBundlerReceipt(rawReceipt)
+	if txHash == "" && txFromOp != "" {
+		txHash = txFromOp
+	}
+	if success == nil && txHash == "" && blockNumber == "" {
+		// Bundler returned a null receipt: still pending.
+		return out, nil
+	}
+	out.TransactionHash = txHash
+	out.BlockNumber = blockNumber
+	out.Success = success
+	switch {
+	case success != nil && *success:
+		out.ExecutionStatus = "confirmed"
+	case success != nil && !*success:
+		out.ExecutionStatus = "failed"
+		if len(out.Calls) == 1 {
+			failed := out.Calls[0]
+			out.FailedCall = &failed
+		}
+	default:
+		if txHash != "" {
+			out.ExecutionStatus = "confirmed"
+		}
+	}
+	return out, nil
+}
+
+func normalizeUserOpHash(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		s = s[2:]
+	}
+	if len(s) != 64 {
+		return "", ErrUserOpHashInvalid
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != 32 {
+		return "", ErrUserOpHashInvalid
+	}
+	return common.BytesToHash(b).Hex(), nil
+}
+
+func asStringMap(v interface{}) map[string]interface{} {
+	m, _ := v.(map[string]interface{})
+	return m
+}
+
+func mapString(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	s, _ := m[key].(string)
+	return s
+}
+
+func parseHexBytes(s string) []byte {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0x" || s == "0X" {
+		return nil
+	}
+	return common.FromHex(s)
+}
+
+// parseBundlerUserOp accepts both the ERC-4337 object-with-userOperation
+// envelope and a flat UserOp map. Returns found=false on nil/empty.
+func parseBundlerUserOp(raw interface{}) (sender common.Address, callData []byte, txHash string, found bool) {
+	m := asStringMap(raw)
+	if m == nil {
+		return common.Address{}, nil, "", false
+	}
+	inner := asStringMap(m["userOperation"])
+	src := inner
+	if src == nil {
+		src = m
+	}
+	senderStr := mapString(src, "sender")
+	if senderStr == "" {
+		return common.Address{}, nil, "", false
+	}
+	if !common.IsHexAddress(senderStr) {
+		return common.Address{}, nil, "", false
+	}
+	sender = common.HexToAddress(senderStr)
+	callData = parseHexBytes(mapString(src, "callData"))
+	txHash = mapString(m, "transactionHash")
+	if txHash == "" {
+		txHash = mapString(src, "transactionHash")
+	}
+	return sender, callData, txHash, true
+}
+
+func parseBundlerReceipt(raw interface{}) (success *bool, txHash string, blockNumber string) {
+	m := asStringMap(raw)
+	if m == nil {
+		return nil, "", ""
+	}
+	if v, ok := m["success"].(bool); ok {
+		success = &v
+	}
+	txHash = mapString(m, "transactionHash")
+	blockNumber = stringifyBlockNumber(m["blockNumber"])
+	if receipt := asStringMap(m["receipt"]); receipt != nil {
+		if txHash == "" {
+			txHash = mapString(receipt, "transactionHash")
+		}
+		if blockNumber == "" {
+			blockNumber = stringifyBlockNumber(receipt["blockNumber"])
+		}
+	}
+	return success, txHash, blockNumber
+}
+
+func stringifyBlockNumber(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return fmt.Sprintf("0x%x", uint64(t))
+	case int64:
+		return fmt.Sprintf("0x%x", uint64(t))
+	default:
+		return ""
+	}
+}

--- a/core/taskengine/userop_status_test.go
+++ b/core/taskengine/userop_status_test.go
@@ -1,11 +1,18 @@
 package taskengine
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
+	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/model"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,4 +93,147 @@ func TestParseBundlerReceipt_SuccessAndNested(t *testing.T) {
 	success, _, _ = parseBundlerReceipt(map[string]interface{}{"success": failed})
 	require.NotNil(t, success)
 	assert.False(t, *success)
+}
+
+const lookupHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type mockUserOpBundler struct {
+	op     interface{}
+	opErr  error
+	rec    interface{}
+	recErr error
+}
+
+func (m *mockUserOpBundler) GetUserOperationByHash(context.Context, string) (interface{}, error) {
+	return m.op, m.opErr
+}
+func (m *mockUserOpBundler) GetUserOperationReceipt(context.Context, string) (interface{}, error) {
+	return m.rec, m.recErr
+}
+func (m *mockUserOpBundler) Close() {}
+
+func lookupTestEngine(t *testing.T) (*Engine, storage.Storage, common.Address, common.Address) {
+	t.Helper()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { storage.Destroy(db.(*storage.BadgerStorage)) })
+
+	sepolia := &config.SmartWalletConfig{
+		ChainID:         11155111,
+		BundlerProvider: config.BundlerProviderSelfHosted,
+		BundlerURL:      "http://bundler-sepolia.test",
+	}
+	base := &config.SmartWalletConfig{
+		ChainID:         84532,
+		BundlerProvider: config.BundlerProviderSelfHosted,
+		BundlerURL:      "http://bundler-base.test",
+	}
+	engine := &Engine{
+		db:                db,
+		smartWalletConfig: sepolia,
+		chainConfigs: map[int64]*config.ChainConfig{
+			11155111: {ChainID: 11155111, Name: "sepolia", SmartWallet: sepolia},
+			84532:    {ChainID: 84532, Name: "base-sepolia", SmartWallet: base},
+		},
+	}
+	owner := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	sender := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	require.NoError(t, StoreWallet(db, 11155111, owner, &model.SmartWallet{Address: &sender}))
+	return engine, db, owner, sender
+}
+
+func packedTransfer(t *testing.T, to common.Address) []byte {
+	t.Helper()
+	packed, err := aa.PackExecute(to, big.NewInt(0), []byte{0xa9, 0x05, 0x9c, 0xbb})
+	require.NoError(t, err)
+	return packed
+}
+
+func installMockBundler(t *testing.T, mock *mockUserOpBundler) {
+	t.Helper()
+	orig := newUserOpBundler
+	t.Cleanup(func() { newUserOpBundler = orig })
+	newUserOpBundler = func(string) (userOpBundler, error) { return mock, nil }
+}
+
+func TestLookupUserOpStatus(t *testing.T) {
+	engine, _, owner, sender := lookupTestEngine(t)
+	user := &model.User{Address: owner, ChainID: 11155111}
+	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	op := map[string]interface{}{
+		"userOperation": map[string]interface{}{
+			"sender":   sender.Hex(),
+			"callData": "0x" + common.Bytes2Hex(packedTransfer(t, token)),
+		},
+	}
+
+	t.Run("pending when receipt is null", func(t *testing.T) {
+		installMockBundler(t, &mockUserOpBundler{op: op})
+		got, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)
+		require.NoError(t, err)
+		assert.Equal(t, "pending", got.ExecutionStatus)
+		require.Len(t, got.Calls, 1)
+		assert.Equal(t, token.Hex(), got.Calls[0].To)
+		assert.Nil(t, got.FailedCall)
+	})
+
+	t.Run("confirmed when receipt success=true", func(t *testing.T) {
+		installMockBundler(t, &mockUserOpBundler{
+			op:  op,
+			rec: map[string]interface{}{"success": true, "transactionHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "blockNumber": "0x64"},
+		})
+		got, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)
+		require.NoError(t, err)
+		assert.Equal(t, "confirmed", got.ExecutionStatus)
+		require.NotNil(t, got.Success)
+		assert.True(t, *got.Success)
+		assert.Nil(t, got.FailedCall)
+	})
+
+	t.Run("failed inner sets failedCall", func(t *testing.T) {
+		installMockBundler(t, &mockUserOpBundler{
+			op:  op,
+			rec: map[string]interface{}{"success": false, "transactionHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+		})
+		got, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)
+		require.NoError(t, err)
+		assert.Equal(t, "failed", got.ExecutionStatus)
+		require.NotNil(t, got.FailedCall)
+		assert.Equal(t, token.Hex(), got.FailedCall.To)
+	})
+
+	t.Run("receipt RPC error is not pending", func(t *testing.T) {
+		installMockBundler(t, &mockUserOpBundler{op: op, recErr: fmt.Errorf("bundler down")})
+		_, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "eth_getUserOperationReceipt")
+		assert.False(t, errors.Is(err, ErrUserOpNotFound))
+	})
+
+	t.Run("unknown hash is not found", func(t *testing.T) {
+		installMockBundler(t, &mockUserOpBundler{})
+		_, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)
+		assert.ErrorIs(t, err, ErrUserOpNotFound)
+	})
+
+	t.Run("foreign sender is not found", func(t *testing.T) {
+		other := common.HexToAddress("0x3333333333333333333333333333333333333333")
+		installMockBundler(t, &mockUserOpBundler{op: map[string]interface{}{
+			"sender":   other.Hex(),
+			"callData": "0x",
+		}})
+		_, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)
+		assert.ErrorIs(t, err, ErrUserOpNotFound)
+	})
+
+	t.Run("explicit unsupported chain is rejected", func(t *testing.T) {
+		installMockBundler(t, &mockUserOpBundler{op: op})
+		_, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 99999)
+		assert.ErrorIs(t, err, ErrUserOpChainUnsupported)
+	})
+
+	t.Run("wallet on chain A does not authorize chain B", func(t *testing.T) {
+		installMockBundler(t, &mockUserOpBundler{op: op})
+		_, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 84532)
+		assert.ErrorIs(t, err, ErrUserOpNotFound)
+	})
 }

--- a/core/taskengine/userop_status_test.go
+++ b/core/taskengine/userop_status_test.go
@@ -166,6 +166,22 @@ func TestLookupUserOpStatus(t *testing.T) {
 		},
 	}
 
+	t.Run("executeUserOp-wrapped calldata still unpacks calls", func(t *testing.T) {
+		wrapped, err := aa.WrapExecuteUserOp(packedTransfer(t, token))
+		require.NoError(t, err)
+		installMockBundler(t, &mockUserOpBundler{op: map[string]interface{}{
+			"userOperation": map[string]interface{}{
+				"sender":   sender.Hex(),
+				"callData": "0x" + common.Bytes2Hex(wrapped),
+			},
+		}})
+		got, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)
+		require.NoError(t, err)
+		require.Len(t, got.Calls, 1)
+		assert.Equal(t, token.Hex(), got.Calls[0].To)
+		assert.Equal(t, "0xa9059cbb", got.Calls[0].Selector)
+	})
+
 	t.Run("pending when receipt is null", func(t *testing.T) {
 		installMockBundler(t, &mockUserOpBundler{op: op})
 		got, err := engine.LookupUserOpStatus(context.Background(), user, lookupHash, 11155111)

--- a/core/taskengine/userop_status_test.go
+++ b/core/taskengine/userop_status_test.go
@@ -1,0 +1,89 @@
+package taskengine
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeUserOpHash(t *testing.T) {
+	want := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	got, err := normalizeUserOpHash("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	require.NoError(t, err)
+	assert.Equal(t, want, strings.ToLower(got))
+
+	_, err = normalizeUserOpHash("0xabc")
+	assert.ErrorIs(t, err, ErrUserOpHashInvalid)
+
+	_, err = normalizeUserOpHash("not-hex")
+	assert.ErrorIs(t, err, ErrUserOpHashInvalid)
+}
+
+func TestParseBundlerUserOp_Envelope(t *testing.T) {
+	token := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+	packed, err := aa.PackExecute(token, big.NewInt(0), []byte{0xa9, 0x05, 0x9c, 0xbb})
+	require.NoError(t, err)
+
+	sender := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	raw := map[string]interface{}{
+		"userOperation": map[string]interface{}{
+			"sender":   sender.Hex(),
+			"callData": "0x" + common.Bytes2Hex(packed),
+		},
+		"transactionHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+	gotSender, callData, txHash, found := parseBundlerUserOp(raw)
+	require.True(t, found)
+	assert.Equal(t, sender, gotSender)
+	assert.Equal(t, packed, callData)
+	assert.Equal(t, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", txHash)
+
+	calls, err := InnerCallsFromExecuteCalldata(callData)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, token.Hex(), calls[0].To)
+}
+
+func TestParseBundlerUserOp_FlatAndNil(t *testing.T) {
+	sender := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	gotSender, _, _, found := parseBundlerUserOp(map[string]interface{}{
+		"sender":   sender.Hex(),
+		"callData": "0x",
+	})
+	require.True(t, found)
+	assert.Equal(t, sender, gotSender)
+
+	_, _, _, found = parseBundlerUserOp(nil)
+	assert.False(t, found)
+	_, _, _, found = parseBundlerUserOp(map[string]interface{}{})
+	assert.False(t, found)
+}
+
+func TestParseBundlerReceipt_SuccessAndNested(t *testing.T) {
+	success, txHash, block := parseBundlerReceipt(map[string]interface{}{
+		"success": true,
+		"receipt": map[string]interface{}{
+			"transactionHash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			"blockNumber":     "0x64",
+		},
+	})
+	require.NotNil(t, success)
+	assert.True(t, *success)
+	assert.Equal(t, "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", txHash)
+	assert.Equal(t, "0x64", block)
+
+	success, txHash, block = parseBundlerReceipt(nil)
+	assert.Nil(t, success)
+	assert.Empty(t, txHash)
+	assert.Empty(t, block)
+
+	failed := false
+	success, _, _ = parseBundlerReceipt(map[string]interface{}{"success": failed})
+	require.NotNil(t, success)
+	assert.False(t, *success)
+}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -1033,6 +1033,7 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 			Success:    false,
 			Error:      userErrorMsg,
 			MethodName: methodName,
+			Receipt:    failedReceiptWithInnerCalls(smartWalletCallData),
 		}
 	}
 
@@ -1050,7 +1051,7 @@ func (r *ContractWriteProcessor) executeRealUserOpTransaction(ctx context.Contex
 	}
 
 	// Create result from real transaction
-	result := r.createRealTransactionResult(methodName, contractAddress.Hex(), callData, parsedABI, userOp, receipt)
+	result := r.createRealTransactionResult(methodName, contractAddress.Hex(), callData, parsedABI, userOp, receipt, smartWalletCallData)
 
 	// Error field should contain only the summary (first sentence)
 	// Detailed logs are already in the execution log (log field)
@@ -1314,7 +1315,9 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 	executionLogBuilder.WriteString(fmt.Sprintf("Atomic batch UserOp for %d calls (%s)\n", n, packKind))
 	userOp, receipt, userErrorMsg := r.submitSmartWalletUserOp(ctx, smartWalletCallData, logLabel, logTarget, &executionLogBuilder)
 	if userErrorMsg != "" {
-		return failAll(userErrorMsg, nil)
+		out := failAll(userErrorMsg, nil)
+		attachFailedInnerCalls(out, smartWalletCallData)
+		return out
 	}
 
 	// Fan the single receipt into one result per sub-call: all share the same tx identity
@@ -1324,13 +1327,15 @@ func (r *ContractWriteProcessor) executeAtomicBatch(
 	results = make([]*avsproto.ContractWriteNode_MethodResult, n)
 	for i := range methodCalls {
 		callDataHex := "0x" + common.Bytes2Hex(datas[i])
-		results[i] = r.createRealTransactionResult(methodNames[i], perCallTargets[i].Hex(), callDataHex, parsedABI, userOp, receipt)
+		results[i] = r.createRealTransactionResult(methodNames[i], perCallTargets[i].Hex(), callDataHex, parsedABI, userOp, receipt, smartWalletCallData)
 	}
 	return results
 }
 
-// createRealTransactionResult creates a result from a real UserOp transaction
-func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contractAddress, callData string, parsedABI *abi.ABI, userOp *preset.SentUserOp, receipt *types.Receipt) *avsproto.ContractWriteNode_MethodResult {
+// createRealTransactionResult creates a result from a real UserOp transaction.
+// packedExecute is the smart-wallet execute / executeBatch calldata we submitted
+// (N14.a): unpacked into receipt.calls so Troubleshoot does not re-decode it.
+func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contractAddress, callData string, parsedABI *abi.ABI, userOp *preset.SentUserOp, receipt *types.Receipt, packedExecute []byte) *avsproto.ContractWriteNode_MethodResult {
 	r.vm.logger.Info("🔍 DEPLOYED WORKFLOW: Creating real transaction result",
 		"method_name", methodName,
 		"contract_address", contractAddress,
@@ -1495,6 +1500,9 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 		} else if !userOpInnerSuccess && foundUserOpEvent {
 			// AA transaction succeeded at EntryPoint level but inner call failed
 			errorMsg = "UserOperation inner execution failed (likely insufficient token balance or other contract error)"
+			if calls, unpackErr := InnerCallsFromExecuteCalldata(packedExecute); unpackErr == nil && len(calls) == 1 {
+				errorMsg = fmt.Sprintf("UserOperation inner execution failed (to %s selector %s)", calls[0].To, calls[0].Selector)
+			}
 		}
 	}
 
@@ -1506,6 +1514,7 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 		if _, hasHash := receiptMap["userOpHash"]; !hasHash && userOp != nil && r.smartWalletConfig != nil {
 			receiptMap["userOpHash"] = userOp.UserOpHash.Hex()
 		}
+		stampInnerCalls(receiptMap, packedExecute, !success && !pending)
 		if v, err := structpb.NewValue(receiptMap); err == nil {
 			receiptValue = v
 		}

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -1448,8 +1448,13 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 				"topics_count", len(log.Topics),
 				"data_length", len(log.Data))
 
-			// If this is a UserOperationEvent, decode the success field
-			if len(log.Topics) > 0 && log.Topics[0] == userOpEventTopic {
+			// If this is a UserOperationEvent for THIS UserOp, decode success.
+			// Bundlers can include multiple UserOps in one handleOps tx; topics[1]
+			// is the indexed userOpHash. Ignore sibling events.
+			if len(log.Topics) > 1 && log.Topics[0] == userOpEventTopic {
+				if userOp == nil || log.Topics[1] != userOp.UserOpHash {
+					continue
+				}
 				foundUserOpEvent = true
 				// UserOperationEvent(bytes32 indexed userOpHash, address indexed sender, address indexed paymaster, uint256 nonce, bool success, uint256 actualGasCost, uint256 actualGasUsed)
 				// Data contains: nonce (32 bytes), success (32 bytes), actualGasCost (32 bytes), actualGasUsed (32 bytes)

--- a/core/taskengine/vm_runner_contract_write.go
+++ b/core/taskengine/vm_runner_contract_write.go
@@ -1514,7 +1514,7 @@ func (r *ContractWriteProcessor) createRealTransactionResult(methodName, contrac
 		if _, hasHash := receiptMap["userOpHash"]; !hasHash && userOp != nil && r.smartWalletConfig != nil {
 			receiptMap["userOpHash"] = userOp.UserOpHash.Hex()
 		}
-		stampInnerCalls(receiptMap, packedExecute, !success && !pending)
+		stampInnerCalls(receiptMap, packedExecute, foundUserOpEvent && !userOpInnerSuccess)
 		if v, err := structpb.NewValue(receiptMap); err == nil {
 			receiptValue = v
 		}

--- a/core/taskengine/vm_runner_contract_write_batch_test.go
+++ b/core/taskengine/vm_runner_contract_write_batch_test.go
@@ -124,6 +124,15 @@ func TestAtomicBatchOnDemand(t *testing.T) {
 		assert.Equal(t, true, results[1]["success"])
 		assert.True(t, step.Success)
 
+		// N14.a: each sub-call receipt carries the full unpacked batch, not
+		// only that method's inner calldata.
+		calls0, ok := receipt0["calls"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, calls0, 2)
+		assert.Equal(t, tokenA.Hex(), calls0[0].(map[string]interface{})["to"])
+		assert.Equal(t, tokenB.Hex(), calls0[1].(map[string]interface{})["to"])
+		assert.Equal(t, receipt0["calls"], receipt1["calls"])
+
 		// The two results share one on-chain receipt (gasUsed 21000), so step gas must be counted
 		// once — not summed per sub-call. Guards against the fan-out double-counting gas.
 		assert.Equal(t, "21000", step.GasUsed, "batch gas must be counted once across sub-calls, not 2x")

--- a/core/taskengine/vm_runner_contract_write_ondemand_test.go
+++ b/core/taskengine/vm_runner_contract_write_ondemand_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/AvaProtocol/EigenLayer-AVS/core/chainio/aa"
 	"github.com/AvaProtocol/EigenLayer-AVS/core/config"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/erc4337/preset"
 	"github.com/AvaProtocol/EigenLayer-AVS/pkg/logger"
@@ -78,7 +79,7 @@ func TestCreateRealTransactionResultExecutionStatus(t *testing.T) {
 	}
 
 	t.Run("mined success -> confirmed", func(t *testing.T) {
-		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(1))
+		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(1), nil)
 		assert.True(t, mr.Success)
 		assert.Empty(t, mr.Error)
 		rm := receiptMapOf(t, mr)
@@ -87,7 +88,7 @@ func TestCreateRealTransactionResultExecutionStatus(t *testing.T) {
 	})
 
 	t.Run("mined revert -> failed", func(t *testing.T) {
-		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(0))
+		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(0), nil)
 		assert.False(t, mr.Success)
 		assert.NotEmpty(t, mr.Error)
 		rm := receiptMapOf(t, mr)
@@ -95,13 +96,39 @@ func TestCreateRealTransactionResultExecutionStatus(t *testing.T) {
 	})
 
 	t.Run("submitted but not mined -> pending, not failure", func(t *testing.T) {
-		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, nil)
+		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, nil, nil)
 		assert.False(t, mr.Success, "pending is not confirmed-success")
 		assert.Empty(t, mr.Error, "pending must not be reported as an error")
 		rm := receiptMapOf(t, mr)
 		assert.Equal(t, "pending", rm["executionStatus"])
 		assert.Equal(t, "pending", rm["transactionHash"])
 		assert.NotEmpty(t, rm["userOpHash"], "pending result must carry a userOpHash to poll")
+	})
+
+	t.Run("packed execute stamps inner calls on pending and mined", func(t *testing.T) {
+		inner := common.FromHex("0xa9059cbb000000000000000000000000e0f7d11fd714674722d325cd86062a5f1882e13a00000000000000000000000000000000000000000000000000000000000003e8")
+		packed, err := aa.PackExecute(contractAddr, big.NewInt(0), inner)
+		require.NoError(t, err)
+
+		pending := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, nil, packed)
+		pendingMap := receiptMapOf(t, pending)
+		assert.Equal(t, "pending", pendingMap["executionStatus"])
+		calls, ok := pendingMap["calls"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, calls, 1)
+		call0 := calls[0].(map[string]interface{})
+		assert.Equal(t, contractAddr.Hex(), call0["to"])
+		assert.Equal(t, "0xa9059cbb", call0["selector"])
+		assert.Equal(t, "0", call0["value"])
+		_, hasFailed := pendingMap["failedCall"]
+		assert.False(t, hasFailed)
+
+		mined := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(1), packed)
+		minedMap := receiptMapOf(t, mined)
+		assert.Equal(t, "confirmed", minedMap["executionStatus"])
+		minedCalls := minedMap["calls"].([]interface{})
+		require.Len(t, minedCalls, 1)
+		assert.Equal(t, contractAddr.Hex(), minedCalls[0].(map[string]interface{})["to"])
 	})
 }
 

--- a/core/taskengine/vm_runner_contract_write_ondemand_test.go
+++ b/core/taskengine/vm_runner_contract_write_ondemand_test.go
@@ -145,6 +145,27 @@ func TestCreateRealTransactionResultExecutionStatus(t *testing.T) {
 		assert.Equal(t, contractAddr.Hex(), failedCall["to"])
 		assert.Equal(t, "0xa9059cbb", failedCall["selector"])
 	})
+
+	t.Run("sibling UserOp event does not stamp failedCall", func(t *testing.T) {
+		inner := common.FromHex("0xa9059cbb000000000000000000000000e0f7d11fd714674722d325cd86062a5f1882e13a00000000000000000000000000000000000000000000000000000000000003e8")
+		packed, err := aa.PackExecute(contractAddr, big.NewInt(0), inner)
+		require.NoError(t, err)
+		ours := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+		other := common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222")
+		userOp.UserOpHash = ours
+		rec := minedReceipt(1)
+		topic := common.HexToHash("0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f")
+		rec.Logs = []*types.Log{{
+			Topics: []common.Hash{topic, other, common.Hash{}},
+			Data:   make([]byte, 128), // sibling inner fail
+		}}
+		mr := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, rec, packed)
+		assert.True(t, mr.Success)
+		rm := receiptMapOf(t, mr)
+		assert.Equal(t, "confirmed", rm["executionStatus"])
+		_, hasFailed := rm["failedCall"]
+		assert.False(t, hasFailed)
+	})
 }
 
 func userOpInnerFailReceipt() *types.Receipt {

--- a/core/taskengine/vm_runner_contract_write_ondemand_test.go
+++ b/core/taskengine/vm_runner_contract_write_ondemand_test.go
@@ -129,7 +129,32 @@ func TestCreateRealTransactionResultExecutionStatus(t *testing.T) {
 		minedCalls := minedMap["calls"].([]interface{})
 		require.Len(t, minedCalls, 1)
 		assert.Equal(t, contractAddr.Hex(), minedCalls[0].(map[string]interface{})["to"])
+
+		outerFail := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, minedReceipt(0), packed)
+		outerMap := receiptMapOf(t, outerFail)
+		assert.Equal(t, "failed", outerMap["executionStatus"])
+		assert.NotEmpty(t, outerMap["calls"])
+		_, hasFailed = outerMap["failedCall"]
+		assert.False(t, hasFailed, "outer tx failure is not an inner revert")
+
+		innerFail := processor.createRealTransactionResult("transfer", contractAddr.Hex(), "0x", nil, userOp, userOpInnerFailReceipt(), packed)
+		innerMap := receiptMapOf(t, innerFail)
+		assert.Equal(t, "failed", innerMap["executionStatus"])
+		failedCall, ok := innerMap["failedCall"].(map[string]interface{})
+		require.True(t, ok, "observed inner revert names failedCall")
+		assert.Equal(t, contractAddr.Hex(), failedCall["to"])
+		assert.Equal(t, "0xa9059cbb", failedCall["selector"])
 	})
+}
+
+func userOpInnerFailReceipt() *types.Receipt {
+	r := minedReceipt(1)
+	topic := common.HexToHash("0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f")
+	r.Logs = []*types.Log{{
+		Topics: []common.Hash{topic, common.Hash{}, common.Hash{}},
+		Data:   make([]byte, 128), // success word at bytes 32-64 is zero
+	}}
+	return r
 }
 
 // G1: the real UserOp path must forward the node's native ETH value into the

--- a/docs/changes/20260824-userop-typed-unpack.md
+++ b/docs/changes/20260824-userop-typed-unpack.md
@@ -1,0 +1,33 @@
+# N14.a — Typed unpack of our UserOps
+
+- **Date**: 2026-08-24
+- **Status**: Implemented
+- **Branch**: `feat/userop-unwrap`
+- **Related**: studio `PLAN_USEROP_UNWRAP.md` (SoT), `PLAN_AGENT_ONDEMAND_ACTIONS.md` G2/G3, `UnpackExecuteCalldata`
+
+## Problem
+
+`nodes:run` already returned `userOpHash` and `executionStatus` (pending ≠ failed).
+It did not return the inner `execute` / `executeBatch` calls we packed, so Studio
+Troubleshoot still had to guess from EntryPoint events. There was no JWT-gated
+way to re-poll a pending UserOp by hash.
+
+## Decision
+
+1. Stamp `receipt.calls: [{ to, value, selector, data }]` from
+   `aa.UnpackExecuteCalldata` on pending and mined contract-write receipts
+   (single-call and atomic batch). Same full array on each batch method result.
+2. On AA23 / bundler reject after we have packed calldata, attach those calls
+   on a failed receipt. On inner revert with a single call, also set
+   `failedCall`.
+3. `GET /api/v1/userops/{userOpHash}` (user JWT, same gate as `nodes:run`).
+   Sender must be one of the caller's smart wallets; unknown and foreign hashes
+   both 404. Not a public AA explorer.
+
+Studio Troubleshoot consumes `receipt.calls` from execution detail and the
+status GET; it does not port `UnpackExecuteCalldata` to TypeScript.
+
+## Verification
+
+- `go test ./core/taskengine -count=1 -run 'InnerCalls|UserOp|CreateRealTransactionResult|AtomicBatchOnDemand'`
+- `go test ./aggregator/rest -count=1 -run 'PermissionMap|SimulateRequiresUserJWT'`


### PR DESCRIPTION
## Summary

Typed unpack of **our** UserOps (N14.a). `nodes:run` already returned `userOpHash` and `executionStatus` (pending ≠ failed). This exposes the inner `execute` / `executeBatch` calls we packed, via existing `UnpackExecuteCalldata`, and adds a JWT-gated re-poll.

Studio Troubleshoot will consume this. It does **not** port the unpacker to TypeScript. This is **not** a public AA explorer.

## Product path

`nodes:run` contract-write receipts (pending **and** mined, single-call **and** atomic batch) now include:

```json
{
  "userOpHash": "0x…",
  "executionStatus": "pending | confirmed | failed",
  "calls": [{ "to": "0x…", "value": "0", "selector": "0xa9059cbb", "data": "0x…" }]
}
```

- Same full `calls[]` on each atomic-batch method result.
- AA23 / bundler reject after packing still attach those calls.
- Inner revert with a single call also sets `failedCall`.

## Status lookup

`GET /api/v1/userops/{userOpHash}?chainId=`

- Same gate as `nodes:run`: user Bearer JWT (partner assertion alone is not enough).
- Sender must be one of the caller’s smart wallets.
- Unknown hashes and foreign hashes both **404**.

## Tests

- `go test ./core/taskengine -count=1 -run 'InnerCalls|UserOp|CreateRealTransactionResult|AtomicBatchOnDemand'`
- `go test ./aggregator/rest -count=1 -run 'PermissionMap|SimulateRequiresUserJWT|UserOpStatusToOpenAPI'`

## Follow-up

- Studio Troubleshoot consume (`innerCalls` / `get_userop_status`) is on studio `feat/userop-unwrap` (separate PR).
- `ava-sdk-js` `readContractWriteExecutions` does not yet copy `calls[]` onto the Auto execute card.

Spec: studio `PLAN_USEROP_UNWRAP.md`. Change doc: `docs/changes/20260824-userop-typed-unpack.md`.
