### PR TITLE
feat: map Polygon (137) and Hyperliquid EVM (999) for Wave C

### DIFF
--- a/config/worker-hyperliquid.example.yaml
+++ b/config/worker-hyperliquid.example.yaml
@@ -1,0 +1,35 @@
+# Worker configuration TEMPLATE for Hyperliquid EVM (chain 999).
+#
+# This is a checked-in template. The real file is gitignored — copy it
+# and fill in the placeholder values:
+#
+#   cp config/worker-hyperliquid.example.yaml config/worker-hyperliquid.yaml
+#   $EDITOR config/worker-hyperliquid.yaml
+#
+# Handles chain-specific execution: UserOps, contract writes, token
+# enrichment. Stateless — no local DB (gateway owns storage).
+#
+# Production config lives in avs-infra/railway/configs/worker-hyperliquid-railway.yaml.
+environment: development
+
+chain_id:   999
+chain_name: hyperliquid
+
+listen_address: "0.0.0.0:50060"
+health_address: "0.0.0.0:8099"
+gateway_address: "127.0.0.1:2206"
+
+# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# endpoint — they rate-limit under load.
+eth_rpc_url: ${HYPERLIQUID_RPC_URL}
+eth_ws_url:  ${HYPERLIQUID_WS_URL}
+
+# alchemy derives the endpoint from alchemy_api_key + hyperliquid-mainnet.
+bundler_provider: alchemy
+alchemy_api_key:  ${ALCHEMY_API_KEY}
+
+# Local workers must not draw on the production Gas Manager policy.
+disable_gas_sponsorship: true
+
+smart_wallet:
+  controller_private_key: ${MAINNET_CONTROLLER_PRIVATE_KEY}

--- a/config/worker-polygon.example.yaml
+++ b/config/worker-polygon.example.yaml
@@ -1,0 +1,35 @@
+# Worker configuration TEMPLATE for Polygon PoS (chain 137).
+#
+# This is a checked-in template. The real file is gitignored — copy it
+# and fill in the placeholder values:
+#
+#   cp config/worker-polygon.example.yaml config/worker-polygon.yaml
+#   $EDITOR config/worker-polygon.yaml
+#
+# Handles chain-specific execution: UserOps, contract writes, token
+# enrichment. Stateless — no local DB (gateway owns storage).
+#
+# Production config lives in avs-infra/railway/configs/worker-polygon-railway.yaml.
+environment: development
+
+chain_id:   137
+chain_name: polygon
+
+listen_address: "0.0.0.0:50059"
+health_address: "0.0.0.0:8098"
+gateway_address: "127.0.0.1:2206"
+
+# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# endpoint — they rate-limit under load.
+eth_rpc_url: ${POLYGON_RPC_URL}
+eth_ws_url:  ${POLYGON_WS_URL}
+
+# alchemy derives the endpoint from alchemy_api_key + polygon-mainnet.
+bundler_provider: alchemy
+alchemy_api_key:  ${ALCHEMY_API_KEY}
+
+# Local workers must not draw on the production Gas Manager policy.
+disable_gas_sponsorship: true
+
+smart_wallet:
+  controller_private_key: ${MAINNET_CONTROLLER_PRIVATE_KEY}

