### PR TITLE
fix: omit platform secrets from configVars and honor backup_dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ build:
 gateway: build
 	@echo "🚀 Starting local-dev gateway (config/gateway.yaml)..."
 	@echo "📝 Logs will be written to gateway.log"
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; ./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway.log
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; ./out/ap aggregator --config=config/gateway.yaml 2>&1 | tee gateway.log
 
 # Legacy per-chain aggregator targets retained as redirects so muscle
 # memory and old runbooks still work. They print a deprecation notice
@@ -274,42 +274,42 @@ operator-default: build
 
 
 ## run-*: BUILD-FREE pure-exec targets — the single source of truth for each
-## local-dev process's command (config + .env.local). studio/scripts/start.sh
+## local-dev process's command (config + .env). studio/scripts/start.sh
 ## (tmux panes) and `make dev-stack` both invoke these, so config paths / ports /
 ## env can't drift between them. Build-free so callers that already ran
 ## `make build` don't fire concurrent go builds racing on ./out/ap. Output goes
 ## to the caller's terminal/pane; callers that want files redirect (dev-stack →
-## logs/, start.sh → tee). Each sources .env.local so ${ALCHEMY_API_KEY} and
+## logs/, start.sh → tee). Each sources .env so ${ALCHEMY_API_KEY} and
 ## the per-chain RPC refs in the YAML resolve.
 .PHONY: run-gateway run-worker-sepolia run-worker-ethereum run-worker-base run-worker-base-sepolia run-operator-sepolia run-operator-ethereum
 run-gateway:
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap aggregator --config=config/gateway.yaml
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap aggregator --config=config/gateway.yaml
 run-worker-sepolia:
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-sepolia.yaml
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-sepolia.yaml
 # MAINNET workers — move REAL funds, pay REAL gas (no paymaster). Need these in
-# .env.local: ETHEREUM_RPC_URL/WS, BASE_RPC_URL/WS, MAINNET_CONTROLLER_PRIVATE_KEY.
+# .env: ETHEREUM_RPC_URL/WS, BASE_RPC_URL/WS, MAINNET_CONTROLLER_PRIVATE_KEY.
 # No *_BUNDLER_URL: every chain runs bundler_provider: alchemy, which derives the
 # endpoint from ALCHEMY_API_KEY and never reads bundler_url — the self-hosted
 # Voltaire tunnels these used to need are retired. start.sh skips these two panes
 # when the mainnet vars are absent, so a Sepolia-only stack still boots.
 run-worker-ethereum:
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-ethereum.yaml
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-ethereum.yaml
 run-worker-base:
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base.yaml
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base.yaml
 # Retired from the default local stack (see studio scripts/start.sh); kept runnable.
 run-worker-base-sepolia:
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base-sepolia.yaml
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap worker --config=config/worker-base-sepolia.yaml
 run-operator-sepolia:
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap operator --config=config/operator-sepolia.yaml
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; exec ./out/ap operator --config=config/operator-sepolia.yaml
 # Second operator, registered against the Ethereum mainnet AVS. Binds its
 # metrics/node-api on 9091/9011 because operator-sepolia already holds
 # 9090/9010 — running both with the stock ports fails on bind, not on config.
 #
 # Mainnet operator keys (alias 0x4f061d46 for operator 0xc6B87) use a DIFFERENT
 # password than Sepolia/vinh. Prefer MAINNET_OPERATOR_{ECDSA,BLS}_KEY_PASSWORD
-# from .env.local so the shared OPERATOR_* vars keep working for sepolia.
+# from .env so the shared OPERATOR_* vars keep working for sepolia.
 run-operator-ethereum:
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; \
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; \
 	if [ -n "$${MAINNET_OPERATOR_ECDSA_KEY_PASSWORD:-}" ]; then \
 		export OPERATOR_ECDSA_KEY_PASSWORD="$$MAINNET_OPERATOR_ECDSA_KEY_PASSWORD"; \
 	fi; \
@@ -355,9 +355,9 @@ dev-stack: build
 	@echo "   Tail with:  tail -f logs/*.log"
 	@echo "   Stop with:  Ctrl-C  (kills the whole stack)"
 	@echo ""
-	@set -a; [ -f .env.local ] && . ./.env.local; set +a; \
+	@set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; \
 		if [ -z "$$ALCHEMY_API_KEY" ]; then \
