### PR TITLE
fix: put step cause on REST trigger failed and error envelopes

### DIFF
--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -1624,8 +1624,9 @@ type TriggerWorkflowResponse struct {
 	Status ExecutionStatus `json:"status"`
 
 	// Steps Execution steps. Populated when isBlocking=true (same as gRPC
-	// TriggerTaskResp.steps). The per-step `error` / `errorCode` is
-	// the source of the envelope `error` summary.
+	// TriggerTaskResp.steps). The envelope `error` summary is built
+	// from each failed step's `error` string. `errorCode` is copied
+	// onto the step only; it is not concatenated into `error`.
 	Steps *[]ExecutionStep `json:"steps,omitempty"`
 }
 

--- a/aggregator/rest/generated/types.gen.go
+++ b/aggregator/rest/generated/types.gen.go
@@ -1602,7 +1602,12 @@ type TriggerWorkflowRequest struct {
 
 // TriggerWorkflowResponse defines model for TriggerWorkflowResponse.
 type TriggerWorkflowResponse struct {
-	EndAt *int64  `json:"endAt,omitempty"`
+	EndAt *int64 `json:"endAt,omitempty"`
+
+	// Error Empty when status is success. On failed, a summary of the form
+	// `N of M steps failed: <name>: <step.error>, …` so the cause
+	// (e.g. a bundler `replacement underpriced`) is on this envelope,
+	// not only on GET /executions/{id}. On error, the system message.
 	Error *string `json:"error,omitempty"`
 
 	// ExecutionId ULID identifier (26-char Crockford base32).
@@ -1617,6 +1622,11 @@ type TriggerWorkflowResponse struct {
 	// logical failure (e.g., a node returned an error, or a wait timed out);
 	// `error` is a system / infrastructure failure (e.g., RPC unreachable).
 	Status ExecutionStatus `json:"status"`
+
+	// Steps Execution steps. Populated when isBlocking=true (same as gRPC
+	// TriggerTaskResp.steps). The per-step `error` / `errorCode` is
+	// the source of the envelope `error` summary.
+	Steps *[]ExecutionStep `json:"steps,omitempty"`
 }
 
 // Ulid ULID identifier (26-char Crockford base32).

--- a/aggregator/rest/handlers_workflows.go
+++ b/aggregator/rest/handlers_workflows.go
@@ -256,22 +256,9 @@ func (s *Server) TriggerWorkflow(ctx echo.Context, id generated.Ulid) error {
 		return notFoundOrError(err)
 	}
 
-	// The proto TriggerTaskResp shape closely mirrors the OpenAPI
-	// response; lift it field-by-field rather than via the JSON
-	// roundtrip helper because the proto Status field is an enum we
-	// translate to a lowercase string.
-	out := generated.TriggerWorkflowResponse{
-		ExecutionId: generated.Ulid(resp.GetExecutionId()),
-		Status:      generated.ExecutionStatus(mapping.ExecutionStatusProtoToWire(resp.GetStatus())),
-	}
-	if v := resp.GetStartAt(); v != 0 {
-		out.StartAt = &v
-	}
-	if v := resp.GetEndAt(); v != 0 {
-		out.EndAt = &v
-	}
-	if msg := resp.GetError(); msg != "" {
-		out.Error = &msg
+	out, mapErr := mapping.ProtoToOpenAPITriggerWorkflow(resp)
+	if mapErr != nil {
+		return mapErr
 	}
 	return ctx.JSON(http.StatusOK, out)
 }

--- a/aggregator/rest/mapping/execution.go
+++ b/aggregator/rest/mapping/execution.go
@@ -267,6 +267,8 @@ func normalizeStepType(t string) string {
 		return "customCode"
 	case "NODE_TYPE_BALANCE":
 		return "balance"
+	case "NODE_TYPE_AWAIT":
+		return "await"
 	}
 	return t
 }

--- a/aggregator/rest/mapping/execution.go
+++ b/aggregator/rest/mapping/execution.go
@@ -85,6 +85,39 @@ func ProtoToOpenAPIExecution(in *avsproto.Execution, workflowID string) (generat
 	return out, nil
 }
 
+// ProtoToOpenAPITriggerWorkflow lifts engine TriggerTaskResp into the REST
+// trigger envelope. gRPC already carries steps when isBlocking=true; REST
+// used to copy only executionId/status/timestamps/error, so clients that
+// only called :trigger never saw step.error (bundler "replacement
+// underpriced" and similar).
+func ProtoToOpenAPITriggerWorkflow(in *avsproto.TriggerTaskResp) (generated.TriggerWorkflowResponse, error) {
+	out := generated.TriggerWorkflowResponse{
+		ExecutionId: generated.Ulid(in.GetExecutionId()),
+		Status:      generated.ExecutionStatus(ExecutionStatusProtoToWire(in.GetStatus())),
+	}
+	if v := in.GetStartAt(); v != 0 {
+		out.StartAt = &v
+	}
+	if v := in.GetEndAt(); v != 0 {
+		out.EndAt = &v
+	}
+	if msg := in.GetError(); msg != "" {
+		out.Error = &msg
+	}
+	if steps := in.GetSteps(); len(steps) > 0 {
+		mapped := make([]generated.ExecutionStep, 0, len(steps))
+		for _, s := range steps {
+			step, err := protoExecutionStepToOpenAPI(s)
+			if err != nil {
+				return out, fmt.Errorf("step %s: %w", s.GetId(), err)
+			}
+			mapped = append(mapped, step)
+		}
+		out.Steps = &mapped
+	}
+	return out, nil
+}
+
 // ProtoExecutionToOpenAPISummary lifts a full Execution into the lightweight
 // status summary shape (skips the steps/cogs/fee payload to keep responses
 // small). Status goes through the shared ExecutionStatusProtoToWire so every

--- a/aggregator/rest/mapping/trigger_workflow_test.go
+++ b/aggregator/rest/mapping/trigger_workflow_test.go
@@ -56,6 +56,34 @@ func TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps(t *testing.T) {
 	assert.Equal(t, "eth_sendUserOperation: replacement underpriced", *write.Error)
 }
 
+func TestProtoToOpenAPITriggerWorkflow_ErrorCopiesVmCauseAndSteps(t *testing.T) {
+	errMsg := "VM execution error: context canceled (step analysis: 1 of 2 steps failed: w: eth_sendUserOperation: replacement underpriced)"
+	in := &avsproto.TriggerTaskResp{
+		ExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		Status:      avsproto.ExecutionStatus_EXECUTION_STATUS_ERROR,
+		Error:       &errMsg,
+		Steps: []*avsproto.Execution_Step{
+			{
+				Id:      "w",
+				Type:    avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE.String(),
+				Name:    "w",
+				Success: false,
+				Error:   "eth_sendUserOperation: replacement underpriced",
+			},
+		},
+	}
+
+	out, err := ProtoToOpenAPITriggerWorkflow(in)
+	require.NoError(t, err)
+	assert.Equal(t, "error", string(out.Status))
+	require.NotNil(t, out.Error)
+	assert.Equal(t, errMsg, *out.Error)
+	require.NotNil(t, out.Steps)
+	require.Len(t, *out.Steps, 1)
+	require.NotNil(t, (*out.Steps)[0].Error)
+	assert.Equal(t, "eth_sendUserOperation: replacement underpriced", *(*out.Steps)[0].Error)
+}
+
 func TestProtoToOpenAPITriggerWorkflow_SuccessOmitsErrorAndEmptySteps(t *testing.T) {
 	in := &avsproto.TriggerTaskResp{
 		ExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",

--- a/aggregator/rest/mapping/trigger_workflow_test.go
+++ b/aggregator/rest/mapping/trigger_workflow_test.go
@@ -84,6 +84,36 @@ func TestProtoToOpenAPITriggerWorkflow_ErrorCopiesVmCauseAndSteps(t *testing.T) 
 	assert.Equal(t, "eth_sendUserOperation: replacement underpriced", *(*out.Steps)[0].Error)
 }
 
+func TestProtoToOpenAPITriggerWorkflow_WaitingNormalizesAwaitStepType(t *testing.T) {
+	in := &avsproto.TriggerTaskResp{
+		ExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		Status:      avsproto.ExecutionStatus_EXECUTION_STATUS_WAITING,
+		Steps: []*avsproto.Execution_Step{
+			{
+				Id:      "trigger",
+				Type:    avsproto.TriggerType_TRIGGER_TYPE_MANUAL.String(),
+				Name:    "manual",
+				Success: true,
+			},
+			{
+				Id:      "approve",
+				Type:    avsproto.NodeType_NODE_TYPE_AWAIT.String(),
+				Name:    "approve",
+				Success: true,
+			},
+		},
+	}
+
+	out, err := ProtoToOpenAPITriggerWorkflow(in)
+	require.NoError(t, err)
+	assert.Equal(t, "waiting", string(out.Status))
+	require.NotNil(t, out.Steps)
+	require.Len(t, *out.Steps, 2)
+	assert.Equal(t, "manual", (*out.Steps)[0].Type)
+	assert.Equal(t, "await", (*out.Steps)[1].Type)
+	assert.NotEqual(t, "NODE_TYPE_AWAIT", (*out.Steps)[1].Type)
+}
+
 func TestProtoToOpenAPITriggerWorkflow_SuccessOmitsErrorAndEmptySteps(t *testing.T) {
 	in := &avsproto.TriggerTaskResp{
 		ExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",

--- a/aggregator/rest/mapping/trigger_workflow_test.go
+++ b/aggregator/rest/mapping/trigger_workflow_test.go
@@ -1,0 +1,69 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	avsproto "github.com/AvaProtocol/EigenLayer-AVS/protobuf"
+)
+
+// TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps is the conversion
+// the REST :trigger handler uses. The previous inline copy dropped
+// TriggerTaskResp.steps, so a blocking failure's step.error (bundler
+// "replacement underpriced") never left the gateway.
+func TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps(t *testing.T) {
+	errMsg := "1 of 2 steps failed: w: eth_sendUserOperation: replacement underpriced"
+	startAt := int64(1_700_000_000_000)
+	endAt := int64(1_700_000_001_000)
+	in := &avsproto.TriggerTaskResp{
+		ExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		Status:      avsproto.ExecutionStatus_EXECUTION_STATUS_FAILED,
+		StartAt:     &startAt,
+		EndAt:       &endAt,
+		Error:       &errMsg,
+		Steps: []*avsproto.Execution_Step{
+			{
+				Id:      "trigger",
+				Type:    avsproto.TriggerType_TRIGGER_TYPE_BLOCK.String(),
+				Name:    "blockTrigger",
+				Success: true,
+			},
+			{
+				Id:      "w",
+				Type:    avsproto.NodeType_NODE_TYPE_CONTRACT_WRITE.String(),
+				Name:    "w",
+				Success: false,
+				Error:   "eth_sendUserOperation: replacement underpriced",
+			},
+		},
+	}
+
+	out, err := ProtoToOpenAPITriggerWorkflow(in)
+	require.NoError(t, err)
+	assert.Equal(t, "01ARZ3NDEKTSV4RRFFQ69G5FAV", string(out.ExecutionId))
+	assert.Equal(t, "failed", string(out.Status))
+	require.NotNil(t, out.Error)
+	assert.Equal(t, errMsg, *out.Error)
+	require.NotNil(t, out.Steps)
+	require.Len(t, *out.Steps, 2)
+
+	write := (*out.Steps)[1]
+	assert.Equal(t, "w", write.Id)
+	assert.False(t, write.Success)
+	require.NotNil(t, write.Error)
+	assert.Equal(t, "eth_sendUserOperation: replacement underpriced", *write.Error)
+}
+
+func TestProtoToOpenAPITriggerWorkflow_SuccessOmitsErrorAndEmptySteps(t *testing.T) {
+	in := &avsproto.TriggerTaskResp{
+		ExecutionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		Status:      avsproto.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+	}
+	out, err := ProtoToOpenAPITriggerWorkflow(in)
+	require.NoError(t, err)
+	assert.Equal(t, "success", string(out.Status))
+	assert.Nil(t, out.Error)
+	assert.Nil(t, out.Steps)
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1188,8 +1188,9 @@ components:
           items: { $ref: '#/components/schemas/ExecutionStep' }
           description: |
             Execution steps. Populated when isBlocking=true (same as gRPC
-            TriggerTaskResp.steps). The per-step `error` / `errorCode` is
-            the source of the envelope `error` summary.
+            TriggerTaskResp.steps). The envelope `error` summary is built
+            from each failed step's `error` string. `errorCode` is copied
+            onto the step only; it is not concatenated into `error`.
 
     SimulateWorkflowRequest:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1176,7 +1176,20 @@ components:
         status: { $ref: '#/components/schemas/ExecutionStatus' }
         startAt: { type: integer, format: int64 }
         endAt: { type: integer, format: int64 }
-        error: { type: string }
+        error:
+          type: string
+          description: |
+            Empty when status is success. On failed, a summary of the form
+            `N of M steps failed: <name>: <step.error>, …` so the cause
+            (e.g. a bundler `replacement underpriced`) is on this envelope,
+            not only on GET /executions/{id}. On error, the system message.
+        steps:
+          type: array
+          items: { $ref: '#/components/schemas/ExecutionStep' }
+          description: |
+            Execution steps. Populated when isBlocking=true (same as gRPC
+            TriggerTaskResp.steps). The per-step `error` / `errorCode` is
+            the source of the envelope `error` summary.
 
     SimulateWorkflowRequest:
       type: object

--- a/core/taskengine/partial_success_test.go
+++ b/core/taskengine/partial_success_test.go
@@ -99,10 +99,15 @@ func TestAnalyzeExecutionResult_SomeStepsFailed(t *testing.T) {
 		t.Errorf("Expected resultStatus=ExecutionFailed, got resultStatus=%v", resultStatus)
 	}
 
-	// Check that error message contains failure information
+	// Check that error message contains failure information and the
+	// step's own error — name-only summaries hid bundler/node causes
+	// on REST :trigger.
 	expectedSubstring := "1 of 4 steps failed"
 	if !strings.HasPrefix(errorMessage, expectedSubstring) {
 		t.Errorf("Expected error message to start with '%s', got: %s", expectedSubstring, errorMessage)
+	}
+	if !strings.Contains(errorMessage, "Database Query: Connection timeout") {
+		t.Errorf("Expected error message to include step cause, got: %s", errorMessage)
 	}
 }
 
@@ -150,6 +155,42 @@ func TestAnalyzeExecutionResult_AllFailure(t *testing.T) {
 	expectedSubstring := "3 of 3 steps failed"
 	if len(errorMessage) == 0 || !strings.Contains(errorMessage, expectedSubstring) {
 		t.Errorf("Expected error message to contain '%s', got: %s", expectedSubstring, errorMessage)
+	}
+	if !strings.Contains(errorMessage, "HTTP Request: HTTP 500 error") {
+		t.Errorf("Expected error message to include step cause, got: %s", errorMessage)
+	}
+}
+
+// TestAnalyzeExecutionResult_IncludesBundlerCause pins the UserOp-contention
+// case: REST :trigger copies execution.error and used to say only
+// "1 of 2 steps failed: w", dropping "replacement underpriced".
+func TestAnalyzeExecutionResult_IncludesBundlerCause(t *testing.T) {
+	vm := NewVM()
+	vm.logger = testutil.GetLogger()
+	vm.ExecutionLogs = []*avsproto.Execution_Step{
+		{
+			Id:      "trigger",
+			Success: true,
+			Name:    "blockTrigger",
+		},
+		{
+			Id:      "w",
+			Success: false,
+			Error:   "eth_sendUserOperation: replacement underpriced",
+			Name:    "w",
+		},
+	}
+
+	errorMessage, failedCount, resultStatus := vm.AnalyzeExecutionResult()
+	if resultStatus != ExecutionFailed {
+		t.Errorf("Expected ExecutionFailed, got %v", resultStatus)
+	}
+	if failedCount != 1 {
+		t.Errorf("Expected failedCount=1, got %d", failedCount)
+	}
+	want := "1 of 2 steps failed: w: eth_sendUserOperation: replacement underpriced"
+	if errorMessage != want {
+		t.Errorf("got %q, want %q", errorMessage, want)
 	}
 }
 

--- a/core/taskengine/vm.go
+++ b/core/taskengine/vm.go
@@ -3621,6 +3621,17 @@ func getStepDisplayName(step *avsproto.Execution_Step) string {
 	return stepName
 }
 
+// failedStepLabel is the per-step fragment in execution.error. Name-only
+// summaries hid the cause (e.g. bundler "replacement underpriced") on
+// REST :trigger, which copies execution.error and used to omit steps.
+func failedStepLabel(step *avsproto.Execution_Step) string {
+	name := getStepDisplayName(step)
+	if msg := strings.TrimSpace(step.GetError()); msg != "" {
+		return name + ": " + msg
+	}
+	return name
+}
+
 // AnalyzeExecutionResult examines all execution steps and determines overall success/failure status.
 // Returns (errorMessage, failedStepCount, resultStatus)
 func (v *VM) AnalyzeExecutionResult() (string, int, ExecutionResultStatus) {
@@ -3631,15 +3642,15 @@ func (v *VM) AnalyzeExecutionResult() (string, int, ExecutionResultStatus) {
 		return "no execution steps found", 0, ExecutionFailed
 	}
 
-	var failedStepNames []string
+	var failedStepLabels []string
 
 	for _, step := range v.ExecutionLogs {
 		if !step.Success && step.Error != "" {
-			failedStepNames = append(failedStepNames, getStepDisplayName(step))
+			failedStepLabels = append(failedStepLabels, failedStepLabel(step))
 		}
 	}
 
-	failedCount := len(failedStepNames)
+	failedCount := len(failedStepLabels)
 
 	if failedCount == 0 {
 		// All executed steps succeeded. Branch/conditional skips are normal
@@ -3649,7 +3660,7 @@ func (v *VM) AnalyzeExecutionResult() (string, int, ExecutionResultStatus) {
 	}
 
 	// One or more steps failed (covers both partial and total failure).
-	errorMessage := formatExecutionErrorMessage("", failedCount, len(v.ExecutionLogs), failedStepNames)
+	errorMessage := formatExecutionErrorMessage("", failedCount, len(v.ExecutionLogs), failedStepLabels)
 	return errorMessage, failedCount, ExecutionFailed
 }
 

--- a/docs/changes/20260908-trigger-rest-error-includes-step-cause.md
+++ b/docs/changes/20260908-trigger-rest-error-includes-step-cause.md
@@ -33,4 +33,5 @@ No retry. The gateway still does not wait-and-resend on `replacement underpriced
 
 - `TestAnalyzeExecutionResult_IncludesBundlerCause`
 - `TestAnalyzeExecutionResult_SomeStepsFailed` / `_AllFailure` now assert the step cause is in the summary
-- `TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps`
+- `TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps` (`status: failed`)
+- `TestProtoToOpenAPITriggerWorkflow_ErrorCopiesVmCauseAndSteps` (`status: error` — `VM execution error: …` plus steps)

--- a/docs/changes/20260908-trigger-rest-error-includes-step-cause.md
+++ b/docs/changes/20260908-trigger-rest-error-includes-step-cause.md
@@ -35,3 +35,4 @@ No retry. The gateway still does not wait-and-resend on `replacement underpriced
 - `TestAnalyzeExecutionResult_SomeStepsFailed` / `_AllFailure` now assert the step cause is in the summary
 - `TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps` (`status: failed`)
 - `TestProtoToOpenAPITriggerWorkflow_ErrorCopiesVmCauseAndSteps` (`status: error` — `VM execution error: …` plus steps)
+- `TestProtoToOpenAPITriggerWorkflow_WaitingNormalizesAwaitStepType` (`status: waiting` → `steps[].type` is `await`, not `NODE_TYPE_AWAIT`)

--- a/docs/changes/20260908-trigger-rest-error-includes-step-cause.md
+++ b/docs/changes/20260908-trigger-rest-error-includes-step-cause.md
@@ -1,0 +1,36 @@
+# Trigger REST envelope includes step cause
+
+- **Date**: 2026-09-08
+- **Status**: Implemented
+- **Branch**: fix/trigger-error-includes-step-cause
+- **Related**: ava-sdk-js #263, `docs/changes/20260413-execution-status-redesign.md`
+
+## Problem
+
+Blocking `POST /workflows/{id}:trigger` returned HTTP 200 with
+
+```json
+{ "status": "failed", "error": "1 of 2 steps failed: w" }
+```
+
+The bundler reason (`eth_sendUserOperation: replacement underpriced`) was on `execution.steps[].error`. gRPC `TriggerTaskResp` already had `steps`; the REST handler copied only `executionId` / `status` / timestamps / `error` and dropped `steps`. `AnalyzeExecutionResult` built `error` from **node names only**.
+
+The SDK pass-through was faithful. Clients that only read `:trigger` could not see why the step failed.
+
+## Decision
+
+1. `failedStepLabel` — `execution.error` is `N of M steps failed: <name>: <step.error>, …`.
+2. `mapping.ProtoToOpenAPITriggerWorkflow` — REST trigger copies proto `error` **and** `steps` (OpenAPI `TriggerWorkflowResponse.steps`). There was no conversion unit test; the handler did the copy inline.
+
+No retry. The gateway still does not wait-and-resend on `replacement underpriced`. It just stops hiding the cause.
+
+## Alternatives
+
+- Envelope-only string, still omit `steps`. Typed `error` would be enough for the SDK today, but REST would stay a lossy projection of gRPC.
+- Retry inside `SendUserOp`. Hides the class of failure; wrong if the pending op is a real replacement.
+
+## Verification
+
+- `TestAnalyzeExecutionResult_IncludesBundlerCause`
+- `TestAnalyzeExecutionResult_SomeStepsFailed` / `_AllFailure` now assert the step cause is in the summary
+- `TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps`


### PR DESCRIPTION
## Summary

REST `POST /workflows/{id}:trigger` (blocking) returned HTTP 200 with a name-only summary:

```json
{ "status": "failed", "error": "1 of 2 steps failed: w" }
```

The bundler cause (`eth_sendUserOperation: replacement underpriced`) lived on `execution.steps[].error`. gRPC `TriggerTaskResp` already had `steps`; the REST handler copied `executionId` / `status` / timestamps / `error` and dropped `steps`. `AnalyzeExecutionResult` built `error` from node names only.

The SDK is a pass-through. This is a gateway envelope fix, not retry.

## Changes

- `execution.error` is now `N of M steps failed: <name>: <step.error>, …`
- `mapping.ProtoToOpenAPITriggerWorkflow` copies proto `error` **and** `steps` (OpenAPI `TriggerWorkflowResponse.steps`)
- Same mapper for `status: failed` and `status: error` (`VM execution error: …`, plus any recorded steps)

## Tests

- `TestAnalyzeExecutionResult_IncludesBundlerCause`
- `TestProtoToOpenAPITriggerWorkflow_CopiesErrorAndSteps`
- `TestProtoToOpenAPITriggerWorkflow_ErrorCopiesVmCauseAndSteps`

See [docs/changes/20260908-trigger-rest-error-includes-step-cause.md](docs/changes/20260908-trigger-rest-error-includes-step-cause.md). Related: AvaProtocol/ava-sdk-js#263.