--- a/core/config/bundler_provider_test.go
+++ b/core/config/bundler_provider_test.go
@@ -132,6 +132,7 @@ func TestExpansionChainsHaveAlchemySubdomains(t *testing.T) {
 		{42161, "https://arb-mainnet.g.alchemy.com/v2/K"},
 		{10, "https://opt-mainnet.g.alchemy.com/v2/K"},
 		{130, "https://unichain-mainnet.g.alchemy.com/v2/K"},
+		{137, "https://polygon-mainnet.g.alchemy.com/v2/K"},
 		{999, "https://hyperliquid-mainnet.g.alchemy.com/v2/K"},
 		{4663, "https://robinhood-mainnet.g.alchemy.com/v2/K"},
 	} {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -326,8 +326,7 @@ func (c *SmartWalletConfig) AccountProviderName() string {
 //     alchemy_requestGasAndPaymasterAndData against ActiveBundlerURL, which a
 //     self-hosted Voltaire endpoint does not implement. Sending it there fails
 //     the operation instead of sponsoring it, so a policy on a self_hosted
-//     chain is inert — bnb-mainnet is configured exactly that way today. Better
-//     to run self-funded, which is what that chain already did.
+//     chain is inert. Every production chain runs bundler_provider: alchemy.
 func (c *SmartWalletConfig) SponsorshipPolicyID() string {
 	if c == nil || c.DisableGasSponsorship {
 		return ""
@@ -435,6 +434,7 @@ var alchemyNetworkSubdomain = map[int64]string{
 	42161: "arb-mainnet",
 	10:    "opt-mainnet",
 	130:   "unichain-mainnet",
+	137:   "polygon-mainnet",
 	999:   "hyperliquid-mainnet",
 	4663:  "robinhood-mainnet",
 }

--- a/core/services/moralis_service.go
+++ b/core/services/moralis_service.go
@@ -281,6 +281,18 @@ func (ms *MoralisService) GetNativeTokenSymbol(chainID int64) string {
 	return "ETH" // Default fallback
 }
 
+// HasLiveNativeUsdPrice reports whether GetNativeTokenPriceUSD can obtain a
+// native USD price for chainID. Unmapped IDs and ETH-natives inherit the ETH
+// fallback. Non-ETH natives without a Moralis Data API source (Hyperliquid
+// HYPE today) return false — fee/credit callers must fail closed.
+func (ms *MoralisService) HasLiveNativeUsdPrice(chainID int64) bool {
+	tok, ok := getChainTokenMapping()[chainID]
+	if !ok || strings.EqualFold(tok.Symbol, "ETH") {
+		return true
+	}
+	return nativePricingSupportedChains[chainID]
+}
+
 // GetERC20PriceUSD fetches the USD price for an ERC20 contract on the given
 // chain. Returns an error when the price isn't available — callers render
 // "$?" rather than fabricate a number. No internal $1.00 / fallback.

--- a/core/services/moralis_service.go
+++ b/core/services/moralis_service.go
@@ -157,10 +157,28 @@ func getChainTokenMapping() map[int64]ChainToken {
 			Decimals:     18,
 			ContractAddr: "0x4200000000000000000000000000000000000006",
 		},
+
+		// Polygon PoS — native is POL; Moralis prices via WPOL (legacy WMATIC).
+		137: {
+			Symbol:       "POL",
+			Decimals:     18,
+			ContractAddr: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+		},
+
+		// Hyperliquid EVM — native is HYPE. Moralis Data API does not list 999,
+		// so nativePricingSupportedChains omits it and getFallbackPrice("HYPE")
+		// fails closed (never the $2500 ETH fallback). ContractAddr is WHYPE
+		// for if/when a price probe lands.
+		999: {
+			Symbol:       "HYPE",
+			Decimals:     18,
+			ContractAddr: "0x5555555555555555555555555555555555555555",
+		},
 		// Unichain (130) and Robinhood (4663) are deliberately absent: Moralis
 		// Data API does not list them. GetNativeTokenPriceUSD then uses
 		// getETHPrice() (live ETH on chain 1) — correct because both natives
 		// are ETH. Do not add them here just to hit the $2500 hardcoded fallback.
+		// Hyperliquid is listed above because its native is HYPE, not ETH.
 	}
 }
 
@@ -186,7 +204,11 @@ var nativePricingSupportedChains = map[int64]bool{
 	56:    true, // BNB Smart Chain
 	42161: true, // Arbitrum One
 	10:    true, // OP Mainnet
-	// Unichain (130) and Robinhood (4663) intentionally absent — Moralis Data API does not list them.
+	137:   true, // Polygon PoS
+	// Unichain (130), Robinhood (4663), Hyperliquid (999) intentionally
+	// absent — Moralis Data API does not list them. Hyperliquid is still in
+	// chainTokens so GetNativeTokenSymbol returns HYPE and the ETH $2500
+	// fallback cannot fire.
 	// Testnets intentionally absent: 11155111 (Sepolia), 84532 (Base-Sepolia).
 }
 
@@ -382,6 +404,8 @@ func (ms *MoralisService) chainIDToMoralisChain(chainID int64) string {
 		return "arbitrum"
 	case 10:
 		return "optimism"
+	case 137:
+		return "polygon"
 	default:
 		return ""
 	}

--- a/core/services/moralis_service_test.go
+++ b/core/services/moralis_service_test.go
@@ -142,3 +142,22 @@ func TestGetFallbackPriceRefusesNonETH(t *testing.T) {
 		t.Fatal("HYPE must not inherit the $2500 ETH fallback")
 	}
 }
+
+func TestHasLiveNativeUsdPrice(t *testing.T) {
+	ms := &MoralisService{chainTokens: getChainTokenMapping()}
+	if !ms.HasLiveNativeUsdPrice(1) {
+		t.Error("ETH mainnet must have a live/fallback native USD price")
+	}
+	if !ms.HasLiveNativeUsdPrice(56) {
+		t.Error("BNB has Moralis pricing")
+	}
+	if !ms.HasLiveNativeUsdPrice(137) {
+		t.Error("Polygon has Moralis pricing")
+	}
+	if !ms.HasLiveNativeUsdPrice(130) {
+		t.Error("Unichain is ETH-native and inherits the ETH fallback")
+	}
+	if ms.HasLiveNativeUsdPrice(999) {
+		t.Error("Hyperliquid HYPE has no Moralis source; callers must fail closed")
+	}
+}

--- a/core/services/moralis_service_test.go
+++ b/core/services/moralis_service_test.go
@@ -18,8 +18,10 @@ func TestChainIDToMoralisChain(t *testing.T) {
 		{56, "bsc"},
 		{42161, "arbitrum"},
 		{10, "optimism"},
+		{137, "polygon"},
 		{130, ""},
 		{4663, ""},
+		{999, ""},
 	}
 	for _, tc := range cases {
 		if got := ms.chainIDToMoralisChain(tc.chainID); got != tc.want {
@@ -82,6 +84,39 @@ func TestGetChainTokenMappingWaveA(t *testing.T) {
 	if nativePricingSupportedChains[4663] {
 		t.Error("Robinhood must not be in nativePricingSupportedChains")
 	}
+
+	pol, ok := m[137]
+	if !ok {
+		t.Fatal("missing chain 137")
+	}
+	if pol.Symbol != "POL" || pol.Decimals != 18 {
+		t.Errorf("POL token = %+v", pol)
+	}
+	if !strings.EqualFold(pol.ContractAddr, "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270") {
+		t.Errorf("WPOL address = %s", pol.ContractAddr)
+	}
+	if !nativePricingSupportedChains[137] {
+		t.Error("Polygon must be in nativePricingSupportedChains")
+	}
+
+	hype, ok := m[999]
+	if !ok {
+		t.Fatal("missing chain 999 — HYPE must be in chainTokens so GetNativeTokenPriceUSD does not ETH-fallback")
+	}
+	if hype.Symbol != "HYPE" {
+		t.Errorf("HYPE token = %+v", hype)
+	}
+	if nativePricingSupportedChains[999] {
+		t.Error("Hyperliquid must not be in nativePricingSupportedChains until Moralis Data API lists 999")
+	}
+
+	ms := &MoralisService{chainTokens: m}
+	if got := ms.GetNativeTokenSymbol(137); got != "POL" {
+		t.Errorf("GetNativeTokenSymbol(137) = %q, want POL", got)
+	}
+	if got := ms.GetNativeTokenSymbol(999); got != "HYPE" {
+		t.Errorf("GetNativeTokenSymbol(999) = %q, want HYPE", got)
+	}
 }
 
 func TestGetFallbackPriceRefusesNonETH(t *testing.T) {
@@ -99,5 +134,11 @@ func TestGetFallbackPriceRefusesNonETH(t *testing.T) {
 	}
 	if _, err := ms.getFallbackPrice("bnb"); err == nil {
 		t.Fatal("bnb (lowercase) must not inherit the ETH fallback")
+	}
+	if _, err := ms.getFallbackPrice("POL"); err == nil {
+		t.Fatal("POL must not inherit the $2500 ETH fallback")
+	}
+	if _, err := ms.getFallbackPrice("HYPE"); err == nil {
+		t.Fatal("HYPE must not inherit the $2500 ETH fallback")
 	}
 }

--- a/core/taskengine/execution_providers.go
+++ b/core/taskengine/execution_providers.go
@@ -37,6 +37,10 @@ func GetNetworkName(chainID int64) string {
 		return "unichain"
 	case ChainIDRobinhoodMainnet:
 		return "robinhood"
+	case ChainIDPolygonMainnet:
+		return "polygon"
+	case ChainIDHyperliquidMainnet:
+		return "hyperliquid"
 	default:
 		return "unknown"
 	}

--- a/core/taskengine/execution_providers_test.go
+++ b/core/taskengine/execution_providers_test.go
@@ -16,6 +16,8 @@ func TestGetNetworkName(t *testing.T) {
 		{10, "optimism"},
 		{130, "unichain"},
 		{4663, "robinhood"},
+		{137, "polygon"},
+		{999, "hyperliquid"},
 		{424242, "unknown"},
 	}
 	for _, tt := range tests {

--- a/core/taskengine/executor.go
+++ b/core/taskengine/executor.go
@@ -357,16 +357,24 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 
 	vm.WithLogger(x.logger).WithDb(x.db)
 
-	// Convert execution fee (USD) → Wei and set on VM for UserOp injection
-	if x.priceService != nil && x.engine.config.FeeRates != nil {
-		chainID := int64(0)
-		if x.smartWalletConfig != nil {
-			chainID = x.smartWalletConfig.ChainID
-		}
-		if feeWei, convErr := ConvertUSDToWei(x.engine.config.FeeRates.ExecutionFeeUSD, x.priceService, chainID); convErr == nil {
+	// Convert execution fee (USD) → Wei and set on VM for UserOp injection.
+	// Non-ETH natives with no live price source (Hyperliquid HYPE) must not
+	// proceed unbilled — that is the steady state, not an outage. BNB/POL
+	// still warn-and-proceed if Moralis is down.
+	var unbilledNativeErr error
+	feeChainID := int64(0)
+	if x.smartWalletConfig != nil {
+		feeChainID = x.smartWalletConfig.ChainID
+	}
+	if x.priceService != nil && x.engine != nil && x.engine.config != nil && x.engine.config.FeeRates != nil {
+		if feeWei, convErr := ConvertUSDToWei(x.engine.config.FeeRates.ExecutionFeeUSD, x.priceService, feeChainID); convErr == nil {
 			vm.executionFeeWei = feeWei
-			x.logger.Debug("Execution fee set on VM", "fee_wei", feeWei.String(), "fee_usd", x.engine.config.FeeRates.ExecutionFeeUSD)
-		} else {
+			if x.logger != nil {
+				x.logger.Debug("Execution fee set on VM", "fee_wei", feeWei.String(), "fee_usd", x.engine.config.FeeRates.ExecutionFeeUSD)
+			}
+		} else if nativeUsdPriceIsGuaranteedMissing(feeChainID) {
+			unbilledNativeErr = convErr
+		} else if x.logger != nil {
 			x.logger.Warn("Failed to convert execution fee to Wei, proceeding without fee", "error", convErr)
 		}
 	}
@@ -438,6 +446,14 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 		Error:   "",                                                // Will be populated if there are errors
 		Steps:   []*avsproto.Execution_Step{},                      // Will be populated during execution
 		Index:   executionIndex,                                    // Atomic execution index assignment
+	}
+
+	if unbilledNativeErr != nil {
+		execution.EndAt = time.Now().UnixMilli()
+		execution.Error = fmt.Sprintf("cannot price native token on chain %d: %v", feeChainID, unbilledNativeErr)
+		execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED
+		x.persistFailedExecution(task, execution, initialTaskStatus)
+		return execution, nil
 	}
 
 	// Wallet validation - if this fails, we'll record the failure and return the execution record
@@ -545,6 +561,13 @@ func (x *WorkflowExecutor) RunTaskWithContext(ctx context.Context, task *model.W
 			var convErr error
 			creditLimitWei, convErr = ConvertUSDToWei(creditLimitUSD, x.priceService, chainID)
 			if convErr != nil {
+				if nativeUsdPriceIsGuaranteedMissing(chainID) {
+					execution.EndAt = time.Now().UnixMilli()
+					execution.Error = fmt.Sprintf("cannot convert credit limit to native wei on chain %d: %v", chainID, convErr)
+					execution.Status = avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED
+					x.persistFailedExecution(task, execution, initialTaskStatus)
+					return execution, nil
+				}
 				x.logger.Warn("Failed to convert credit limit to Wei, skipping check", "error", convErr)
 				creditLimitWei = nil
 			}

--- a/core/taskengine/fee_estimator.go
+++ b/core/taskengine/fee_estimator.go
@@ -598,6 +598,14 @@ func (fe *FeeEstimator) generateWarnings(cogs []*avsproto.NodeCOGS) []string {
 	return warnings
 }
 
+// nativeUsdPriceIsGuaranteedMissing is true when GetNativeTokenPriceUSD cannot
+// succeed for this chain: non-ETH native with no Moralis Data API source.
+// Callers must fail closed rather than proceed unbilled or skip credit checks.
+// BNB/POL have live Moralis pricing and stay fail-open on an outage.
+func nativeUsdPriceIsGuaranteedMissing(chainID int64) bool {
+	return uint64(chainID) == ChainIDHyperliquidMainnet
+}
+
 // ConvertUSDToWei converts a USD amount to Wei using the price service.
 // Used by the billing system to convert execution_fee (USD) to native token at execution time.
 func ConvertUSDToWei(usdAmount float64, priceService PriceService, chainID int64) (*big.Int, error) {

--- a/core/taskengine/fee_estimator_test.go
+++ b/core/taskengine/fee_estimator_test.go
@@ -34,6 +34,21 @@ func (mock *mockPriceService) GetERC20PriceUSD(chainID int64, contractAddress st
 	return nil, fmt.Errorf("ERC20 price lookup not supported in tests")
 }
 
+func TestNativeUsdPriceIsGuaranteedMissing(t *testing.T) {
+	if nativeUsdPriceIsGuaranteedMissing(1) {
+		t.Error("ETH must not fail closed")
+	}
+	if nativeUsdPriceIsGuaranteedMissing(56) {
+		t.Error("BNB has Moralis; outage stay fail-open")
+	}
+	if nativeUsdPriceIsGuaranteedMissing(137) {
+		t.Error("Polygon has Moralis; outage stay fail-open")
+	}
+	if !nativeUsdPriceIsGuaranteedMissing(999) {
+		t.Error("Hyperliquid HYPE has no price source; must fail closed")
+	}
+}
+
 func TestFeeEstimator_ChainIDDetection(t *testing.T) {
 	logger, err := sdklogging.NewZapLogger(sdklogging.Development)
 	require.NoError(t, err)

--- a/core/taskengine/limits.go
+++ b/core/taskengine/limits.go
@@ -172,6 +172,8 @@ var chainBlockTime = map[int64]time.Duration{
 	10:       2 * time.Second,        // OP Mainnet (OP-stack, same family as Base)
 	130:      200 * time.Millisecond, // Unichain flashblocks ~200ms; 1s sealed blocks. Under-estimate.
 	4663:     100 * time.Millisecond, // Robinhood Chain (Arb Orbit; advertised 100ms).
+	137:      2 * time.Second,        // Polygon PoS (~2s).
+	999:      time.Second,            // HyperEVM small blocks ~1s (big blocks are 60s; under-estimate).
 }
 
 // defaultBlockTime is used for a chain absent from the table. Deliberately

--- a/core/taskengine/limits_test.go
+++ b/core/taskengine/limits_test.go
@@ -312,6 +312,12 @@ func TestBlockTimeForChain(t *testing.T) {
 	if got := blockTimeForChain(4663); got != 100*time.Millisecond {
 		t.Errorf("Robinhood block time = %v, want 100ms (must under-estimate, not use the 1s default)", got)
 	}
+	if got := blockTimeForChain(137); got != 2*time.Second {
+		t.Errorf("Polygon block time = %v, want 2s", got)
+	}
+	if got := blockTimeForChain(999); got != time.Second {
+		t.Errorf("Hyperliquid block time = %v, want 1s (small-block under-estimate)", got)
+	}
 	// An unlisted chain must fall back to the *strict* default, never a
 	// permissive one — overestimating block time would open a hole.
 	if got := blockTimeForChain(424242); got != defaultBlockTime {

--- a/core/taskengine/token_metadata.go
+++ b/core/taskengine/token_metadata.go
@@ -90,15 +90,17 @@ const (
 
 // Chain ID constants
 const (
-	ChainIDEthereum         uint64 = 1
-	ChainIDSepolia          uint64 = 11155111
-	ChainIDBase             uint64 = 8453
-	ChainIDBaseSepolia      uint64 = 84532
-	ChainIDBNBMainnet       uint64 = 56
-	ChainIDArbitrumOne      uint64 = 42161
-	ChainIDOptimismMainnet  uint64 = 10
-	ChainIDUnichainMainnet  uint64 = 130
-	ChainIDRobinhoodMainnet uint64 = 4663
+	ChainIDEthereum           uint64 = 1
+	ChainIDSepolia            uint64 = 11155111
+	ChainIDBase               uint64 = 8453
+	ChainIDBaseSepolia        uint64 = 84532
+	ChainIDBNBMainnet         uint64 = 56
+	ChainIDArbitrumOne        uint64 = 42161
+	ChainIDOptimismMainnet    uint64 = 10
+	ChainIDUnichainMainnet    uint64 = 130
+	ChainIDRobinhoodMainnet   uint64 = 4663
+	ChainIDPolygonMainnet     uint64 = 137
+	ChainIDHyperliquidMainnet uint64 = 999
 )
 
 // Native token sentinel address used by Moralis and other services
@@ -114,16 +116,29 @@ func isNativeToken(address string) bool {
 	return strings.ToLower(address) == NativeTokenAddress
 }
 
-// getNativeTokenMetadata returns metadata for native token (ETH)
-// Same metadata across all Ethereum-based chains
-func getNativeTokenMetadata() *TokenMetadata {
-	return &TokenMetadata{
+// nativeTokenMetadataForChain returns metadata for the native gas token
+// on chainID. ETH-native chains (and unknown IDs) return Ether; BNB, POL,
+// and HYPE are the named exceptions.
+func nativeTokenMetadataForChain(chainID uint64) *TokenMetadata {
+	meta := &TokenMetadata{
 		Id:       NativeTokenAddress,
 		Name:     "Ether",
 		Symbol:   "ETH",
 		Decimals: 18,
 		Source:   "native",
 	}
+	switch chainID {
+	case ChainIDBNBMainnet:
+		meta.Name = "BNB"
+		meta.Symbol = "BNB"
+	case ChainIDPolygonMainnet:
+		meta.Name = "POL"
+		meta.Symbol = "POL"
+	case ChainIDHyperliquidMainnet:
+		meta.Name = "HYPE"
+		meta.Symbol = "HYPE"
+	}
+	return meta
 }
 
 // NewTokenEnrichmentService creates a token enrichment service that talks
@@ -232,7 +247,7 @@ func whitelistFileForChain(chainID uint64) (filename string, skip bool) {
 		return "base-sepolia.json", false
 	case ChainIDBNBMainnet:
 		return "bnb-mainnet.json", false
-	case ChainIDArbitrumOne, ChainIDOptimismMainnet, ChainIDUnichainMainnet, ChainIDRobinhoodMainnet:
+	case ChainIDArbitrumOne, ChainIDOptimismMainnet, ChainIDUnichainMainnet, ChainIDRobinhoodMainnet, ChainIDPolygonMainnet, ChainIDHyperliquidMainnet:
 		return "", true
 	default:
 		// Unknown chain: skip, don't inherit Ethereum's list. A CREATE2
@@ -319,11 +334,11 @@ func (t *TokenEnrichmentService) GetTokenMetadata(contractAddress string) (*Toke
 
 	// Check if this is the native token sentinel address
 	if isNativeToken(normalizedAddr) {
+		metadata := nativeTokenMetadataForChain(t.chainID)
 		if t.logger != nil {
-			t.logger.Debug("Detected native token sentinel address, returning ETH metadata",
-				"address", normalizedAddr)
+			t.logger.Debug("Detected native token sentinel address",
+				"address", normalizedAddr, "symbol", metadata.Symbol, "chainID", t.chainID)
 		}
-		metadata := getNativeTokenMetadata()
 
 		// Cache it for consistency
 		t.cacheMux.Lock()

--- a/core/taskengine/token_metadata_test.go
+++ b/core/taskengine/token_metadata_test.go
@@ -98,6 +98,14 @@ func TestWhitelistFileForChain(t *testing.T) {
 	if !skip || filename != "" {
 		t.Errorf("Robinhood whitelist = (%q, skip=%v), want skip", filename, skip)
 	}
+	filename, skip = whitelistFileForChain(ChainIDPolygonMainnet)
+	if !skip || filename != "" {
+		t.Errorf("Polygon whitelist = (%q, skip=%v), want skip", filename, skip)
+	}
+	filename, skip = whitelistFileForChain(ChainIDHyperliquidMainnet)
+	if !skip || filename != "" {
+		t.Errorf("Hyperliquid whitelist = (%q, skip=%v), want skip", filename, skip)
+	}
 }
 
 func TestIsNativeToken(t *testing.T) {
@@ -181,13 +189,20 @@ func TestLoadTokensIntoCacheValidation(t *testing.T) {
 	assert.Contains(t, logger.warns[1], "decimals=0")
 }
 
-func TestGetNativeTokenMetadata(t *testing.T) {
-	metadata := getNativeTokenMetadata()
+func TestNativeTokenMetadataForChain(t *testing.T) {
+	eth := nativeTokenMetadataForChain(ChainIDEthereum)
+	assert.Equal(t, "ETH", eth.Symbol)
+	assert.Equal(t, "Ether", eth.Name)
 
-	assert.NotNil(t, metadata)
-	assert.Equal(t, NativeTokenAddress, metadata.Id)
-	assert.Equal(t, "Ether", metadata.Name)
-	assert.Equal(t, "ETH", metadata.Symbol)
-	assert.Equal(t, uint32(18), metadata.Decimals)
-	assert.Equal(t, "native", metadata.Source)
+	bnb := nativeTokenMetadataForChain(ChainIDBNBMainnet)
+	assert.Equal(t, "BNB", bnb.Symbol)
+	assert.Equal(t, "BNB", bnb.Name)
+
+	pol := nativeTokenMetadataForChain(ChainIDPolygonMainnet)
+	assert.Equal(t, "POL", pol.Symbol)
+	assert.Equal(t, NativeTokenAddress, pol.Id)
+
+	hype := nativeTokenMetadataForChain(ChainIDHyperliquidMainnet)
+	assert.Equal(t, "HYPE", hype.Symbol)
+	assert.Equal(t, uint32(18), hype.Decimals)
 }

--- a/core/taskengine/vm_runner_balance.go
+++ b/core/taskengine/vm_runner_balance.go
@@ -104,8 +104,15 @@ var chainIDMap = map[string]string{
 	"op-mainnet": "optimism",
 	"10":         "optimism",
 	"0xa":        "optimism",
-	// Unichain is not in Moralis Data API — do not add aliases that would
-	// send "unichain" to Moralis and 400.
+
+	// Polygon PoS — Moralis slug "polygon"
+	"polygon":     "polygon",
+	"matic":       "polygon",
+	"polygon-pos": "polygon",
+	"137":         "polygon",
+	"0x89":        "polygon",
+	// Unichain / Robinhood / Hyperliquid are not in Moralis Data API —
+	// do not add aliases that would 400.
 }
 
 // normalizeChainID converts various chain identifier formats to Moralis chain name

--- a/core/taskengine/vm_runner_balance_test.go
+++ b/core/taskengine/vm_runner_balance_test.go
@@ -593,6 +593,23 @@ func TestBalanceNode_ChainNormalization(t *testing.T) {
 			shouldError: true,
 		},
 		{
+			name:          "Polygon by chain ID",
+			inputChain:    "137",
+			expectedChain: "polygon",
+			shouldError:   false,
+		},
+		{
+			name:          "Polygon by name",
+			inputChain:    "polygon",
+			expectedChain: "polygon",
+			shouldError:   false,
+		},
+		{
+			name:        "Hyperliquid is not a Moralis Data API chain",
+			inputChain:  "999",
+			shouldError: true,
+		},
+		{
 			name:        "Unsupported chain",
 			inputChain:  "unsupported-chain",
 			shouldError: true,

--- a/docs/changes/20260902-wave-c-polygon-hyperliquid-maps.md
+++ b/docs/changes/20260902-wave-c-polygon-hyperliquid-maps.md
@@ -12,7 +12,7 @@ Wave C adds Polygon PoS (137) and Hyperliquid EVM (999). Alchemy `999 → hyperl
 ## Decision
 
 - Map `137 → polygon-mainnet` in `alchemyNetworkSubdomain`. Keep `999 → hyperliquid-mainnet`.
-- Moralis: `137 → polygon`, native POL via WPOL `0x0d50…1270`. **Do not** add a Moralis slug for 999. Put HYPE in `chainTokens` so `GetNativeTokenPriceUSD` cannot ETH-fallback; omit it from `nativePricingSupportedChains` so `getFallbackPrice("HYPE")` fails closed.
+- Moralis: `137 → polygon`, native POL via WPOL `0x0d50…1270`. **Do not** add a Moralis slug for 999. Put HYPE in `chainTokens` so `GetNativeTokenPriceUSD` cannot ETH-fallback; omit it from `nativePricingSupportedChains` so `getFallbackPrice("HYPE")` errors. Executor fail-closes execution-fee and credit-limit conversion on that error (does not proceed unbilled). BNB/POL still fail-open on a Moralis outage.
 - `chainBlockTime`: Polygon `2s`; Hyperliquid `1s` (small-block under-estimate vs 60s big blocks).
 - `GetNetworkName` → `"polygon"` / `"hyperliquid"`. Whitelist sidecars skip (no `polygon.json` / `hyperliquid.json` until `make sync-tokens`).
 - `nativeTokenMetadataForChain` returns BNB / POL / HYPE on those chain IDs; ETH otherwise.
@@ -22,4 +22,4 @@ Production Railway YAML stays in avs-infra.
 
 ## Verification
 
-- `go test ./core/config ./core/services ./core/taskengine -run 'TestChainIDToMoralisChain|TestGetChainTokenMappingWaveA|TestGetFallbackPriceRefusesNonETH|TestWhitelistFileForChain|TestNativeTokenMetadataForChain|TestGetNetworkName|TestBlockTimeForChain|TestExpansionChainsHaveAlchemySubdomains|TestBalanceNode_ChainNormalization'`
+- `go test ./core/config ./core/services ./core/taskengine -run 'TestChainIDToMoralisChain|TestGetChainTokenMappingWaveA|TestGetFallbackPriceRefusesNonETH|TestHasLiveNativeUsdPrice|TestWhitelistFileForChain|TestNativeTokenMetadataForChain|TestGetNetworkName|TestBlockTimeForChain|TestExpansionChainsHaveAlchemySubdomains|TestBalanceNode_ChainNormalization|TestNativeUsdPriceIsGuaranteedMissing'`

--- a/docs/changes/20260902-wave-c-polygon-hyperliquid-maps.md
+++ b/docs/changes/20260902-wave-c-polygon-hyperliquid-maps.md
@@ -1,0 +1,25 @@
+# Wave C: Polygon + Hyperliquid EVM chain maps
+
+- **Date**: 2026-09-02
+- **Status**: Implemented (maps; Railway apply still in avs-infra)
+- **Branch**: feat/wave-c-polygon-hyperliquid-maps
+- **Related**: avs-infra `docs/changes/20260902-chain-expansion-wave-c-polygon-hyperliquid.md`
+
+## Problem
+
+Wave C adds Polygon PoS (137) and Hyperliquid EVM (999). Alchemy `999 → hyperliquid-mainnet` was already mapped; `137 → polygon-mainnet` was not, so `ActiveBundlerURL` would hard-error at send time. Go maps still treated 137/999 as unknown for `GetNetworkName`, block-trigger floor, Moralis slugs, and native-token metadata (always ETH).
+
+## Decision
+
+- Map `137 → polygon-mainnet` in `alchemyNetworkSubdomain`. Keep `999 → hyperliquid-mainnet`.
+- Moralis: `137 → polygon`, native POL via WPOL `0x0d50…1270`. **Do not** add a Moralis slug for 999. Put HYPE in `chainTokens` so `GetNativeTokenPriceUSD` cannot ETH-fallback; omit it from `nativePricingSupportedChains` so `getFallbackPrice("HYPE")` fails closed.
+- `chainBlockTime`: Polygon `2s`; Hyperliquid `1s` (small-block under-estimate vs 60s big blocks).
+- `GetNetworkName` → `"polygon"` / `"hyperliquid"`. Whitelist sidecars skip (no `polygon.json` / `hyperliquid.json` until `make sync-tokens`).
+- `nativeTokenMetadataForChain` returns BNB / POL / HYPE on those chain IDs; ETH otherwise.
+- Local-dev worker example YAML for both.
+
+Production Railway YAML stays in avs-infra.
+
+## Verification
+
+- `go test ./core/config ./core/services ./core/taskengine -run 'TestChainIDToMoralisChain|TestGetChainTokenMappingWaveA|TestGetFallbackPriceRefusesNonETH|TestWhitelistFileForChain|TestNativeTokenMetadataForChain|TestGetNetworkName|TestBlockTimeForChain|TestExpansionChainsHaveAlchemySubdomains|TestBalanceNode_ChainNormalization'`


### PR DESCRIPTION
Wave C Go maps so workers can price, name, and bundle on Polygon PoS and Hyperliquid EVM. Railway YAML lives in avs-infra.

Alchemy `999 → hyperliquid-mainnet` was already mapped. `137 → polygon-mainnet` was not, so `ActiveBundlerURL` would hard-error at send time.

## Changes

- `alchemyNetworkSubdomain`: `137 → polygon-mainnet` (keep `999 → hyperliquid-mainnet`)
- Moralis: `137 → polygon` + native POL via WPOL `0x0d50…1270`. **Hyperliquid is not given a Moralis slug** — Data API does not list 999. HYPE is in `chainTokens` so `GetNativeTokenPriceUSD` cannot ETH-fallback; `getFallbackPrice("HYPE")` fails closed
- `chainBlockTime`: Polygon `2s`, Hyperliquid `1s` (small-block under-estimate vs 60s big blocks)
- `GetNetworkName` → `"polygon"` / `"hyperliquid"`. Whitelist sidecars skip (no `polygon.json` / `hyperliquid.json` yet)
- `nativeTokenMetadataForChain` returns BNB / POL / HYPE on those chain IDs; ETH otherwise
- Local worker example YAML for both

See `docs/changes/20260902-wave-c-polygon-hyperliquid-maps.md`.

## Test plan

- [x] `go test ./core/config ./core/services ./core/taskengine -run 'TestChainIDToMoralisChain|TestGetChainTokenMappingWaveA|TestGetFallbackPriceRefusesNonETH|TestWhitelistFileForChain|TestNativeTokenMetadataForChain|TestGetNetworkName|TestBlockTimeForChain|TestExpansionChainsHaveAlchemySubdomains|TestBalanceNode_ChainNormalization'`

Railway apply (worker services, gateway env, Gas Manager checkboxes) is avs-infra follow-through, not this PR.