### PR TITLE
fix: treat missing gocron jobs as already removed

### DIFF
--- a/core/taskengine/trigger/time.go
+++ b/core/taskengine/trigger/time.go
@@ -184,13 +184,8 @@ func (t *TimeTrigger) AddCheck(check *avsproto.SyncMessagesResp_TaskMetadata) er
 	// duplicate MonitorTaskTrigger messages or direct re-enable).
 	if existing, exists := t.registry.GetTask(taskID); exists {
 		if existing.TimeData != nil {
-			for _, job := range existing.TimeData.Jobs {
-				if job != nil {
-					if err := t.scheduler.RemoveJob(job.ID()); err != nil {
-						t.logger.Warn("failed to remove existing job during AddCheck cleanup",
-							"task_id", taskID, "error", err)
-					}
-				}
+			for i, job := range existing.TimeData.Jobs {
+				t.removeSchedulerJob(taskID, i, job)
 			}
 		}
 		t.registry.RemoveTask(taskID)
@@ -317,16 +312,27 @@ func (t *TimeTrigger) AddCheck(check *avsproto.SyncMessagesResp_TaskMetadata) er
 	return nil
 }
 
-// RemoveCheck removes a scheduled job associated with the given taskID.
-// It locks the mutex to ensure thread-safe access to the jobs map, checks if
-// a job exists for the provided taskID, and removes it from the scheduler and
-// the jobs map. If the job does not exist, the method does nothing.
-//
-// Parameters:
-// - taskID: The unique identifier of the task whose associated job should be removed.
-//
-// Returns:
-// - An error if the job removal from the scheduler fails. The error is logged but not returned.
+// removeSchedulerJob drops a gocron job. Caller must hold t.mu.
+// Nil job/scheduler, t.shutdown, and ErrJobNotFound are no-ops (the
+// job is already gone). Other RemoveJob errors log Error (Sentry).
+func (t *TimeTrigger) removeSchedulerJob(taskID string, jobIndex int, job gocron.Job) {
+	if job == nil || t.scheduler == nil || t.shutdown {
+		return
+	}
+	if err := t.scheduler.RemoveJob(job.ID()); err != nil {
+		if errors.Is(err, gocron.ErrJobNotFound) {
+			t.logger.Debug("scheduler job already removed",
+				"task_id", taskID, "job_index", jobIndex)
+			return
+		}
+		t.logger.Error("failed to remove job",
+			"task_id", taskID, "job_index", jobIndex, "error", err)
+	}
+}
+
+// RemoveCheck removes scheduled jobs for taskID from gocron and the registry.
+// Missing tasks and already-removed jobs are no-ops. Always returns nil;
+// scheduler failures are logged rather than propagated.
 func (t *TimeTrigger) RemoveCheck(taskID string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -341,21 +347,9 @@ func (t *TimeTrigger) RemoveCheck(taskID string) error {
 		return nil
 	}
 
-	// Limited-run jobs delete themselves after firing, so ErrJobNotFound
-	// is already-gone. Warn rather than Error so it does not page Sentry.
-	if task.TimeData != nil && len(task.TimeData.Jobs) > 0 {
+	if task.TimeData != nil {
 		for i, job := range task.TimeData.Jobs {
-			if job != nil {
-				if err := t.scheduler.RemoveJob(job.ID()); err != nil {
-					if errors.Is(err, gocron.ErrJobNotFound) {
-						t.logger.Warn("scheduler job already removed",
-							"task_id", taskID, "job_index", i, "error", err)
-					} else {
-						t.logger.Error("failed to remove job",
-							"task_id", taskID, "job_index", i, "error", err)
-					}
-				}
-			}
+			t.removeSchedulerJob(taskID, i, job)
 		}
 	}
 
@@ -374,19 +368,21 @@ func (t *TimeTrigger) Run(ctx context.Context) error {
 	t.scheduler.Start()
 
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				if err := t.scheduler.Shutdown(); err != nil {
-					t.logger.Error("failed to shutdown scheduler on context done", "error", err)
-				}
-				return
-			case <-t.done:
-				if err := t.scheduler.Shutdown(); err != nil {
-					t.logger.Error("failed to shutdown scheduler on done signal", "error", err)
-				}
-				return
-			}
+		select {
+		case <-ctx.Done():
+		case <-t.done:
+		}
+		// Mark closed before Shutdown so concurrent RemoveCheck skips
+		// gocron instead of racing a stopped scheduler (EIGENLAYER-AVS-37).
+		t.mu.Lock()
+		t.shutdown = true
+		sched := t.scheduler
+		t.mu.Unlock()
+		if sched == nil {
+			return
+		}
+		if err := sched.Shutdown(); err != nil {
+			t.logger.Error("failed to shutdown scheduler", "error", err)
 		}
 	}()
 

--- a/core/taskengine/trigger/time_test.go
+++ b/core/taskengine/trigger/time_test.go
@@ -1,6 +1,7 @@
 package trigger
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -231,17 +232,10 @@ func (l *recordingLogger) snapshot() (warns, errors []string) {
 	return append([]string(nil), l.warns...), append([]string(nil), l.errors...)
 }
 
-// TestTimeTrigger_RemoveCheck_AlreadyRemovedJob covers the EIGENLAYER-AVS-37
-// path: the task is still in the registry but gocron already dropped the job
-// (FixedTime WithLimitedRuns(1) after fire, or a prior RemoveJob). RemoveCheck
-// must return nil and log Warn, not Error.
-func TestTimeTrigger_RemoveCheck_AlreadyRemovedJob(t *testing.T) {
-	triggerCh := make(chan TriggerMetadata[uint64], 10)
-	logger := &recordingLogger{}
-	timeTrigger := NewTimeTrigger(triggerCh, logger)
-
-	taskMetadata := &avsproto.SyncMessagesResp_TaskMetadata{
-		TaskId: "test-already-removed-job",
+func cronTaskMetadata(taskID string) *avsproto.SyncMessagesResp_TaskMetadata {
+	return &avsproto.SyncMessagesResp_TaskMetadata{
+		TaskId:  taskID,
+		StartAt: time.Now().UnixMilli(),
 		Trigger: &avsproto.TaskTrigger{
 			TriggerType: &avsproto.TaskTrigger_Cron{
 				Cron: &avsproto.CronTrigger{
@@ -252,8 +246,18 @@ func TestTimeTrigger_RemoveCheck_AlreadyRemovedJob(t *testing.T) {
 			},
 		},
 	}
+}
 
-	err := timeTrigger.AddCheck(taskMetadata)
+// TestTimeTrigger_RemoveCheck_AlreadyRemovedJob covers the EIGENLAYER-AVS-37
+// path: the task is still in the registry but gocron already dropped the job
+// (FixedTime WithLimitedRuns(1) after fire, or a prior RemoveJob). RemoveCheck
+// must return nil and not log Warn/Error — already-absent is the desired state.
+func TestTimeTrigger_RemoveCheck_AlreadyRemovedJob(t *testing.T) {
+	triggerCh := make(chan TriggerMetadata[uint64], 10)
+	logger := &recordingLogger{}
+	timeTrigger := NewTimeTrigger(triggerCh, logger)
+
+	err := timeTrigger.AddCheck(cronTaskMetadata("test-already-removed-job"))
 	require.NoError(t, err)
 
 	task, exists := timeTrigger.registry.GetTask("test-already-removed-job")
@@ -273,8 +277,58 @@ func TestTimeTrigger_RemoveCheck_AlreadyRemovedJob(t *testing.T) {
 
 	warns, errors := logger.snapshot()
 	assert.Empty(t, errors, "already-removed jobs must not log Error (that pages Sentry)")
-	require.NotEmpty(t, warns)
-	assert.Contains(t, warns, "scheduler job already removed")
+	assert.Empty(t, warns, "already-removed jobs are a no-op, not a warning")
+}
+
+// TestTimeTrigger_RemoveCheck_AfterSchedulerShutdown covers runWorkLoop
+// calling RemoveCheck after TimeTrigger.Run has shut the gocron scheduler
+// down (ctx cancel). gocron.RemoveJob then returns ErrJobNotFound; that
+// must not page Sentry.
+func TestTimeTrigger_RemoveCheck_AfterSchedulerShutdown(t *testing.T) {
+	triggerCh := make(chan TriggerMetadata[uint64], 10)
+	logger := &recordingLogger{}
+	timeTrigger := NewTimeTrigger(triggerCh, logger)
+
+	err := timeTrigger.AddCheck(cronTaskMetadata("test-shutdown-remove"))
+	require.NoError(t, err)
+
+	err = timeTrigger.scheduler.Shutdown()
+	require.NoError(t, err)
+
+	err = timeTrigger.RemoveCheck("test-shutdown-remove")
+	require.NoError(t, err)
+	assert.Equal(t, 0, timeTrigger.registry.GetTimeTaskCount())
+
+	warns, errors := logger.snapshot()
+	assert.Empty(t, errors, "RemoveJob after Shutdown must not log Error")
+	assert.Empty(t, warns, "RemoveJob after Shutdown is a no-op")
+}
+
+func TestTimeTrigger_RemoveCheck_AfterRunContextCancel(t *testing.T) {
+	triggerCh := make(chan TriggerMetadata[uint64], 10)
+	logger := &recordingLogger{}
+	timeTrigger := NewTimeTrigger(triggerCh, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, timeTrigger.Run(ctx))
+
+	err := timeTrigger.AddCheck(cronTaskMetadata("test-run-cancel-remove"))
+	require.NoError(t, err)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		timeTrigger.mu.Lock()
+		defer timeTrigger.mu.Unlock()
+		return timeTrigger.shutdown
+	}, 2*time.Second, 10*time.Millisecond)
+
+	err = timeTrigger.RemoveCheck("test-run-cancel-remove")
+	require.NoError(t, err)
+	assert.Equal(t, 0, timeTrigger.registry.GetTimeTaskCount())
+
+	warns, errors := logger.snapshot()
+	assert.Empty(t, errors, "RemoveCheck after Run cancel must not log Error")
+	assert.Empty(t, warns, "closed-scheduler RemoveCheck is a no-op")
 }
 
 func TestTimeTrigger_LegacyMigration(t *testing.T) {


### PR DESCRIPTION
## Why

Sentry [EIGENLAYER-AVS-37](https://ava-protocol.sentry.io/issues/7683902826/) (`gocron: job not found`) fired from `operator-ethereum-railway` when `TimeTrigger.RemoveCheck` logged Error on `scheduler.RemoveJob`. `SentryLogger.Error` pages.

Staging already demoted `ErrJobNotFound` to Warn (#776). That still treats an already-gone job as a failure. Limited-run FixedTime jobs (`WithLimitedRuns(1)`) delete themselves after firing; `runWorkLoop` then calls `RemoveCheck` because `RemainingExecutions == 0`. The same `ErrJobNotFound` is what gocron returns after `Scheduler.Shutdown`, so a concurrent RemoveCheck on operator cancel is the same class.

`AddCheck` cleanup had its own unguarded `RemoveJob`.

## What

- Shared `removeSchedulerJob`: nil job/scheduler, `t.shutdown`, and `ErrJobNotFound` are Debug no-ops. Other `RemoveJob` errors still log Error.
- `Run` sets `t.shutdown` before `gocron.Shutdown` so a concurrent `RemoveCheck` skips gocron instead of racing a stopped scheduler.
- Tests: already-removed job, RemoveCheck after Shutdown, RemoveCheck after `Run` context cancel.

## Commits

- **fix: treat missing gocron jobs as already removed**