### PR TITLE
test: Stop waits for in-flight backup; aggregator RunE exits 1

### DIFF
--- a/cmd/runAggregator.go
+++ b/cmd/runAggregator.go
@@ -15,7 +15,7 @@ var (
 		Long: `Initialize and run aggregator.
 
 Use --config=path-to-your-config-file. default is=./config/aggregator.yaml `,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// The REST API surface (api/openapi.yaml) is mounted here at
 			// the cmd layer rather than inside the aggregator package so
 			// the aggregator core never imports aggregator/rest. That
@@ -31,7 +31,9 @@ Use --config=path-to-your-config-file. default is=./config/aggregator.yaml `,
 				srv.Mount(e)
 			}
 
-			aggregator.RunWithConfig(config, aggregator.WithHTTPMount(mountRest))
+			// RunE so Start errors (e.g. fail-closed periodic backup dir)
+			// reach rootCmd.Execute and os.Exit(1). Bare Run discarded them.
+			return aggregator.RunWithConfig(config, aggregator.WithHTTPMount(mountRest))
 		},
 	}
 )

--- a/cmd/runAggregator_test.go
+++ b/cmd/runAggregator_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "testing"
+
+// StartPeriodicBackup failure is fatal to aggregator.Start. That only
+// reaches the process exit if this command uses RunE; cobra Run ignores
+// the return value (Claude on #786).
+func TestRunAggregatorUsesRunE(t *testing.T) {
+	if runAggregatorCmd.RunE == nil {
+		t.Fatal("aggregator command must use RunE so Start errors exit 1")
+	}
+	if runAggregatorCmd.Run != nil {
+		t.Fatal("aggregator command must not set Run; it discards errors")
+	}
+}

--- a/core/backup/backup_test.go
+++ b/core/backup/backup_test.go
@@ -1,12 +1,17 @@
 package backup
 
 import (
+	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/AvaProtocol/EigenLayer-AVS/core/testutil"
+	"github.com/AvaProtocol/EigenLayer-AVS/storage"
 )
 
 func TestBackup(t *testing.T) {
@@ -138,4 +143,93 @@ func TestPruneOldBackups(t *testing.T) {
 	}
 }
 
-// Mock implementations for testing
+// blockingStorage wraps a real store and parks Backup until release is closed.
+// Copilot #786: StopPeriodicBackup's wg.Wait is the shutdown guarantee;
+// an idle-ticker test would still pass if Wait were removed.
+type blockingStorage struct {
+	storage.Storage
+	started chan struct{}
+	once    sync.Once
+	release chan struct{}
+	held    atomic.Bool
+}
+
+func (b *blockingStorage) Backup(ctx context.Context, w io.Writer, since uint64) (uint64, error) {
+	b.held.Store(true)
+	defer b.held.Store(false)
+	b.once.Do(func() { close(b.started) })
+	select {
+	case <-b.release:
+		return 0, nil
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}
+
+func TestStopPeriodicBackupWaitsForInFlightBackup(t *testing.T) {
+	logger := testutil.GetLogger()
+	inner := testutil.TestMustDB()
+	t.Cleanup(func() { _ = inner.Close() })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	db := &blockingStorage{
+		Storage: inner,
+		started: started,
+		release: release,
+	}
+	svc := NewService(logger, db, t.TempDir())
+	if err := svc.StartPeriodicBackup(15 * time.Millisecond); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Backup did not start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		svc.StopPeriodicBackup()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("StopPeriodicBackup returned while Backup was still held")
+	case <-time.After(150 * time.Millisecond):
+	}
+	if !db.held.Load() {
+		t.Fatal("expected Backup to still be in flight while Stop waits")
+	}
+
+	close(release)
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopPeriodicBackup did not return after Backup released")
+	}
+}
+
+func TestConcurrentStartStop(t *testing.T) {
+	logger := testutil.GetLogger()
+	db := testutil.TestMustDB()
+	t.Cleanup(func() { _ = db.Close() })
+	svc := NewService(logger, db, t.TempDir())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = svc.StartPeriodicBackup(time.Hour)
+			svc.StopPeriodicBackup()
+		}()
+	}
+	wg.Wait()
+	svc.StopPeriodicBackup()
+	if svc.backupEnabled {
+		t.Error("backup should be stopped after concurrent Start/Stop")
+	}
+}

--- a/docs/changes/20260908-backup-mutex-reserved-secrets.md
+++ b/docs/changes/20260908-backup-mutex-reserved-secrets.md
@@ -19,4 +19,7 @@ Claude's #782 review left three non-blocking follow-ups: periodic backup Start/S
 ## Tests
 
 - `core/backup`: Start after Stop recreates the stop channel; Stop waits for the loop before returning.
+- `TestStopPeriodicBackupWaitsForInFlightBackup`: blocking `storage.Storage` double; Stop cannot return while `Backup` is held.
+- `TestConcurrentStartStop`: 16 goroutines Start/Stop (run under `-race` in CI).
+- `cmd`: aggregator cobra command uses `RunE` so `Start` errors (`periodic backup to …`) exit 1. `Run` discarded them.
 - `core/taskengine`: Create and Update reject all three platform names and their uppercase variants; `TestIsPlatformSecretName` covers the case-insensitive lookup and non-reserved names (notify tokens stay interpolable).


### PR DESCRIPTION
## Summary

Folds Copilot + Claude comments on staging→main [#786](https://github.com/AvaProtocol/EigenLayer-AVS/pull/786) into staging.

**Copilot:** `StopPeriodicBackup` waiting on `wg` was not tested. The idle 1-hour ticker test would still pass if `Wait` were removed.

- Blocking `storage.Storage` double parks `Backup`; Stop cannot return until it is released.
- 16 goroutines Start/Stop (`go test -race ./core/backup`).

**Claude:** `aggregator.Start` returns a fatal backup error, but cobra `Run` discarded `RunWithConfig`. Switch to `RunE` so `os.Exit(1)` happens. `TestRunAggregatorUsesRunE` pins that.

Does not change backup mutex logic itself.
