### PR TITLE
ci: cache Go modules and retry proxy flakes in unit tests

### DIFF
--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -26,9 +26,11 @@ on:
       - "config/**"
       - "go.mod"
       - "go.sum"
+      - ".github/workflows/run-test-on-pr.yml"
+      - ".github/actions/**"
+      - ".github/scripts/**"
       - "!scripts/**"
       - "!**.md"
-      - "!.github/**"
       - "!docs/**"
   workflow_dispatch:
     inputs:
@@ -114,9 +116,10 @@ jobs:
           alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+          cache: true
 
       - name: Cache golangci-lint binary
         uses: actions/cache@v3
@@ -197,8 +200,39 @@ jobs:
           # Required: CI uses Alchemy (production path). Missing key fails closed.
           alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}
 
+      # The matrix job used to skip setup-go and compile from a cold
+      # module cache. operator (and anything that pulls
+      # core/taskengine/macros → dop251/goja) then failed setup on a
+      # proxy.golang.org HTTP/2 INTERNAL_ERROR — not a test assertion.
+      # Cache modules, fall back to VCS if the proxy flakes, and retry
+      # the download a couple of times.
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+
+      - name: Download modules
+        env:
+          GOPROXY: https://proxy.golang.org,direct
+        run: |
+          ok=0
+          for i in 1 2 3; do
+            if go mod download; then
+              ok=1
+              break
+            fi
+            echo "go mod download failed (attempt $i/3)"
+            sleep $((i * 3))
+          done
+          if [ "$ok" != 1 ]; then
+            echo "go mod download failed after 3 attempts"
+            exit 1
+          fi
+
       - name: Run Go test
         env:
+          GOPROXY: https://proxy.golang.org,direct
           OWNER_EOA: ${{ vars.OWNER_EOA }}
         run: |
           cd ./${{ matrix.test }}

--- a/.github/workflows/run-test-on-pr.yml
+++ b/.github/workflows/run-test-on-pr.yml
@@ -78,7 +78,7 @@ jobs:
           # Check if any changes are in relevant directories.
           # `|| true` is required: with bash -e, grep exit 1 (no match) aborts
           # the job as failure instead of setting should_run=false.
-          RELEVANT_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.go$|go\.mod|go\.sum|^core/|^pkg/|^aggregator/|^operator/|^model/|^cmd/|^version/|^config/' || true)
+          RELEVANT_CHANGES=$(echo "$CHANGED_FILES" | grep -E '\.go$|go\.mod|go\.sum|^core/|^pkg/|^aggregator/|^operator/|^model/|^cmd/|^version/|^config/|^\.github/workflows/run-test-on-pr\.yml|^\.github/actions/|^\.github/scripts/' || true)
 
           if [ -n "$RELEVANT_CHANGES" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
@@ -205,7 +205,7 @@ jobs:
       # core/taskengine/macros → dop251/goja) then failed setup on a
       # proxy.golang.org HTTP/2 INTERNAL_ERROR — not a test assertion.
       # Cache modules, fall back to VCS if the proxy flakes, and retry
-      # the download a couple of times.
+      # go mod download up to 3 times.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary

The `Unit Test (operator)` failure on #774 was **not** a flaky operator test. The job died at compile/setup:

```
FAIL github.com/AvaProtocol/EigenLayer-AVS/operator [setup failed]
../core/taskengine/macros/goja_utils.go:8:2: github.com/dop251/goja@…:
  read "https://proxy.golang.org/…/goja/…zip": stream error: stream ID 59; INTERNAL_ERROR
```

`operator` imports `core/taskengine/macros` → `dop251/goja`. The unit-test matrix never called `actions/setup-go`, so every shard compiled from a cold module cache against `proxy.golang.org`. A mid-download HTTP/2 error looks like “operator tests failed.”

## Fix

- `actions/setup-go@v5` with `cache: true` on the test matrix (and lint)
- `GOPROXY=https://proxy.golang.org,direct`
- Retry `go mod download` up to 3 times before `go test`
- Run this workflow when its YAML / test-config action changes (previously `!.github/**` skipped that)

Operator unit tests themselves (`chain_liveness_test.go`, `multi_chain_test.go`, …) are in-process and were not the failure.