-			echo "❌ Missing ALCHEMY_API_KEY — add it to .env.local (bundler endpoint is derived from the key)"; \
+			echo "❌ Missing ALCHEMY_API_KEY — add it to .env (bundler endpoint is derived from the key)"; \
 			exit 1; \
 		fi; \
 		set -m; \

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ func main() {
 Production and local development use Alchemy's ERC-4337 bundler. With
 `bundler_provider: alchemy`, the endpoint is derived as
 `https://<network>.g.alchemy.com/v2/<ALCHEMY_API_KEY>` (e.g. `eth-sepolia`,
-`base-sepolia`, `eth-mainnet`). Set `ALCHEMY_API_KEY` in `.env.local`.
+`base-sepolia`, `eth-mainnet`). Set `ALCHEMY_API_KEY` in `.env`.
 
 ### Basic Connectivity Test
 

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -332,6 +332,12 @@ func (agg *Aggregator) Start(ctx context.Context, opts ...StartOption) error {
 
 	agg.migrate()
 
+	if agg.config.BackupInterval > 0 {
+		if err := agg.backup.StartPeriodicBackup(agg.config.BackupInterval); err != nil {
+			agg.logger.Error("failed to start periodic backup", "error", err, "dir", agg.config.BackupDir)
+		}
+	}
+
 	// In gateway mode, create chain registry and connect to workers
 	if agg.config.IsGateway {
 		agg.chainRegistry = NewChainRegistry(
@@ -378,6 +384,10 @@ func (agg *Aggregator) Start(ctx context.Context, opts ...StartOption) error {
 
 	if agg.chainRegistry != nil {
 		agg.chainRegistry.Close()
+	}
+
+	if agg.backup != nil {
+		agg.backup.StopPeriodicBackup()
 	}
 
 	agg.db.Close()

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -12,14 +12,17 @@
 environment: development
 
 db_path: /tmp/ap-avs/gateway
+# Honored when set. Empty → `{db_path}_backup`. Periodic writes only when
+# backup_interval_hours > 0; otherwise backups run on migration only.
 backup_dir: /tmp/ap-avs-gateway-backup
+backup_interval_hours: 0
 
 # AVS operator EOA private key (testnet). Anything funded on Sepolia
 # will do — this signs EigenLayer registration + task-aggregation txs.
 ecdsa_private_key: <testnet-ecdsa-private-key-hex>
 
 # EigenLayer contracts live on Sepolia (the AVS registration chain).
-# Set via .env.local / env.
+# Set via .env / env.
 # Supply a chain RPC you control. Do NOT point this at a free public endpoint
 # (publicnode, *.base.org, ankr, llamarpc, ...): they rate-limit under load,
 # which makes runs fail nondeterministically on whichever request happens to be
@@ -78,7 +81,9 @@ alchemy_paymaster_policy_id: ""
 gas_manager_webhook_secret: ""
 
 # Token price service for fee USD lines / estimateFees. Env: MORALIS_API_KEY.
-# Distinct from macros.secrets.moralis_api_key (workflow templates only).
+# Distinct from macros.secrets.moralis_api_key (engine-internal: BalanceNode
+# and restApi options.auth.provider=moralis). Never interpolated into
+# apContext.configVars.
 moralis_api_key: ${MORALIS_API_KEY}
 
 # Top-level smart_wallet — required by the aa package globals (factory +
@@ -160,7 +165,10 @@ partners:
 # can't be replayed elsewhere; assertions must carry a matching `aud`.
 partner_assertion_audience: "avs-gateway-staging"
 
-# Optional: per-macro secret values referenced from workflow JSON.
+# Optional: per-macro secret values.
+# Notify tokens (sendgrid, telegram) interpolate via apContext.configVars.
+# Platform keys (moralis_api_key, goplus_app_*) stay engine-internal —
+# BalanceNode / options.auth.provider; they are NOT copied into configVars.
 # Leave keys empty unless your local workflows actually use them.
 macros:
   secrets:

--- a/config/operator-sepolia.example.yaml
+++ b/config/operator-sepolia.example.yaml
@@ -19,7 +19,7 @@ operator_address: <operator-eoa-address>
 avs_registry_coordinator_address: 0xcA95381802FD1398d5BF2D01243210cFb3a2b3BD
 operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
 
-# RPC endpoints for AVS operations (Sepolia). Set via .env.local / env.
+# RPC endpoints for AVS operations (Sepolia). Set via .env / env.
 # eth_ws_url must support eth_call over WebSocket (not only eth_subscribe);
 # the EigenLayer SDK calls ServiceManager on the WS client at startup.
 # Supply a chain RPC you control. Do NOT point this at a free public endpoint

--- a/config/test.example.yaml
+++ b/config/test.example.yaml
@@ -24,7 +24,7 @@ backup_dir: /tmp/ap-avs-test-backup
 ecdsa_private_key: <testnet-ecdsa-private-key-hex>
 
 # EigenLayer contracts live on Sepolia (the AVS registration chain).
-# Set via .env.local / env.
+# Set via .env / env.
 # Supply a chain RPC you control. Do NOT point this at a free public endpoint
 # (publicnode, *.base.org, ankr, llamarpc, ...): they rate-limit under load,
 # which makes runs fail nondeterministically on whichever request happens to be
@@ -94,7 +94,9 @@ chains:
       paymaster_address:      0xd856f532F7C032e6b30d76F19187F25A068D6d92
       max_wallets_per_owner:  3
 
-# Optional: per-macro secret values referenced from workflow JSON.
+# Optional: per-macro secret values. Notify tokens interpolate via
+# apContext.configVars. Platform keys (moralis_api_key, goplus_app_*) stay
+# engine-internal and are NOT copied into configVars.
 macros:
   secrets:
     ap_notify_bot_token: ""

--- a/config/worker-arbitrum.example.yaml
+++ b/config/worker-arbitrum.example.yaml
@@ -19,7 +19,7 @@ listen_address: "0.0.0.0:50055"
 health_address: "0.0.0.0:8094"
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# Chain RPC. Set via .env / env. Do NOT point this at a free public
 # endpoint — they rate-limit under load.
 eth_rpc_url: ${ARBITRUM_RPC_URL}
 eth_ws_url:  ${ARBITRUM_WS_URL}

--- a/config/worker-base-sepolia.example.yaml
+++ b/config/worker-base-sepolia.example.yaml
@@ -24,7 +24,7 @@ health_address: "0.0.0.0:8091"
 # Gateway address (worker registers with gateway on startup).
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC endpoints (Base Sepolia). Set via .env.local / env.
+# Chain RPC endpoints (Base Sepolia). Set via .env / env.
 # Supply a chain RPC you control. Do NOT point this at a free public endpoint
 # (publicnode, *.base.org, ankr, llamarpc, ...): they rate-limit under load,
 # which makes runs fail nondeterministically on whichever request happens to be
@@ -34,7 +34,7 @@ eth_ws_url:  ${BASE_SEPOLIA_WS_URL}
 
 # Bundler. alchemy (matching production) derives the endpoint from
 # alchemy_api_key + the chain subdomain and never reads bundler_url. Set
-# ALCHEMY_API_KEY in .env.local before launching. self_hosted remains only for
+# ALCHEMY_API_KEY in .env before launching. self_hosted remains only for
 # a locally-run Voltaire — the shared bundler-*.avaprotocol.org hosts are retired.
 bundler_provider: alchemy
 alchemy_api_key:  ${ALCHEMY_API_KEY}

--- a/config/worker-hyperliquid.example.yaml
+++ b/config/worker-hyperliquid.example.yaml
@@ -19,7 +19,7 @@ listen_address: "0.0.0.0:50060"
 health_address: "0.0.0.0:8099"
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# Chain RPC. Set via .env / env. Do NOT point this at a free public
 # endpoint — they rate-limit under load.
 eth_rpc_url: ${HYPERLIQUID_RPC_URL}
 eth_ws_url:  ${HYPERLIQUID_WS_URL}

--- a/config/worker-optimism.example.yaml
+++ b/config/worker-optimism.example.yaml
@@ -19,7 +19,7 @@ listen_address: "0.0.0.0:50056"
 health_address: "0.0.0.0:8095"
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# Chain RPC. Set via .env / env. Do NOT point this at a free public
 # endpoint — they rate-limit under load.
 eth_rpc_url: ${OPTIMISM_RPC_URL}
 eth_ws_url:  ${OPTIMISM_WS_URL}

--- a/config/worker-polygon.example.yaml
+++ b/config/worker-polygon.example.yaml
@@ -19,7 +19,7 @@ listen_address: "0.0.0.0:50059"
 health_address: "0.0.0.0:8098"
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# Chain RPC. Set via .env / env. Do NOT point this at a free public
 # endpoint — they rate-limit under load.
 eth_rpc_url: ${POLYGON_RPC_URL}
 eth_ws_url:  ${POLYGON_WS_URL}

--- a/config/worker-robinhood.example.yaml
+++ b/config/worker-robinhood.example.yaml
@@ -19,7 +19,7 @@ listen_address: "0.0.0.0:50058"
 health_address: "0.0.0.0:8097"
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# Chain RPC. Set via .env / env. Do NOT point this at a free public
 # endpoint — they rate-limit under load.
 eth_rpc_url: ${ROBINHOOD_RPC_URL}
 eth_ws_url:  ${ROBINHOOD_WS_URL}

--- a/config/worker-sepolia.example.yaml
+++ b/config/worker-sepolia.example.yaml
@@ -24,7 +24,7 @@ health_address: "0.0.0.0:8090"
 # Gateway address (worker registers with gateway on startup).
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC endpoints. Set via .env.local / env.
+# Chain RPC endpoints. Set via .env / env.
 # Supply a chain RPC you control. Do NOT point this at a free public endpoint
 # (publicnode, *.base.org, ankr, llamarpc, ...): they rate-limit under load,
 # which makes runs fail nondeterministically on whichever request happens to be
@@ -34,7 +34,7 @@ eth_ws_url:  ${ETH_WS_URL}
 
 # Bundler. alchemy (matching production) derives the endpoint from
 # alchemy_api_key + the chain subdomain and never reads bundler_url. Set
-# ALCHEMY_API_KEY in .env.local before launching. self_hosted remains only for
+# ALCHEMY_API_KEY in .env before launching. self_hosted remains only for
 # a locally-run Voltaire — the shared bundler-*.avaprotocol.org hosts are retired.
 bundler_provider: alchemy
 alchemy_api_key:  ${ALCHEMY_API_KEY}

--- a/config/worker-unichain.example.yaml
+++ b/config/worker-unichain.example.yaml
@@ -19,7 +19,7 @@ listen_address: "0.0.0.0:50057"
 health_address: "0.0.0.0:8096"
 gateway_address: "127.0.0.1:2206"
 
-# Chain RPC. Set via .env.local / env. Do NOT point this at a free public
+# Chain RPC. Set via .env / env. Do NOT point this at a free public
 # endpoint — they rate-limit under load.
 eth_rpc_url: ${UNICHAIN_RPC_URL}
 eth_ws_url:  ${UNICHAIN_WS_URL}

--- a/core/config/backup_dir_test.go
+++ b/core/config/backup_dir_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveBackupDir(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		dbPath, backupDir, want string
+	}{
+		{"/data/gateway", "", "/data/gateway_backup"},
+		{"/data/gateway", "/data/gateway_backup", "/data/gateway_backup"},
+		{"/data/gateway", "/data/gateway-backup", "/data/gateway-backup"},
+		{"/data/gateway", "  /data/gateway_backup  ", "/data/gateway_backup"},
+		{"", "", ""},
+		{"", "/custom", "/custom"},
+	}
+	for _, c := range cases {
+		got := resolveBackupDir(c.dbPath, c.backupDir)
+		if got != c.want {
+			t.Errorf("resolveBackupDir(%q, %q) = %q, want %q", c.dbPath, c.backupDir, got, c.want)
+		}
+	}
+}
+
+func TestResolveBackupInterval(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveBackupInterval(0); got != 0 {
+		t.Errorf("0 hours: got %v, want 0", got)
+	}
+	if got := resolveBackupInterval(-1); got != 0 {
+		t.Errorf("negative: got %v, want 0", got)
+	}
+	if got := resolveBackupInterval(24); got != 24*time.Hour {
+		t.Errorf("24 hours: got %v, want 24h", got)
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -100,6 +101,9 @@ type Config struct {
 
 	DbPath    string
 	BackupDir string
+	// BackupInterval is 0 when periodic backups are off (migration-only).
+	// Set from yaml backup_interval_hours.
+	BackupInterval time.Duration
 
 	JwtSecret []byte
 
@@ -512,10 +516,30 @@ func redactBundlerURLForLog(u string) string {
 	return u
 }
 
-type BackupConfig struct {
-	Enabled         bool   // Whether periodic backups are enabled
-	IntervalMinutes int    // Interval between backups in minutes
-	BackupDir       string // Directory to store backups
+// resolveBackupDir picks the on-disk backup directory.
+//
+// yaml `backup_dir` is honored when set. If it is empty, the historical
+// default is `{db_path}_backup` (e.g. /data/gateway → /data/gateway_backup).
+// A previous bug ignored yaml backup_dir entirely, so production's real
+// directory is the derived underscore path even when yaml said
+// /data/gateway-backup.
+func resolveBackupDir(dbPath, backupDir string) string {
+	if dir := strings.TrimSpace(backupDir); dir != "" {
+		return dir
+	}
+	if dbPath == "" {
+		return ""
+	}
+	return dbPath + "_backup"
+}
+
+// resolveBackupInterval converts yaml backup_interval_hours to a duration.
+// 0 or negative means periodic backups are off (migration-triggered only).
+func resolveBackupInterval(hours int) time.Duration {
+	if hours <= 0 {
+		return 0
+	}
+	return time.Duration(hours) * time.Hour
 }
 
 // SmartWalletConfigRaw represents the raw YAML config for smart wallet operations.
@@ -583,8 +607,10 @@ type ConfigRaw struct {
 	OperatorStateRetrieverAddr string `yaml:"operator_state_retriever_address"`
 	AVSRegistryCoordinatorAddr string `yaml:"avs_registry_coordinator_address"`
 
-	DbPath    string `yaml:"db_path"`
-	JwtSecret string `yaml:"jwt_secret"`
+	DbPath              string `yaml:"db_path"`
+	BackupDir           string `yaml:"backup_dir"`
+	BackupIntervalHours int    `yaml:"backup_interval_hours"`
+	JwtSecret           string `yaml:"jwt_secret"`
 
 	// REST rate-limit overrides; see Config.RestRateLimitPerSecond.
 	RestRateLimitPerSecond float64 `yaml:"rest_rate_limit_per_second"`
@@ -849,9 +875,10 @@ func NewConfig(configFilePath string) (*Config, error) {
 		TxMgr:                             txMgr,
 		AggregatorAddress:                 aggregatorAddr,
 
-		DbPath:    configRaw.DbPath,
-		BackupDir: configRaw.DbPath + "_backup",
-		JwtSecret: []byte(configRaw.JwtSecret),
+		DbPath:         configRaw.DbPath,
+		BackupDir:      resolveBackupDir(configRaw.DbPath, configRaw.BackupDir),
+		BackupInterval: resolveBackupInterval(configRaw.BackupIntervalHours),
+		JwtSecret:      []byte(configRaw.JwtSecret),
 
 		RestRateLimitPerSecond: configRaw.RestRateLimitPerSecond,
 		RestRateLimitBurst:     configRaw.RestRateLimitBurst,

--- a/core/taskengine/limits.go
+++ b/core/taskengine/limits.go
@@ -21,9 +21,10 @@ import (
 // with a summarizer enabled spends an LLM call per run. Occurrence *is* the
 // cost, so these ceilings are universal rather than conditional on which
 // providers a workflow happens to reference. That also sidesteps a detection
-// problem: BalanceNode reads `macroSecrets["moralis_api_key"]` directly rather
-// than through an `{{apContext.configVars.*}}` template, so no static scan of
-// the task body can reliably tell which tasks spend which quota.
+// problem: BalanceNode reads macros.secrets[platformSecretMoralisAPIKey]
+// directly rather than through an `{{apContext.configVars.*}}` template, so
+// no static scan of the task body can reliably tell which tasks spend which
+// quota.
 //
 // These are deliberately compile-time constants, not config: the point is a
 // bound that holds in every environment without an operator having to set it,

--- a/core/taskengine/secret.go
+++ b/core/taskengine/secret.go
@@ -12,6 +12,10 @@ import (
 // restApi options.auth.provider=moralis / goplus) but must NEVER copy
 // into apContext.configVars. restApi / customCode templates would
 // otherwise let a workflow spend or exfiltrate the platform keys.
+//
+// This is a denylist: a new macros.secrets credential that is engine-only
+// MUST be added here, or it fails open into configVars. Notify tokens
+// (sendgrid, telegram) stay interpolable on purpose.
 const (
 	platformSecretMoralisAPIKey   = "moralis_api_key"
 	platformSecretGoplusAppKey    = "goplus_app_key"

--- a/core/taskengine/secret.go
+++ b/core/taskengine/secret.go
@@ -8,6 +8,27 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// Platform secret names the engine may read internally (BalanceNode,
+// restApi options.auth.provider=moralis / goplus) but must NEVER copy
+// into apContext.configVars. restApi / customCode templates would
+// otherwise let a workflow spend or exfiltrate the platform keys.
+const (
+	platformSecretMoralisAPIKey   = "moralis_api_key"
+	platformSecretGoplusAppKey    = "goplus_app_key"
+	platformSecretGoplusAppSecret = "goplus_app_secret"
+)
+
+var platformSecretNames = map[string]struct{}{
+	platformSecretMoralisAPIKey:   {},
+	platformSecretGoplusAppKey:    {},
+	platformSecretGoplusAppSecret: {},
+}
+
+func isPlatformSecretName(name string) bool {
+	_, ok := platformSecretNames[name]
+	return ok
+}
+
 func LoadSecretForTask(db storage.Storage, task *model.Workflow) (map[string]string, error) {
 	secrets := map[string]string{}
 

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -539,11 +539,18 @@ func NewVMWithDataAndTransferLog(task *model.Workflow, triggerData *TriggerData,
 	// Initialize logger if it's nil to prevent panic (using shared utility)
 	v.logger = logger.EnsureLogger(v.logger)
 
-	// Initialize apContext with configVars containing secrets and macro variables
+	// Initialize apContext with configVars containing user/workflow secrets.
+	// Platform keys (Moralis, GoPlus app credentials) stay in macros.secrets
+	// for engine code (BalanceNode, restApi options.auth.provider=moralis
+	// / goplus) and are never copied here — a restApi/customCode template
+	// must not be able to send {{apContext.configVars.moralis_api_key}} at
+	// deep-index.moralis.io (or dump goplus_app_secret to a webhook).
 	configVars := make(map[string]string)
-	// Add secrets (they override macro variables if there are conflicts)
-	for k, v := range secrets {
-		configVars[k] = v
+	for k, val := range secrets {
+		if isPlatformSecretName(k) {
+			continue
+		}
+		configVars[k] = val
 	}
 
 	v.AddVar(APContextVarName, map[string]map[string]string{

--- a/core/taskengine/vm_runner_balance.go
+++ b/core/taskengine/vm_runner_balance.go
@@ -304,22 +304,6 @@ func (v *VM) runBalance(taskNode *avsproto.TaskNode) (*avsproto.Execution_Step, 
 		return executionLogStep, err
 	}
 
-	// Debug logging for CI/testing (show first 20 chars of API key to verify it's loaded)
-	if len(moralisAPIKey) > 20 {
-		fmt.Printf("DEBUG: Moralis API key loaded: %s... (length: %d)\n", moralisAPIKey[:20], len(moralisAPIKey))
-	} else {
-		fmt.Printf("DEBUG: Moralis API key loaded (length: %d)\n", len(moralisAPIKey))
-	}
-
-	// Additional debug: check if it looks like a JWT
-	if strings.HasPrefix(moralisAPIKey, "eyJ") {
-		fmt.Printf("DEBUG: Moralis API key format: JWT (starts with eyJ)\n")
-	} else if moralisAPIKey == "test-api-key" {
-		fmt.Printf("DEBUG: Moralis API key format: test/mock key\n")
-	} else {
-		fmt.Printf("DEBUG: Moralis API key format: unknown/other\n")
-	}
-
 	// Fetch balances from Moralis
 	// Note: If client specifies tokenAddresses, we need a two-phase approach:
 	// 1. Get all tokens first (to include native token)

--- a/core/taskengine/vm_runner_balance.go
+++ b/core/taskengine/vm_runner_balance.go
@@ -296,7 +296,7 @@ func (v *VM) runBalance(taskNode *avsproto.TaskNode) (*avsproto.Execution_Step, 
 	// Get Moralis API key from macro secrets (global package variable set by SetMacroSecrets)
 	moralisAPIKey := ""
 	if macroSecrets != nil {
-		moralisAPIKey = macroSecrets["moralis_api_key"]
+		moralisAPIKey = macroSecrets[platformSecretMoralisAPIKey]
 	}
 	if moralisAPIKey == "" {
 		err = fmt.Errorf("moralis API key is not configured in macros.secrets")
@@ -517,6 +517,9 @@ func (vm *VM) fetchMoralisBalances(
 
 	// Create HTTP client with timeout to prevent indefinite blocking
 	client := resty.New().SetTimeout(30 * time.Second)
+	// Don't follow redirects while carrying X-API-Key (resty forwards custom
+	// headers off-host). Moralis does not redirect off-host today.
+	client.SetRedirectPolicy(resty.NoRedirectPolicy())
 	request := client.R().
 		SetHeader("X-API-Key", apiKey).
 		SetQueryParam("chain", chain)

--- a/core/taskengine/vm_runner_balance_test.go
+++ b/core/taskengine/vm_runner_balance_test.go
@@ -177,13 +177,13 @@ func setupBalanceVM(t *testing.T, config *avsproto.BalanceNode_Config) (*VM, *av
 			fmt.Printf("TEST SETUP: Loaded real Moralis API key: %s... (length: %d)\n", moralisAPIKey[:20], len(moralisAPIKey))
 		}
 		SetMacroSecrets(map[string]string{
-			"moralis_api_key": moralisAPIKey,
+			platformSecretMoralisAPIKey: moralisAPIKey,
 		})
 	} else {
 		// Fallback for tests that don't need real API
 		fmt.Printf("TEST SETUP: No real Moralis API key found, using test-api-key\n")
 		SetMacroSecrets(map[string]string{
-			"moralis_api_key": "test-api-key",
+			platformSecretMoralisAPIKey: "test-api-key",
 		})
 	}
 
@@ -909,7 +909,7 @@ func TestBalanceNode_MissingAPIKey(t *testing.T) {
 
 	// Restore API key for other tests
 	SetMacroSecrets(map[string]string{
-		"moralis_api_key": "test-api-key",
+		platformSecretMoralisAPIKey: "test-api-key",
 	})
 }
 
@@ -987,7 +987,7 @@ func TestBalanceNode_TokenAddressesWithTemplateVariables(t *testing.T) {
 		t.Skip("real moralis API key not configured in macros.secrets - skipping integration test")
 	}
 	SetMacroSecrets(map[string]string{
-		"moralis_api_key": moralisAPIKey,
+		platformSecretMoralisAPIKey: moralisAPIKey,
 	})
 
 	t.Log("Running BalanceNode with template variables in tokenAddresses...")
@@ -1272,7 +1272,7 @@ func TestBalanceNode_ExtractAddressFromObject(t *testing.T) {
 
 			// Set up mock API key
 			SetMacroSecrets(map[string]string{
-				"moralis_api_key": "test-api-key",
+				platformSecretMoralisAPIKey: "test-api-key",
 			})
 
 			// Create mock Moralis server
@@ -1342,7 +1342,7 @@ func TestBalanceNode_MultipleTokenAddresses(t *testing.T) {
 	// Get real Moralis API key from macro secrets (already set in setupBalanceVM)
 	moralisAPIKey := ""
 	if macroSecrets != nil {
-		moralisAPIKey = macroSecrets["moralis_api_key"]
+		moralisAPIKey = macroSecrets[platformSecretMoralisAPIKey]
 	}
 	if moralisAPIKey == "" || moralisAPIKey == "test-api-key" {
 		t.Skip("real moralis API key not configured in macros.secrets - skipping integration test")

--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -576,10 +577,10 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 		processedHeaders[processedKey] = processedValue
 	}
 
-	// Server-side auth providers (options.auth): mint + attach a provider token so the
-	// credential never lives in the workflow JSON. GoPlus first; on "" (keys unset or
-	// mint failed) we send no Authorization header — GoPlus still answers keyless.
-	if restAuthProvider(node) == "goplus" {
+	// Server-side auth providers (options.auth): attach a provider credential
+	// so the secret never lives in the workflow JSON / apContext.configVars.
+	switch restAuthProvider(node) {
+	case restAuthProviderGoplus:
 		if token := goplusTokenProvider(); token != "" {
 			processedHeaders["Authorization"] = token
 			if r.vm.logger != nil {
@@ -588,6 +589,19 @@ func (r *RestProcessor) Execute(stepID string, node *avsproto.RestAPINode) (*avs
 		} else if r.vm.logger != nil {
 			// Keys unset or mint failed: GoPlus still answers keyless (lower limits).
 			r.vm.logger.Warn("REST: GoPlus auth requested but no token minted; falling back to keyless", "stepID", stepID)
+		}
+	case restAuthProviderMoralis:
+		if key := moralisAPIKeyHeader(url); key != "" {
+			processedHeaders["X-API-Key"] = key
+			if r.vm.logger != nil {
+				r.vm.logger.Debug("REST: attached Moralis API key (authed)", "stepID", stepID)
+			}
+		} else if r.vm.logger != nil {
+			if isMoralisDataAPIURL(url) {
+				r.vm.logger.Warn("REST: Moralis auth requested but macros.secrets.moralis_api_key is empty", "stepID", stepID)
+			} else {
+				r.vm.logger.Warn("REST: Moralis auth requested but URL is not https://deep-index.moralis.io; skipping key", "stepID", stepID)
+			}
 		}
 	}
 
@@ -885,11 +899,16 @@ func detectNotificationProvider(u string) string {
 // ── REST auth providers ─────────────────────────────────────────────────────
 // A restApi node can request server-side credential injection with
 //
-//	config.options.auth = { "provider": "goplus" }
+//	config.options.auth = { "provider": "goplus" | "moralis" }
 //
-// The gateway mints the provider's token from macros.secrets and attaches it as
-// the Authorization header at execution time, so the secret never appears in the
-// (client-visible) workflow JSON. GoPlus is the first provider; add more here.
+// The gateway reads the provider's secret from macros.secrets and attaches it
+// at execution time, so the secret never appears in the workflow JSON or in
+// apContext.configVars (templates cannot spend or exfiltrate it).
+const (
+	restAuthProviderGoplus  = "goplus"
+	restAuthProviderMoralis = "moralis"
+	moralisDataAPIHost      = "deep-index.moralis.io"
+)
 
 // restAuthProvider returns the lower-cased options.auth.provider (e.g. "goplus"),
 // or "" when none is set. Mirrors shouldSummarize's options-bag read.
@@ -907,6 +926,29 @@ func restAuthProvider(node *avsproto.RestAPINode) string {
 	}
 	provider, _ := auth["provider"].(string)
 	return strings.ToLower(strings.TrimSpace(provider))
+}
+
+// isMoralisDataAPIURL is true only for https://deep-index.moralis.io/...
+// Host-pin so options.auth.provider=moralis cannot exfiltrate the platform
+// key to an attacker-controlled URL.
+func isMoralisDataAPIURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), moralisDataAPIHost)
+}
+
+// moralisAPIKeyHeader returns the platform Moralis key when destURL is the
+// Moralis Data API, else "". Callers attach it as X-API-Key.
+func moralisAPIKeyHeader(destURL string) string {
+	if !isMoralisDataAPIURL(destURL) {
+		return ""
+	}
+	return GetMacroSecret(platformSecretMoralisAPIKey)
 }
 
 // goplusTokenProvider is the seam the REST runner calls to obtain a GoPlus

--- a/core/taskengine/vm_runner_rest.go
+++ b/core/taskengine/vm_runner_rest.go
@@ -43,7 +43,17 @@ func NewProductionHTTPExecutor() *ProductionHTTPExecutor {
 }
 
 func (p *ProductionHTTPExecutor) ExecuteRequest(method, url, body string, headers map[string]string) (*resty.Response, error) {
-	request := p.client.R()
+	client := p.client
+	if isMoralisDataAPIURL(url) {
+		// Don't follow redirects while carrying X-API-Key (resty forwards
+		// custom headers off-host). Use a per-call client so other restApi
+		// traffic still follows redirects.
+		c := resty.New()
+		c.SetTimeout(30 * time.Second)
+		c.SetRedirectPolicy(resty.NoRedirectPolicy())
+		client = c
+	}
+	request := client.R()
 
 	// Set headers
 	for key, value := range headers {
@@ -975,8 +985,8 @@ var goplusTokenCache struct {
 // Returns "" to fall back to keyless GoPlus access (lower rate limits) when the
 // keys are unset or minting fails — the caller then sends no Authorization header.
 func goplusAuthHeader() string {
-	appKey := GetMacroSecret("goplus_app_key")
-	appSecret := GetMacroSecret("goplus_app_secret")
+	appKey := GetMacroSecret(platformSecretGoplusAppKey)
+	appSecret := GetMacroSecret(platformSecretGoplusAppSecret)
 	if appKey == "" || appSecret == "" {
 		return ""
 	}

--- a/core/taskengine/vm_runner_rest_moralis_test.go
+++ b/core/taskengine/vm_runner_rest_moralis_test.go
@@ -7,270 +7,86 @@ import (
 	"github.com/AvaProtocol/EigenLayer-AVS/model"
 	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// TestRestRequestMoralisWalletBalances tests the Moralis API integration for wallet token balances
-// This test demonstrates how to use the existing restApi node to get wallet balances
-// instead of creating a new balance_node type
-func TestRestRequestMoralisWalletBalances(t *testing.T) {
-	// Test wallet address (Ethereum mainnet address with some tokens)
-	testWalletAddress := "0xcB1C1FdE09f811B294172696404e88E658659905"
+const testPlatformMoralisKey = "platform-moralis-should-not-leak"
 
-	// Create the REST API node for Moralis wallet balances
-	node := &avsproto.RestAPINode{
-		Config: &avsproto.RestAPINode_Config{
-			Url:    "https://deep-index.moralis.io/api/v2.2/wallets/" + testWalletAddress + "/tokens?chain=eth&limit=25&exclude_spam=true&exclude_unverified_contracts=true",
-			Method: "GET",
-			Headers: map[string]string{
-				"Accept":     "application/json",
-				"X-API-Key":  "{{apContext.configVars.moralis_api_key}}",
-				"User-Agent": "AvaProtocol-EigenLayer-AVS/1.0",
-			},
-		},
-	}
-
-	nodes := []*avsproto.TaskNode{
-		{
-			Id:   "moralis-wallet-balances",
-			Name: "restApi",
-			TaskType: &avsproto.TaskNode_RestApi{
-				RestApi: node,
-			},
-		},
-	}
-
-	trigger := &avsproto.TaskTrigger{
-		Id:   "triggertest",
-		Name: "triggertest",
-	}
-	edges := []*avsproto.TaskEdge{
-		{
-			Id:     "e1",
-			Source: trigger.Id,
-			Target: "moralis-wallet-balances",
-		},
-	}
-
-	// Get the test config which includes secrets from aggregator.yaml
-	testConfig := testutil.GetTestConfig()
-	if testConfig == nil {
-		t.Skip("Test config not loaded, skipping integration test")
-	}
-
-	// Extract secrets from the loaded config
-	globalSecrets := map[string]string{}
-	if testConfig.MacroSecrets != nil {
-		// Convert map[string]string to the format expected by VM
-		for k, v := range testConfig.MacroSecrets {
-			globalSecrets[k] = v
-		}
-	}
-
-	// Verify moralis_api_key is available
-	moralisKey, exists := globalSecrets["moralis_api_key"]
-	if !exists || moralisKey == "" {
-		t.Skip("Moralis API key not configured in test config, skipping integration test")
-	}
-
-	t.Logf("✅ Loaded moralis_api_key from aggregator.yaml config: %s", moralisKey[:20]+"...")
-
+func newRestVM(t *testing.T, secrets map[string]string) *VM {
+	t.Helper()
 	vm, err := NewVMWithData(&model.Workflow{
 		Task: &avsproto.Task{
-			Id:      "moralis-test",
-			Nodes:   nodes,
-			Edges:   edges,
-			Trigger: trigger,
+			Id: "moralis-test",
+			Trigger: &avsproto.TaskTrigger{
+				Id:   "triggertest",
+				Name: "triggertest",
+			},
 		},
-	}, nil, testutil.GetTestSmartWalletConfig(), globalSecrets)
-
-	require.NoError(t, err, "failed to create VM")
-
-	// Create REST API processor
-	processor := NewRestProcessor(vm)
-
-	// Execute the node
-	stepID := "moralis-wallet-balances"
-	result, err := processor.Execute(stepID, node)
-	require.NoError(t, err, "Moralis API call should succeed")
-	require.NotNil(t, result, "Result should not be nil")
-
-	// Verify execution was successful
-	require.True(t, result.Success, "Moralis API call should be successful")
-	require.Empty(t, result.Error, "No error should be returned")
-
-	// Verify output data structure
-	require.NotNil(t, result.OutputData, "Output data should not be nil")
-	restOutput := result.GetRestApi()
-	require.NotNil(t, restOutput, "REST API output should not be nil")
-	require.NotNil(t, restOutput.Data, "REST API data should not be nil")
-
-	// Extract the actual data from protobuf response
-	dataInterface := restOutput.Data.AsInterface()
-	require.NotNil(t, dataInterface, "Data interface should not be nil")
-
-	// The response is wrapped in a "data" field
-	dataMap, ok := dataInterface.(map[string]interface{})
-	require.True(t, ok, "Data should be a map")
-	require.Contains(t, dataMap, "data", "Response should contain 'data' field")
-
-	// Get the actual API response data
-	apiResponse, ok := dataMap["data"].(map[string]interface{})
-	require.True(t, ok, "API response should be a map")
-	require.Contains(t, apiResponse, "result", "API response should contain 'result' field")
-
-	// Get the token balances array
-	tokenBalances, ok := apiResponse["result"].([]interface{})
-	require.True(t, ok, "Result should be an array")
-
-	// Log some basic information
-	t.Logf("✅ Moralis API integration test passed!")
-	t.Logf("✅ Retrieved %d token balances for wallet %s", len(tokenBalances), testWalletAddress)
-	t.Logf("✅ Template variable {{apContext.configVars.moralis_api_key}} was properly resolved from aggregator.yaml")
-	t.Logf("✅ Response contains valid Moralis API structure")
-
-	// Log first few tokens for verification
-	for i, tokenBalance := range tokenBalances {
-		if i >= 3 { // Only log first 3 tokens
-			break
-		}
-		tokenData, ok := tokenBalance.(map[string]interface{})
-		if ok {
-			t.Logf("Token %d: %s (%s) - Balance: %s",
-				i+1,
-				tokenData["name"],
-				tokenData["symbol"],
-				tokenData["balance_formatted"])
-		}
-	}
+	}, nil, testutil.GetTestSmartWalletConfig(), secrets)
+	require.NoError(t, err)
+	return vm
 }
 
-// TestRestRequestMoralisSpecificTokens tests getting balances for specific tokens using correct format
-func TestRestRequestMoralisSpecificTokens(t *testing.T) {
-	// Test wallet address
-	testWalletAddress := "0xcB1C1FdE09f811B294172696404e88E658659905"
+// TestRestRequestMoralisWalletBalances documents that restApi must NOT be
+// able to send the platform Moralis key via a template. Wallet balances go
+// through BalanceNode (macros.secrets, engine-side). A restApi template
+// that interpolates {{apContext.configVars.moralis_api_key}} used to turn
+// any workflow into a billed Moralis client; that key is now omitted from
+// configVars.
+func TestRestRequestMoralisWalletBalances(t *testing.T) {
+	secrets := map[string]string{
+		platformSecretMoralisAPIKey: testPlatformMoralisKey,
+		"sendgrid_key":              "user-visible-sendgrid",
+	}
+	vm := newRestVM(t, secrets)
 
-	// Test without token_addresses filter to avoid invalid address errors
-	// This demonstrates the restApi node working with Moralis API
+	expanded := vm.preprocessText("{{apContext.configVars.moralis_api_key}}")
+	require.NotEqual(t, testPlatformMoralisKey, expanded, "platform moralis_api_key must not interpolate into restApi templates")
+	require.NotContains(t, expanded, testPlatformMoralisKey, "platform moralis_api_key must not leak into restApi headers")
 
-	// Create the REST API node for all token balances (no specific filter)
-	node := &avsproto.RestAPINode{
-		Config: &avsproto.RestAPINode_Config{
-			Url:    "https://deep-index.moralis.io/api/v2.2/wallets/" + testWalletAddress + "/tokens?chain=eth&limit=10&exclude_spam=true",
-			Method: "GET",
-			Headers: map[string]string{
-				"Accept":     "application/json",
-				"X-API-Key":  "{{apContext.configVars.moralis_api_key}}",
-				"User-Agent": "AvaProtocol-EigenLayer-AVS/1.0",
-			},
-		},
+	sendgrid := vm.preprocessText("{{apContext.configVars.sendgrid_key}}")
+	require.Equal(t, "user-visible-sendgrid", sendgrid, "notify secrets must still interpolate")
+}
+
+func TestRestMoralisAuthProviderInjectsKeyOnMoralisHost(t *testing.T) {
+	prev := macroSecrets
+	t.Cleanup(func() { SetMacroSecrets(prev) })
+	SetMacroSecrets(map[string]string{
+		platformSecretMoralisAPIKey: testPlatformMoralisKey,
+	})
+
+	moralisURL := "https://deep-index.moralis.io/api/v2.2/wallets/0xabc/approvals?chain=eth"
+	require.Equal(t, testPlatformMoralisKey, moralisAPIKeyHeader(moralisURL))
+
+	opts, err := structpb.NewValue(map[string]interface{}{
+		"auth": map[string]interface{}{"provider": restAuthProviderMoralis},
+	})
+	require.NoError(t, err)
+	require.Equal(t, restAuthProviderMoralis, restAuthProvider(&avsproto.RestAPINode{
+		Config: &avsproto.RestAPINode_Config{Url: moralisURL, Method: "GET", Options: opts},
+	}))
+}
+
+func TestRestMoralisAuthProviderDoesNotInjectOnForeignHost(t *testing.T) {
+	prev := macroSecrets
+	t.Cleanup(func() { SetMacroSecrets(prev) })
+	SetMacroSecrets(map[string]string{
+		platformSecretMoralisAPIKey: testPlatformMoralisKey,
+	})
+
+	foreign := []string{
+		"https://webhook.site/abc",
+		"http://deep-index.moralis.io/api/v2.2/wallets/0xabc/tokens",
+		"https://deep-index.moralis.io.evil.com/api/v2.2/wallets/0xabc/tokens",
+		"https://evil.com/?host=deep-index.moralis.io",
+		"https://user:pass@evil.com/",
+		"https://deep-index.moralis.io@evil.com/steal",
+	}
+	for _, raw := range foreign {
+		require.False(t, isMoralisDataAPIURL(raw), raw)
+		require.Empty(t, moralisAPIKeyHeader(raw), raw)
 	}
 
-	nodes := []*avsproto.TaskNode{
-		{
-			Id:   "moralis-specific-tokens",
-			Name: "restApi",
-			TaskType: &avsproto.TaskNode_RestApi{
-				RestApi: node,
-			},
-		},
-	}
-
-	trigger := &avsproto.TaskTrigger{
-		Id:   "triggertest",
-		Name: "triggertest",
-	}
-	edges := []*avsproto.TaskEdge{
-		{
-			Id:     "e1",
-			Source: trigger.Id,
-			Target: "moralis-specific-tokens",
-		},
-	}
-
-	// Get the test config which includes secrets from aggregator.yaml
-	testConfig := testutil.GetTestConfig()
-	if testConfig == nil {
-		t.Skip("Test config not loaded, skipping integration test")
-	}
-
-	// Extract secrets from the loaded config
-	globalSecrets := map[string]string{}
-	if testConfig.MacroSecrets != nil {
-		// Convert map[string]string to the format expected by VM
-		for k, v := range testConfig.MacroSecrets {
-			globalSecrets[k] = v
-		}
-	}
-
-	// Verify moralis_api_key is available
-	moralisKey, exists := globalSecrets["moralis_api_key"]
-	if !exists || moralisKey == "" {
-		t.Skip("Moralis API key not configured in test config, skipping integration test")
-	}
-
-	t.Logf("✅ Loaded moralis_api_key from aggregator.yaml config: %s", moralisKey[:20]+"...")
-
-	vm, err := NewVMWithData(&model.Workflow{
-		Task: &avsproto.Task{
-			Id:      "moralis-specific-test",
-			Nodes:   nodes,
-			Edges:   edges,
-			Trigger: trigger,
-		},
-	}, nil, testutil.GetTestSmartWalletConfig(), globalSecrets)
-
-	require.NoError(t, err, "failed to create VM")
-
-	// Create REST API processor
-	processor := NewRestProcessor(vm)
-
-	// Execute the node
-	stepID := "moralis-specific-tokens"
-	result, err := processor.Execute(stepID, node)
-	require.NoError(t, err, "Moralis API call should succeed")
-	require.NotNil(t, result, "Result should not be nil")
-
-	// Verify execution was successful
-	if !result.Success {
-		t.Logf("❌ API call failed with error: %s", result.Error)
-		t.Logf("❌ Response data: %v", result.OutputData)
-	}
-	require.True(t, result.Success, "Moralis API call should be successful")
-	require.Empty(t, result.Error, "No error should be returned")
-
-	// Extract the actual data from protobuf response
-	dataInterface := result.GetRestApi().Data.AsInterface()
-	require.NotNil(t, dataInterface, "Data interface should not be nil")
-
-	// The response is wrapped in a "data" field
-	dataMap, ok := dataInterface.(map[string]interface{})
-	require.True(t, ok, "Data should be a map")
-	require.Contains(t, dataMap, "data", "Response should contain 'data' field")
-
-	// Get the actual API response data
-	apiResponse, ok := dataMap["data"].(map[string]interface{})
-	require.True(t, ok, "API response should be a map")
-	require.Contains(t, apiResponse, "result", "API response should contain 'result' field")
-
-	// Get the token balances array
-	tokenBalances, ok := apiResponse["result"].([]interface{})
-	require.True(t, ok, "Result should be an array")
-
-	// Log some basic information
-	t.Logf("✅ Moralis API integration test passed!")
-	t.Logf("✅ Retrieved %d token balances for wallet %s", len(tokenBalances), testWalletAddress)
-	t.Logf("✅ RestAPI node successfully integrates with Moralis API")
-
-	// Log tokens for verification
-	for i, tokenBalance := range tokenBalances {
-		tokenData, ok := tokenBalance.(map[string]interface{})
-		if ok {
-			t.Logf("Token %d: %s (%s) - Balance: %s, Address: %s",
-				i+1,
-				tokenData["name"],
-				tokenData["symbol"],
-				tokenData["balance_formatted"],
-				tokenData["token_address"])
-		}
-	}
+	require.True(t, isMoralisDataAPIURL("https://deep-index.moralis.io/api/v2.2/wallets/0x/tokens"))
+	require.True(t, isMoralisDataAPIURL("https://deep-index.moralis.io:443/api/v2.2/wallets/0x/tokens"))
 }

--- a/core/taskengine/vm_secrets_test.go
+++ b/core/taskengine/vm_secrets_test.go
@@ -1,6 +1,7 @@
 package taskengine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
@@ -152,6 +153,7 @@ func TestSecretAccessInCustomCode(t *testing.T) {
 	}
 
 	processor := NewJSProcessor(vm)
+
 	executionLog, err := processor.Execute("test_node", node)
 
 	if err != nil {
@@ -253,5 +255,58 @@ func TestCollectInputsIncludesSecrets(t *testing.T) {
 	if _, exists := inputs["test_var.data"]; !exists {
 		keys := testGetStringMapKeys(inputs)
 		t.Errorf("test_var.data not found in CollectInputs output, available keys: %v", keys)
+	}
+}
+
+// TestPlatformSecretsOmittedFromConfigVars: macros.secrets.moralis_api_key
+// (and GoPlus app credentials) must stay engine-internal. A restApi node
+// with X-API-Key: {{apContext.configVars.moralis_api_key}} must not be able
+// to spend the platform Moralis quota.
+func TestPlatformSecretsOmittedFromConfigVars(t *testing.T) {
+	secrets := map[string]string{
+		"moralis_api_key":     "platform-moralis-should-not-leak",
+		"goplus_app_key":      "platform-goplus-key",
+		"goplus_app_secret":   "platform-goplus-secret",
+		"sendgrid_key":        "user-visible-sendgrid",
+		"ap_notify_bot_token": "user-visible-telegram",
+	}
+
+	vm, err := NewVMWithData(&model.Workflow{
+		Task: &avsproto.Task{
+			Id: "test_platform_secrets",
+			Trigger: &avsproto.TaskTrigger{
+				Id:   "trigger1",
+				Name: "test_trigger",
+			},
+		},
+	}, nil, testutil.GetTestSmartWalletConfig(), secrets)
+	if err != nil {
+		t.Fatalf("Failed to create VM: %v", err)
+	}
+
+	vm.mu.Lock()
+	apContextValue := vm.vars[APContextVarName]
+	vm.mu.Unlock()
+	apContextMap, ok := apContextValue.(map[string]map[string]string)
+	if !ok {
+		t.Fatalf("apContext type %T", apContextValue)
+	}
+	configVars := apContextMap[ConfigVarsPath]
+
+	for _, k := range []string{"moralis_api_key", "goplus_app_key", "goplus_app_secret"} {
+		if _, exists := configVars[k]; exists {
+			t.Errorf("platform secret %q must not appear in apContext.configVars", k)
+		}
+	}
+	if configVars["sendgrid_key"] != "user-visible-sendgrid" {
+		t.Errorf("sendgrid_key should remain in configVars for restApi notify templates")
+	}
+	if configVars["ap_notify_bot_token"] != "user-visible-telegram" {
+		t.Errorf("ap_notify_bot_token should remain in configVars for restApi notify templates")
+	}
+
+	got := vm.preprocessText("X-API-Key: {{apContext.configVars.moralis_api_key}}")
+	if strings.Contains(got, "platform-moralis-should-not-leak") {
+		t.Errorf("template expanded the platform Moralis key: %q", got)
 	}
 }

--- a/core/taskengine/vm_secrets_test.go
+++ b/core/taskengine/vm_secrets_test.go
@@ -264,11 +264,11 @@ func TestCollectInputsIncludesSecrets(t *testing.T) {
 // to spend the platform Moralis quota.
 func TestPlatformSecretsOmittedFromConfigVars(t *testing.T) {
 	secrets := map[string]string{
-		"moralis_api_key":     "platform-moralis-should-not-leak",
-		"goplus_app_key":      "platform-goplus-key",
-		"goplus_app_secret":   "platform-goplus-secret",
-		"sendgrid_key":        "user-visible-sendgrid",
-		"ap_notify_bot_token": "user-visible-telegram",
+		platformSecretMoralisAPIKey:   "platform-moralis-should-not-leak",
+		platformSecretGoplusAppKey:    "platform-goplus-key",
+		platformSecretGoplusAppSecret: "platform-goplus-secret",
+		"sendgrid_key":                "user-visible-sendgrid",
+		"ap_notify_bot_token":         "user-visible-telegram",
 	}
 
 	vm, err := NewVMWithData(&model.Workflow{
@@ -293,7 +293,7 @@ func TestPlatformSecretsOmittedFromConfigVars(t *testing.T) {
 	}
 	configVars := apContextMap[ConfigVarsPath]
 
-	for _, k := range []string{"moralis_api_key", "goplus_app_key", "goplus_app_secret"} {
+	for k := range platformSecretNames {
 		if _, exists := configVars[k]; exists {
 			t.Errorf("platform secret %q must not appear in apContext.configVars", k)
 		}

--- a/core/taskengine/vm_workflow_state_test.go
+++ b/core/taskengine/vm_workflow_state_test.go
@@ -119,7 +119,7 @@ func TestWorkflowStateBinding_SimulationDoesNotPersist(t *testing.T) {
 }
 
 // TestRestAuthProvider covers the options.auth.provider parsing that gates
-// server-side GoPlus token injection.
+// server-side GoPlus / Moralis credential injection.
 func TestRestAuthProvider(t *testing.T) {
 	mk := func(opts map[string]interface{}) *avsproto.RestAPINode {
 		var o *structpb.Value
@@ -131,11 +131,14 @@ func TestRestAuthProvider(t *testing.T) {
 		return &avsproto.RestAPINode{Config: &avsproto.RestAPINode_Config{Options: o}}
 	}
 
-	require.Equal(t, "goplus", restAuthProvider(mk(map[string]interface{}{
-		"auth": map[string]interface{}{"provider": "goplus"},
+	require.Equal(t, restAuthProviderGoplus, restAuthProvider(mk(map[string]interface{}{
+		"auth": map[string]interface{}{"provider": restAuthProviderGoplus},
+	})))
+	require.Equal(t, restAuthProviderMoralis, restAuthProvider(mk(map[string]interface{}{
+		"auth": map[string]interface{}{"provider": restAuthProviderMoralis},
 	})))
 	// Trimmed + lower-cased.
-	require.Equal(t, "goplus", restAuthProvider(mk(map[string]interface{}{
+	require.Equal(t, restAuthProviderGoplus, restAuthProvider(mk(map[string]interface{}{
 		"auth": map[string]interface{}{"provider": "  GoPlus "},
 	})))
 	// No auth key.

--- a/core/testutil/utils.go
+++ b/core/testutil/utils.go
@@ -51,9 +51,10 @@ var testConfig *config.Config
 // so tests can resolve ${VAR} references in config/test.yaml (e.g.
 // ${ALCHEMY_API_KEY}, ${ETH_RPC_URL}) and read secrets like OWNER_EOA.
 //
-// Files are loaded in order: .env.local first, then .env. The first file to set
-// a given key wins, so .env.local overrides .env (dotenv convention), and a real
-// process environment variable overrides both. Each file is optional.
+// Files are loaded in order: leftover `.env.local` first, then `.env`.
+// Keys already in the process env (or an earlier file) are skipped, so
+// `.env.local` wins when both exist. Real process env overrides both.
+// Canonical local-dev file is `.env`; `.env.local` is an optional leftover.
 //
 // Note: both files are gitignored. In a fresh git worktree they are absent, so
 // ${VAR} references resolve to empty — that is the cause of alchemy-path
@@ -80,7 +81,7 @@ func LoadDotEnv() error {
 	if !loadedAny {
 		// Not fatal — vars may come from the real environment (e.g. CI) — but
 		// surface it so a missing dotenv in a worktree isn't a silent mystery.
-		log.Printf("testutil: no .env.local or .env found under %s; ${VAR} refs in test.yaml rely on the process environment", repoRoot)
+		log.Printf("testutil: no .env or .env.local found under %s; ${VAR} refs in test.yaml rely on the process environment", repoRoot)
 	}
 
 	return nil

--- a/docs/changes/20260907-platform-secrets-and-backup-dir.md
+++ b/docs/changes/20260907-platform-secrets-and-backup-dir.md
@@ -12,8 +12,8 @@
 
 ## Decision
 
-- Denylist `moralis_api_key`, `goplus_app_key`, `goplus_app_secret` from configVars. BalanceNode and GoPlus mint still read `macros.secrets` / `GetMacroSecret`. Notify tokens stay interpolable.
-- First-party Moralis restApi uses `options.auth.provider: moralis`. The gateway attaches `X-API-Key` only when the URL host is `https://deep-index.moralis.io`.
+- Denylist `moralis_api_key`, `goplus_app_key`, `goplus_app_secret` from configVars. BalanceNode and GoPlus mint still read `macros.secrets` / `GetMacroSecret` via `platformSecret*` constants. Notify tokens stay interpolable. New engine-only secrets must be added to `platformSecretNames` or they fail open into configVars.
+- First-party Moralis restApi uses `options.auth.provider: moralis`. The gateway attaches `X-API-Key` only when the URL host is `https://deep-index.moralis.io`, and that request does not follow redirects (resty would otherwise forward `X-API-Key` off-host).
 - Honor yaml `backup_dir` (fallback `{db_path}_backup`). yaml `backup_interval_hours` > 0 starts the existing periodic ticker (retention 3). Production yaml (avs-infra) is `/data/gateway_backup` + 24h; that field is ignored until this binary is deployed.
 
 ## Verification

--- a/docs/changes/20260907-platform-secrets-and-backup-dir.md
+++ b/docs/changes/20260907-platform-secrets-and-backup-dir.md
@@ -1,0 +1,22 @@
+# Platform secrets out of configVars + honor backup_dir
+
+- **Date**: 2026-09-07
+- **Status**: Implemented
+- **Branch**: fix/platform-secrets-and-backup-dir
+- **Related**: restApi `options.auth` (`docs/changes/20260717-workflow-state-and-rest-auth.md`); avs-infra `RAILWAY_OPERATIONS.md` volume layout
+
+## Problem
+
+1. Every `macros.secrets` entry was copied into `apContext.configVars`. A restApi/customCode node could send `X-API-Key: {{apContext.configVars.moralis_api_key}}` at any URL and spend or exfiltrate the platform Moralis/GoPlus credentials. The in-repo rest-moralis tests did that live HTTP call.
+2. yaml `backup_dir` was dead: `ConfigRaw` had no field, and `NewConfig` always set `BackupDir` to `{db_path}_backup`. Production yaml said `/data/gateway-backup`; the volume has `/data/gateway_backup`. App backups only ran on migration (`StartPeriodicBackup` was never called), so the newest `full-backup.db` was 2026-06-27.
+
+## Decision
+
+- Denylist `moralis_api_key`, `goplus_app_key`, `goplus_app_secret` from configVars. BalanceNode and GoPlus mint still read `macros.secrets` / `GetMacroSecret`. Notify tokens stay interpolable.
+- First-party Moralis restApi uses `options.auth.provider: moralis`. The gateway attaches `X-API-Key` only when the URL host is `https://deep-index.moralis.io`.
+- Honor yaml `backup_dir` (fallback `{db_path}_backup`). yaml `backup_interval_hours` > 0 starts the existing periodic ticker (retention 3). Production yaml (avs-infra) is `/data/gateway_backup` + 24h; that field is ignored until this binary is deployed.
+
+## Verification
+
+- `go test ./core/config/` — `resolveBackupDir` / `resolveBackupInterval`
+- `go test ./core/taskengine/ -run 'TestPlatformSecretsOmittedFromConfigVars|TestRestRequestMoralis|TestRestMoralis|TestRestAuthProvider|TestRestGoPlusAuthInjection'`

--- a/scripts/dev/dump-invalid-tasks/main.go
+++ b/scripts/dev/dump-invalid-tasks/main.go
@@ -4,7 +4,7 @@
 // (e.g. the legacy "send eth" node-name and missing-trigger-config cohorts).
 //
 // READ-ONLY in intent, but BadgerDB takes an exclusive directory lock, so run
-// this against a COPY/backup of the gateway DB (e.g. /data/gateway-backup),
+// this against a COPY/backup of the gateway DB (e.g. /data/gateway_backup),
 // NOT the live directory while the gateway is running.
 //
 // Usage:

--- a/scripts/start-gateway.sh
+++ b/scripts/start-gateway.sh
@@ -19,7 +19,7 @@
 #   2 (top-right)    Worker Sepolia       — :50051
 #   3 (bottom-right) Worker Base Sepolia  — :50052
 #
-# Bundler: ALCHEMY_API_KEY is sourced from ./.env.local and exported into the
+# Bundler: ALCHEMY_API_KEY is sourced from ./.env and exported into the
 # tmux session so the YAMLs' ${ALCHEMY_API_KEY} placeholders resolve. Every
 # chain uses bundler_provider: alchemy (endpoint derived from the key).
 
@@ -52,16 +52,16 @@ command -v tmux >/dev/null 2>&1 || { echo "❌ tmux not found. Run: brew install
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Source env from .env.local (so YAML ${VAR} expansion resolves).
-if [[ -f "$PROJECT_DIR/.env.local" ]]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$PROJECT_DIR/.env.local"
-    set +a
-fi
+# Source env from .env (so YAML ${VAR} expansion resolves). Optional leftover
+# .env.local still overrides if present.
+set -a
+# shellcheck disable=SC1090
+[[ -f "$PROJECT_DIR/.env" ]] && source "$PROJECT_DIR/.env"
+[[ -f "$PROJECT_DIR/.env.local" ]] && source "$PROJECT_DIR/.env.local"
+set +a
 
 if [[ -z "$ALCHEMY_API_KEY" ]]; then
-    echo "❌ Missing ALCHEMY_API_KEY. Set in $PROJECT_DIR/.env.local:"
+    echo "❌ Missing ALCHEMY_API_KEY. Set in $PROJECT_DIR/.env:"
     echo "     ALCHEMY_API_KEY=..."
     echo ""
     echo "   The bundler endpoint is derived from this key (bundler_provider: alchemy)."


### PR DESCRIPTION
## Summary

- Stop copying `moralis_api_key` / `goplus_app_*` into `apContext.configVars`. restApi/customCode templates can no longer spend or exfiltrate the platform keys. BalanceNode and GoPlus mint still read `macros.secrets`.
- First-party Moralis restApi uses `options.auth.provider: moralis`, attached only when the URL host is `https://deep-index.moralis.io`.
- Honor yaml `backup_dir` (previously ignored; engine always used `{db_path}_backup`) and `backup_interval_hours` for periodic Badger backups (retention 3). Production yaml in avs-infra already points at `/data/gateway_backup` + 24h; those fields stay inert until this image is deployed.
- Local-dev env loading prefers `.env`, with optional `.env.local` override.

See `docs/changes/20260907-platform-secrets-and-backup-dir.md`.

## Test plan

- [x] `go test ./core/config/`
- [x] `go test ./core/taskengine/ -run 'TestPlatformSecretsOmittedFromConfigVars|TestRestRequestMoralis|TestRestMoralis|TestRestAuthProvider|TestRestGoPlusAuthInjection'`
- [ ] After merge + image: confirm gateway logs `Started periodic backup every 24h0m0s to /data/gateway_backup` and no `DEBUG: Moralis API key loaded`